### PR TITLE
feat(serving): OFF package-quantity backfill + package/portion serving fixes (Defects 3 & 4)

### DIFF
--- a/prisma/migrations/20260719070000_add_offfood_package_quantity/migration.sql
+++ b/prisma/migrations/20260719070000_add_offfood_package_quantity/migration.sql
@@ -1,0 +1,7 @@
+-- OFF product_quantity backfill target (Cluster A pt2 Defect 3, Jul 2026).
+-- Net package quantity per barcode ("591 ml" Gatorade bottle, "92 g" chip bag)
+-- from OFF's quantity/product_quantity fields, which the ingest previously
+-- discarded. Populated by scripts/backfill-off-package-quantity.ts from the
+-- OFF CSV export; future ingests may set it directly.
+ALTER TABLE "OffFood" ADD COLUMN "packageQuantity" DOUBLE PRECISION;
+ALTER TABLE "OffFood" ADD COLUMN "packageQuantityUnit" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -378,6 +378,8 @@ model OffFood {
   nutrientsPer100g Json?                       // { kcal, protein, carbs, fat, fiber, sugar, sodium }
   servingSize      String?                     // Raw label string
   servingGrams     Float?                      // Parsed default serving weight
+  packageQuantity  Float?                      // OFF product_quantity: net package quantity (see packageQuantityUnit)
+  packageQuantityUnit String?                  // 'g' | 'ml', inferred from the OFF quantity label string; null when unknown
   imageUrl         String?                     // Product image from OFF
   categories       String?                     // OFF categories CSV
   syncedAt         DateTime      @default(now())

--- a/scripts/backfill-off-package-quantity.ts
+++ b/scripts/backfill-off-package-quantity.ts
@@ -1,0 +1,99 @@
+/**
+ * backfill-off-package-quantity.ts — populate OffFood.packageQuantity(+Unit)
+ * from OFF's CSV export (Cluster A pt2 Defect 3, Jul 2026).
+ *
+ * The OFF CSV carries `product_quantity` (normalized net quantity, g or ml)
+ * and the raw `quantity` label string ("591 ml", "1.75 L") that our JSONL
+ * ingest never selected. This streams the CSV, collects (barcode, quantity,
+ * unit) for rows with a usable product_quantity, loads them into a temp table
+ * on ONE connection (transaction-pinned), and joins onto OffFood — barcodes we
+ * never ingested are simply skipped by the join.
+ *
+ * Run on the Mini-PC (CSV + Postgres both local; node streaming keeps RAM low):
+ *   ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/backfill-off-package-quantity.ts \
+ *     ~/Recipe-App/data/openfoodfacts.csv.gz
+ */
+
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import zlib from 'zlib';
+import { PrismaClient, Prisma } from '@prisma/client';
+
+// 1-indexed tab-separated columns of the OFF CSV export (verified 2026-07-19
+// against the Apr-2026 file: 1=code, 14=quantity, 73=product_quantity).
+const COL_CODE = 0;
+const COL_QUANTITY = 13;
+const COL_PRODUCT_QUANTITY = 72;
+
+const INSERT_BATCH = 5000;
+
+/** 'ml' for volume-labeled packages, 'g' for weight-labeled, null if unclear. */
+function inferUnit(quantityStr: string): 'g' | 'ml' | null {
+    const s = quantityStr.toLowerCase();
+    if (/\d\s*(ml|cl|dl|l|litre|liter|fl\s*\.?\s*oz)\b/.test(s)) return 'ml';
+    if (/\d\s*(g|gr|grams?|kg|mg|oz|lbs?|pounds?)\b/.test(s)) return 'g';
+    return null;
+}
+
+async function main() {
+    const csvPath = process.argv[2];
+    if (!csvPath || !fs.existsSync(csvPath)) {
+        console.error('Usage: backfill-off-package-quantity.ts <openfoodfacts.csv[.gz]>');
+        process.exit(1);
+    }
+
+    const prisma = new PrismaClient();
+    let input: NodeJS.ReadableStream = fs.createReadStream(csvPath);
+    if (path.extname(csvPath) === '.gz') input = (input as fs.ReadStream).pipe(zlib.createGunzip());
+    const rl = readline.createInterface({ input, crlfDelay: Infinity });
+
+    // Collect qualifying rows first (tiny objects; ~1.3M rows ≈ manageable),
+    // then load in one transaction so the temp table stays on one connection.
+    const rows: Array<{ barcode: string; qty: number; unit: string | null }> = [];
+    let lineNo = 0;
+    for await (const line of rl) {
+        lineNo++;
+        if (lineNo === 1) continue; // header
+        const cols = line.split('\t');
+        const barcode = cols[COL_CODE];
+        const pq = Number(cols[COL_PRODUCT_QUANTITY]);
+        if (!barcode || !Number.isFinite(pq) || pq <= 0 || pq > 100000) continue;
+        const quantityStr = cols[COL_QUANTITY] ?? '';
+        // Multipacks ("6 x 355 ml"): product_quantity is the TOTAL, which
+        // would overbill "1 bottle" by the pack count. Skip them.
+        if (/\d\s*[x×*]\s*\d/i.test(quantityStr)) continue;
+        // Buffer round-trip detaches the barcode from its parent line: V8's
+        // split() returns sliced strings that pin the ENTIRE multi-KB CSV line
+        // in memory — retaining 1M+ of those OOMs a 4GB heap.
+        rows.push({ barcode: Buffer.from(barcode).toString(), qty: pq, unit: inferUnit(quantityStr) });
+        if (rows.length % 200000 === 0) console.log(`collected ${rows.length.toLocaleString()} (scanned ${lineNo.toLocaleString()})`);
+    }
+    console.log(`CSV done: ${rows.length.toLocaleString()} rows with product_quantity (of ${lineNo.toLocaleString()} scanned).`);
+
+    const updated = await prisma.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(
+            `CREATE TEMP TABLE pkg_tmp (barcode TEXT PRIMARY KEY, qty DOUBLE PRECISION, unit TEXT) ON COMMIT DROP`);
+        for (let i = 0; i < rows.length; i += INSERT_BATCH) {
+            const chunk = rows.slice(i, i + INSERT_BATCH);
+            const values = Prisma.join(chunk.map(r => Prisma.sql`(${r.barcode}, ${r.qty}, ${r.unit})`));
+            await tx.$executeRaw`INSERT INTO pkg_tmp (barcode, qty, unit) VALUES ${values} ON CONFLICT (barcode) DO NOTHING`;
+            if ((i / INSERT_BATCH) % 40 === 0) console.log(`loaded ${Math.min(i + INSERT_BATCH, rows.length).toLocaleString()} into temp`);
+        }
+        const n = await tx.$executeRawUnsafe(`
+            UPDATE "OffFood" f
+            SET "packageQuantity" = t.qty, "packageQuantityUnit" = t.unit
+            FROM pkg_tmp t WHERE f.barcode = t.barcode`);
+        return n;
+    }, { timeout: 1000 * 60 * 30 });
+
+    console.log(`\n✅ Done. ${updated.toLocaleString()} OffFood rows now carry packageQuantity.`);
+    await prisma.$disconnect();
+}
+
+main().catch(err => {
+    console.error('❌ Backfill crashed:', err);
+    process.exit(1);
+});

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -3595,8 +3595,7 @@
         300,
         400
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable across 2 probes): '1 celsius' (a 12 fl oz / ~355 ml canned drink) resolves to the 100g no-serving fallback, not a full can (~355g). Unitless branded canned drink is NOT backfilled to a can serving. Per-100g nutrition is fine (~2.8 kcal/100g); only the serving weight is wrong. Expected ~300-400g; observed 100g. Non-gating until discrete-drink serving backfill covers canned beverages."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). Matched Celsius SKU has null brandName + no serving; brand guessed from the food name's first token, sibling-borrow finds the ~355ml can median. Was flat 100g."
     },
     {
       "id": "n-supp-27",
@@ -3619,8 +3618,7 @@
         140,
         180
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): '1 chobani greek yogurt' (a single-serve container is ~150g / 5.3 oz) resolves to the 100g no-serving fallback instead of one container (~150g). Correct brand/product ('Chobani Greek Yogurt'), wrong serving. Expected ~140-180g; observed 100g. Same discrete-unit-not-backfilled family as n-supp-26/28. Non-gating."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). Majority-vote sibling package median: Chobani's hundreds of ~150g cups outvote its half-gallon drinkable line (an ml-first heuristic billed 709g). Was flat 100g."
     },
     {
       "id": "n-supp-28",
@@ -3643,8 +3641,7 @@
         28,
         55
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED BUG (stable): unitless 'chomps beef stick' (a Chomps stick is ~35g / 1.15 oz) resolves to the 100g no-serving fallback. Also: input brand='chomps' but brandName comes back null (brand not attached), even though foodName='Chomps original beef stick'. Contrast n-supp-25 (clif) which DOES backfill a discrete bar serving. Expected ~28-55g; observed 100g. Non-gating."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). Chomps stick via brand-guess sibling package median (~32g single-stick 'g'-band). Was flat 100g."
     },
     {
       "id": "n-serv-01",
@@ -4199,8 +4196,7 @@
         300,
         650
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 3 = flat-100 package, most extreme UNDER: ratio ~0.2x). '1 gatorade' -> 100g: unitless branded bottle (~591g for 20oz, ~355g for 12oz) not backfilled to a container serving; falls to the 100g no-serving fallback. Target [300,650]; observed 100g. Fix = route unitless packages (bottle/can/pouch) to the ambiguous-unit backfill."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). '1 gatorade' (unitless branded count) now bills the same-brand median package via the OFF product_quantity backfill (207k rows) + sibling-borrow: ~500-600ml bottle. Was flat capped-100g."
     },
     {
       "id": "n-serv-24",
@@ -4224,7 +4220,7 @@
         200
       ],
       "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 3 = flat-100 package). '1 capri sun' -> 100g: a pouch is ~177g (6 fl oz). Target [130,200]; observed 100g. Same flat-100 fallback as n-serv-23/celsius/chobani; the pouch package size is never resolved."
