### PR TITLE
fix(mapping): dry-solid volume density + expand match-quality eval

### DIFF
--- a/docs/eval-hardening-plan.md
+++ b/docs/eval-hardening-plan.md
@@ -1,0 +1,92 @@
+# Eval Hardening Plan — Match-Quality Frontier (2026-07-19)
+
+## Where we are
+
+The serving/count pipeline is at a natural stopping point: full golden eval = **0 real
+failures** (search 101/104, nlp 150/156; every miss is a documented `knownIssue`). The
+high-value serving defects (100×count over-billing, package-median resolution, portion
+units) are all shipped and prod-verified (PRs #97–102).
+
+## The real frontier: match quality, not serving math
+
+A characterization pass (throwing 21 realistic parser-fed magic-log lines at the live
+pipeline, `scripts/eval/` characterization) showed the current golden set **over-indexes
+on serving math and under-tests whether we matched the right food record.** Of 3 new
+defects found, **2 are "matched the wrong / a garbage record,"** not "computed the wrong
+grams." That is the next place to push.
+
+New cases added this round (`golden-set.json`, ids `n-mq-*`):
+- 9 lock-in passes (branded-SKU precision, condiment density, portion units) with bands
+  from observed live values.
+- 2 graceful-degrade guards (unknown/fake brand → sane generic).
+- 3 tracked defects (`knownIssue`) — see below.
+
+## The 3 defects (tracked as knownIssue, ranked by leverage)
+
+1. **`n-mq-20` macro-plausibility** — `1 mission carb balance tortilla` matches an OFF row
+   whose per-serving numbers are mislabeled as per-100g (`70 kcal @ 19g carb` — impossible),
+   under-counting calories ~2×. **Fix = a macro-plausibility gate** that rejects
+   self-inconsistent records (`kcal` vs `4·carb + 4·protein + 9·fat`, and any macro > 100g)
+   *regardless of name match*. Highest leverage: one gate would catch a whole class of
+   garbage-record matches, not just this line.
+2. **`n-mq-21` count over-bill residual** — `3 real good chicken tenders` → 336g while
+   `4oz` of the same SKU → 113g. Multi-piece serving billed per-piece × count. Same family
+   as the shipped Cluster A fix; likely a small cap on the count path.
+3. **`n-mq-22` generic staple match quality** — `grilled chicken breast` matches a deli/roll
+   product (low protein, high fat); `white rice` resolves to 45g dry vs ~150g cooked.
+   Needs generic-staple ranking to prefer canonical cooked forms + a cooked-vs-dry serving
+   axis.
+
+## Next rounds (characterize first, then assert)
+
+Grow the golden set along match-quality axes the current set barely covers. **Always
+characterize new lines against the live API first (record what they actually match), then
+set bands from observed-correct values — never guess bands.**
+
+1. **Macro-plausibility gate** (implement) — closes `n-mq-20` and an unknown number of
+   silent wrong-record matches. Add plausibility-probe cases across branded packaged foods.
+2. **Cooked-vs-dry staples** (new axis) — rice, pasta, oats, beans, lentils: does a bare
+   staple name in a meal resolve to the cooked serving/nutrition or the dry one?
+3. **Branded-SKU-vs-generic** — for each of N popular brands (Real Good, Mission Carb
+   Balance, Quest, RXBAR, Built, Premier, Chomps, …): does the branded line beat the plain
+   generic AND carry the brand's own macros?
+4. **Count over-bill sweep** — multi-piece-serving SKUs (tenders, nuggets, wings, ravioli)
+   at count vs explicit weight, to bound `n-mq-21`'s class.
+
+## Config / infra follow-ups (separate from cases)
+
+- **Parse-model config is a three-way mismatch — needs a decision.** Intent stated: "magic
+  log should default to OpenRouter Gemini-2.0-flash first." Reality on this Mac's `.env`:
+  provider chain for `purpose:'parse'` is **Ollama `qwen2.5:14b` FIRST** (`OLLAMA_ENABLED=true`),
+  then OpenRouter **`openai/gpt-4o-mini`** (`CHEAP_AI_MODEL_PRIMARY`), then `mistral-nemo`,
+  then OpenAI. Gemini-2.0-flash appears ONLY in `.env.example` and a **stale code comment**
+  (`src/app/api/nlp/parse/route.ts:191`). The runtime `.env` on the Mini-PC/OptiPlex is not
+  visible from here and may differ again. **Action:** verify the deployed `.env`, then decide
+  the intended chain and align `.env` + `.env.example` + the stale comment.
+- **No cache on the segmentation result** — identical free-text lines re-hit the LLM every
+  time (only the mapped food is cached, keyed on normalized name). A `text`→segmentation
+  cache would flatten a chunk of the latency tail cheaply.
+- **Latency tail lives in stage-2, not segmentation** — segmentation is hard-capped at an 8s
+  overall deadline then degrades to the heuristic splitter; the observed 73s max came from
+  stage-2 per-item mapping AI calls, which don't share that cap. If the tail matters, bound
+  stage-2 next.
+
+## Progress — round 2 (2026-07-19 pt5)
+
+**SHIPPED (deployed to Mini-PC, live-verified, 0 real failures):**
+- **Dry-solid volume density** (`n-serv-14` class). Both `volumeToGrams` tables (OFF `buildOffResult` + generic/FDC) used a flat 0.5 g/ml for solids, under-weighting dense dry solids ~40% (sugar 2.5g/tsp → 4.25g). Fixed via `density.ts` category density, gated on a new `DRY_GRANULE_DENSITY_CATEGORIES` allowlist (sugar/flour/starch/oats/powder/whey/nut/seed) so cooked/dry-ambiguous grains and high-water foods stay on 0.5 and don't trip serving bands. +7 golden lock-ins (`n-dens-01..07`), `n-serv-14` promoted.
+
+**CHARACTERIZED → new tracked defects (knownIssue), fixes deferred (risky):**
+- **Cooked-vs-dry staples** — GRAINS only (rice/pasta/quinoa/oats default DRY; legumes already cooked). Root: `detectGrainCookingContext` (filter-candidates.ts:345) ignores the unit; `basic_produce_bypass` (gather-candidates.ts:516) locks the dry top1; `cook-state-detector.ts` is DEAD CODE. Quinoa/oats also corpus-blocked. Lock-ins `n-cook-01/02/03`; defects `n-cook-04/05/06`. Fix HIGH-risk (recipe cups logged dry).
+- **Brand-hijack** — brand is a tiebreaker behind `simple-rerank.ts:1452` + weak +0.25 bonus. Ranking-fixable: `n-seg-21`, `n-brand-02`. Ingest/detection-blocked: `s-supp-11`, `n-brand-05` (c4), `n-brand-06` (bang; both absent from brand-lexicon.json), `s-supp-17`. Positive controls `n-brand-03/04` added hard. Fix risks generic-word over-fire → needs 2-gram brand guard.
+
+## How to run
+
+```
+# full eval
+npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
+  scripts/eval/run-eval.ts --base http://192.168.1.21:3000
+
+# just the new match-quality cases
+... run-eval.ts --base http://192.168.1.21:3000 --only nlp --grep n-mq
+```

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams \u2014 the RESOLVED serving weight). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect \u2014 its failure is EXPECTED, reported as \ud83d\udfe1, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise.",
+  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams — the RESOLVED serving weight). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect — its failure is EXPECTED, reported as 🟡, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise.",
   "search": [
     {
       "id": "s-gen-01",
@@ -860,7 +860,7 @@
     {
       "id": "s-uni-01",
       "category": "unicode",
-      "query": "jalape\u00f1o",
+      "query": "jalapeño",
       "rank": 5,
       "match": [
         [
@@ -871,28 +871,28 @@
     {
       "id": "s-uni-02",
       "category": "unicode",
-      "query": "a\u00e7a\u00ed",
+      "query": "açaí",
       "rank": 5,
       "match": [
         [
           "acai"
         ],
         [
-          "a\u00e7a\u00ed"
+          "açaí"
         ]
       ]
     },
     {
       "id": "s-uni-03",
       "category": "unicode",
-      "query": "cr\u00e8me fra\u00eeche",
+      "query": "crème fraîche",
       "rank": 5,
       "match": [
         [
           "creme"
         ],
         [
-          "cr\u00e8me"
+          "crème"
         ],
         [
           "cream"
@@ -1144,7 +1144,7 @@
         ]
       ],
       "knownIssue": true,
-      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. 'cinnamon toast crunch' is a strong cereal-brand collision that can hijack the whole query off the RYSE brand token. CURRENT (aspirational): should rank a RYSE record top-3; KNOWN GAP if the cereal collision wins. Non-gating. NOTE: RYSE may be sparsely present in the corpus — verify before promoting."
+      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. VERIFIED 2026-07-19: INGEST-BLOCKED, not ranking-fixable. RYSE brand IS in corpus (Ryse Clear Protein, RYSE Loaded Protein Banana Pudding) but NO Cinnamon-Toast-Crunch flavor SKU exists, so nothing RYSE can be ranked up; the query lands on generic cereal records. Needs the flavor SKU ingested before any ranking fix engages. knownIssue, non-gating."
     },
     {
       "id": "s-supp-12",
@@ -1267,6 +1267,19 @@
       ],
       "knownIssue": true,
       "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'banan' -> banana. KNOWN GAP, same family as s-typo-08 'banna': truncated/misspelled banana queries get hijacked by literal 'banan'/'banna'-named junk products in the OFF corpus. Non-gating until the banana typo cluster is fixed."
+    },
+    {
+      "id": "s-supp-17",
+      "category": "branded_supplements",
+      "query": "ghost gamer sour patch",
+      "rank": 3,
+      "match": [
+        [
+          "ghost"
+        ]
+      ],
+      "knownIssue": true,
+      "notes": "DEFECT (flavor-ingest-blocked), SEARCH. Ghost Gamer line IS in corpus (off_0810028292666 'Gamer' brand 'Ghost') but the 'sour patch' flavor is not; nearest is 'Sour Watermelon' with an empty brand field. Not ranking-fixable without the flavor SKU. knownIssue, non-gating."
     }
   ],
   "nlp": [
@@ -2580,7 +2593,7 @@
           "coffee"
         ]
       ],
-      "notes": "segmenter keeps this as one composite item mapped to 'Iced Coffee with sugar and cream' \u2014 defensible (composite record covers all components), so expectation relaxed to 1 item."
+      "notes": "segmenter keeps this as one composite item mapped to 'Iced Coffee with sugar and cream' — defensible (composite record covers all components), so expectation relaxed to 1 item."
     },
     {
       "id": "n-seg-07",
@@ -2829,7 +2842,7 @@
         ]
       ],
       "knownIssue": true,
