### PR TITLE
fix(parse): honor word-number quantities ("two eggs" -> 2)

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -2600,7 +2600,7 @@
         140
       ],
       "knownIssue": true,
-      "notes": "word-quantity defect: 'two eggs' resolves to 50g total (a single small egg) \u2014 the word 'two' is not honored \u2014 and maps to an 'Eggs White' record instead of whole egg. Splitting itself is fine (bagel+cream cheese composite is a real record). expectItems relaxed to 2."
+      "notes": "The word-quantity half is FIXED 2026-07-18 (quantity.ts WORD_NUMBERS): 'two eggs' now = qty 2 -> ~100g. Kept knownIssue because this is a multi-item text case ('and' + 'with') that runs the LLM segmenter first, so item count/order and which item the grams band checks are segmentation-nondeterministic. The deterministic word-number assertion lives in n-qty-03. Promote once always-AI-first segmentation is proven stable on this phrasing."
     },
     {
       "id": "n-seg-08",
@@ -3270,8 +3270,7 @@
         88,
         140
       ],
-      "knownIssue": true,
-      "notes": "Pattern 10 (word-number 'two'). KNOWN GAP (same defect as n-seg-07): the word 'two' is not honored, so 'two eggs' resolves to ~50g (a single small egg) instead of ~100-120g. Non-gating; promote when word-number quantities are parsed."
+      "notes": "Pattern 10 (word-number 'two'). FIXED 2026-07-18 (quantity.ts WORD_NUMBERS map): the word 'two' is now honored -> 'two eggs' = qty 2 -> ~100g (2 x 50g egg default). Deterministic single-item path (no 'and'/'with', <=6 words -> singleItemFromText bypass, no LLM), so promoted from knownIssue to hard assertion."
     },
     {
       "id": "n-qty-04",
@@ -3303,6 +3302,38 @@
         ]
       ],
       "notes": "Pattern 10 (no explicit quantity -> default to 1 serving). Bare food name with no number/unit must still map to one yogurt item. Hard assertion on name/segmentation."