+      "notes": "KNOWN ISSUE (improved 2026-07-19, kept known). Was flat capped-100g; now bills the Capri Sun brand-median package (330ml \u2014 some Capri Suns ARE 330ml PETs) via the product_quantity backfill. The [130,200] band presumes the iconic US 177ml pouch, which needs the MATCHED SKU itself to carry pouch-level package data (it has none). Revisit if a pouch-size Capri Sun SKU with product_quantity becomes the match."
     },
     {
       "id": "n-serv-25",
@@ -4247,8 +4243,7 @@
         18,
         45
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 4 = ambiguous unit not resolved, extreme UNDER). '1 handful almonds' -> 1.2g: 'handful' is treated as a single almond (~1.2g) instead of a handful portion (~28-35g). Target [18,45]; observed 1.2g. Contrast n-serv-31 '1 scoop whey' which DOES resolve. 'handful'/'bowl' need portion backfill; 'scoop'/'glass' already work."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 4). 'handful' is now a recognized parse unit routed to the AI estimator with a 10g floor; previously it parsed as a unitless count of 'handful almonds' and billed ONE almond's 1.2g seed weight."
     },
     {
       "id": "n-serv-26",
@@ -4271,8 +4266,7 @@
         25,
         70
       ],
-      "knownIssue": true,
-      "notes": "CENSUS BUG (Cluster A, Defect 4 = ambiguous unit not resolved). '1 bowl cereal' -> 100g flat: 'bowl' is not resolved to a portion; a bowl of dry cereal is ~40-60g. Target [25,70]; observed 100g. Same ambiguous-unit gap as n-serv-25 (handful)."
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 4). 'bowl' is now a recognized parse unit routed to the AI estimator (25g floor, dry-cereal anchor). Was flat 100g."
     },
     {
       "id": "n-serv-27",

--- a/src/lib/ai/ambiguous-serving-estimator.ts
+++ b/src/lib/ai/ambiguous-serving-estimator.ts
@@ -61,6 +61,43 @@ export const AMBIGUOUS_UNITS = new Set([
     'dollop', 'dollops',
 ]);
 
+// Unit-specific weight sanity floors (Cluster A pt2 Defect 4, Jul 2026).
+// A "handful" or "bowl" is inherently a multi-piece/portion quantity — an
+// estimate (or poisoned cached serving) below these is a per-piece weight in
+// disguise ("handful of almonds" = 1.2g) and must not be served.
+export const UNIT_MIN_GRAMS: Record<string, number> = {
+    handful: 10, handfuls: 10,
+    bowl: 25, bowls: 25,
+    plate: 50, plates: 50,
+};
+
+/** Sanity bounds for an ambiguous unit's per-unit grams; either side may be undefined. */
+export function getAmbiguousUnitBounds(unit: string): { min?: number; max?: number } {
+    const u = unit.toLowerCase().trim();
+    return { min: UNIT_MIN_GRAMS[u], max: UNIT_MAX_GRAMS[u] };
+}
+
+// Unit-specific weight sanity caps (safety net for AI hallucinations).
+// These prevent catastrophic misestimates like 100g/spray or 86g/scoop.
+// Module scope so getAmbiguousUnitBounds can validate cached servings too.
+const UNIT_MAX_GRAMS: Record<string, number> = {
+    // Micro-units: these should NEVER exceed a few grams
+    spray: 2, sprays: 2, squirt: 5, squirts: 5,
+    dash: 1, pinch: 0.5,
+    // True micro-volume units (drops of hot sauce, liquid stevia)
+    drop: 0.5, drops: 0.5,
+    // Cooking spray duration (0.4 second = ~0.25g oil)
+    second: 1, seconds: 1,
+    // Packet-like units: sweetener packet = 1g, ketchup packet = 9g max
+    packet: 10, packets: 10,
+    sachet: 10, sachets: 10, envelope: 15, envelopes: 15,
+    // Scoops: protein powder scoops are 30-35g max, competition scoops up to 45g
+    scoop: 50, scoops: 50,
+    // Pieces/strips/chunks/breasts: reasonable max for cut produce/meat
+    piece: 200, pieces: 200, strip: 50, strips: 50, chunk: 50, chunks: 50,
+    breast: 300, breasts: 300, thigh: 200, thighs: 200,
+};
+
 export interface AmbiguousServingRequest {
     foodName: string;
     brandName?: string | null;
@@ -289,26 +326,6 @@ export async function estimateAmbiguousServing(
             };
         }
 
-        // Unit-specific weight sanity caps (safety net for AI hallucinations)
-        // These prevent catastrophic misestimates like 100g/spray or 86g/scoop
-        const UNIT_MAX_GRAMS: Record<string, number> = {
-            // Micro-units: these should NEVER exceed a few grams
-            spray: 2, sprays: 2, squirt: 5, squirts: 5,
-            dash: 1, pinch: 0.5,
-            // True micro-volume units (drops of hot sauce, liquid stevia)
-            drop: 0.5, drops: 0.5,
-            // Cooking spray duration (0.4 second = ~0.25g oil)
-            second: 1, seconds: 1,
-            // Packet-like units: sweetener packet = 1g, ketchup packet = 9g max
-            packet: 10, packets: 10,
-            sachet: 10, sachets: 10, envelope: 15, envelopes: 15,
-            // Scoops: protein powder scoops are 30-35g max, competition scoops up to 45g
-            scoop: 50, scoops: 50,
-            // Pieces/strips/chunks/breasts: reasonable max for cut produce/meat
-            piece: 200, pieces: 200, strip: 50, strips: 50, chunk: 50, chunks: 50,
-            breast: 300, breasts: 300, thigh: 200, thighs: 200,
-        };
-
         // Novel (estimable-unknown) units have no curated cap — bound them
         // generously so a hallucinated weight can't produce absurd calories,
         // while still allowing legitimately large portions (bowl, plate, etc.).
@@ -322,6 +339,16 @@ export async function estimateAmbiguousServing(
                 reasoning,
             });
             clampedGrams = maxGrams;
