### PR TITLE
Add Sentry observability (errors + performance) and guardrails

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,9 +37,9 @@ export default withSentryConfig(nextConfig, {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: "ineffable-collective",
+  org: process.env.SENTRY_ORG,
 
-  project: "javascript-nextjs",
+  project: process.env.SENTRY_PROJECT,
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,7 +3,13 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN || undefined,
   environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV,
-  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.05),
+  tracesSampleRate: (() => {
+    const fromEnv = Number(process.env.SENTRY_TRACES_SAMPLE_RATE);
+    if (!Number.isNaN(fromEnv) && fromEnv > 0) return fromEnv;
+    const isProd = process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production";
+    return isProd ? 0.15 : 1.0;
+  })(),
   profilesSampleRate: Number(process.env.SENTRY_PROFILES_SAMPLE_RATE ?? 0),
   enableLogs: process.env.NODE_ENV !== "production",
+  sendDefaultPii: process.env.NODE_ENV === "production" ? false : undefined,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,11 +3,18 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN || undefined,
   environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV,
-  // Performance / tracing:
-  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.05), // 5% default
-  profilesSampleRate: Number(process.env.SENTRY_PROFILES_SAMPLE_RATE ?? 0), // optional, 0–0.1 typical
+  // Performance / tracing (env-based with sane defaults):
+  tracesSampleRate: (() => {
+    const fromEnv = Number(process.env.SENTRY_TRACES_SAMPLE_RATE);
+    if (!Number.isNaN(fromEnv) && fromEnv > 0) return fromEnv;
+    const isProd = process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production";
+    return isProd ? 0.15 : 1.0;
+  })(),
+  profilesSampleRate: Number(process.env.SENTRY_PROFILES_SAMPLE_RATE ?? 0),
   // Logging in dev only:
   enableLogs: process.env.NODE_ENV !== "production",
+  // Ensure no PII is sent in production
+  sendDefaultPii: process.env.NODE_ENV === "production" ? false : undefined,
   // If you want to limit where trace headers propagate:
   // tracePropagationTargets: [/^https:\/\/yourdomain\.vercel\.app$/],
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { SearchBar } from '@/components/home/SearchBar';
 import { RecipeCard } from '@/components/recipe/RecipeCard';
 import { FeedTabs } from '@/components/home/FeedTabs';
 import { getCurrentUser } from '@/lib/auth';
+import { ErrorBoundary as ClientErrorBoundary } from '@/components/obs/ErrorBoundary';
 
 // Force dynamic rendering for pages that use authentication
 export const dynamic = 'force-dynamic';
@@ -40,7 +41,9 @@ export default async function HomePage() {
       )}
 
       <HomeSection title={currentUser ? 'For you · Following' : 'For you'}>
-        <FeedTabs signedIn={!!currentUser} currentUserId={currentUser?.id || null} />
+        <ClientErrorBoundary>
+          <FeedTabs signedIn={!!currentUser} currentUserId={currentUser?.id || null} />
+        </ClientErrorBoundary>
       </HomeSection>
     </div>
   );

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -15,6 +15,7 @@ import { AuthorLink } from "@/components/recipe/AuthorLink";
 import { RecipeNutritionDisplay } from "@/components/recipe/RecipeNutritionDisplay";
 import { SuggestionCard } from "@/components/SuggestionCard";
 import { AlsoViewed } from "./_components/AlsoViewed";