-      "notes": "KNOWN ISSUE (branded-competitor hijack, mapper ranking gap — demoted from hard 2026-07-18 after live re-probe contradicted the old 'CURRENT: works' note). 6 words -> under the single-item cap, so segmentation is NOT involved; the mapper receives the full brand-bearing raw line yet still maps to Optimum Nutrition 'Cinnamon Roll Protein' 0.78775/62g. Holds even with an explicit brand:'ghost' hint. Root cause: the query's non-brand tokens (protein/cinnamon/roll, 3) are fully covered by a BRANDED competitor whose SKU is literally named 'Cinnamon Roll Protein', while Ghost's real SKU 'Ghost Vegan Protein' covers only 2 (ghost/protein); the brand-match signal is not decisive enough to overturn the higher-coverage competitor. Sibling n-seg-22 passes only because adding 'vegan' gives Ghost a TYING token count so the brand tiebreak flips it. Fix belongs in the mapper ranking pass (stronger brand gating when the query names a corpus-present brand), not segmentation — bundled with the deferred buildOffResult/ranking follow-up."
+      "notes": "KNOWN ISSUE (branded-competitor hijack, RANKING-FIXABLE). '2 scoops ghost protein cinnamon roll' maps to Optimum Nutrition 'Cinnamon Roll Protein' (off_0748927070545). VERIFIED 2026-07-19: a Ghost-branded cinnamon protein IS in corpus but under the flavor name 'Cinnabon' (off_0810169602454 / off_0810128902335), so 'cinnamon roll' vs 'cinnabon' share no flavor tokens -> only a decisive brand gate can flip it (right-brand/near-flavor, not exact). Root: simple-rerank.ts:1452 brand is a tiebreaker behind the score short-circuit + weak +0.25 bonus. Fix has generic-word over-fire risk. knownIssue."
     },
     {
       "id": "n-seg-22",
@@ -3988,8 +4001,7 @@
         4,
         6
       ],
-      "knownIssue": true,
-      "notes": "DISCOVERED (stable across 2 probes): '1 tsp sugar' -> 'Granulated sugar' resolves to 2.5g. A level tsp of granulated sugar is ~4.2g, so the tsp volume is under-weighted (~40% low) for this dense solid. Expected ~4-6g; observed 2.5g. Minor but stable serving-density gap. Non-gating. (Also saw matchConfidence flip between 1 and 6.9 across runs — an out-of-range confidence to investigate separately; not asserted here since it is nondeterministic.)"
+      "notes": "FIXED 2026-07-19 (dry-solid density). '1 tsp sugar' was 2.5g (flat 0.5 g/ml solid default); buildOffResult/generic volume paths now use the sugar category density (0.85 g/ml) for allowlisted dry-granular categories -> 4.25g. Item-form, deterministic. Hard assertion. See density.ts DRY_GRANULE_DENSITY_CATEGORIES."
     },
     {
       "id": "n-serv-15",
@@ -4220,7 +4232,7 @@
         200
       ],
       "knownIssue": true,
