### PR TITLE
fix(serving): stop buildOffResult count over-billing (Cluster A pt.1)

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -4113,6 +4113,335 @@
       ],
       "knownIssue": true,
       "notes": "DISCOVERED BUG (stable): '2 eggo waffles' resolves to 150g (~75g/waffle). A single Eggo waffle is ~35g (label serving is 2 waffles = 70g), so 2 is ~70g; 150g is ~2x too high. Same per-count over-billing as n-serv-18. Correct brand/product ('Eggo waffles', Kellogg's). Expected ~50-90g; observed 150g. Non-gating."
+    },
+    {
+      "id": "n-serv-20",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "15 pretzels",
+        "quantity": 15,
+        "unit": "",
+        "name": "pretzels",
+        "brand": "",
+        "normalizedForm": "pretzels",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "pretzel"
+        ]
+      ],
+      "grams": [
+        8,
+        45
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount, most extreme found: ratio ~100x). '15 pretzels' -> 1500g: buildOffResult unitless-count branch finds no seed and no discrete-regex match, so bills 100g per piece (15 x 100). A mini pretzel is ~1.2g so 15 is ~18g. Target [8,45]; observed 1500g. Fix = intercept the per-unit==100 no-serving fallback (prefer label per-unit / ambiguous backfill / per-unit cap)."
+    },
+    {
+      "id": "n-serv-21",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "12 m&ms",
+        "quantity": 12,
+        "unit": "",
+        "name": "m&ms",
+        "brand": "m&ms",
+        "normalizedForm": "m&ms",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "m&m"
+        ]
+      ],
+      "grams": [
+        6,
+        25
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount). '12 m&ms' -> 1200g (12 x 100g default). One M&M is ~0.9g so 12 is ~11g. Target [6,25]; observed 1200g. Same 100xcount root as n-serv-20."
+    },
+    {
+      "id": "n-serv-22",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "10 grapes",
+        "quantity": 10,
+        "unit": "",
+        "name": "grapes",
+        "brand": "",
+        "normalizedForm": "grapes",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "grape"
+        ]
+      ],
+      "grams": [
+        30,
+        90
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount on a WHOLE FOOD). '10 grapes' -> 1000g (10 x 100g default). A grape is ~5g so 10 is ~50g. Target [30,90]; observed 1000g. Shows the 100xcount defect is not brand-specific -- any count food lacking a per-piece seed/serving over-bills."
+    },
+    {
+      "id": "n-serv-23",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 gatorade",
+        "quantity": 1,
+        "unit": "bottle",
+        "name": "gatorade",
+        "brand": "gatorade",
+        "normalizedForm": "sports drink",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "gatorade"
+        ]
+      ],
+      "grams": [
+        300,
+        650
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 3 = flat-100 package, most extreme UNDER: ratio ~0.2x). '1 gatorade' -> 100g: unitless branded bottle (~591g for 20oz, ~355g for 12oz) not backfilled to a container serving; falls to the 100g no-serving fallback. Target [300,650]; observed 100g. Fix = route unitless packages (bottle/can/pouch) to the ambiguous-unit backfill."
+    },
+    {
+      "id": "n-serv-24",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 capri sun",
+        "quantity": 1,
+        "unit": "pouch",
+        "name": "capri sun",
+        "brand": "capri sun",
+        "normalizedForm": "juice pouch",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "capri"
+        ]
+      ],
+      "grams": [
+        130,
+        200
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 3 = flat-100 package). '1 capri sun' -> 100g: a pouch is ~177g (6 fl oz). Target [130,200]; observed 100g. Same flat-100 fallback as n-serv-23/celsius/chobani; the pouch package size is never resolved."
+    },
+    {
+      "id": "n-serv-25",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 handful almonds",
+        "quantity": 1,
+        "unit": "handful",
+        "name": "almonds",
+        "brand": "",
+        "normalizedForm": "almonds",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "almond"
+        ]
+      ],
+      "grams": [
+        18,
+        45
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 4 = ambiguous unit not resolved, extreme UNDER). '1 handful almonds' -> 1.2g: 'handful' is treated as a single almond (~1.2g) instead of a handful portion (~28-35g). Target [18,45]; observed 1.2g. Contrast n-serv-31 '1 scoop whey' which DOES resolve. 'handful'/'bowl' need portion backfill; 'scoop'/'glass' already work."
+    },
+    {
+      "id": "n-serv-26",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 bowl cereal",
+        "quantity": 1,
+        "unit": "bowl",
+        "name": "cereal",
+        "brand": "",
+        "normalizedForm": "cereal",
+        "mealType": "breakfast"
+      },
+      "expectName": [
+        [
+          "cereal"
+        ]
+      ],
+      "grams": [
+        25,
+        70
+      ],
+      "knownIssue": true,
+      "notes": "CENSUS BUG (Cluster A, Defect 4 = ambiguous unit not resolved). '1 bowl cereal' -> 100g flat: 'bowl' is not resolved to a portion; a bowl of dry cereal is ~40-60g. Target [25,70]; observed 100g. Same ambiguous-unit gap as n-serv-25 (handful)."
+    },
+    {
+      "id": "n-serv-27",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 red bull",
+        "quantity": 1,
+        "unit": "can",
+        "name": "red bull",
+        "brand": "red bull",
+        "normalizedForm": "energy drink",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "red bull"
+        ]
+      ],
+      "grams": [
+        200,
+        300
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 250g). Branded can WITH a genuine OFF serving resolves properly (~250g / 8.4 fl oz). Hard assertion -- the Cluster A fix must NOT regress packages that already resolve. Contrast n-serv-23 gatorade (no usable serving -> 100g)."
+    },
+    {
+      "id": "n-serv-28",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 clif bar",
+        "quantity": 1,
+        "unit": "bar",
+        "name": "clif bar",
+        "brand": "clif",
+        "normalizedForm": "bar",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "clif"
+        ]
+      ],
+      "grams": [
+        55,
+        82
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 68g). Branded bar with a genuine serving (~68g). Hard assertion; the fix must preserve this. Contrast the over-billed generic-seed bars (n-serv-18 oreo, n-serv-19 eggo)."
+    },
+    {
+      "id": "n-serv-29",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 string cheese",
+        "quantity": 1,
+        "unit": "stick",
+        "name": "string cheese",
+        "brand": "",
+        "normalizedForm": "string cheese",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "cheese"
+        ]
+      ],
+      "grams": [
+        18,
+        36
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 28g). A string cheese stick (~28g) resolves via a genuine serving even though 'stick' is a discrete unit. Hard assertion; contrast n-serv-28-family chomps 'stick' which falls to 100g -- the fix must lift chomps WITHOUT breaking this."
+    },
+    {
+      "id": "n-serv-30",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "20 almonds",
+        "quantity": 20,
+        "unit": "",
+        "name": "almonds",
+        "brand": "",
+        "normalizedForm": "almonds",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "almond"
+        ]
+      ],
+      "grams": [
+        16,
+        34
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 24g). Unitless count WITH a genuine per-piece resolution (~1.2g/almond x 20). Hard assertion -- proves the count path works when a real per-piece weight exists; the 100xcount fix must not disturb it."
+    },
+    {
+      "id": "n-serv-31",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "5 strawberries",
+        "quantity": 5,
+        "unit": "",
+        "name": "strawberries",
+        "brand": "",
+        "normalizedForm": "strawberries",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "strawberr"
+        ]
+      ],
+      "grams": [
+        38,
+        88
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 60g). Whole-food count with a genuine per-piece weight (~12g/berry x 5). Hard assertion; guards the count path alongside n-serv-30."
+    },
+    {
+      "id": "n-serv-32",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 scoop whey protein",
+        "quantity": 1,
+        "unit": "scoop",
+        "name": "whey protein",
+        "brand": "",
+        "normalizedForm": "whey protein",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "whey"
+        ]
+      ],
+      "grams": [
+        22,
+        42
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 30g). Ambiguous unit 'scoop' resolves to a real scoop portion (~30g). Hard assertion -- 'scoop'/'glass' work; the fix for the broken ambiguous units (n-serv-25 handful, n-serv-26 bowl) must not regress the working ones."
+    },
+    {
+      "id": "n-serv-33",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 glass milk",
+        "quantity": 1,
+        "unit": "glass",
+        "name": "milk",
+        "brand": "",
+        "normalizedForm": "milk",
+        "mealType": "breakfast"
+      },
+      "expectName": [
+        [
+          "milk"
+        ]
+      ],
+      "grams": [
+        200,
+        290
+      ],
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 250g). Ambiguous unit 'glass' resolves to a real glass portion (~244g). Hard assertion; guards the working ambiguous-unit path alongside n-serv-32."
     }
   ]
 }

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -4015,8 +4015,7 @@
         10,
         60
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable, dramatic): '10 mission tortilla chips' resolves to 1000g (each chip billed at the 100g default -> 10x100). A tortilla chip is ~2g so 10 chips is ~20g; 1000g is a kilo of chips, ~50x too high. Count-based discrete unit is NOT resolved to a per-piece weight for this record; the count is instead multiplied against the 100g no-serving fallback. Highest-value failure mode found. Expected ~10-60g; observed 1000g. Non-gating."
+      "notes": "FIXED 2026-07-18 (Cluster A). Was 1000g (100xcount, the most dramatic failure found). Added a 'tortilla chip' seed (~2g), matched via last-two-word alias -> 10 x 2 = 20g. Hard assertion."
     },
     {
       "id": "n-serv-16",
@@ -4039,8 +4038,7 @@
         12,
         40
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): '2 rice cakes' resolves to 200g (each rice cake billed at the 100g default -> 2x100). A plain rice cake is ~9g so 2 is ~18g; 200g is ~11x too high. Same count-x-100g-default failure as n-serv-15. Expected ~12-40g; observed 200g. Non-gating."
+      "notes": "FIXED 2026-07-18 (Cluster A). Was 200g (100xcount). Added a 'rice cake' seed (~9g) -> 2 x 9 = 18g. Hard assertion."
     },
     {
       "id": "n-serv-17",
@@ -4063,8 +4061,7 @@
         3,
         20
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): '10 goldfish crackers' resolves to 40g (~4g/goldfish). A Goldfish cracker is ~0.5g (a 30g serving is ~55 pieces), so 10 is ~5g; 40g is ~8x too high. Per-piece weight for tiny count units is over-estimated. Expected ~3-20g; observed 40g. Non-gating."
+      "notes": "FIXED 2026-07-18 (Cluster A, Defect 2 = generic seed too heavy). Was 40g (matched the generic 'cracker' seed = 4g). Added a specific 'goldfish cracker' seed (~0.5g), which wins via last-two-word alias -> 10 x 0.5 = 5g. Hard assertion."
     },
     {
       "id": "n-serv-18",
@@ -4087,8 +4084,7 @@
         30,
         60
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): '4 oreo cookies' resolves to 120g (~30g/cookie). A single Oreo is ~11.3g (label serving is 3 cookies = 34g), so 4 is ~45g; 120g is ~2.7x too high. Likely the per-3-cookie label serving is billed per single 'cookie' count. Expected ~30-60g; observed 120g. Non-gating."
+      "notes": "FIXED 2026-07-18 (Cluster A, Defect 2 = generic seed too heavy). Was 120g (matched the generic 'cookie' seed = 30g). Added a specific 'oreo' seed (~11.3g) -> 4 x 11.3 = 45.2g. Hard assertion."
     },
     {
       "id": "n-serv-19",
@@ -4111,8 +4107,7 @@
         50,
         90
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): '2 eggo waffles' resolves to 150g (~75g/waffle). A single Eggo waffle is ~35g (label serving is 2 waffles = 70g), so 2 is ~70g; 150g is ~2x too high. Same per-count over-billing as n-serv-18. Correct brand/product ('Eggo waffles', Kellogg's). Expected ~50-90g; observed 150g. Non-gating."
+      "notes": "FIXED 2026-07-18 (Cluster A, Defect 2 = generic seed too heavy). Was 150g (matched the generic 'waffle' seed = 75g). Added a specific 'eggo waffle' seed (~35g) -> 2 x 35 = 70g. Hard assertion."
     },
     {
       "id": "n-serv-20",
@@ -4135,8 +4130,7 @@
         8,
         45
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount, most extreme found: ratio ~100x). '15 pretzels' -> 1500g: buildOffResult unitless-count branch finds no seed and no discrete-regex match, so bills 100g per piece (15 x 100). A mini pretzel is ~1.2g so 15 is ~18g. Target [8,45]; observed 1500g. Fix = intercept the per-unit==100 no-serving fallback (prefer label per-unit / ambiguous backfill / per-unit cap)."
+      "notes": "FIXED 2026-07-18 (Cluster A). '15 pretzels' was 1500g (100xcount). Added a 'pretzel' seed (~2g/piece) -> 15 x 2 = 30g. Hard assertion. The structural 100xcount guard in buildOffResult also bounds any unseeded count food to one serving."
     },
     {
       "id": "n-serv-21",
@@ -4159,8 +4153,7 @@
         6,
         25
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount). '12 m&ms' -> 1200g (12 x 100g default). One M&M is ~0.9g so 12 is ~11g. Target [6,25]; observed 1200g. Same 100xcount root as n-serv-20."
+      "notes": "FIXED 2026-07-18 (Cluster A). '12 m&ms' was 1200g (100xcount). Added an 'm&m' seed (~0.9g) -> 12 x 0.9 = 10.8g. Hard assertion (deterministic seed path, ~50ms)."
     },
     {
       "id": "n-serv-22",
@@ -4183,8 +4176,7 @@
         30,
         90
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 1 = 100xcount on a WHOLE FOOD). '10 grapes' -> 1000g (10 x 100g default). A grape is ~5g so 10 is ~50g. Target [30,90]; observed 1000g. Shows the 100xcount defect is not brand-specific -- any count food lacking a per-piece seed/serving over-bills."
+      "notes": "FIXED 2026-07-18 (Cluster A). '10 grapes' was 1000g (100xcount on a whole food). Added a 'grape' seed (~5g) -> 10 x 5 = 50g. Hard assertion."
     },
     {
       "id": "n-serv-23",

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -3796,6 +3796,12 @@ async function buildOffResult(
 
     let grams: number | null = null;
     let servingDescription: string | null = null;
+    // Set when the item is a unitless integer count ("15 pretzels") for which no
+    // per-piece weight could be resolved (no seed, no discrete-unit backfill, no
+    // genuine label serving). Such counts must NOT bill the 100g no-serving
+    // default per piece (15 x 100 = 1500g); the fallback bills one bounded
+    // serving instead.
+    let unitlessCountUnresolved = false;
 
     // Label serving unit info: e.g. label "2 scoops (46g)" → unit "scoop",
     // count 2, per-unit 23g. Divides multi-unit label servings so "2 scoops"
@@ -3902,12 +3908,34 @@ async function buildOffResult(
                 }
             }
         }