+import { ErrorBoundary as ClientErrorBoundary } from "@/components/obs/ErrorBoundary";
 
 interface RecipePageProps {
   params: Promise<{
@@ -175,19 +176,23 @@ export default async function RecipePage({ params, searchParams }: RecipePagePro
                 <CardTitle>Photos</CardTitle>
               </CardHeader>
               <CardContent>
-                <PhotoGallery photos={recipe.photos} recipeTitle={recipe.title} canDelete={canDelete} />
+                <ClientErrorBoundary>
+                  <PhotoGallery photos={recipe.photos} recipeTitle={recipe.title} canDelete={canDelete} />
+                </ClientErrorBoundary>
               </CardContent>
             </Card>
           )}
 
           {/* Nutrition Breakdown - Mobile/Tablet (shown after photos) */}
           <div className="xl:hidden">
-            <RecipeNutritionDisplay 
-              recipeId={recipe.id}
-              servings={recipe.servings}
-              isAuthor={canDelete}
-              fallbackNutrition={recipe.nutrition}
-            />
+            <ClientErrorBoundary>
+              <RecipeNutritionDisplay 
+                recipeId={recipe.id}
+                servings={recipe.servings}
+                isAuthor={canDelete}
+                fallbackNutrition={recipe.nutrition}
+              />
+            </ClientErrorBoundary>
           </div>
 
           {/* Ingredients */}
@@ -232,13 +237,15 @@ export default async function RecipePage({ params, searchParams }: RecipePagePro
               <CardTitle>Comments</CardTitle>
             </CardHeader>
             <CardContent>
-              <Comments
-                recipeId={recipe.id}
-                initial={comments as any}
-                canPost={Boolean(current)}
-                currentUserId={current?.id ?? null}
-                recipeAuthorId={recipe.authorId}
-              />
+              <ClientErrorBoundary>
+                <Comments
+                  recipeId={recipe.id}
+                  initial={comments as any}
+                  canPost={Boolean(current)}
+                  currentUserId={current?.id ?? null}
+                  recipeAuthorId={recipe.authorId}
+                />
+              </ClientErrorBoundary>
             </CardContent>
           </Card>
 
@@ -250,12 +257,14 @@ export default async function RecipePage({ params, searchParams }: RecipePagePro
 
         {/* Nutrition Sidebar - Desktop only */}
         <div className="hidden xl:block xl:col-span-1">
-          <RecipeNutritionDisplay 
-            recipeId={recipe.id}
-            servings={recipe.servings}
-            isAuthor={canDelete}
-            fallbackNutrition={recipe.nutrition}
-          />
+          <ClientErrorBoundary>
+            <RecipeNutritionDisplay 
+              recipeId={recipe.id}
+              servings={recipe.servings}
+              isAuthor={canDelete}
+              fallbackNutrition={recipe.nutrition}
+            />
+          </ClientErrorBoundary>
         </div>
       </div>
 

--- a/src/components/obs/ErrorBoundary.tsx
+++ b/src/components/obs/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Component, ReactNode } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: any) {
+    Sentry.captureException(error, { extra: { errorInfo } as any });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-[200px] flex items-center justify-center p-4">
+          <Card className="max-w-md w-full p-6 text-center">
+            <h2 className="text-xl font-semibold mb-4">Something went wrong</h2>
+            <p className="text-muted-foreground mb-4">
+              An unexpected error occurred. Please try again.
+            </p>
+            <div className="space-y-2">
+              <Button onClick={() => window.location.reload()} className="w-full">
+                Retry
+              </Button>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+

--- a/src/lib/obs/capture.ts
+++ b/src/lib/obs/capture.ts
@@ -1,0 +1,8 @@
+import * as Sentry from "@sentry/nextjs";
+
+export function capture(err: unknown, context?: Record<string, any>) {
+  if (context) Sentry.setContext("extra", context);
+  Sentry.captureException(err);
+}
+
+

--- a/src/lib/obs/withSpan.ts
+++ b/src/lib/obs/withSpan.ts
@@ -1,0 +1,7 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function withSpan<T>(name: string, fn: () => Promise<T>) {
+  return Sentry.startSpan({ name }, fn);
+}
+
+


### PR DESCRIPTION
adds a minimal, production-safe observability setup with Sentry for both errors and performance. It also introduces tiny helpers for consistent error capture and spans, and wraps critical client surfaces with a global error boundary.

Changes

next.config.ts:

Wrap with withSentryConfig to upload source maps in CI

Keep USDA JSON excluded from bundling

Preserve serverExternalPackages for Prisma

sentry.server.config.ts, sentry.edge.config.ts

Env-driven sampling: SENTRY_TRACES_SAMPLE_RATE (prod default 0.15, dev/preview 1.0)

sendDefaultPii: false in production

SENTRY_ENVIRONMENT support

Performance spans:

src/lib/obs/withSpan.ts helper

Instrument /api/feed/foryou, /api/recipes/[id] (GET), /api/foods/search

Add Sentry.setTag('endpoint', ...) for easy filtering

Error capture:

src/lib/obs/capture.ts helper

Use capture() in the three endpoints’ catch blocks

Client crash UX:

src/components/obs/ErrorBoundary.tsx

Wrap key client surfaces on Home and Recipe detail

Test hook:

/api/oops endpoint to force a server error (validates wiring)

No functional changes to business logic