### PR TITLE
feat(serving): search/rerank prefer count-labeled SKUs for counted-piece queries

### DIFF
--- a/scripts/backfill-typesense-count-serving.ts
+++ b/scripts/backfill-typesense-count-serving.ts
@@ -1,0 +1,102 @@
+/**
+ * backfill-typesense-count-serving.ts — one-time Typesense backfill for the
+ * `hasCountServing` retrieval flag (Cluster A pt2, Jul 2026).
+ *
+ * Adds the field to the live `off_foods` collection schema (PATCH — no
+ * recreate, no full resync), then partial-updates (action=update) ONLY the
+ * OffFood rows whose label serving enumerates pieces ("14 chips (28g)",
+ * "15 pieces (28g)"): ~tens of thousands of docs instead of 1M+.
+ *
+ * Docs absent from Typesense (not yet synced) fail their update line — that's
+ * expected and non-fatal; they'll get the flag from the next full sync, which
+ * now computes it inline (scripts/sync-typesense.ts).
+ *
+ * Run (Mac or Mini-PC; TYPESENSE_HOST/DATABASE_URL from .env):
+ *   ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/backfill-typesense-count-serving.ts
+ */
+
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import {
+    isTypesenseAvailable,
+    updateTypesenseCollection,
+    updateTypesenseDocumentsByFilter,
+} from '../src/lib/search/typesense-client';
+import { servingLabelHasPieceCount } from '../src/lib/mapping/count-label';
+
+const BATCH = 10000;
+// Barcodes per update-by-filter PATCH. Keeps the filter_by query string well
+// under URI limits (~200 × 14 chars ≈ 3KB).
+const PATCH_BATCH = 200;
+
+async function main() {
+    if (!(await isTypesenseAvailable())) {
+        console.error('❌ Typesense unreachable — check TYPESENSE_HOST.');
+        process.exit(1);
+    }
+
+    // 1. Add the field to the schema (idempotent: 400 "already exists" is fine).
+    try {
+        await updateTypesenseCollection('off_foods', {
+            fields: [{ name: 'hasCountServing', type: 'bool', optional: true }],
+        });
+        console.log('✅ Added hasCountServing to off_foods schema.');
+    } catch (e) {
+        const msg = (e as Error).message;
+        if (/already (exists|part of the schema)/i.test(msg)) {
+            console.log('ℹ️ hasCountServing already in schema, continuing.');
+        } else {
+            throw e;
+        }
+    }
+
+    // 2. Page through rows that can possibly qualify and flag the ones that do.
+    const prisma = new PrismaClient();
+    let lastBarcode = '';
+    let scanned = 0, flagged = 0, updateErrors = 0;
+
+    while (true) {
+        const rows: Array<{ barcode: string; servingSize: string | null; servingGrams: number | null }> =
+            await prisma.offFood.findMany({
+                where: {
+                    barcode: { gt: lastBarcode },
+                    servingSize: { not: null },
+                    servingGrams: { not: null },
+                },
+                select: { barcode: true, servingSize: true, servingGrams: true },
+                orderBy: { barcode: 'asc' },
+                take: BATCH,
+            });
+        if (rows.length === 0) break;
+        lastBarcode = rows[rows.length - 1].barcode;
+        scanned += rows.length;
+
+        // The live collection's doc ids are auto-assigned (not barcodes), so
+        // address docs through the indexed barcode field via update-by-filter.
+        const barcodes = rows
+            .filter(r => servingLabelHasPieceCount(r.servingSize, r.servingGrams))
+            .map(r => r.barcode);
+
+        for (let i = 0; i < barcodes.length; i += PATCH_BATCH) {
+            const chunk = barcodes.slice(i, i + PATCH_BATCH);
+            const res = await updateTypesenseDocumentsByFilter(
+                'off_foods',
+                `barcode:=[${chunk.join(',')}]`,
+                { hasCountServing: true }
+            );
+            flagged += res.num_updated ?? 0;
+            updateErrors += chunk.length - (res.num_updated ?? 0);
+        }
+
+        console.log(`scanned ${scanned.toLocaleString()} (flagged ${flagged.toLocaleString()}, update misses ${updateErrors})`);
+    }
+
+    console.log(`\n✅ Done. Scanned ${scanned.toLocaleString()} serving-bearing rows; flagged ${flagged.toLocaleString()} count-labeled docs; ${updateErrors} docs not in Typesense (will be covered by next full sync).`);
+    await prisma.$disconnect();
+}
+
+main().catch(err => {
+    console.error('❌ Backfill crashed:', err);
+    process.exit(1);
+});

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -4449,6 +4449,21 @@
         12
       ],
       "notes": "LABEL-COUNT-DERIVED path (Cluster A pt2, 2026-07-18). Full-pipeline text case: the matched 'Tzatziki Hummus Chips' SKU declares its OWN per-piece count on the label ('18 chips (28 g)' -> 1.56g/chip); buildOffResult derives 5 x 1.56 = 7.78g from servingGrams/labelUnitCount instead of the generic 'chip' seed. Proves the unitless-count path prefers a product's own declared count when present (~64k OFF records carry such counts). Hard assertion. Note: the STRUCTURED item form ('name: tzatziki chips') matches a generic 'Chips' SKU with a null serving and falls to the seed (5g) -- the label path needs the full-pipeline match, hence text-type."
+    },
+    {
+      "id": "n-serv-35",
+      "category": "serving_unit",
+      "text": "13 tortilla chips",
+      "expectName": [
+        [
+          "chip"
+        ]
+      ],
+      "grams": [
+        28,
+        70
+      ],
+      "notes": "COUNT-LABELED SKU RETRIEVAL + RERANK (Cluster A pt2 lever, 2026-07-19). The generic 'tortilla chips' candidate pool has NO count-labeled SKUs by plain name relevance, so gatherCandidates runs a secondary Typesense query filtered to hasCountServing:=true (33.6k flagged docs), the rerank COUNT_LABEL_BOOST prefers a count-labeled SKU among near-ties, and buildOffResult derives per-piece from ITS label (verified live: 'Tortilla Chips' 16 chips (45g) -> 2.81g/chip -> 36.6g). Range [28,70] deliberately EXCLUDES the 2g/chip generic seed answer (26g): this case fails if the retrieval/rerank lever regresses to seed. Also exercises the counted-piece FoodMapping cache escape (label-less cached winner is bypassed once, count-labeled winner is written back). Hard assertion."
     }
   ]
 }