+        }
+        // Floor guard: a portion unit estimated below its floor is a per-piece
+        // weight in disguise ("handful of almonds" → 1.2g). Clamp up.
+        const minGrams = UNIT_MIN_GRAMS[unit.toLowerCase()];
+        if (minGrams && clampedGrams < minGrams) {
+            logger.warn('ambiguous_estimation.clamped_low', {
+                foodName, unit, originalGrams: estimatedGrams, clampedTo: minGrams,
+                reasoning,
+            });
+            clampedGrams = minGrams;
         }
 
         return {
@@ -355,6 +382,7 @@ function buildPrompt(request: AmbiguousServingRequest): string {
         `- "package" of tofu: Typically 14oz (400g)`,
         `- "scoop" of protein powder: Typically 30-35g`,
         `- "bowl" of cereal: About 200-300g including milk, 30-60g dry`,
+        `- "handful" of nuts, chips, or snacks: About 28-40g — a handful is MANY pieces, NEVER the weight of a single piece`,
         `- "can" of soda: Usually 355ml`,
         `- "packet" of sweetener: About 1g`,
         ``,

--- a/src/lib/mapping/ambiguous-unit-backfill.ts
+++ b/src/lib/mapping/ambiguous-unit-backfill.ts
@@ -302,18 +302,33 @@ export async function getOrCreateAmbiguousServing(
         return { status: 'error', error: `"${unit}" is not an estimable unit` };
     }
 
-    // Check existing
+    // Check existing — but reject cached servings outside the unit's sanity
+    // bounds (a poisoned "handful" row of 1.2g is a per-piece weight in
+    // disguise; fall through so the estimator overwrites it).
     const existing = await findExistingServing(foodId, normalizedUnit);
     if (existing?.grams) {
-        logger.debug('ambiguous_backfill.cache_hit', {
-            foodId,
-            unit: normalizedUnit,
-            grams: existing.grams,
-        });
-        return {
-            status: 'cached',
-            grams: existing.grams,
-        };
+        const { getAmbiguousUnitBounds } = await import('../ai/ambiguous-serving-estimator');
+        const bounds = getAmbiguousUnitBounds(normalizedUnit);
+        const outOfBounds = (bounds.min != null && existing.grams < bounds.min)
+            || (bounds.max != null && existing.grams > bounds.max);
+        if (outOfBounds) {
+            logger.warn('ambiguous_backfill.cached_out_of_bounds', {
+                foodId,
+                unit: normalizedUnit,
+                grams: existing.grams,
+                bounds,
+            });
+        } else {
+            logger.debug('ambiguous_backfill.cache_hit', {
+                foodId,
+                unit: normalizedUnit,
+                grams: existing.grams,
+            });
+            return {
+                status: 'cached',
+                grams: existing.grams,
+            };
+        }
     }
 
     // Sibling-serving borrow: before paying for an AI estimate, try to borrow a

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -3798,6 +3798,55 @@ function candidateHasCountLabel(candidate: UnifiedCandidate, pieceNoun: string):
     return servingLabelCountsPiece(raw?.servingSize, raw?.servingGrams, pieceNoun);
 }
 
+// Plausible single-retail-unit bands for package quantities. 'ml' is the
+// beverage archetype (a bottle/can/pouch someone counts as one drink); 'g'
+// is capped low so multi-serve family packages (a 432g Oreo package) never
+// pass as one piece — only single-serve cups/sticks/bars do.
+const PACKAGE_BAND: Record<'ml' | 'g', { min: number; max: number }> = {
+    ml: { min: 100, max: 1000 },
+    g: { min: 20, max: 250 },
+};
+
+function packageGramsInBand(qty: number | null | undefined, unitKind: string | null | undefined): number | null {
+    if (qty == null || (unitKind !== 'ml' && unitKind !== 'g')) return null;
+    const band = PACKAGE_BAND[unitKind];
+    return qty >= band.min && qty <= band.max ? qty : null;
+}
+
+/**
+ * Median same-brand package quantity from the OFF product_quantity backfill
+ * (Cluster A pt2 Defect 3). Lets "1 gatorade" resolve to ~a bottle even when
+ * the matched SKU itself lacks package data — its brand siblings know. The
+ * unit class (ml vs g) is decided by MAJORITY VOTE across in-band siblings:
+ * Chobani's hundreds of 150g cups must outvote its handful of half-gallon
+ * drinkables, and Gatorade's ml bottles outvote its powder tubs. Requires
+ * >=2 sibling SKUs in the winning class.
+ */
+async function borrowSiblingPackageGrams(
+    brandName: string | null | undefined
+): Promise<number | null> {
+    const brand = brandName?.trim();
+    if (!brand) return null;
+    try {
+        const { prisma } = await import('../db');
+        const rows = await prisma.$queryRaw<Array<{ unit: string; med: number | null; n: number }>>`
+            SELECT "packageQuantityUnit" AS unit,
+                   percentile_cont(0.5) WITHIN GROUP (ORDER BY "packageQuantity") AS med,
+                   count(*)::int AS n
+            FROM "OffFood"
+            WHERE "brandName" ILIKE ${brand}
+              AND (("packageQuantityUnit" = 'ml' AND "packageQuantity" BETWEEN ${PACKAGE_BAND.ml.min} AND ${PACKAGE_BAND.ml.max})
+                OR ("packageQuantityUnit" = 'g'  AND "packageQuantity" BETWEEN ${PACKAGE_BAND.g.min} AND ${PACKAGE_BAND.g.max}))
+            GROUP BY 1
+            ORDER BY count(*) DESC`;
+        const winner = rows[0];
+        if (!winner?.med || winner.n < 2) return null;
+        return winner.med;
+    } catch {
+        return null;
+    }
+}
+
 async function buildOffResult(
     candidate: UnifiedCandidate,
     parsed: ParsedIngredient | null,
@@ -3867,7 +3916,31 @@ async function buildOffResult(
         'container', 'containers', 'packet', 'packets', 'package', 'packages',
         'pack', 'packs', 'bottle', 'bottles', 'jar', 'jars', 'pouch', 'pouches',
         'tub', 'tubs', 'box', 'boxes', 'bag', 'bags', 'sachet', 'sachets',
+        'can', 'cans', 'carton', 'cartons',
     ]);
+
+    // SKU's own net quantity (OFF product_quantity backfill, 207k rows).
+    // Used ONLY when the label serving is absent — for multipack SKUs
+    // product_quantity is the OUTER box (a 10-pouch Capri Sun = 1774ml), so
+    // the label serving must always win when present. ml ≈ g is close enough
+    // for beverages (±6%); PACKAGE_BAND keeps corrupt values and multi-serve
+    // family packages out. When this SKU lacks package data, borrow the
+    // same-brand median (Gatorade's siblings know a bottle is ~591ml).
+    const packageGrams = packageGramsInBand(hydrated.packageQuantity, hydrated.packageQuantityUnit);
+    // Brand for sibling-borrowing package sizes. OFF rows sometimes carry a
+    // null brandName even for clearly branded products ("Celsius", "Chomps
+    // original beef stick") — fall back to the food name's first token; the
+    // borrow itself requires >=2 exact-brand-match SKUs with in-band package
+    // data, which filters bogus guesses.
+    const brandForBorrow = hydrated.brandName ?? (() => {
+        const tok = (hydrated.foodName || '').trim().split(/\s+/)[0] ?? '';
+        return tok.length >= 4 ? tok : null;
+    })();
+    let packageFallbackGrams: number | null = null;
+    if (unit && PACKAGE_LIKE_UNITS.has(unit) && !(hydrated.servingGrams && hydrated.servingGrams > 0)) {
+        packageFallbackGrams = packageGrams
+            ?? await borrowSiblingPackageGrams(brandForBorrow);
+    }
 
     if (unit && weightToGrams[unit]) {
         grams = qty * weightToGrams[unit];
@@ -3890,6 +3963,20 @@ async function buildOffResult(
     } else if (unit && PACKAGE_LIKE_UNITS.has(unit) && hydrated.servingGrams && hydrated.servingGrams > 0) {
         grams = qty * hydrated.servingGrams;
         servingDescription = `${qty} ${unit} (${hydrated.servingGrams}g each)`;
+    } else if (unit && PACKAGE_LIKE_UNITS.has(unit) && packageFallbackGrams != null) {
+        // Package-like unit with NO label serving ("1 bottle gatorade" on a
+        // SKU without servingGrams): the SKU's own net quantity — or the
+        // same-brand median package — is the best available answer. Cluster A
+        // pt2 Defect 3 (Jul 2026): these previously fell to the flat 100g
+        // no-serving default.
+        grams = qty * packageFallbackGrams;
+        servingDescription = `${qty} ${unit} (${packageFallbackGrams.toFixed(0)}g each)`;
+        logger.info('off.build_result.package_quantity_fallback', {
+            foodId: candidate.id,
+            unit,
+            packageGrams: packageFallbackGrams,
+            ownLabel: packageGrams != null,
+        });
     } else if (unit && (isAmbiguousUnit(unit) || classifyUnit(unit) === 'count')) {
         // Count/size/unknown units ("slice", "medium", "can", "knob", "rasher"):
         // deterministic count defaults + cached per-food servings + AI estimation.
@@ -3988,6 +4075,32 @@ async function buildOffResult(
                         status: amb.status,
                     });
                 }
+            }
+        }
+
+        // (D) WHOLE-PACKAGE COUNT — "1 gatorade", "2 celsius": a unitless count
+        // of a BRANDED packaged product that names no piece noun is a count of
+        // retail units. Bill the SKU's own net quantity, or the same-brand
+        // median package when this SKU lacks it (Cluster A pt2 Defect 3,
+        // Jul 2026 — previously the flat capped-100g default). Gated to
+        // branded, label-serving-less matches and PACKAGE_BAND sizes, so
+        // "2 oreos" can never bill two 432g family packages.
+        if (
+            grams == null && brandForBorrow
+            && (!hydrated.servingGrams || hydrated.servingGrams <= 0)
+            && pieceNounInName(itemNameForCount) == null
+        ) {
+            const pkg = packageGrams
+                ?? await borrowSiblingPackageGrams(brandForBorrow);
+            if (pkg != null) {
+                grams = qty * pkg;
+                servingDescription = `${qty} package (${pkg.toFixed(0)}g each)`;
+                logger.info('off.build_result.package_count', {
+                    foodId: candidate.id,
+                    name: itemNameForCount,
+                    perPackageGrams: pkg,
+                    ownLabel: packageGrams != null,
+                });
             }
         }
 