+
+        // Still no per-piece weight for a counted item: flag it so the fallback
+        // below bills a single bounded serving instead of 100g * count.
+        if (grams == null) {
+            unitlessCountUnresolved = true;
+        }
     }
 
     if (grams == null || servingDescription == null) {
         if (hydrated.servingGrams && hydrated.servingGrams > 0) {
+            // Genuine label serving exists: honor the count against it. For a
+            // discrete item whose piece IS its serving this is correct ("2 rx
+            // bars" -> 2 x 52g = 104g); the per-piece defect only bites when
+            // there is NO serving at all (handled below).
             grams = qty * hydrated.servingGrams;
             servingDescription = `${qty} serving (${hydrated.servingGrams}g each)`;
+        } else if (unitlessCountUnresolved) {
+            // Unitless count with NO per-piece weight AND no label serving: we
+            // cannot honor the count, so bill ONE bounded 100g serving rather
+            // than 100g * count. This stops the long tail of unseeded count
+            // foods from exploding into kilograms ("15 pretzels" was 1500g).
+            grams = 100;
+            servingDescription = `1 serving (count unresolved, 100.0g)`;
+            logger.info('off.build_result.unitless_count_unresolved_capped', {
+                foodId: candidate.id,
+                requestedQty: qty,
+                billedGrams: grams,
+            });
         } else {
             grams = 100 * qty;
             servingDescription = `${grams.toFixed(1)}g`;

--- a/src/lib/servings/default-count-grams.ts
+++ b/src/lib/servings/default-count-grams.ts
@@ -168,6 +168,26 @@ const COUNT_DEFAULTS: Record<string, SeedEntry> = {
     // Cooking spray duration: 1 second of spray ≈ 0.25g oil
     'second': { grams: 0.25, confidence: 0.85, aliases: ['seconds'] },
 
+    // ===== COUNT SNACKS (small discrete pieces) =====
+    // Curated per-piece weights for common count-logged snacks. Without these,
+    // buildOffResult's unitless-count branch found no per-piece and billed the
+    // 100g no-serving default PER PIECE ("10 tortilla chips" → 1000g). Specific
+    // entries also override generic seeds that were too heavy for a branded item
+    // (goldfish vs the 4g 'cracker' seed; oreo vs the 30g 'cookie' seed; a 35g
+    // Eggo vs the 75g 'waffle' seed). More-specific last-two-word aliases win
+    // over the generic last-word match, so these take precedence.
+    'tortilla chip': { grams: 2, confidence: 0.75, aliases: ['tortilla chips'] },
+    'potato chip': { grams: 1, confidence: 0.7, aliases: ['potato chips', 'chips', 'chip'] },
+    'pretzel': { grams: 2, confidence: 0.7, sizes: { small: 1, medium: 2, large: 6 }, aliases: ['pretzels', 'mini pretzel', 'mini pretzels'] },
+    'rice cake': { grams: 9, confidence: 0.8, aliases: ['rice cakes'] },
+    'goldfish cracker': { grams: 0.5, confidence: 0.8, aliases: ['goldfish crackers', 'goldfish'] },
+    'oreo': { grams: 11.3, confidence: 0.8, aliases: ['oreos', 'oreo cookie', 'oreo cookies'] },
+    'eggo waffle': { grams: 35, confidence: 0.8, aliases: ['eggo waffles', 'eggo', 'eggos'] },
+    'tater tot': { grams: 10, confidence: 0.75, aliases: ['tater tots', 'tots'] },
+    'grape': { grams: 5, confidence: 0.8, sizes: { small: 3, medium: 5, large: 8 }, aliases: ['grapes'] },
+    'm&m': { grams: 0.9, confidence: 0.7, aliases: ['m&ms', 'm and m', 'm and ms', 'mnm', 'mnms'] },
+    'gummy bear': { grams: 2.3, confidence: 0.7, aliases: ['gummy bears'] },
+
     // ===== SUPPLEMENTS & POWDERS =====
     'protein powder scoop': { grams: 30, confidence: 0.9, aliases: ['scoop protein powder', 'protein scoop'] },
     'whey protein scoop': { grams: 30, confidence: 0.9, aliases: ['scoop whey protein', 'whey scoop'] },


### PR DESCRIPTION
## What
Systematic fix for the census-documented serving-weight bugs where `buildOffResult` billed the **100g no-serving default per piece** for unitless counts — "10 tortilla chips" → **1000g**, "15 pretzels" → **1500g**, "12 m&ms" → **1200g**.

Two parts:
1. **Deterministic fast-path** — expand the count-serving seed table (`default-count-grams.ts`) with common count snacks (tortilla chip, potato chip, pretzel, rice cake, goldfish cracker, oreo, eggo waffle, tater tot, grape, m&m, gummy bear). Specific last-two-word aliases win over generic seeds that were too heavy (goldfish vs the 4g `cracker`; oreo vs the 30g `cookie`; a 35g Eggo vs the 75g `waffle`).
2. **Structural safety guard** — in the unitless-count branch, when **no** per-piece weight **and** no genuine label serving resolves, bill **one bounded 100g serving** instead of `100 × count`. Bounds the unseeded long tail (a novel count food can't explode into kilos). Ordered *after* the genuine-serving check so "2 rx bars" (52g serving) still bills 2×52=104g.

## Approach
Built test-census-first (commit 1): probed prod across the full taxonomy (unitless count / package / ambiguous unit / mass-volume control / OFF-FDC parity), which mapped the real defect surface (far beyond the original 8 cases) and produced regression guards for every currently-correct mode.

## Tests (real corpus)
- **8 count cases promoted knownIssue → hard**: `n-serv-15/16/17/18/19` (tortilla chips/rice cakes/goldfish/oreo/eggo), `n-serv-20/21/22` (pretzels/m&ms/grapes). Deterministic seed path (~50ms).
- **7 census regression guards pass** (red bull, clif, string cheese, almonds-count, strawberries, scoop-whey, glass-milk) — the fix does not regress the working modes.
- `n-supp-22` rx-bars preserved (104g); `serving_grams 8/8`; **0 real failures**.
- **Deferred follow-up** (still knownIssue): Defect 3 flat-100 packages (`n-serv-23` gatorade, `-24` capri sun) and Defect 4 ambiguous units (`n-serv-25` handful, `-26` bowl) — need package-size / portion backfill, which is AI-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y