--- a/scripts/sync-typesense.ts
+++ b/scripts/sync-typesense.ts
@@ -7,6 +7,7 @@ import {
     importTypesenseDocuments,
     isTypesenseAvailable
 } from '../src/lib/search/typesense-client';
+import { servingLabelHasPieceCount } from '../src/lib/mapping/count-label';
 
 async function main() {
     console.log('🚀 Starting Typesense database synchronization...');
@@ -58,6 +59,10 @@ async function main() {
             { name: 'servingGrams', type: 'float', optional: true, index: false },
             { name: 'servingSize', type: 'string', optional: true, index: false },
             { name: 'categories', type: 'string', optional: true, index: false },
+            // Label serving enumerates >=2 pieces with a sane per-piece weight
+            // ("14 chips (28g)", "15 pieces (28g)"). Filterable so counted-piece
+            // queries can pull count-labeled SKUs into the candidate pool.
+            { name: 'hasCountServing', type: 'bool', optional: true },
             // Semantic-search vector (bge-small-en-v1.5). Bring-your-own vectors
             // (embedded externally on the GPU box); optional so rows without an
             // embedding still index for keyword search.
@@ -145,7 +150,8 @@ async function main() {
                 nutrientsPer100g: JSON.stringify(f.nutrientsPer100g || {}),
                 servingGrams: f.servingGrams != null ? Number(f.servingGrams) : null,
                 servingSize: f.servingSize || '',
-                categories: f.categories || ''
+                categories: f.categories || '',
+                hasCountServing: servingLabelHasPieceCount(f.servingSize, f.servingGrams != null ? Number(f.servingGrams) : null)
             };
             if (f.embedding) {
                 doc.embedding = JSON.parse(f.embedding) as number[];

--- a/src/lib/mapping/__tests__/count-label.test.ts
+++ b/src/lib/mapping/__tests__/count-label.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for count-label helpers (Cluster A pt2, Jul 2026)
+ *
+ * These predicates decide when a product's own label piece-count
+ * ("14 chips (28g)", "15 pieces (28g)") is authoritative for a counted-piece
+ * query, powering serving resolution, rerank preference, the cache escape,
+ * and the Typesense hasCountServing retrieval flag.
+ */
+
+import {
+    countedPieceNoun,
+    pieceNounInName,
+    servingLabelCountsPiece,
+    servingLabelHasPieceCount,
+} from '../count-label';
+
+describe('countedPieceNoun', () => {
+    it('extracts the counted snack noun from a unitless integer count', () => {
+        expect(countedPieceNoun({ qty: 13, multiplier: 1, unit: null, name: 'tortilla chips' } as any)).toBe('chip');
+        expect(countedPieceNoun({ qty: 10, multiplier: 1, unit: null, name: 'pretzels' } as any)).toBe('pretzel');
+    });
+
+    it('returns null when a unit is present or qty is fractional', () => {
+        expect(countedPieceNoun({ qty: 2, multiplier: 1, unit: 'cup', name: 'pretzels' } as any)).toBeNull();
+        expect(countedPieceNoun({ qty: 1.5, multiplier: 1, unit: null, name: 'cookies' } as any)).toBeNull();
+    });
+
+    it('returns null for non-snack nouns (produce stays on the seed table)', () => {
+        expect(countedPieceNoun({ qty: 3, multiplier: 1, unit: null, name: 'baby carrots' } as any)).toBeNull();
+        expect(countedPieceNoun({ qty: 2, multiplier: 1, unit: null, name: 'bananas' } as any)).toBeNull();
+    });
+});
+
+describe('servingLabelCountsPiece', () => {
+    it('accepts an exact-noun multi-piece label', () => {
+        expect(servingLabelCountsPiece('14 chips (28 g)', 28, 'chip')).toBe(true);
+        expect(servingLabelCountsPiece('18 chips (28g)', 28, 'chip')).toBe(true);
+    });
+
+    it('accepts the generic "pieces" counter for any counted snack noun', () => {
+        expect(servingLabelCountsPiece('15 pieces (28 g)', 28, 'pretzel')).toBe(true);
+        expect(servingLabelCountsPiece('15 pieces (28 g)', 28, 'chip')).toBe(true);
+    });
+
+    it('rejects single-piece labels — a "1 piece (57g)" whole-bar serving is not a per-piece weight', () => {
+        expect(servingLabelCountsPiece('1 piece (57g)', 57, 'cookie')).toBe(false);
+    });
+
+    it('rejects labels whose word is neither the noun nor a generic counter', () => {
+        expect(servingLabelCountsPiece('2 scoops (46g)', 46, 'chip')).toBe(false);
+        expect(servingLabelCountsPiece('28 g', 28, 'chip')).toBe(false);
+        expect(servingLabelCountsPiece('14 crackers (30g)', 30, 'chip')).toBe(false);
+    });
+
+    it('rejects implausible per-piece weights', () => {
+        expect(servingLabelCountsPiece('2 chips (0.2g)', 0.2, 'chip')).toBe(false);
+    });
+});
+
+describe('servingLabelHasPieceCount (noun-agnostic, retrieval flag)', () => {
+    it('true for any recognized piece word with count >= 2', () => {
+        expect(servingLabelHasPieceCount('14 chips (28 g)', 28)).toBe(true);
+        expect(servingLabelHasPieceCount('15 pieces (28 g)', 28)).toBe(true);
+        expect(servingLabelHasPieceCount('5 crackers (15g)', 15)).toBe(true);
+    });
+
+    it('false for weight-only, single-piece, and non-piece labels', () => {
+        expect(servingLabelHasPieceCount('28 g', 28)).toBe(false);
+        expect(servingLabelHasPieceCount('1 piece (57g)', 57)).toBe(false);
+        expect(servingLabelHasPieceCount('2 scoops (46g)', 46)).toBe(false);
+        expect(servingLabelHasPieceCount(null, 28)).toBe(false);
+        expect(servingLabelHasPieceCount('15 pieces (28 g)', null)).toBe(false);
+    });
+});
+
+describe('pieceNounInName', () => {
+    it('finds the first snack noun, singularized', () => {
+        expect(pieceNounInName('chocolate chip cookies')).toBe('chip');
+        expect(pieceNounInName('chicken nuggets')).toBe('nugget');
+        expect(pieceNounInName('almonds')).toBeNull();
+    });
+});

--- a/src/lib/mapping/__tests__/simple-rerank.test.ts
+++ b/src/lib/mapping/__tests__/simple-rerank.test.ts
@@ -175,3 +175,70 @@ describe('nutrition tiebreaker', () => {
         expect(result!.winner.id).toBe('food_0');
     });
 });
+
+describe('count-labeled SKU preference (Cluster A pt2)', () => {
+    // Identically-named OFF candidates: the null-serving one is generic (earns
+    // the NO_BRAND +0.05), the count-labeled one is branded. Only the boost
+    // (+0.08) can flip the winner, so these tests isolate it exactly.
+    function makeChipCandidates(): RerankCandidate[] {
+        return [
+            {
+                id: 'off_null_serving',
+                name: 'Tortilla Chips',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+            },
+            {
+                id: 'off_count_label',
+                name: 'Tortilla Chips',
+                brandName: 'BrandB',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+                countLabelMatch: true,
+            },
+        ];
+    }
+
+    it('prefers the count-labeled SKU when preferCountLabeled is set', () => {
+        const result = simpleRerank(
+            'tortilla chips', makeChipCandidates(), undefined, '13 tortilla chips',
+            undefined, undefined, true
+        );
+        expect(result.winner).not.toBeNull();
+        expect(result.winner!.id).toBe('off_count_label');
+    });
+
+    it('boost is inert when preferCountLabeled is not set', () => {
+        const result = simpleRerank(
+            'tortilla chips', makeChipCandidates(), undefined, 'tortilla chips'
+        );
+        expect(result.winner).not.toBeNull();
+        // Generic (brandless) candidate keeps its NO_BRAND edge.
+        expect(result.winner!.id).toBe('off_null_serving');
+    });
+
+    it('boost does not overcome a clearly better name match', () => {
+        const candidates: RerankCandidate[] = [
+            {
+                id: 'off_exact',
+                name: 'Tortilla Chips',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+            },
+            {
+                id: 'off_bloated_count_label',
+                name: 'Zesty Ranch Flavored Party Mix Snack Blend',
+                brandName: 'BrandC',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+                countLabelMatch: true,
+            },
+        ];
+        const result = simpleRerank(
+            'tortilla chips', candidates, undefined, '13 tortilla chips',
+            undefined, undefined, true
+        );
+        expect(result.winner).not.toBeNull();
+        expect(result.winner!.id).toBe('off_exact');
+    });
+});

--- a/src/lib/mapping/count-label.ts
+++ b/src/lib/mapping/count-label.ts
@@ -1,0 +1,125 @@
+/**
+ * Count-labeled serving helpers (Cluster A pt2, Jul 2026)
+ *
+ * ~64k OFF records natively enumerate pieces in their label serving —
+ * "14 chips (28g)", "10 pretzels (28g)", or the generic "15 pieces (28g)"
+ * phrasing. When a user counts pieces ("13 tortilla chips"), that label's
+ * per-piece weight (servingGrams / count) is authoritative for the SKU and
+ * beats any curated seed average. These predicates power:
+ *   - buildOffResult's label-count-derived serving resolution
+ *   - simpleRerank's count-labeled SKU preference (COUNT_LABEL_BOOST)
+ *   - the counted-piece cache escape in map-ingredient-with-fallback
+ *   - retrieval: the Typesense `hasCountServing` flag (sync + backfill scripts)
+ *     and the targeted secondary search in openfoodfacts/search.ts
+ */
+
+import type { ParsedIngredient } from '../parse/ingredient-line';
+
+/** Minimal unit singularizer for label/serving unit words ("scoops" → "scoop"). */
+export function singularizeUnit(w: string): string {
+    const s = w.toLowerCase();
+    if (s.endsWith('ies')) return s.slice(0, -3) + 'y';
+    if (s.endsWith('sses')) return s.slice(0, -2);
+    if (s.endsWith('s') && !s.endsWith('ss')) return s.slice(0, -1);
+    return s;
+}
+
+/** The unit word of a label serving description ("2 scoops" → "scoop", "1 container" → "container"). */
+export function extractLabelServingUnit(description: string | null): string | null {
+    if (!description) return null;
+    const m = description.match(/^\s*\d*\.?\d*\s*([a-z]+)/i);
+    if (!m) return null;
+    return singularizeUnit(m[1]);
+}
+
+// Packaged-snack nouns whose OFF label serving natively enumerates pieces.
+// Kept to packaged snacks where label counts are common and a single seed
+// average is least reliable; whole-food produce (almond/grape/strawberry)
+// stays on the curated seed table.
+export const LABEL_COUNT_PIECE_NOUNS = new Set([
+    'chip', 'crisp', 'cracker', 'pretzel', 'cookie',
+    'wafer', 'biscuit', 'nugget', 'puff', 'tot', 'gummy',
+]);
+
+// Labels frequently enumerate with the generic counter word — "15 pieces (28 g)"
+// on a pretzel bag — instead of the product noun. Those pieces ARE the matched
+// product, so a generic counter counts the user's noun too (guarded by the
+// callers: the item must name a LABEL_COUNT_PIECE_NOUN and the label must be
+// genuinely multi-piece, count >= 2, so a "1 piece (57g)" whole-bar serving
+// never masquerades as a per-piece weight).
+export const GENERIC_PIECE_WORDS = new Set(['piece', 'pc']);
+
+/** First packaged-snack piece noun appearing in a food/item name, else null. */
+export function pieceNounInName(name: string): string | null {
+    for (const tok of (name || '').toLowerCase().split(/[^a-z&]+/)) {
+        if (tok === '') continue;
+        const sing = singularizeUnit(tok);
+        if (LABEL_COUNT_PIECE_NOUNS.has(sing)) return sing;
+    }
+    return null;
+}
+
+/** True if the label's piece word is literally one of the words the user is counting. */
+export function labelPieceMatchesItem(labelWord: string | null, itemName: string): boolean {
+    if (!labelWord || !itemName) return false;
+    const target = singularizeUnit(labelWord);
+    return itemName
+        .toLowerCase()
+        .split(/[^a-z&]+/)
+        .some((tok) => tok !== '' && singularizeUnit(tok) === target);
+}
+
+/**
+ * The piece noun the user is counting when the line is a unitless integer count
+ * ("13 tortilla chips" → "chip"), else null. Mirrors buildOffResult's
+ * unitless-count gate so retrieval/rerank preference and serving resolution
+ * stay aligned.
+ */
+export function countedPieceNoun(parsed: ParsedIngredient | null): string | null {
+    if (!parsed || parsed.unit || !Number.isInteger(parsed.qty) || parsed.qty < 1) return null;
+    return pieceNounInName(parsed.name || '');
+}
+
+/** Leading integer count of a label serving string, or null ("15 pieces (28 g)" → 15). */
+function labelLeadingCount(servingSize: string): number | null {
+    const count = Number((servingSize.match(/^\s*(\d+(?:\.\d+)?)/) || [])[1]);
+    return Number.isInteger(count) && count >= 2 ? count : null;
+}
+
+/**
+ * True when an OFF label serving string usably enumerates the counted piece:
+ * either the noun itself ("14 chips (28g)") or the generic multi-piece counter
+ * ("15 pieces (28g)").
+ */
+export function servingLabelCountsPiece(
+    servingSize: string | null | undefined,
+    servingGrams: number | null | undefined,
+    pieceNoun: string
+): boolean {
+    if (!servingSize || !servingGrams || servingGrams <= 0) return false;
+    const count = labelLeadingCount(servingSize);
+    if (count == null) return false;
+    const labelWord = extractLabelServingUnit(servingSize);
+    if (labelWord !== pieceNoun && !(labelWord && GENERIC_PIECE_WORDS.has(labelWord))) return false;
+    const perPiece = servingGrams / count;
+    return perPiece >= 0.2 && perPiece <= 500;
+}
+
+/**
+ * Noun-agnostic form of servingLabelCountsPiece — does this label enumerate
+ * ≥2 of ANY recognized piece word with a sane per-piece weight? Used to compute
+ * the Typesense `hasCountServing` retrieval flag, where the queried noun isn't
+ * known at index time.
+ */
+export function servingLabelHasPieceCount(
+    servingSize: string | null | undefined,
+    servingGrams: number | null | undefined
+): boolean {
+    if (!servingSize || !servingGrams || servingGrams <= 0) return false;
+    const count = labelLeadingCount(servingSize);
+    if (count == null) return false;
+    const labelWord = extractLabelServingUnit(servingSize);
+    if (!labelWord || (!LABEL_COUNT_PIECE_NOUNS.has(labelWord) && !GENERIC_PIECE_WORDS.has(labelWord))) return false;
+    const perPiece = servingGrams / count;
+    return perPiece >= 0.2 && perPiece <= 500;
+}

--- a/src/lib/mapping/gather-candidates.ts
+++ b/src/lib/mapping/gather-candidates.ts
@@ -10,6 +10,7 @@ import { parseIngredientLine, type ParsedIngredient } from '../parse/ingredient-
 import { normalizeIngredientName } from './normalization-rules';
 import { logger } from '../logger';
 import { searchOffSimple, searchOffSemantic } from '../openfoodfacts/search';
+import { countedPieceNoun } from './count-label';
 import { SEMANTIC_SEARCH_ENABLED, warmupEmbedder } from '../search/query-embedding';
 
 // Start loading the ONNX query-embedding model as soon as the mapping
@@ -325,6 +326,10 @@ export async function gatherCandidates(
             searchOffSimple(primaryQuery, {
                 limit: maxPerSource,
                 isBrandedQuery,
+                // Counted-piece lines ("13 tortilla chips") also pull SKUs whose
+                // label enumerates pieces, so their authoritative per-piece
+                // weight can compete in rerank.
+                countedPieceQuery: countedPieceNoun(parsed) != null,
             })
         );
     }

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -22,6 +22,11 @@ import {
     hasNullOrInvalidMacros,
 } from './filter-candidates';
 import { simpleRerank, toRerankCandidate, extractLeanPercentage, isGenericGroundMeatQuery, stripPrepModifiers } from './simple-rerank';