-      "notes": "KNOWN ISSUE (improved 2026-07-19, kept known). Was flat capped-100g; now bills the Capri Sun brand-median package (330ml \u2014 some Capri Suns ARE 330ml PETs) via the product_quantity backfill. The [130,200] band presumes the iconic US 177ml pouch, which needs the MATCHED SKU itself to carry pouch-level package data (it has none). Revisit if a pouch-size Capri Sun SKU with product_quantity becomes the match."
+      "notes": "KNOWN ISSUE (improved 2026-07-19, kept known). Was flat capped-100g; now bills the Capri Sun brand-median package (330ml — some Capri Suns ARE 330ml PETs) via the product_quantity backfill. The [130,200] band presumes the iconic US 177ml pouch, which needs the MATCHED SKU itself to carry pouch-level package data (it has none). Revisit if a pouch-size Capri Sun SKU with product_quantity becomes the match."
     },
     {
       "id": "n-serv-25",
@@ -4458,6 +4470,621 @@
         70
       ],
       "notes": "COUNT-LABELED SKU RETRIEVAL + RERANK (Cluster A pt2 lever, 2026-07-19). The generic 'tortilla chips' candidate pool has NO count-labeled SKUs by plain name relevance, so gatherCandidates runs a secondary Typesense query filtered to hasCountServing:=true (33.6k flagged docs), the rerank COUNT_LABEL_BOOST prefers a count-labeled SKU among near-ties, and buildOffResult derives per-piece from ITS label (verified live: 'Tortilla Chips' 16 chips (45g) -> 2.81g/chip -> 36.6g). Range [28,70] deliberately EXCLUDES the 2g/chip generic seed answer (26g): this case fails if the retrieval/rerank lever regresses to seed. Also exercises the counted-piece FoodMapping cache escape (label-less cached winner is bypassed once, count-labeled winner is written back). Hard assertion."