+    },
+    {
+      "id": "n-qty-06",
+      "category": "quantity_parsing",
+      "text": "three eggs",
+      "expectItems": 1,
+      "expectName": [
+        [
+          "egg"
+        ]
+      ],
+      "grams": [
+        130,
+        170
+      ],
+      "notes": "Pattern 10 (word-number 'three'). Added 2026-07-18 with the quantity.ts WORD_NUMBERS fix: 'three eggs' = qty 3 -> ~150g (3 x 50g egg default). Deterministic single-item path (singleItemFromText bypass, no LLM). Hard assertion."
+    },
+    {
+      "id": "n-qty-07",
+      "category": "quantity_parsing",
+      "text": "a dozen eggs",
+      "expectItems": 1,
+      "expectName": [
+        [
+          "egg"
+        ]
+      ],
+      "grams": [
+        520,
+        700
+      ],
+      "notes": "Pattern 10 (collective word-number 'a dozen' -> 12, article + word consumed). Added 2026-07-18 with the quantity.ts WORD_NUMBERS fix: 'a dozen eggs' = qty 12 -> ~600g (12 x ~50g egg default). Deterministic single-item path. Hard assertion; band widened to tolerate a 44-58g per-egg record serving."
     },
     {
       "id": "n-supp-16",

--- a/src/lib/parse/__tests__/quantity.test.ts
+++ b/src/lib/parse/__tests__/quantity.test.ts
@@ -144,3 +144,57 @@ test('range with both fractions "1½-2½"', () => {
   expect(r?.qty).toBeCloseTo(2.0); // (1.5 + 2.5) / 2
   expect(r?.consumed).toBe(3);
 });
+// Word-number quantities ("two eggs" -> 2, "a dozen eggs" -> 12)
+test('word-number "two"', () => {
+  const r = parseQuantityTokens(['two', 'eggs']);
+  expect(r?.qty).toBe(2);
+  expect(r?.consumed).toBe(1);
+});
+
+test('word-number "three"', () => {
+  const r = parseQuantityTokens(['three', 'eggs']);
+  expect(r?.qty).toBe(3);
+  expect(r?.consumed).toBe(1);
+});
+
+test('word-number "ten"', () => {
+  const r = parseQuantityTokens(['ten', 'wings']);
+  expect(r?.qty).toBe(10);
+  expect(r?.consumed).toBe(1);
+});
+
+test('word-number "one" is consumed (frees the unit)', () => {
+  const r = parseQuantityTokens(['one', 'cup', 'flour']);
+  expect(r?.qty).toBe(1);
+  expect(r?.consumed).toBe(1);
+});
+
+test('"a dozen" -> 12 (article consumed)', () => {
+  const r = parseQuantityTokens(['a', 'dozen', 'eggs']);
+  expect(r?.qty).toBe(12);
+  expect(r?.consumed).toBe(2);
+});
+
+test('"a couple of" -> 2 (article + partitive "of" consumed)', () => {
+  const r = parseQuantityTokens(['a', 'couple', 'of', 'eggs']);
+  expect(r?.qty).toBe(2);
+  expect(r?.consumed).toBe(3);
+});
+
+test('"couple of" -> 2 (bare, partitive "of" consumed)', () => {
+  const r = parseQuantityTokens(['couple', 'of', 'eggs']);
+  expect(r?.qty).toBe(2);
+  expect(r?.consumed).toBe(2);
+});
+
+test('bare article "a" is NOT a number word', () => {
+  // "a bagel" must fall through so the caller applies its qty=1 default
+  const r = parseQuantityTokens(['a', 'bagel']);
+  expect(r).toBeNull();
+});
+
+test('word-number does not break "one and a half"', () => {
+  const r = parseQuantityTokens(['one', 'and', 'a', 'half']);
+  expect(r?.qty).toBeCloseTo(1.5);
+  expect(r?.consumed).toBe(4);
+});

--- a/src/lib/parse/quantity.ts
+++ b/src/lib/parse/quantity.ts
@@ -206,6 +206,29 @@ export function parseQuantityTokens(tokens: string[]): { qty: number; consumed: 
     return { qty: 1.5, consumed: 3 };
   }
 
+  // Handle word-number quantities: "two eggs" -> 2, "a dozen eggs" -> 12,
+  // "a couple of eggs" -> 2. Deliberately placed AFTER the "one and a half" /
+  // "1 and 1/2" blocks above so those still match the literal "one"/"a" tokens.
+  // "a"/"an" is NOT a number on its own (bare "a bagel" already defaults to
+  // qty 1); it only counts here as the article in "a dozen"/"a couple".
+  const WORD_NUMBERS: Record<string, number> = {
+    one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8,
+    nine: 9, ten: 10, eleven: 11, twelve: 12, dozen: 12, couple: 2,
+  };
+  const article = tokens[0].toLowerCase();
+  const hasArticle =
+    (article === 'a' || article === 'an') &&
+    tokens.length >= 2 &&
+    (tokens[1].toLowerCase() === 'dozen' || tokens[1].toLowerCase() === 'couple');
+  const numIdx = hasArticle ? 1 : 0;
+  const word = tokens[numIdx].toLowerCase();
+  if (WORD_NUMBERS[word] !== undefined) {
+    let wordConsumed = numIdx + 1;
+    // Consume an optional partitive "of": "a couple of eggs", "couple of eggs".
+    if (tokens[wordConsumed]?.toLowerCase() === 'of') wordConsumed += 1;
+    return { qty: WORD_NUMBERS[word], consumed: wordConsumed };
+  }
+
   // Handle "number fraction" pattern (e.g., "1 1/2", "4 1/2")
   if (tokens.length >= 2) {
     const firstNum = parseFloat(tokens[0]);


### PR DESCRIPTION
## What
`parseQuantityTokens` had no word→integer map, so **"two eggs"** fell through to `parseFloat("two")=NaN`, left qty at the default 1, and (because "two" was never consumed) leaked into the food name — resolving to ~50g (one small egg) plus a degraded search query.

Add a `WORD_NUMBERS` map (`one`..`twelve`, `dozen`, `couple`) + the collective article form (`a dozen`, `a couple of`), consuming an optional partitive `of`. Placed **after** the "one and a half" / "1 and 1/2" blocks so those still match literal `one`/`a`; bare `a`/`an` is not a number (`a bagel` keeps the qty=1 default). Consuming the word also frees the following count noun to be read as the unit, cleaning the name.

## Why now
Cluster B of the magic-log follow-up backlog — self-contained, deterministic, no dependency on the larger serving/ranking work (Clusters A/C, still held).

## Tests
- **+9 unit tests** in `quantity.test.ts`, incl. regression guards for `one and a half` and bare `a`. All parse suites green (120 tests).
- Golden set: promote `n-qty-03` "two eggs" knownIssue→hard; add `n-qty-06` "three eggs", `n-qty-07` "a dozen eggs"; re-note `n-seg-07` (word-number half fixed, kept knownIssue for segmentation variance).
- Local eval vs real corpus: **0 real failures**, `quantity_parsing 7/7`, no regression on `n-qty-04` "three slices of bacon" (now correctly qty 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y