--- a/src/lib/openfoodfacts/hydrate.ts
+++ b/src/lib/openfoodfacts/hydrate.ts
@@ -28,6 +28,10 @@ export interface HydratedOffFood {
     servingDescription: string | null;
     /** Units the label serving covers ("2 scoops" → 2). Divide servingGrams by this for per-unit weight. */
     servingUnitCount: number;
+    /** Net package quantity (OFF product_quantity backfill); interpret per packageQuantityUnit. */
+    packageQuantity: number | null;
+    /** 'g' | 'ml', or null when the label didn't say. */
+    packageQuantityUnit: string | null;
 }
 
 // ============================================================
@@ -72,6 +76,8 @@ export async function hydrateOffCandidate(candidate: {
             servingGrams:    existing.servingGrams,
             servingDescription: existing.servingGrams ? existingServing.description : null,
             servingUnitCount:   existingServing.unitCount,
+            packageQuantity:     existing.packageQuantity,
+            packageQuantityUnit: existing.packageQuantityUnit,
         };
     }
 
@@ -177,6 +183,11 @@ export async function hydrateOffCandidate(candidate: {
         servingGrams:     servingGrams ?? null,
         servingDescription: servingGrams ? servingDescription : null,
         servingUnitCount:   servingUnitCount,
+        // Fresh hydrates have no package data (search candidates don't carry
+        // it); the CSV backfill populates it on the OffFood row, so the
+        // cache-first path above picks it up from the next request on.
+        packageQuantity:     null,
+        packageQuantityUnit: null,
     };
 }
 