+    },
+    {
+      "id": "n-mq-01",
+      "category": "match_quality",
+      "text": "4oz real good chicken tenders",
+      "expectName": [
+        [
+          "chicken",
+          "tender"
+        ]
+      ],
+      "grams": [
+        105,
+        120
+      ],
+      "macros": {
+        "protein100": [
+          16,
+          25
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in (2026-07-19 characterization). Branded low-carb SKU (Real Good) with explicit weight; 4oz -> 113.4g exact, macros plausible (obs 161kcal/100g, 20.5p). Guards that an explicit-weight branded line resolves grams deterministically AND carries the brand's own macros, not a generic tender."
+    },
+    {
+      "id": "n-mq-02",
+      "category": "match_quality",
+      "text": "2 rxbar chocolate sea salt",
+      "expectName": [
+        [
+          "rxbar"
+        ],
+        [
+          "chocolate",
+          "sea",
+          "salt"
+        ]
+      ],
+      "grams": [
+        95,
+        115
+      ],
+      "macros": {
+        "protein100": [
+          18,
+          28
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in. 2 bars -> 104g (2x52g), obs 385kcal/100g 23p. Multi-count branded bar."
+    },
+    {
+      "id": "n-mq-03",
+      "category": "match_quality",
+      "text": "1 chomps original beef stick",
+      "expectName": [
+        [
+          "chomps"
+        ],
+        [
+          "beef",
+          "stick"
+        ]
+      ],
+      "grams": [
+        28,
+        38
+      ],
+      "macros": {
+        "protein100": [
+          24,
+          34
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in. Confirms the shipped chomps serving fix (32.6g, obs 281kcal/100g 28p) holds via the full text path."
+    },
+    {
+      "id": "n-mq-04",
+      "category": "match_quality",
+      "text": "1 premier protein cafe latte shake",
+      "expectName": [
+        [
+          "latte"
+        ]
+      ],
+      "grams": [
+        300,
+        340
+      ],
+      "macros": {
+        "protein100": [
+          7,
+          12
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in. RTD shake -> 325g (=11 fl oz) with per-100g kcal ~49 (160/shake), 9.2p. Guards liquid-serving resolution for a branded shake."
+    },
+    {
+      "id": "n-mq-05",
+      "category": "match_quality",
+      "text": "1 tbsp peanut butter",
+      "expectName": [
+        [
+          "peanut",
+          "butter"
+        ]
+      ],
+      "grams": [
+        14,
+        20
+      ],
+      "macros": {
+        "kcal100": [
+          520,
+          650
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in (condiment density). tbsp -> 16g, obs 594kcal/100g. Correct nut-butter density."
+    },
+    {
+      "id": "n-mq-06",
+      "category": "match_quality",
+      "text": "1 tsp honey",
+      "expectName": [
+        [
+          "honey"
+        ]
+      ],
+      "grams": [
+        6,
+        9
+      ],
+      "macros": {
+        "kcal100": [
+          280,
+          340
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in + companion to n-serv-14 (sugar tsp KNOWN-ISSUE). honey tsp -> 7g CORRECT (dense), obs 304kcal/100g. Proves the tsp density gap is SUGAR-SPECIFIC, not a blanket volume->density hole; if honey ever regresses to the light ~2.5g sugar value, this fails."
+    },
+    {
+      "id": "n-mq-07",
+      "category": "match_quality",
+      "text": "handful of cashews",
+      "expectName": [
+        [
+          "cashew"
+        ]
+      ],
+      "grams": [
+        18,
+        40
+      ],
+      "notes": "MATCH-QUALITY lock-in (portion unit). Confirms shipped 'handful' estimator (obs 28g) holds via full text path."
+    },
+    {
+      "id": "n-mq-08",
+      "category": "match_quality",
+      "text": "1 quest chocolate chip protein bar",
+      "expectName": [
+        [
+          "quest"
+        ]
+      ],
+      "grams": [
+        50,
+        70
+      ],
+      "macros": {
+        "protein100": [
+          25,
+          40
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in (loose). Quest bar -> 60g, obs 300kcal/100g 33p. Branded protein-bar SKU precision."
+    },
+    {
+      "id": "n-mq-09",
+      "category": "match_quality",
+      "text": "1 built puff protein bar",
+      "expectName": [
+        [
+          "built"
+        ]
+      ],
+      "grams": [
+        32,
+        46
+      ],
+      "macros": {
+        "protein100": [
+          34,
+          48
+        ]
+      },
+      "notes": "MATCH-QUALITY lock-in (loose). Built Puff -> 40g, obs 350kcal/100g 42.5p."
+    },
+    {
+      "id": "n-mq-10",
+      "category": "weak_brand_fallback",
+      "text": "1 ghugh's protein cookie",
+      "expectName": [
+        [
+          "cookie"
+        ]
+      ],
+      "grams": [
+        25,
+        80
+      ],
+      "notes": "GRACEFUL-DEGRADE guard. Unknown/fake brand ('ghugh's') is stripped and the line degrades to a sane generic 'Protein cookie' (obs 50g) instead of crashing or mis-billing. Guards weak-brand robustness."
+    },
+    {
+      "id": "n-mq-11",
+      "category": "weak_brand_fallback",
+      "text": "2 tbsp ghugh's sugar free honey mustard",
+      "expectName": [
+        [
+          "mustard"
+        ]
+      ],
+      "grams": [
+        20,
+        45
+      ],
+      "notes": "GRACEFUL-DEGRADE guard. Fake brand stripped -> generic 'Honey Mustard' with sane tbsp density (obs 32g = 2x16g). Note the 'sugar free' qualifier is dropped (generic has 20g carb/100g) -- acceptable fallback, tracked here so a future qualifier-aware match can be measured against it."
+    },
+    {
+      "id": "n-mq-20",
+      "category": "match_quality",
+      "text": "1 mission carb balance tortilla",
+      "expectName": [
+        [
+          "tortilla"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          130,
+          190
+        ]
+      },
+      "knownIssue": true,
+      "notes": "DEFECT (found 2026-07-19 characterization) — MACRO-PLAUSIBILITY. Grams correct (45g) but the matched OFF row reports per-100g kcal=70 with carb=19g -- internally impossible (19g carb alone = 76 kcal), i.e. per-SERVING values mislabeled as per-100g. Logging it under-counts calories ~2x. Band [130,190] is the CORRECT per-100g range for a Mission Carb Balance tortilla; case flips green when a macro-plausibility gate rejects self-inconsistent records regardless of name match. This is a WRONG-RECORD (match-quality) defect, not a serving-math one."
+    },
+    {
+      "id": "n-mq-21",
+      "category": "match_quality",
+      "text": "3 real good chicken tenders",
+      "expectName": [
+        [
+          "chicken",
+          "tender"
+        ]
+      ],
+      "grams": [
+        90,
+        150
+      ],
+      "notes": "FIXED 2026-07-19 (hard assertion): COUNT OVER-BILL residual (Cluster A family). Was 336g = ~3x one serving; multi-piece serving ('3 tenders (~112g)') was billed per-piece x count. Fix = per-piece count seeds (chicken tender=37g, nugget=18g) in src/lib/servings/default-count-grams.ts so a counted piece uses a per-piece weight, not the whole portion. Now 3->111g (deterministic); 4oz control still 113g (n-mq-01)."
+    },
+    {
+      "id": "n-mq-22",
+      "category": "match_quality",
+      "text": "grilled chicken breast with white rice and broccoli",
+      "expectItems": 3,
+      "expectName": [
+        [
+          "chicken"
+        ]
+      ],
+      "macros": {
+        "protein100": [
+          25,
+          38
+        ]
+      },
+      "knownIssue": true,
+      "notes": "DEFECT (found 2026-07-19) — GENERIC MATCH QUALITY. PARTIALLY IMPROVED 2026-07-19: shipped lean-cut protein FLOOR (18g/100g, macro-plausibility.ts) which demoted the worst deli 'roll' (14.6p) -> now 'sliced chicken breast' 16.8p, but STILL below [25,38] because the real ~30g grilled-breast record is NOT retrieved for this phrasing (word-order-sensitive candidate gathering; 'chicken breast grilled' finds 29.5p but 'grilled chicken breast' does not). 'white rice' still resolves to 45g DRY vs ~150g cooked. REMAINING (deferred, own PR behind full eval): (a) cooked-default for bare staples [HIGH risk — cook-state-detector.ts is dead code, gather-candidates.ts:~516 auto-bypasses bare 'rice' to dry top1], (b) retrieval/rerank so the grilled-breast record enters the pool order-independently."
+    },
+    {
+      "id": "n-dens-01",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 tbsp sugar",
+        "quantity": 1,
+        "unit": "tbsp",
+        "name": "sugar",
+        "brand": "",
+        "normalizedForm": "sugar",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "sugar"
+        ]
+      ],
+      "grams": [
+        11,
+        14
+      ],
+      "notes": "Dry-solid density lock-in. Observed 12.75g (15ml x 0.85 sugar). Was 7.5g before the fix. Hard."
+    },
+    {
+      "id": "n-dens-02",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 cup sugar",
+        "quantity": 1,
+        "unit": "cup",
+        "name": "sugar",
+        "brand": "",
+        "normalizedForm": "sugar",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "sugar"
+        ]
+      ],
+      "grams": [
+        190,
+        215
+      ],
+      "notes": "Dry-solid density lock-in. Observed 204g (240ml x 0.85). Real 1 cup granulated sugar ~200g. Was 120g. Hard."
+    },
+    {
+      "id": "n-dens-03",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 tsp brown sugar",
+        "quantity": 1,
+        "unit": "tsp",
+        "name": "brown sugar",
+        "brand": "",
+        "normalizedForm": "brown sugar",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "sugar"
+        ]
+      ],
+      "grams": [
+        3.5,
+        5.5
+      ],
+      "notes": "Dry-solid density lock-in. Observed 4.25g (sugar category). Was 2.5g. Hard."
+    },
+    {
+      "id": "n-dens-04",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 cup flour",
+        "quantity": 1,
+        "unit": "cup",
+        "name": "flour",
+        "brand": "",
+        "normalizedForm": "flour",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "flour"
+        ]
+      ],
+      "grams": [
+        120,
+        135
+      ],
+      "notes": "Dry-solid density lock-in. Observed 127.2g (240ml x 0.53 flour). Real AP flour 1 cup ~125g. Light-powder side of the fix (barely moved from 120). Hard."
+    },
+    {
+      "id": "n-dens-05",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 cup rolled oats",
+        "quantity": 1,
+        "unit": "cup",
+        "name": "rolled oats",
+        "brand": "",
+        "normalizedForm": "rolled oats",
+        "mealType": "breakfast"
+      },
+      "expectName": [
+        [
+          "oat"
+        ]
+      ],
+      "grams": [
+        78,
+        95
+      ],
+      "notes": "Dry-solid density lock-in. Observed 86.4g (240ml x 0.36 oats). Real 1 cup rolled oats (dry) ~85g. Hard. (Cooked-oatmeal nutrition is a separate corpus gap, see n-cook-07.)"
+    },
+    {
+      "id": "n-dens-06",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 tbsp peanut butter",
+        "quantity": 1,
+        "unit": "tbsp",
+        "name": "peanut butter",
+        "brand": "",
+        "normalizedForm": "peanut butter",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "peanut"
+        ]
+      ],
+      "grams": [
+        14,
+        18
+      ],
+      "notes": "REGRESSION GUARD for the density fix. Peanut butter is isPaste (16g/tbsp), NOT allowlisted dry-granular, so the density change must NOT touch it. Observed 16g unchanged. Hard."
+    },
+    {
+      "id": "n-dens-07",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "1 tsp salt",
+        "quantity": 1,
+        "unit": "tsp",
+        "name": "salt",
+        "brand": "",
+        "normalizedForm": "salt",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "salt"
+        ]
+      ],
+      "grams": [
+        2,
+        3.5
+      ],
+      "notes": "REGRESSION GUARD for the density fix. 'salt' infers NO density category, so it must keep the flat 0.5 g/ml solid default (2.5g), not regress. Confirms uncategorized spices/salt are untouched. Hard."
+    },
+    {
+      "id": "n-cook-01",
+      "category": "match_quality",
+      "text": "1 cup cooked rice",
+      "expectName": [
+        [
+          "rice"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          120,
+          170
+        ],
+        "carbs100": [
+          26,
+          36
+        ]
+      },
+      "notes": "Lock-in. Cooked rice resolves to FDC 'brown parboiled cooked uncle bens rice' (kcal100=147, carbs100=31.3), STABLE across 3 rounds. Freezes correct cooked-grain behavior so a future cooked-vs-dry ranking change can't silently regress it."
+    },
+    {
+      "id": "n-cook-02",
+      "category": "match_quality",
+      "text": "1 cup cooked pasta",
+      "expectName": [
+        [
+          "pasta"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          110,
+          155
+        ],
+        "carbs100": [
+          20,
+          30
+        ]
+      },
+      "notes": "Lock-in. Cooked pasta -> FDC 'spinach cooked pasta' (kcal100=130, carbs100=25), record stable (grams wobble 150-200, macros stable). Hard."
+    },
+    {
+      "id": "n-cook-03",
+      "category": "match_quality",
+      "text": "1 cup cooked black beans",
+      "expectName": [
+        [
+          "bean"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          110,
+          150
+        ],
+        "carbs100": [
+          20,
+          29
+        ]
+      },
+      "notes": "Lock-in. Cooked black beans -> FDC 'black turtle...cooked' (kcal100=130, carbs100=24.4), stable. Legumes already resolve cooked (unlike grains). Hard."
+    },
+    {
+      "id": "n-cook-04",
+      "category": "match_quality",
+      "text": "1 cup white rice",
+      "expectName": [
+        [
+          "rice"
+        ]
+      ],
+      "macros": {
+        "carbs100": [
+          26,
+          36
+        ]
+      },
+      "knownIssue": true,
+      "notes": "DEFECT (cooked-vs-dry, 2026-07-19). Bare 'white rice' resolves to DRY OFF 'Rice' (kcal100=347, carbs100=81.6) instead of cooked. Isolates the rice half of n-mq-22. Band = observed cooked-rice carbs100 (31.3). Root cause: detectGrainCookingContext (filter-candidates.ts) ignores the unit + basic_produce_bypass (gather-candidates.ts:516) locks the dry top1. HIGH-risk fix (recipe 'cups' logged dry), deferred. knownIssue, non-gating."
+    },
+    {
+      "id": "n-cook-05",
+      "category": "match_quality",
+      "text": "1 cup cooked quinoa",
+      "expectName": [
+        [
+          "quinoa"
+        ]
+      ],
+      "macros": {
+        "carbs100": [
+          18,
+          28
+        ]
+      },
+      "knownIssue": true,
+      "notes": "DEFECT + CORPUS-BLOCKED. Explicit 'cooked quinoa' still returns FDC 'uncooked quinoa' (kcal100=368, carbs100=64.2) because NO cooked-quinoa record is retrievable. Band is a TARGET (cooked quinoa ~21g carb/100g), NOT observed-correct. Same root as n-serv-06's nutrition. Needs ingest, not ranking. knownIssue, non-gating."
+    },
+    {
+      "id": "n-cook-06",
+      "category": "match_quality",
+      "text": "1 cup cooked oats",
+      "expectName": [
+        [
+          "oat"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          45,
+          95
+        ]
+      },
+      "knownIssue": true,
+      "notes": "DEFECT + CORPUS-BLOCKED. 'cooked oats'/'oatmeal' returns DRY 'Rolled Oats' (kcal100=361) — no cooked-oatmeal record in corpus, explicit-cooked token ignored. Band is a TARGET (cooked oatmeal ~70 kcal/100g), NOT observed. Needs ingest. knownIssue, non-gating."
+    },
+    {
+      "id": "n-brand-02",
+      "category": "match_quality",
+      "text": "one bar birthday cake",
+      "expectName": [
+        [
+          "one",
+          "birthday"
+        ]
+      ],
+      "expectItems": 1,
+      "knownIssue": true,
+      "notes": "DEFECT (branded-competitor hijack, RANKING-FIXABLE). Maps to 'Birthday Cake' brand 'Cake Cup' (off_0810257005259); correct 'One Birthday Cake Protein bar' brand 'ONE Brands' (off_0788434107730) IS in corpus and tops the search. Same class as n-seg-21. Root: simple-rerank.ts brand match is only a tiebreaker behind a score short-circuit (:1452) + a weak +0.25 bonus. Fix risks 'one'/'ghost'/'built' generic-word over-fire; needs 2-gram brand guard. knownIssue, non-gating."
+    },
+    {
+      "id": "n-brand-03",
+      "category": "match_quality",
+      "text": "premier protein cafe latte",
+      "expectName": [
+        [
+          "premier"
+        ]
+      ],
+      "notes": "POSITIVE CONTROL (hard). Correctly maps to Premier Protein Cafe Latte (off_0643843759386, conf 0.98). Guards the blast radius of any future brand-gating fix — must stay green."
+    },
+    {
+      "id": "n-brand-04",
+      "category": "match_quality",
+      "text": "rxbar chocolate sea salt",
+      "expectName": [
+        [
+          "rxbar"
+        ]
+      ],
+      "notes": "POSITIVE CONTROL (hard). Correctly maps to Chocolate Sea Salt RXBAR (off_0193908007926, conf 0.98). Guards against brand-gate over-correction — must stay green."
+    },
+    {
+      "id": "n-brand-05",
+      "category": "match_quality",
+      "text": "c4 fruit punch pre workout",
+      "expectName": [
+        [
+          "c4"
+        ]
+      ],
+      "knownIssue": true,
+      "notes": "DEFECT (DETECTION + INGEST-BLOCKED). Bare 'c4' is NOT in brand-lexicon.json (only 'c4 energy'/'cellucor c4'), so isBranded/targetBrand never fire; degrades to generic 'fruit punch' (off_03855334, brand ''). No C4 SKU surfaced either. Needs a lexicon entry AND ingest before ranking could engage. knownIssue, non-gating."
+    },
+    {
+      "id": "n-brand-06",
+      "category": "match_quality",
+      "text": "bang cotton candy",
+      "expectName": [
+        [
+          "bang"
+        ]
+      ],
+      "knownIssue": true,
+      "notes": "DEFECT (DETECTION + INGEST-BLOCKED). 'bang' not in brand lexicon; maps to generic 'Cotton candy' (off_0609015727782, brand ''). Same class as n-brand-05. knownIssue, non-gating."
     }
   ]
 }

