### PR TITLE
feat(serving): use product's own label piece-count for unitless counts (Cluster A pt2)

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -4434,6 +4434,21 @@
         290
       ],
       "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 250g). Ambiguous unit 'glass' resolves to a real glass portion (~244g). Hard assertion; guards the working ambiguous-unit path alongside n-serv-32."
+    },
+    {
+      "id": "n-serv-34",
+      "category": "serving_unit",
+      "text": "5 tzatziki chips",
+      "expectName": [
+        [
+          "chip"
+        ]
+      ],
+      "grams": [
+        6,
+        12
+      ],
+      "notes": "LABEL-COUNT-DERIVED path (Cluster A pt2, 2026-07-18). Full-pipeline text case: the matched 'Tzatziki Hummus Chips' SKU declares its OWN per-piece count on the label ('18 chips (28 g)' -> 1.56g/chip); buildOffResult derives 5 x 1.56 = 7.78g from servingGrams/labelUnitCount instead of the generic 'chip' seed. Proves the unitless-count path prefers a product's own declared count when present (~64k OFF records carry such counts). Hard assertion. Note: the STRUCTURED item form ('name: tzatziki chips') matches a generic 'Chips' SKU with a null serving and falls to the seed (5g) -- the label path needs the full-pipeline match, hence text-type."
     }
   ]
 }

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -3751,6 +3751,29 @@ function inferDiscreteUnit(name: string): string | null {
     return m ? singularizeUnit(m[1]) : null;
 }
 