+import {
+    singularizeUnit, extractLabelServingUnit,
+    LABEL_COUNT_PIECE_NOUNS, GENERIC_PIECE_WORDS,
+    pieceNounInName, labelPieceMatchesItem, countedPieceNoun, servingLabelCountsPiece,
+} from './count-label';
 import { getValidatedMappingByNormalizedName, saveValidatedMapping, getAiNormalizeCache } from './validated-mapping-helpers';
 import { logMappingAnalysis } from './mapping-logger';
 import { logger } from '../logger';
@@ -545,6 +550,7 @@ export async function mapIngredientWithFallback(
 
             let earlyNutritionInvalid = false;
             let loadedFdcNutrition: any = null;
+            let cachedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
 
             if (!earlyCoreTokenMismatch) {
                 const { prisma } = await import('../db');
@@ -578,9 +584,12 @@ export async function mapIngredientWithFallback(
                         const barcode = earlyCacheHit.foodId.replace('off_', '');
                         const off = await prisma.offFood.findUnique({
                             where: { barcode },
-                            select: { nutrientsPer100g: true }
+                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true }
                         });
                         nutrients = off?.nutrientsPer100g;
+                        if (off) {
+                            cachedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
+                        }
                     } else {
                         const ai = await prisma.aiGeneratedFood.findUnique({
                             where: { id: earlyCacheHit.foodId },
@@ -635,8 +644,19 @@ export async function mapIngredientWithFallback(
                 }
             }
 
+            // Counted-piece cache escape (Cluster A pt2, Jul 2026): the user is
+            // counting pieces but the cached OFF food's label can't provide a
+            // per-piece weight. Fall through to the full pipeline so rerank's
+            // count-label preference can pick a SKU that can; the write-back to
+            // FoodMapping makes this a one-time re-resolution per name.
+            const earlyCountedNoun = countedPieceNoun(parsed);
+            const earlyCountLabelEscape = earlyCountedNoun != null
+                && earlyCacheHit.foodId.startsWith('off_')
+                && !servingLabelCountsPiece(cachedOffServing?.servingSize, cachedOffServing?.servingGrams, earlyCountedNoun);
+
             if (earlyCoreTokenMismatch ||
                 earlyNutritionInvalid ||
+                earlyCountLabelEscape ||
                 isCategoryMismatch(normalizedName, earlyCacheHit.foodName, earlyCacheHit.brandName) ||
                 isMultiIngredientMismatch(normalizedName, earlyCacheHit.foodName) ||
                 hasCriticalModifierMismatch(trimmed, earlyCacheHit.foodName, 'cache') ||
@@ -655,6 +675,7 @@ export async function mapIngredientWithFallback(
                     normalized: normalizedName,
                     coreTokenMismatch: earlyCoreTokenMismatch,
                     nutritionInvalid: earlyNutritionInvalid,
+                    countLabelEscape: earlyCountLabelEscape,
                 });
                 // Fall through to normal search - don't use stale cached mapping
             } else {
@@ -876,6 +897,7 @@ export async function mapIngredientWithFallback(
 
                 // Validate nutrition data - reject cached mappings to foods with zero/null nutrition
                 let normalizedNutritionInvalid = false;
+                let normalizedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
                 if (!normalizedCoreTokenMismatch) {
                     const { prisma } = await import('../db');
                     let nutrients: any = null;
@@ -890,9 +912,12 @@ export async function mapIngredientWithFallback(
                         const barcode = normalizedCache.foodId.replace('off_', '');
                         const off = await prisma.offFood.findUnique({
                             where: { barcode },
-                            select: { nutrientsPer100g: true }
+                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true }
                         });
                         nutrients = off?.nutrientsPer100g;
+                        if (off) {
+                            normalizedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
+                        }
                     } else {
                         const ai = await prisma.aiGeneratedFood.findUnique({
                             where: { id: normalizedCache.foodId },
@@ -936,8 +961,17 @@ export async function mapIngredientWithFallback(
                     }
                 }
 
+                // Counted-piece cache escape — same rationale as the early-cache
+                // check: without it this layer would re-pin the label-less food
+                // the early check just escaped from.
+                const normalizedCountedNoun = countedPieceNoun(parsed);
+                const normalizedCountLabelEscape = normalizedCountedNoun != null
+                    && normalizedCache.foodId.startsWith('off_')
+                    && !servingLabelCountsPiece(normalizedOffServing?.servingSize, normalizedOffServing?.servingGrams, normalizedCountedNoun);
+
                 if (normalizedCoreTokenMismatch ||
                     normalizedNutritionInvalid ||
+                    normalizedCountLabelEscape ||
                     isCategoryMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName) ||
                     isMultiIngredientMismatch(normalizedName, normalizedCache.foodName) ||
                     // For branded queries: skip modifier mismatch when the cached food's brand
@@ -1212,8 +1246,22 @@ export async function mapIngredientWithFallback(
                         // Use filtered (not sortedFiltered) to ensure high-overlap candidates aren't pushed out
                         // simpleRerank will do its own scoring based on token overlap + other factors
 
+                        // Count-labeled SKU preference (Cluster A pt2, Jul 2026): when the
+                        // user is counting pieces, nudge rerank toward SKUs whose label
+                        // declares that piece's count — their per-piece weight is
+                        // authoritative via the label-count-derived path in buildOffResult.
+                        const countedNoun = countedPieceNoun(parsed);
+
                         // Enrich Generic candidates with cached nutrition data.
                         const candidatesForRerank = filtered.slice(0, 10);
+                        // Counted queries: let count-labeled SKUs below the top-10 cutoff
+                        // compete too (they still have to win the rerank on merit).
+                        if (countedNoun) {
+                            for (const c of filtered.slice(10)) {
+                                if (candidatesForRerank.length >= 13) break;
+                                if (candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
+                            }
+                        }
                         const fsCandidatesMissingNutr = candidatesForRerank
                             .filter(c => c.source === 'ai_generated' && !c.nutrition);
                         if (fsCandidatesMissingNutr.length > 0) {
@@ -1277,13 +1325,14 @@ export async function mapIngredientWithFallback(
                             score: c.score,
                             source: c.source,
                             nutrition: c.nutrition,  // Include for Route C macro sanity check + nutrition tiebreaker
+                            countLabelMatch: countedNoun ? candidateHasCountLabel(c, countedNoun) : undefined,
                         }));
 
                         // Hybrid prep stripping: prefer AI canonicalBase (strips prep but preserves
                         // nutritional modifiers), fall back to local prep-word stripping.
                         // The raw line (trimmed) is still passed for modifier constraint extraction.
                         const rerankQuery = aiCanonicalBase || stripPrepModifiers(searchQuery);
-                        const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined);
+                        const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNoun != null);
 
                         if (rerankResult && rerankResult.winner) {
                             const selected = filtered.find(c => c.id === rerankResult.winner!.id);
@@ -1884,6 +1933,7 @@ export async function mapIngredientWithFallback(
                 const searchFilterResult = filterCandidatesByTokens(searchCandidates, normalizedName, { debug, rawLine: trimmed });
 
                 // Run reranker to ensure anomaly penalties (e.g. canned beans) are applied
+                const countedNounFB = countedPieceNoun(parsed);
                 const rerankCandidates = searchFilterResult.filtered.map(c => toRerankCandidate({
                     id: c.id,
                     name: c.name,
@@ -1892,9 +1942,10 @@ export async function mapIngredientWithFallback(
                     score: c.score,
                     source: c.source,
                     nutrition: c.nutrition,
+                    countLabelMatch: countedNounFB ? candidateHasCountLabel(c, countedNounFB) : undefined,
                 }));
                 const rerankQuery = aiCanonicalBase || stripPrepModifiers(normalizedName);
-                const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined);
+                const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNounFB != null);
                 
                 // simpleRerank returns the fully sorted list based on semantic score, nutrition ties, and FDC preferencing
                 const sortedFallbackCandidates = rerankResult.sortedCandidates.map(
@@ -3724,23 +3775,6 @@ async function buildFdcResult(
  * Hydrates the candidate into the local DB, resolves grams from the parsed unit,
  * and falls back to AI nutrition backfill when the Atwater gate rejects label data.
  */
-/** Minimal unit singularizer for label/serving unit words ("scoops" → "scoop"). */
-function singularizeUnit(w: string): string {
-    const s = w.toLowerCase();
-    if (s.endsWith('ies')) return s.slice(0, -3) + 'y';
-    if (s.endsWith('sses')) return s.slice(0, -2);
-    if (s.endsWith('s') && !s.endsWith('ss')) return s.slice(0, -1);
-    return s;
-}
-
-/** The unit word of a label serving description ("2 scoops" → "scoop", "1 container" → "container"). */
-function extractLabelServingUnit(description: string | null): string | null {
-    if (!description) return null;
-    const m = description.match(/^\s*\d*\.?\d*\s*([a-z]+)/i);
-    if (!m) return null;
-    return singularizeUnit(m[1]);
-}
-
 // Discrete packaged-snack nouns: when a unitless branded item names one of these
 // and has no genuine serving, estimate that unit's weight (sibling-borrow / AI)
 // rather than defaulting to a flat 100g. Deliberately excludes ambiguous words
@@ -3751,27 +3785,17 @@ function inferDiscreteUnit(name: string): string | null {
     return m ? singularizeUnit(m[1]) : null;
 }
 
-// Packaged-snack nouns whose OFF label serving natively enumerates pieces
-// ("14 chips (28g)", "10 pretzels (28g)"). ~64k OFF records carry such counts.
-// When a matched product's label declares its own per-piece weight AND that piece
-// word is what the user is counting, that per-piece (servingGrams / labelUnitCount)
-// is authoritative for THIS SKU and beats the generic seed — it self-adjusts to
-// the actual product (a thin baked chip vs a thick kettle chip). Kept to packaged
-// snacks where label counts are common and a single seed average is least reliable;
-// whole-food produce (almond/grape/strawberry) stays on the curated seed table.
-const LABEL_COUNT_PIECE_NOUNS = new Set([
-    'chip', 'crisp', 'cracker', 'pretzel', 'cookie',
-    'wafer', 'biscuit', 'nugget', 'puff', 'tot', 'gummy',
-]);
-
-/** True if the label's piece word is literally one of the words the user is counting. */
-function labelPieceMatchesItem(labelWord: string | null, itemName: string): boolean {
-    if (!labelWord || !itemName) return false;
-    const target = singularizeUnit(labelWord);
-    return itemName
-        .toLowerCase()
-        .split(/[^a-z&]+/)
-        .some((tok) => tok !== '' && singularizeUnit(tok) === target);
+/**
+ * True when an OFF search candidate's raw label serving enumerates >=2 of the
+ * counted piece with a sane per-piece weight ("14 chips (28g)" for a chip
+ * count, or the generic multi-piece counter "15 pieces (28g)"). Such SKUs carry
+ * their own authoritative per-piece grams, so rerank prefers them over
+ * null-serving SKUs that would fall to the generic seed.
+ */
+function candidateHasCountLabel(candidate: UnifiedCandidate, pieceNoun: string): boolean {
+    if (candidate.source !== 'openfoodfacts') return false;
+    const raw = candidate.rawData as { servingSize?: string | null; servingGrams?: number | null } | undefined;
+    return servingLabelCountsPiece(raw?.servingSize, raw?.servingGrams, pieceNoun);
 }
 
 async function buildOffResult(
@@ -3894,19 +3918,26 @@ async function buildOffResult(
         const itemNameForCount = parsed.name || hydrated.foodName;
 
         // (A) PRODUCT'S OWN LABEL COUNT — most authoritative. If the matched SKU's
-        // label enumerates pieces ("14 chips (28g)") and that piece word is what the
-        // user is counting, derive per-piece from the label (servingGrams / count).
-        // Self-adjusts per product and uses count data present on ~64k OFF records
-        // that the generic seed can only average. Gated tightly (packaged-snack
-        // piece nouns + the label word must appear in the item name + sane per-piece
-        // band) so "13 chips" never divides by a "1 container (170g)" label.
+        // label enumerates pieces ("14 chips (28g)", or the generic "15 pieces
+        // (28g)" phrasing) and that piece is what the user is counting, derive
+        // per-piece from the label (servingGrams / count). Self-adjusts per
+        // product and uses count data present on ~64k OFF records that the
+        // generic seed can only average. Gated tightly (packaged-snack piece
+        // nouns + sane per-piece band; generic "pieces" additionally requires a
+        // multi-piece label) so "13 chips" never divides by a "1 container
+        // (170g)" label.
+        const genericPieceNoun = labelUnitWord && GENERIC_PIECE_WORDS.has(labelUnitWord)
+            && labelUnitCount >= 2 ? pieceNounInName(itemNameForCount) : null;
+        const labelCountsUserPiece = labelUnitWord != null && (
+            (LABEL_COUNT_PIECE_NOUNS.has(labelUnitWord) && labelPieceMatchesItem(labelUnitWord, itemNameForCount)) ||
+            genericPieceNoun != null
+        );
         if (
             perLabelUnitGrams != null && perLabelUnitGrams >= 0.2 && perLabelUnitGrams <= 500 &&
-            labelUnitWord && LABEL_COUNT_PIECE_NOUNS.has(labelUnitWord) &&
-            labelPieceMatchesItem(labelUnitWord, itemNameForCount)
+            labelCountsUserPiece
         ) {
             grams = qty * perLabelUnitGrams;
-            servingDescription = `${qty} ${labelUnitWord} (${perLabelUnitGrams.toFixed(1)}g each)`;
+            servingDescription = `${qty} ${genericPieceNoun ?? labelUnitWord} (${perLabelUnitGrams.toFixed(1)}g each)`;
             logger.info('off.build_result.label_count_derived', {
                 foodId: candidate.id,
                 name: itemNameForCount,

--- a/src/lib/mapping/simple-rerank.ts
+++ b/src/lib/mapping/simple-rerank.ts
@@ -22,6 +22,13 @@ export interface RerankCandidate {
         fat: number;
         per100g: boolean;
     };
+    /**
+     * True when the query counts pieces ("13 tortilla chips") and this
+     * candidate's OFF label serving natively enumerates that same piece
+     * ("14 chips (28g)"). Precomputed by the mapper; earns COUNT_LABEL_BOOST
+     * when the caller passes preferCountLabeled.
+     */
+    countLabelMatch?: boolean;
 }
 
 export interface AiNutritionEstimate {
@@ -68,6 +75,8 @@ const WEIGHTS = {
     ATTRIBUTE_CONTRADICTION_PENALTY: 0.35,  // Penalty when query says "green" but candidate says "red"
     // Missing cooking state penalty (Batch 4, Mar 2026)
     MISSING_COOKING_STATE_PENALTY: 0.40, // Penalty when query says "fried" but candidate doesn't
+    // Count-labeled SKU preference (Cluster A pt2, Jul 2026)
+    COUNT_LABEL_BOOST: 0.08,  // Tie-break toward SKUs whose label declares a per-piece count when the user is counting pieces. Deliberately small: must not beat EXACT_MATCH or token penalties.
 };
 
 
@@ -1325,7 +1334,8 @@ export function simpleRerank(
     aiNutritionEstimate?: AiNutritionEstimate,
     rawLine?: string,
     isBranded?: boolean,
-    targetBrand?: string
+    targetBrand?: string,
+    preferCountLabeled?: boolean
 ): { winner: RerankCandidate | null; confidence: number; reason: string; sortedCandidates: RerankCandidate[] } {
     if (candidates.length === 0) {
         return {
@@ -1390,14 +1400,17 @@ export function simpleRerank(
             // Apply constraint penalty
             const constraintPenalty = constraintResult.penalty * 0.5; // Scale penalty to reasonable range
 
+            const countLabelBoost = (preferCountLabeled && c.countLabelMatch) ? WEIGHTS.COUNT_LABEL_BOOST : 0;
+
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score - constraintPenalty,
+                score: baseScore + nutritionResult.score - constraintPenalty + countLabelBoost,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
                 constraintPenalty,
                 constraintReason: constraintResult.reason,
+                countLabelBoost,
             };
         })
         .filter((s): s is NonNullable<typeof s> => s !== null);
@@ -1417,14 +1430,16 @@ export function simpleRerank(
         const fallbackScored = candidates.map(c => {
             const baseScore = computeSimpleScore(c, query, isBranded, targetBrand);
             const nutritionResult = computeNutritionScore(c, aiNutritionEstimate);
+            const countLabelBoost = (preferCountLabeled && c.countLabelMatch) ? WEIGHTS.COUNT_LABEL_BOOST : 0;
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score,
+                score: baseScore + nutritionResult.score + countLabelBoost,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
                 constraintPenalty: 0,
                 constraintReason: 'fallback_no_rejection',
+                countLabelBoost,
             };
         });
         scored.push(...fallbackScored);
@@ -1512,7 +1527,7 @@ export function simpleRerank(
                 `phrase=${phrase.toFixed(2)} mod=${modifier.toFixed(2)} cover=${coverage.toFixed(2)} ` +
                 `fdc=${fdcBoost.toFixed(2)} brand=${brand.toFixed(2)}] ` +
                 `nutr=${s.nutritionScore.toFixed(3)} nutrDev=${nutrDev} constr=-${s.constraintPenalty.toFixed(3)} ` +
-                `src=${s.candidate.source}`
+                `cnt=${((s as any).countLabelBoost ?? 0).toFixed(2)} src=${s.candidate.source}`
             );
         });
         console.log();
@@ -1619,6 +1634,7 @@ export function toRerankCandidate(candidate: {
         fat: number;
         per100g: boolean;
     };
+    countLabelMatch?: boolean;
 }): RerankCandidate {
     // Some FDC entries have doubled descriptions (a known FDC data quality issue).
     // e.g. "peeled plum tomatoes peeled plum tomatoes" → "peeled plum tomatoes"
@@ -1641,5 +1657,6 @@ export function toRerankCandidate(candidate: {
         score: candidate.score,
         source: candidate.source,
         nutrition: candidate.nutrition,
+        countLabelMatch: candidate.countLabelMatch,
     };
 }

--- a/src/lib/openfoodfacts/search.ts
+++ b/src/lib/openfoodfacts/search.ts
@@ -220,6 +220,45 @@ export async function searchOffSemantic(
 export interface SearchOffOptions {
     limit?: number;
     isBrandedQuery?: boolean;
+    /**
+     * Set when the user's line counts pieces of a packaged snack ("13 tortilla
+     * chips"). Adds a secondary Typesense query filtered to SKUs whose label
+     * serving enumerates pieces (hasCountServing) so those candidates reach the
+     * rerank pool even when plain name relevance wouldn't surface them.
+     */
+    countedPieceQuery?: boolean;
+}
+
+/** Extra count-labeled SKUs appended to the pool for counted-piece queries. */
+const COUNT_LABELED_EXTRA = 3;
+
+/**
+ * Secondary retrieval for counted-piece queries: same keyword search, but
+ * filtered to count-labeled SKUs. Failure (e.g. the hasCountServing field is
+ * not in the collection schema yet) is non-fatal — the primary results stand.
+ */
+async function searchOffCountLabeled(
+    query: string,
+    isBrandedQuery: boolean,
+): Promise<UnifiedCandidate[]> {
+    try {
+        const { searchTypesense } = await import('../search/typesense-client');
+        const hits = await searchTypesense(
+            'off_foods', query, 'name,brandName', COUNT_LABELED_EXTRA * 2, 'hasCountServing:=true');
+        const candidates = hits
+            .map(hit => mapOffHitToCandidate(hit, query, isBrandedQuery))
+            .filter(candidateHasUsableNutrition)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, COUNT_LABELED_EXTRA);
+        logger.debug('off.search.count_labeled_hit', { query, count: candidates.length });
+        return candidates;
+    } catch (err) {
+        logger.debug('off.search.count_labeled_failed', {
+            query,
+            error: (err as Error).message,
+        });
+        return [];
+    }
 }
 
 /**
@@ -229,7 +268,7 @@ export async function searchOffSimple(
     query: string,
     options: SearchOffOptions = {},
 ): Promise<UnifiedCandidate[]> {
-    const { limit = 5, isBrandedQuery = false } = options;
+    const { limit = 5, isBrandedQuery = false, countedPieceQuery = false } = options;
 
     const queryLower = query.toLowerCase().trim();
 
@@ -242,6 +281,15 @@ export async function searchOffSimple(
                 .filter(candidateHasUsableNutrition)
                 .sort((a, b) => b.score - a.score)
                 .slice(0, limit);
+
+            // Counted-piece queries: append count-labeled SKUs the primary
+            // search didn't surface. They still have to win rerank on merit.
+            if (countedPieceQuery) {
+                const seen = new Set(candidates.map(c => c.id));
+                for (const extra of await searchOffCountLabeled(query, isBrandedQuery)) {
+                    if (!seen.has(extra.id)) candidates.push(extra);
+                }
+            }
 
             logger.debug('off.search.typesense_hit', { query, count: candidates.length });
             return candidates;

--- a/src/lib/search/typesense-client.ts
+++ b/src/lib/search/typesense-client.ts
@@ -55,14 +55,16 @@ export async function searchTypesense(
     collectionName: string,
     query: string,
     queryBy: string,
-    limit: number = 5
+    limit: number = 5,
+    filterBy?: string
 ): Promise<any[]> {
     try {
         // typo_tokens_threshold: by default Typesense stops expanding typo-corrected
         // variants as soon as it finds 1 result, which starves fuzzy recall on
         // misspellings relative to Meilisearch. Raise it so we keep collecting
         // typo-corrected candidates up to `limit`; the caller re-scores/dedupes anyway.
-        const url = `/collections/${collectionName}/documents/search?q=${encodeURIComponent(query)}&query_by=${queryBy}&limit=${limit}&typo_tokens_threshold=${limit}`;
+        const url = `/collections/${collectionName}/documents/search?q=${encodeURIComponent(query)}&query_by=${queryBy}&limit=${limit}&typo_tokens_threshold=${limit}`
+            + (filterBy ? `&filter_by=${encodeURIComponent(filterBy)}` : '');
         const res = await typesenseReq(url, { method: 'GET' });
         // Map Typesense's hit layout to raw document layout so it matches the expected candidates layout
         return (res.hits || []).map((hit: any) => hit.document);
@@ -118,6 +120,35 @@ export async function createTypesenseCollection(schema: any): Promise<any> {
     return typesenseReq('/collections', {
         method: 'POST',
         body: JSON.stringify(schema),
+    });
+}
+
+/**
+ * Partial-update every document matching a filter with the same field values.
+ * PATCH /collections/<name>/documents?filter_by=... — returns {num_updated}.
+ * Needed when doc ids are unknown/auto-assigned (the live off_foods collection
+ * predates id=barcode keying) but an indexed field can address the docs.
+ */
+export async function updateTypesenseDocumentsByFilter(
+    collectionName: string,
+    filterBy: string,
+    partialDoc: Record<string, unknown>
+): Promise<{ num_updated: number }> {
+    return typesenseReq(
+        `/collections/${collectionName}/documents?filter_by=${encodeURIComponent(filterBy)}`,
+        { method: 'PATCH', body: JSON.stringify(partialDoc) }
+    );
+}
+
+/**
+ * Alter an existing collection's schema (e.g. add a new optional field).
+ * PATCH /collections/<name> with {"fields": [...]}.
+ */
+export async function updateTypesenseCollection(collectionName: string, patch: any): Promise<any> {
+    logger.info('typesense.updating_collection', { collectionName });
+    return typesenseReq(`/collections/${collectionName}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
     });
 }
 


### PR DESCRIPTION
## What

The Cluster A pt2 **lever**: make the pipeline actively *seek out* SKUs whose label serving enumerates pieces ("16 chips (45g)", "15 pieces (28g)") when the user is counting pieces — so the label-count-derived serving path (PR #100) reaches generic queries like "13 tortilla chips" instead of only firing when a count-labeled SKU happens to match by name relevance.

## How

Four coordinated pieces (shared predicates in new `src/lib/mapping/count-label.ts`):

1. **Retrieval** — new indexed `hasCountServing` bool on the `off_foods` Typesense collection. Counted-piece gathers run a secondary filtered query and append up to 3 count-labeled SKUs to the candidate pool. **Already backfilled live: 33,577 docs flagged** via update-by-filter (`scripts/backfill-typesense-count-serving.ts`, one-time; `sync-typesense.ts` computes the flag inline for future full syncs). Graceful no-op if the field is absent.
2. **Rerank** — `COUNT_LABEL_BOOST` (+0.08), gated on the query being a unitless integer count of a packaged-snack piece noun. Deliberately smaller than EXACT_MATCH (0.30) / token penalties (0.35+) and subordinate to nutrition-typicality: it breaks near-ties only. Verified live: a seasoned 464kcal/100g pretzel SKU still loses to the nutritionally-typical generic — no food-identity hijack.
3. **Cache escape** — counted-piece queries bypass a cached label-less OFF winner in both FoodMapping cache layers; the full pipeline re-resolves and writes the count-labeled winner back. One-time per normalized name (converges; verified: 2nd query onward is a fast cache hit on the new winner).
4. **Label parsing** — generic "pieces"/"pc" counter words now satisfy the count gate for multi-piece labels (count ≥ 2), covering the very common "15 pieces (28 g)" phrasing that the exact-noun gate missed.

## Verified live (dev server against prod data)

| query | before | after |
|---|---|---|
| 13 tortilla chips | 26g (2g/chip seed) | **36.6g** — "Tortilla Chips", label "16 chips (45g)" → 2.81g/chip, stable 3/3 |
| 6 saltine crackers | seed | **18g** (3g/cracker from label) |
| 4 chicken nuggets | seed | **65g** (16.25g/nugget from label) |
| 10 pretzels | 20g seed | 20g seed (unchanged — only atypical-macro count SKUs exist; boost correctly doesn't hijack) |

- Full golden eval (search + nlp) vs local: **0 real failures**; all 13 known issues unchanged.
- 152 jest tests pass (11 new: count-label predicates, rerank boost isolation incl. "boost must not overcome a better name match").
- New golden case **n-serv-35** ("13 tortilla chips", grams [28,70]) deliberately excludes the seed answer, so a regression of this lever fails the eval.

## Notes

- Counted-piece queries whose corpus genuinely has no acceptable count-labeled SKU will re-run the full pipeline on each query (cache escape fires, same winner re-saved). Scope is narrow (packaged-snack nouns only) and these lines already ride the multi-second AI text pipeline.
- The live `off_foods` docs have auto-assigned ids (not barcodes), hence update-by-filter in the backfill; the next full `sync-typesense` run keys docs by barcode and carries the flag natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y