--- a/src/lib/mapping/__tests__/macro-plausibility.test.ts
+++ b/src/lib/mapping/__tests__/macro-plausibility.test.ts
@@ -268,4 +268,51 @@ describe('assessMacroPlausibility', () => {
         expect(assessMacroPlausibility('spinach', 'Spinach', null).plausible).toBe(true);
         expect(assessMacroPlausibility('spinach', 'Spinach', undefined).plausible).toBe(true);
     });
+
+    // ============================================================
+    // Lean-cut protein floor (golden n-mq-22)
+    // ============================================================
+    describe('lean-cut protein floor (n-mq-22)', () => {
+        it('flags a "grilled chicken breast" deli/roll record at 14.6g protein', () => {
+            const r = assessMacroPlausibility(
+                'grilled chicken breast',
+                'roll oven-roasted chicken breast',
+                { kcal: 134, protein: 14.6, carbs: 1.79, fat: 7.65 }
+            );
+            expect(r.plausible).toBe(false);
+            expect(r.impossible).toBe(false); // penalize, never drop
+            expect(r.penalty).toBe(IMPLAUSIBLE_MACRO_PENALTY);
+            expect(r.reasons.some(x => x.startsWith('category:lean_cut_protein_below_floor'))).toBe(true);
+        });
+
+        it('does NOT flag a real grilled chicken breast at 29.5g', () => {
+            const r = assessMacroPlausibility(
+                'grilled chicken breast',
+                'cooked grilled chicken breast',
+                { kcal: 165, protein: 29.5, carbs: 0, fat: 3.6 }
+            );
+            expect(r.plausible).toBe(true);
+        });
+
+        it('does NOT apply the cut-floor to legumes/tofu (uses >0 rule only)', () => {
+            const r = assessMacroPlausibility('tofu', 'Firm Tofu', { kcal: 76, protein: 8, carbs: 2, fat: 4.8 });
+            expect(r.plausible).toBe(true); // 8g is fine for tofu
+        });
+
+        it('still exempts chicken breast broth/soup from the floor', () => {
+            const r = assessMacroPlausibility('chicken breast broth', 'Chicken Broth', {
+                kcal: 4,
+                protein: 0.5,
+                carbs: 0.5,
+                fat: 0.1,
+            });
+            expect(r.reasons.some(x => x.includes('lean_cut'))).toBe(false);
+        });
+
+        it('does NOT apply the cut-floor to bare "chicken" (unscoped)', () => {
+            // generic "chicken" is not a named lean cut → floor must not fire
+            const r = assessMacroPlausibility('chicken', 'Chicken Nuggets', { kcal: 250, protein: 14, carbs: 15, fat: 15 });
+            expect(r.reasons.some(x => x.includes('lean_cut'))).toBe(false);
+        });
+    });
 });