+// Packaged-snack nouns whose OFF label serving natively enumerates pieces
+// ("14 chips (28g)", "10 pretzels (28g)"). ~64k OFF records carry such counts.
+// When a matched product's label declares its own per-piece weight AND that piece
+// word is what the user is counting, that per-piece (servingGrams / labelUnitCount)
+// is authoritative for THIS SKU and beats the generic seed — it self-adjusts to
+// the actual product (a thin baked chip vs a thick kettle chip). Kept to packaged
+// snacks where label counts are common and a single seed average is least reliable;
+// whole-food produce (almond/grape/strawberry) stays on the curated seed table.
+const LABEL_COUNT_PIECE_NOUNS = new Set([
+    'chip', 'crisp', 'cracker', 'pretzel', 'cookie',
+    'wafer', 'biscuit', 'nugget', 'puff', 'tot', 'gummy',
+]);
+
+/** True if the label's piece word is literally one of the words the user is counting. */
+function labelPieceMatchesItem(labelWord: string | null, itemName: string): boolean {
+    if (!labelWord || !itemName) return false;
+    const target = singularizeUnit(labelWord);
+    return itemName
+        .toLowerCase()
+        .split(/[^a-z&]+/)
+        .some((tok) => tok !== '' && singularizeUnit(tok) === target);
+}
+
 async function buildOffResult(
     candidate: UnifiedCandidate,
     parsed: ParsedIngredient | null,
@@ -3867,23 +3890,51 @@ async function buildOffResult(
             });
         }
     } else if (!unit && parsed && Number.isInteger(parsed.qty) && parsed.qty >= 1) {
-        // Unitless integer count ("3 baby carrots"): if the food is a discrete
-        // item with a known per-piece weight, use it instead of the label
-        // serving (label serving for baby carrots is a ~100g portion, not 1 carrot).
-        try {
-            const { getDefaultCountServing } = await import('../servings/default-count-grams');
-            const countDefault = getDefaultCountServing(parsed.name || hydrated.foodName, 'each');
-            if (countDefault && countDefault.grams > 0) {
-                grams = qty * countDefault.grams;
-                servingDescription = `${qty} each (${countDefault.grams.toFixed(1)}g each)`;
-                logger.info('off.build_result.unitless_count_default', {
-                    foodId: candidate.id,
-                    name: parsed.name || hydrated.foodName,
-                    perPieceGrams: countDefault.grams,
-                });
+        // Unitless integer count ("3 baby carrots", "13 tortilla chips").
+        const itemNameForCount = parsed.name || hydrated.foodName;
+
+        // (A) PRODUCT'S OWN LABEL COUNT — most authoritative. If the matched SKU's
+        // label enumerates pieces ("14 chips (28g)") and that piece word is what the
+        // user is counting, derive per-piece from the label (servingGrams / count).
+        // Self-adjusts per product and uses count data present on ~64k OFF records
+        // that the generic seed can only average. Gated tightly (packaged-snack
+        // piece nouns + the label word must appear in the item name + sane per-piece
+        // band) so "13 chips" never divides by a "1 container (170g)" label.
+        if (
+            perLabelUnitGrams != null && perLabelUnitGrams >= 0.2 && perLabelUnitGrams <= 500 &&
+            labelUnitWord && LABEL_COUNT_PIECE_NOUNS.has(labelUnitWord) &&
+            labelPieceMatchesItem(labelUnitWord, itemNameForCount)
+        ) {
+            grams = qty * perLabelUnitGrams;
+            servingDescription = `${qty} ${labelUnitWord} (${perLabelUnitGrams.toFixed(1)}g each)`;
+            logger.info('off.build_result.label_count_derived', {
+                foodId: candidate.id,
+                name: itemNameForCount,
+                labelUnitWord,
+                labelUnitCount,
+                perPieceGrams: perLabelUnitGrams,
+            });
+        }
+
+        // (B) GENERIC SEED TABLE — curated per-piece for common discrete items with
+        // no usable label count (label serving for baby carrots is a ~100g portion,
+        // not 1 carrot).
+        if (grams == null) {
+            try {
+                const { getDefaultCountServing } = await import('../servings/default-count-grams');
+                const countDefault = getDefaultCountServing(itemNameForCount, 'each');
+                if (countDefault && countDefault.grams > 0) {
+                    grams = qty * countDefault.grams;
+                    servingDescription = `${qty} each (${countDefault.grams.toFixed(1)}g each)`;
+                    logger.info('off.build_result.unitless_count_default', {
+                        foodId: candidate.id,
+                        name: itemNameForCount,
+                        perPieceGrams: countDefault.grams,
+                    });
+                }
+            } catch {
+                // fall through to discrete-unit backfill / label-serving / 100g defaults
             }
-        } catch {
-            // fall through to discrete-unit backfill / label-serving / 100g defaults
         }
 
         // No deterministic per-piece weight and no genuine label serving: if the


### PR DESCRIPTION
## What
Unitless count phrasings ("13 tortilla chips", "10 pretzels") now prefer the **matched product's own declared per-piece count** from its OFF label over the generic seed table.

## Why
~**64,169** OFF records carry an explicit piece count in their serving label (`"14 chips (28 g)"`, `"10 pretzels (28 g)"`). `parseOffServingSize` already extracts that count (`labelUnitCount`) and `buildOffResult` already computes `perLabelUnitGrams = servingGrams / labelUnitCount` — but it was only consumed when the *requested* token was a recognized measurement unit. The natural unitless phrasing bypassed it entirely and fell to a generic seed, so a product declaring `10 pretzels (28 g)` = 2.8 g/pretzel was logged at the seed's 2 g.

## How
New label-count-derived priority in the unitless-count branch, gated tightly:
- packaged-snack piece nouns only (`chip/crisp/cracker/pretzel/cookie/wafer/biscuit/nugget/puff/tot/gummy`); whole-food produce stays on the curated seed
- the label's piece word must appear as a token of the requested item name (so "13 chips" never divides by a `"1 container (170 g)"` label)
- per-piece must land in a sane 0.2–500 g band

Generic seed remains the fallback for the (common) null/non-count-serving matches, so everyday queries are unchanged; the label path fires when a count-labeled SKU is actually the match.

## Verification
- Live: `5 tzatziki chips` → matched **Tzatziki Hummus Chips** (`18 chips (28 g)`) → 1.56 g/chip → **7.78 g** (was 5 g seed), stable 4/4 runs.
- Eval (`--only nlp`, local): **0 real failures**; all count guard cases (n-serv-15/17/18/20/21/22/30/31) still pass. New hard assertion **n-serv-34** locks the label-count path.
- `lint:ci` 0 errors, `typecheck` clean, `next build` green.

## Note / follow-up
Real-world reach is narrower than the 64k count suggests: for a bare "10 pretzels", search often ranks a *null-serving* SKU first, so the seed still handles it. A larger, separate lever would be to have search/mapping **prefer count-labeled SKUs** when present — deferred (ranking change, riskier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y