--- a/src/lib/parse/unit.ts
+++ b/src/lib/parse/unit.ts
@@ -86,6 +86,13 @@ export function normalizeUnitToken(tok: string): NormalizedUnit {
     'squirt': 'squirt', 'squirts': 'squirt',
     'breast': 'breast', 'breasts': 'breast', // For chicken breast
     'thigh': 'thigh', 'thighs': 'thigh', // For chicken thigh
+    // Portion units (Cluster A pt2 Defect 4, Jul 2026): previously unrecognized,
+    // so "1 handful almonds" parsed as a unitless count of "handful almonds"
+    // and billed ONE almond's seed weight. As count units they route to the
+    // ambiguous-serving estimator, which has portion floors for them.
+    'handful': 'handful', 'handfuls': 'handful',
+    'bowl': 'bowl', 'bowls': 'bowl',
+    'plate': 'plate', 'plates': 'plate',
   };
 
   if (countUnits[token]) {

--- a/src/lib/servings/default-count-grams.ts
+++ b/src/lib/servings/default-count-grams.ts
@@ -249,6 +249,11 @@ export function getDefaultCountServing(
         'roll', 'rolls', 'tin', 'tins', 'case', 'cases', 'jar', 'jars',
         'bottle', 'bottles', 'can', 'cans', 'pouch', 'pouches', 'tub', 'tubs',
         'container', 'containers',
+        // Portion units (Cluster A pt2 Defect 4, Jul 2026): a per-piece seed
+        // ('almond' = 1.2g) must never answer "1 handful of almonds" — a
+        // handful is many pieces. Same only-exact-"<name> <unit>"-seed
+        // contract as container units; the AI estimator handles them instead.
+        'handful', 'handfuls', 'bowl', 'bowls', 'plate', 'plates',
     ]);
     const isContainerUnit = CONTAINER_UNITS.has(unitLower);
 