--- a/src/lib/mapping/macro-plausibility.ts
+++ b/src/lib/mapping/macro-plausibility.ts
@@ -125,6 +125,18 @@ const MUST_HAVE_PROTEIN_PATTERN = new RegExp(
 const PROTEIN_EXEMPT_PATTERN =
     /\b(broth|stock|bouillon|seasonings?|flavou?r(?:ed|ing)?|extract|oil|fat|sauce|vinaigrette|dressing|marinade|rub|spice)\b/i;
 
+/**
+ * Lean animal-muscle cuts queried by name: cooked protein reliably >25g/100g,
+ * raw >20g. A "chicken breast" candidate at 14.6g protein is a deli/roll/luncheon
+ * product, not the muscle cut, and should be demoted. Deliberately scoped to
+ * poultry breast/thigh + specific red-meat cuts — NOT generic "chicken"/"fish"/
+ * bare "filet" (cod/haddock fillets legitimately sit near the floor).
+ */
+const LEAN_PROTEIN_CUT_PATTERN =
+    /\b(chicken breast|chicken thigh|turkey breast|pork chop|pork loin|pork tenderloin|beef tenderloin|sirloin|ribeye)\b/i;
+/** g protein/100g floor: below raw breast (~22) and cooked (~31), above deli rolls (~14-16). */
+const LEAN_CUT_PROTEIN_FLOOR = 18;
+
 /** Alcohol carries 7 kcal/g that never shows up in P/C/F — exempt from the high-side Atwater check. */
 const ALCOHOL_PATTERN =
     /\b(beer|wine|vodka|whiske?y|rum|gin|tequila|liqueur|brandy|cognac|sake|cider|cocktail|margarita|sangria|champagne|prosecco|bourbon|scotch|mead|soju|alcoholic?|spirits?|ale|lager|stout|ipa)\b/i;
@@ -248,6 +260,20 @@ export function assessMacroPlausibility(
         !PROTEIN_EXEMPT_PATTERN.test(combinedNames)
     ) {
         reasons.push(`category:protein_food_with_zero_protein`);
+    }
+
+    // 3c. Lean muscle cuts queried by name must clear a protein FLOOR. Catches the
+    //     "chicken breast" → deli/roll product (14.6g) case that 3b's >0 rule misses.
+    //     Soft-penalize (never drop): if the low-protein record is the only candidate
+    //     it still surfaces. Broth/soup/sauce stay exempt via PROTEIN_EXEMPT_PATTERN.
+    if (
+        protein != null &&
+        protein > 0 &&
+        protein < LEAN_CUT_PROTEIN_FLOOR &&
+        LEAN_PROTEIN_CUT_PATTERN.test(query) &&
+        !PROTEIN_EXEMPT_PATTERN.test(combinedNames)
+    ) {
+        reasons.push(`category:lean_cut_protein_below_floor(${round1(protein)})`);
     }
 
     if (reasons.length > 0) {

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -3417,15 +3417,37 @@ async function buildFdcResult(
     // Handle volume units - estimate grams based on typical density
     // Note: This is an approximation. Actual density varies by food.
     const isLiquid = /broth|stock|water|juice|milk|sauce|vinegar|oil|syrup/i.test(candidate.name) || /broth|stock|water|juice|milk|sauce|vinegar|oil|syrup/i.test(parsed?.name || '');
-    
+
+    // Resolve a food-specific density (g/ml) instead of a flat liquid/solid guess.
+    // The old binary split billed every non-liquid solid at 0.5 g/ml, which is fine
+    // for light powders (flour ~0.53, cocoa ~0.55) but under-weights DENSE solids by
+    // ~40%: granulated/brown sugar (~0.85), packed grains, etc. Reuse the category
+    // density table (density.ts) — the same one gramsForServing() already trusts — and
+    // only fall back to the old liquid=1.0 / solid=0.5 defaults when no category is
+    // inferred, so uncategorized spices (cinnamon) keep their correct ~0.5. (n-serv-14:
+    // "1 tsp sugar" 2.5g → 4.25g; "1 cup sugar" 120g → 204g.)
+    let densityGml = isLiquid ? 1.0 : 0.5;
+    try {
+        const { inferCategoryFromName, categoryDensity, DRY_GRANULE_DENSITY_CATEGORIES } = require('../units/density');
+        const inferredCategory = inferCategoryFromName(candidate.name) || inferCategoryFromName(parsed?.name || '');
+        // Only override for unambiguous dry-granular categories (sugar/flour/…) so
+        // cooked/dry-ambiguous grains and high-water foods keep the flat default.
+        if (inferredCategory && DRY_GRANULE_DENSITY_CATEGORIES.has(inferredCategory)) {
+            const catDensity = categoryDensity(inferredCategory);
+            if (catDensity && catDensity > 0) densityGml = catDensity;
+        }
+    } catch {
+        // density.ts unavailable — keep the flat liquid/solid default
+    }
+
     const volumeToGrams: Record<string, number> = {
-        'cup': isLiquid ? 240 : 120,      // 1 cup ≈ 240ml ≈ 240g for liquids, 120g for granular solids
-        'tbsp': isLiquid ? 15 : 7.5,     // 1 tbsp ≈ 15ml ≈ 15g for liquids, 7.5g for solids
-        'tablespoon': isLiquid ? 15 : 7.5, 'tablespoons': isLiquid ? 15 : 7.5,
-        'tsp': isLiquid ? 5 : 2.5,      // 1 tsp ≈ 5ml ≈ 5g for liquids, 2.5g for solids
-        'teaspoon': isLiquid ? 5 : 2.5, 'teaspoons': isLiquid ? 5 : 2.5,
-        'ml': 1,         // 1 ml ≈ 1g (for water-like liquids)
-        'floz': 30,      // 1 fl oz ≈ 30ml
+        'cup': 240 * densityGml,       // 1 cup ≈ 240ml × density
+        'tbsp': 15 * densityGml,       // 1 tbsp ≈ 15ml × density
+        'tablespoon': 15 * densityGml, 'tablespoons': 15 * densityGml,
+        'tsp': 5 * densityGml,         // 1 tsp ≈ 5ml × density
+        'teaspoon': 5 * densityGml, 'teaspoons': 5 * densityGml,
+        'ml': densityGml,              // 1 ml × density
+        'floz': 30 * densityGml,       // 1 fl oz ≈ 30ml × density
         // Micro-volume units (spice measures)
         'dash': 0.6,     // 1 dash ≈ 1/8 tsp ≈ 0.6ml ≈ 0.5-0.6g
         'dashes': 0.6,
@@ -3458,21 +3480,17 @@ async function buildFdcResult(
             try {
                 const { insertFdcAiServing } = await import('../usda/fdc-ai-backfill');
                 const aiResult = await insertFdcAiServing(fdcId, 'volume', { targetUnit: unit });
-                if (aiResult.success) {
-                    // Fetch the AI-created serving from cache
-                    const { prisma: prismaDb } = await import('../db');
-                    const aiServing = await prismaDb.fdcServing.findFirst({
-                        where: { fdcId, isAiEstimated: true },
-                        orderBy: { id: 'desc' },
+                // Use the grams the estimator computed for THIS unit. The old code
+                // re-read fdcServing by `orderBy id desc`, which ignored `unit` and
+                // grabbed an arbitrary AI serving — for honey (tbsp/tsp/cup all AI)
+                // that surfaced "1 tsp"=7g for a tbsp query. (n-serv-05)
+                if (aiResult.success && aiResult.grams && aiResult.grams > 0) {
+                    grams = qty * aiResult.grams;
+                    servingDescription = `${qty} ${unit}`;
+                    aiEstimated = true;
+                    logger.info('fdc.volume_ai_estimated', {
+                        foodName: candidate.name, unit, gramsPerUnit: aiResult.grams, totalGrams: grams,
                     });
-                    if (aiServing && aiServing.grams > 0) {
-                        grams = qty * aiServing.grams;
-                        servingDescription = `${qty} ${unit}`;
-                        aiEstimated = true;
-                        logger.info('fdc.volume_ai_estimated', {
-                            foodName: candidate.name, unit, gramsPerUnit: aiServing.grams, totalGrams: grams,
-                        });
-                    }
                 }
             } catch (err) {
                 logger.warn('fdc.volume_ai_failed', { foodName: candidate.name, unit, error: (err as Error).message });
@@ -3879,9 +3897,28 @@ async function buildOffResult(
     // Dense pastes/spreads (~1g/ml): the dry-goods 7.5g/tbsp default badly
     // undercounts them (2 tbsp peanut butter is ~32g, not 15g).
     const isPaste = !isLiquid && /butter|spread|hummus|yogurt|yoghurt|honey|mayo|mayonnaise|jam|jelly|nutella|tahini|cream cheese|sour cream|ricotta|paste|dressing|ketchup|mustard/i.test(candidate.name);
-    const cupG  = isLiquid ? 240 : isPaste ? 250 : 120;
-    const tbspG = isLiquid ? 15  : isPaste ? 16  : 7.5;
-    const tspG  = isLiquid ? 5   : isPaste ? 5.3 : 2.5;
+    // Dry-solid density (g/ml): prefer the food's category density (sugar 0.85,
+    // flour 0.53, oats 0.36, rice 0.85 …) over a flat 0.5, which under-weighted
+    // DENSE solids ~40% — granulated/brown sugar billed 2.5g/tsp instead of ~4.25g
+    // (n-serv-14). Uncategorized solids (salt, cinnamon) keep the 0.5 default, so
+    // light spices/powders don't regress. Liquids and pastes keep their tuned values.
+    let solidDensity = 0.5;
+    try {
+        const { inferCategoryFromName, categoryDensity, DRY_GRANULE_DENSITY_CATEGORIES } = require('../units/density');
+        const solidCategory = inferCategoryFromName(candidate.name);
+        // Only override for unambiguous dry-granular categories (sugar/flour/…);
+        // rice/grain/dairy stay at 0.5 to avoid overshooting cooked servings and
+        // tripping serving bands (n-serv-01/03/04).
+        if (solidCategory && DRY_GRANULE_DENSITY_CATEGORIES.has(solidCategory)) {
+            const solidCatDensity = categoryDensity(solidCategory);
+            if (solidCatDensity && solidCatDensity > 0) solidDensity = solidCatDensity;
+        }
+    } catch {
+        // density.ts unavailable — keep the flat 0.5 g/ml solid default
+    }
+    const cupG  = isLiquid ? 240 : isPaste ? 250 : 240 * solidDensity;
+    const tbspG = isLiquid ? 15  : isPaste ? 16  : 15 * solidDensity;
+    const tspG  = isLiquid ? 5   : isPaste ? 5.3 : 5 * solidDensity;
     const volumeToGrams: Record<string, number> = {
         'cup': cupG, 'cups': cupG,
         'tbsp': tbspG, 'tablespoon': tbspG, 'tablespoons': tbspG,

--- a/src/lib/servings/__tests__/default-count-grams.test.ts
+++ b/src/lib/servings/__tests__/default-count-grams.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit tests for the count-serving seed table (default-count-grams.ts).
+ *
+ * Anchored on golden n-mq-21: "3 real good chicken tenders" was billing
+ * 3 × 112g (the whole multi-piece portion) = 336g. A per-piece seed makes a
+ * counted tender resolve to ~37g, so 3 → 111g (within the golden 90-150 band).
+ */
+
+import { getDefaultCountServing } from '../default-count-grams';
+
+describe('getDefaultCountServing — breaded chicken pieces (n-mq-21)', () => {
+    it('resolves a per-piece weight for a multi-piece "portion" SKU', () => {
+        const r = getDefaultCountServing('real good chicken tenders', 'each');
+        expect(r).not.toBeNull();
+        expect(r!.key).toBe('chicken tender');
+        expect(r!.grams).toBe(37);
+        // 3 tenders → 111g, not 336g — inside the golden n-mq-21 band [90,150].
+        expect(r!.grams * 3).toBeGreaterThanOrEqual(90);
+        expect(r!.grams * 3).toBeLessThanOrEqual(150);
+    });
+
+    it('matches tender/finger/nugget aliases', () => {
+        expect(getDefaultCountServing('chicken fingers', 'each')!.key).toBe('chicken tender');
+        expect(getDefaultCountServing('chicken strips', 'each')!.key).toBe('chicken tender');
+        expect(getDefaultCountServing('chicken nuggets', 'each')!.key).toBe('chicken nugget');
+    });
+
+    it('does not hijack unrelated "strip"/"tender"/"tenderloin" foods', () => {
+        expect(getDefaultCountServing('steak strips', 'each')).toBeNull();
+        expect(getDefaultCountServing('beef tenderloin', 'each')).toBeNull();
+    });
+});

--- a/src/lib/servings/default-count-grams.ts
+++ b/src/lib/servings/default-count-grams.ts
@@ -124,6 +124,13 @@ const COUNT_DEFAULTS: Record<string, SeedEntry> = {
     'chicken thigh': { grams: 116, confidence: 0.85, aliases: ['chicken thighs'] },
     'chicken wing': { grams: 34, confidence: 0.85, aliases: ['chicken wings', 'wing'] },
     'chicken skin': { grams: 15, confidence: 0.85, aliases: ['chicken skins', 'skin'] },
+    // Breaded chicken pieces: the label serving is often a multi-piece "portion"
+    // (e.g. Real Good "1 portion (112g)" ≈ 3 tenders), so a counted piece must use a
+    // per-piece weight, NOT the whole portion — otherwise "3 tenders" bills 3×112=336g.
+    // ~37g/tender matches USDA breaded chicken strip. Fully-qualified `chicken …`
+    // aliases only, so "steak strips"/"beef tenderloin" can't be hijacked. (n-mq-21)
+    'chicken tender': { grams: 37, confidence: 0.85, aliases: ['chicken tenders', 'chicken strip', 'chicken strips', 'chicken finger', 'chicken fingers', 'chicken tenderloin', 'chicken tenderloins'] },
+    'chicken nugget': { grams: 18, confidence: 0.85, aliases: ['chicken nuggets'] },
     'bacon strip': { grams: 12, confidence: 0.85, aliases: ['bacon strips', 'strip bacon', 'bacon slice'] },
     'sausage link': { grams: 45, confidence: 0.8, aliases: ['sausage links', 'breakfast sausage'] },
     'sausage patty': { grams: 27, confidence: 0.8, aliases: ['sausage patties'] },

--- a/src/lib/units/density.ts
+++ b/src/lib/units/density.ts
@@ -99,6 +99,21 @@ export function categoryDensity(categoryId?: string | null): number | undefined 
     CATEGORY_DENSITY_GML[categoryId.toLowerCase()];
 }
 
+// Categories whose volume→grams density is unambiguous for a DRY, granular solid.
+// Gates the volume conversion in the mapper: applying category density to THESE
+// corrects dense dry solids (sugar billed 2.5g/tsp → 4.25g, n-serv-14) without
+// disturbing categories where a volume→grams bump collides with something else:
+//   - rice/grain/legume: cooked-vs-dry nutrition ambiguity — a bigger dry-cup weight
+//     compounds a wrong cooked/dry record pick (n-mq-22), and dry-grain density
+//     overshoots cooked servings (cooked-rice cup 204g > real ~180g).
+//   - dairy/cheese/protein/vegetable/fruit/condiment/liquid/beverage: high-water
+//     foods that should use liquid/paste/label servings, not a granular-solid density.
+// Uncategorized solids (salt, cinnamon) and the excluded categories keep the flat
+// 0.5 g/ml solid default, so nothing that was calibrated to it regresses.
+export const DRY_GRANULE_DENSITY_CATEGORIES: ReadonlySet<Category> = new Set<Category>([
+  'sugar', 'flour', 'starch', 'oats', 'powder', 'whey', 'nut', 'seed',
+]);
+
 /**
  * Resolve density with metadata about source (for user alerts)
  */

--- a/src/lib/usda/fdc-ai-backfill.ts
+++ b/src/lib/usda/fdc-ai-backfill.ts
@@ -145,7 +145,7 @@ export async function insertFdcAiServing(
     fdcId: number,
     gapType: ServingGapType,
     options: InsertFdcAiServingOptions = {}
-): Promise<{ success: boolean; reason?: string }> {
+): Promise<{ success: boolean; reason?: string; grams?: number; servingLabel?: string }> {
     const food = await prisma.fdcFood.findUnique({
         where: { fdcId },
         include: { servings: true },
@@ -261,5 +261,9 @@ export async function insertFdcAiServing(
         fdcId: String(fdcId), gapType, label: suggestion.servingLabel,
     });
 
-    return { success: true };
+    // Return the grams we just computed for THIS requested unit. Callers must use
+    // this rather than re-reading the fdcServing table by id — a food can have
+    // several AI volume servings (tbsp/tsp/cup) and an id-ordered readback would
+    // grab an arbitrary one, decoupling the result from the requested unit. (honey tbsp→7g bug)
+    return { success: true, grams: suggestion.grams, servingLabel: suggestion.servingLabel };
 }


### PR DESCRIPTION
## Summary
- Fixes a flat 0.5 g/ml volume→grams default that under-weighted dense dry solids ~40% (sugar 2.5g/tsp → 4.25g), gated on a new density-category allowlist so cooked/dry-ambiguous grains and high-water foods don't regress.
- Folds in prior-session fixes: honey/volume-readback bug (fdc-ai-backfill), chicken-tender count-serving seed, lean-cut protein floor in the macro-plausibility gate.
- Expands the golden eval set by 19 cases from a live characterization pass: density lock-ins/regression guards, a newly-characterized cooked-vs-dry staples defect class, and a brand-hijack ranking gap (split into ranking-fixable vs ingest-blocked).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] New unit tests (`default-count-grams.test.ts`, lean-cut protein cases) green
- [x] Deployed to Mini-PC (build + `systemctl --user restart recipe-api.service`), live density values verified via direct API probes
- [x] Full golden eval against live API: **0 real failures** (search 102/105, nlp 175/188, remainder documented `knownIssue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dRPkKAwFmtkC4427YcA2a