### PR DESCRIPTION
## What

Closes the last two Cluster A pt2 serving-resolution defect families:

**Defect 3 — flat-100g packaged products.** "1 gatorade" / celsius can / chobani container billed 100g because the matched SKU had no label serving and no notion of its own package size. Now:
- `OffFood.packageQuantity(+Unit)` — OFF's `product_quantity` (net package size), which the ingest always discarded. **Already backfilled live: 207,405 rows** from the OFF CSV export via `scripts/backfill-off-package-quantity.ts` (streamed, temp-table join, multipack strings skipped, migration already applied to prod DB).
- `buildOffResult`: package-like units with no label serving bill the SKU's own net quantity; **label serving always wins when present** (a multipack SKU's `product_quantity` is the outer box — a 10-pouch Capri Sun is 1774ml). Unitless counts of branded products naming no piece-noun ("1 gatorade") bill one package.
- **Sibling-borrow**: when the matched SKU lacks package data (or even a brandName — Celsius/Chomps rows are brand-null), the same-brand median package is used, with the unit class picked by **majority vote** (Chobani's ~150g cups outvote its half-gallon drinkable line; an ml-first draft billed 709g). Bands ml 100–1000 / g 20–250 mean "2 oreos" can never bill two 432g family packages.

**Defect 4 — "1 handful almonds" = 1.2g.** Root cause: `handful` wasn't a parse unit, so the line became a unitless count of "handful almonds" and the per-piece almond seed answered it. Now handful/bowl/plate are count units routed to the AI estimator, portion units are excluded from per-piece seeds, the estimator has portion floors (handful 10g / bowl 25g / plate 50g) + a handful prompt anchor, and cached servings outside a unit's bounds are rejected and re-estimated (self-heals poisoned rows).

## Eval

Full local search+nlp golden: **0 real failures**, and **six former known issues promoted to hard assertions**:

| case | before | after |
|---|---|---|
| n-serv-23 "1 gatorade" (bottle) | 100g | ~500-600g sibling-median bottle ✅ |
| n-serv-25 "1 handful almonds" | 1.2g | ~30g AI estimate ✅ |
| n-serv-26 "1 bowl cereal" | 100g | in [25,70] ✅ |
| n-supp-26 "1 celsius" (can) | 100g | ~355g ✅ |
| n-supp-27 "1 chobani" (container) | 100g | ~150g ✅ |
| n-supp-28 "chomps beef stick" | 100g | ~32g ✅ |
| n-serv-24 "1 capri sun" (pouch) | 100g | 330g (brand median; stays known — band presumes the 177ml US pouch) |

474 jest tests pass. Migration `20260719070000_add_offfood_package_quantity` is additive (two nullable columns) and already applied to the prod DB; `migrate-smoke` covers the shadow-DB run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y