### PR TITLE
Phase 0 flywheel: MappingEventLog telemetry, nocache cold-run flag, billed-total eval assertions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,11 @@ TYPESENSE_API_KEY=xyzapikey
 # `vector` extension and populated OffFood.embedding column.
 SEMANTIC_SEARCH_ENABLED=false
 
+# Per-line mapping telemetry (MappingEventLog table) written by /api/nlp/parse:
+# cache hit/escape, serving-resolution tier, billed totals, latency. Default on;
+# set to "false" to disable writes (reads/analytics unaffected).
+MAPPING_EVENT_LOG_ENABLED=true
+
 # OpenFoodFacts Configuration
 # Enable/disable OpenFoodFacts candidate search (default: true)
 OFF_ENABLED=true

--- a/prisma/migrations/20260719150000_add_mapping_event_log/migration.sql
+++ b/prisma/migrations/20260719150000_add_mapping_event_log/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "MappingEventLog" (
+    "id" TEXT NOT NULL,
+    "rawLine" TEXT NOT NULL,
+    "normalizedForm" TEXT,
+    "cacheHit" TEXT,
+    "cacheEscape" TEXT,
+    "foodId" TEXT,
+    "foodName" TEXT,
+    "brandName" TEXT,
+    "source" TEXT,
+    "confidence" DOUBLE PRECISION,
+    "servingTier" TEXT,
+    "grams" DOUBLE PRECISION,
+    "totalKcal" DOUBLE PRECISION,
+    "latencyMs" INTEGER,
+    "noCache" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MappingEventLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MappingEventLog_createdAt_idx" ON "MappingEventLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "MappingEventLog_normalizedForm_idx" ON "MappingEventLog"("normalizedForm");
+
+-- CreateIndex
+CREATE INDEX "MappingEventLog_cacheHit_idx" ON "MappingEventLog"("cacheHit");
+
+-- CreateIndex
+CREATE INDEX "MappingEventLog_servingTier_idx" ON "MappingEventLog"("servingTier");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -655,6 +655,35 @@ model NlpRequestLog {
   @@map("nlp_requests_log")
 }
 
+/// Per-line mapping telemetry (Phase 0 of the cache-accuracy flywheel).
+/// One row per ingredient line handled by /api/nlp/parse: which cache path
+/// served it, which serving-resolution tier billed the grams, and the billed
+/// totals — ground truth for warming corpora, tier-coverage audits, and
+/// cold-vs-warm parity runs.
+model MappingEventLog {
+  id             String   @id @default(cuid())
+  rawLine        String
+  normalizedForm String?  // mapper's cache key input (post-normalization), not the segmenter hint
+  cacheHit       String?  // 'early' | 'normalized'; null = full pipeline resolved it
+  cacheEscape    String?  // reason a cached row was bypassed (core_token_mismatch, grain_cooked, ...)
+  foodId         String?
+  foodName       String?
+  brandName      String?
+  source         String?  // fdc | openfoodfacts | ai_estimated
+  confidence     Float?
+  servingTier    String?  // gram-resolution branch that billed (weight_unit, label_count_derived, flat_100g_default, ...)
+  grams          Float?
+  totalKcal      Float?
+  latencyMs      Int?
+  noCache        Boolean  @default(false) // request ran with the admin nocache flag (cold run)
+  createdAt      DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([normalizedForm])
+  @@index([cacheHit])
+  @@index([servingTier])
+}
+
 // ============================================================================
 // Enums
 // ============================================================================

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams — the RESOLVED serving weight). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect — its failure is EXPECTED, reported as 🟡, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise.",
+  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams — the RESOLVED serving weight), optional total (band on items[0].nutrition — the BILLED totals for the requested quantity; keys calories/protein/carbs/fat/fiber/sugar/sodium). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect — its failure is EXPECTED, reported as 🟡, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise.",
   "search": [
     {
       "id": "s-gen-01",
@@ -5080,6 +5080,131 @@
       ],
       "knownIssue": true,
       "notes": "DEFECT (DETECTION + INGEST-BLOCKED). 'bang' not in brand lexicon; maps to generic 'Cotton candy' (off_0609015727782, brand ''). Same class as n-brand-05. knownIssue, non-gating."
+    },
+    {
+      "id": "n-tot-01",
+      "category": "total_macros",
+      "item": {
+        "rawText": "1 tbsp olive oil",
+        "quantity": 1,
+        "unit": "tbsp",
+        "name": "olive oil"
+      },
+      "expectName": [
+        [
+          "olive oil"
+        ],
+        [
+          "oil"
+        ]
+      ],
+      "total": {
+        "calories": [
+          100,
+          140
+        ],
+        "fat": [
+          11,
+          16
+        ]
+      },
+      "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). First end-to-end billed-total case: 1 tbsp (~13.5-15g) of ~884kcal/100g oil must bill ~119-133 kcal. Catches wrong-record, wrong-density, and wrong-scaling failures that the per-100g fat band (n-gen-05) is blind to."
+    },
+    {
+      "id": "n-tot-02",
+      "category": "total_macros",
+      "item": {
+        "rawText": "1 cup white rice",
+        "quantity": 1,
+        "unit": "cup",
+        "name": "white rice"
+      },
+      "expectName": [
+        [
+          "rice"
+        ]
+      ],
+      "total": {
+        "calories": [
+          160,
+          260
+        ]
+      },
+      "knownIssue": true,
+      "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). Volume-unit grain prefers a COOKED basis (PR #104): ~158g cooked at ~130kcal/100g bills ~205 kcal; band [160,260] also rejects dry-basis billing (300+). DEFECT FOUND AT AUTHORING (live, stable, conf 1.0): 'white rice' serves cached FoodMapping row -> FDC 'brown parboiled cooked uncle bens rice', 195-200g, ~287-294 kcal. Wrong-record hijack the grams band can't see: record IS cooked (so the grain-cooked cache escape correctly stays quiet) but is BROWN parboiled branded rice for a WHITE rice query — the white/brown modifier is not treated as critical. Fix path: Phase 2 identity audit purges the row + white-vs-brown modifier guard; promote to hard once stable."
+    },
+    {
+      "id": "n-tot-03",
+      "category": "total_macros",
+      "item": {
+        "rawText": "1 quest protein bar",
+        "quantity": 1,
+        "unit": "",
+        "name": "quest protein bar"
+      },
+      "expectName": [
+        [
+          "quest"
+        ],
+        [
+          "protein bar"
+        ]
+      ],
+      "total": {
+        "calories": [
+          140,
+          230
+        ],
+        "protein": [
+          14,
+          25
+        ]
+      },
+      "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). Unitless count of a discrete branded bar (~60g, ~180-200 kcal, ~20g protein). Exercises the inferDiscreteUnit('bar') backfill / label-serving tier; the flat-100g failure mode bills ~330 kcal and the count-explosion mode even more — both outside band."
+    },
+    {
+      "id": "n-tot-04",
+      "category": "total_macros",
+      "item": {
+        "rawText": "1 mission carb balance tortilla",
+        "quantity": 1,
+        "unit": "",
+        "name": "mission carb balance tortilla"
+      },
+      "expectName": [
+        [
+          "carb balance"
+        ],
+        [
+          "mission",
+          "tortilla"
+        ]
+      ],
+      "total": {
+        "calories": [
+          50,
+          120
+        ]
+      },
+      "knownIssue": true,
+      "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). A Carb Balance flour tortilla is ~42-45g and ~70-80 kcal (high-fiber net-carb product). OBSERVED AT AUTHORING (live): grams resolve CORRECTLY (45g) but billed only 31.5 kcal — the OFF record ('Mission, carb, balance, tortilla') stores ~70 kcal as PER-100G when it is really the PER-SERVING(45g) value, i.e. the per-serving-as-100g ingest corruption class (n-mq-20). So the defect here is nutrition DATA, on top of the known 'tortilla'-missing-from-LABEL_COUNT_PIECE_NOUNS lexicon gap. Fix path: Phase 2 nutritional-plausibility audit (a 155kcal/100g tortilla stored at 70 fails the category prior) + n-mq-20 ingest cross-check. Promote to hard once it passes 3 consecutive runs."
+    },
+    {
+      "id": "n-tot-05",
+      "category": "total_macros",
+      "text": "13 tortilla chips",
+      "expectName": [
+        [
+          "chip"
+        ]
+      ],
+      "total": {
+        "calories": [
+          130,
+          320
+        ]
+      },
+      "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). Companion to n-serv-35 (same query, grams band): asserts the BILLED kcal for a 13-count chip line (~28-70g of ~490-530kcal/100g chips → 140-350 kcal; band trimmed to reject edge inflation). The flat-100g failure bills ~500 kcal and the 13x100g count explosion ~6500 — both far outside band. Short text takes the single-item fast path, no LLM segmentation cost."
     }
   ]
 }

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -153,6 +153,22 @@ async function runNlpCase(c: any): Promise<CaseResult> {
             }
         }
 
+        // Billed totals for the requested quantity — the grams-scaled `nutrition`
+        // block the app actually logs. This is the end-to-end assertion a per-100g
+        // band can't provide: a wrong record, wrong serving, or wrong scaling all
+        // surface as a wrong billed total ("1 tbsp olive oil" must bill ~119 kcal,
+        // whether the failure was density, record choice, or grams math).
+        // Keys: calories | protein | carbs | fat (also fiber/sugar/sodium).
+        if (c.total) {
+            const tot = items[0]?.nutrition ?? {};
+            for (const [key, range] of Object.entries(c.total) as [string, [number, number]][]) {
+                const v = tot[key];
+                if (typeof v !== 'number' || v < range[0] || v > range[1]) {
+                    failures.push(`total.${key}=${typeof v === 'number' ? v.toFixed(1) : v} outside [${range[0]}, ${range[1]}] (grams=${items[0]?.grams}, mapped: "${items[0]?.foodName}")`);
+                }
+            }
+        }
+
         const confidence = items[0]?.matchConfidence;
         return {
             id: c.id, kind: 'nlp', category: c.category, query,

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -166,6 +166,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Either "text" (string) or "items" (array) field is required' }, { status: 400 });
     }
 
+    // Cold-run flag for cache audits (Phase 0 flywheel): bypasses BOTH
+    // FoodMapping cache layers so cold-vs-warm parity runs measure the full
+    // pipeline. Admin-only — regular users must never pay cold latency.
+    const noCache = isDevBypass &&
+      (req.nextUrl.searchParams.get('nocache') === '1' || body.nocache === true);
+
     let items: Array<{ rawText: string; mealType: 'breakfast' | 'lunch' | 'dinner' | 'snacks'; brand?: string; normalizedForm?: string }> = [];
 
     if (inputItems && Array.isArray(inputItems)) {
@@ -274,6 +280,18 @@ Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs"
         }
       }
     }
+    // Per-line telemetry rows (MappingEventLog), written in one createMany
+    // after mapping. Fail-open: telemetry must never break a user request.
+    type EventRow = {
+      rawLine: string; normalizedForm: string | null; cacheHit: string | null;
+      cacheEscape: string | null; foodId: string | null; foodName: string | null;
+      brandName: string | null; source: string | null; confidence: number | null;
+      servingTier: string | null; grams: number | null; totalKcal: number | null;
+      latencyMs: number; noCache: boolean;
+    };
+    const eventRows: EventRow[] = [];
+    const telemetryEnabled = process.env.MAPPING_EVENT_LOG_ENABLED !== 'false';
+
     // Map all items concurrently — each mapping is independent, and identical
     // items are deduplicated by the pipeline's in-flight lock.
     const parsedItems = await Promise.all(items.map(async (item) => {
@@ -286,10 +304,35 @@ Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs"
       const qty = parsed?.qty ?? 1;
       const unit = parsed?.unit ?? '';
 
+      const telemetry: import('@/lib/mapping/map-ingredient-with-fallback').MappingTelemetry = {};
+      const mapStart = Date.now();
       const mapped = await mapIngredientWithFallback(rawText, {
         brand: brand || undefined,
-        normalizedForm: normalizedForm || undefined
+        normalizedForm: normalizedForm || undefined,
+        skipCache: noCache,
+        telemetry,
       });
+      const mapLatencyMs = Date.now() - mapStart;
+      const isMapped = !!mapped && !('status' in mapped);
+      if (telemetryEnabled) {
+        eventRows.push({
+          rawLine: rawText,
+          normalizedForm: telemetry.normalizedForm ?? null,
+          cacheHit: telemetry.cacheHit ?? null,
+          cacheEscape: telemetry.cacheEscape ?? null,
+          foodId: isMapped ? (mapped as any).foodId : null,
+          foodName: isMapped ? (mapped as any).foodName : null,
+          brandName: isMapped ? ((mapped as any).brandName ?? null) : null,
+          source: isMapped ? (mapped as any).source : null,
+          confidence: isMapped ? (mapped as any).confidence : null,
+          servingTier: isMapped ? ((mapped as any).servingTier ?? null) : null,
+          grams: isMapped ? (mapped as any).grams : null,
+          totalKcal: isMapped ? (mapped as any).kcal : null,
+          latencyMs: mapLatencyMs,
+          noCache,
+        });
+      }
+
       if (!mapped || 'status' in mapped) {
         return {
           rawText,
@@ -366,6 +409,16 @@ Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs"
         servingOptions: details.servingOptions,
       };
     }));
+
+    // One round trip for all lines; awaited so serverless runtimes can't kill
+    // the write after the response, but failures never fail the request.
+    if (eventRows.length > 0) {
+      try {
+        await prisma.mappingEventLog.createMany({ data: eventRows });
+      } catch (telemetryErr) {
+        console.warn('[nlp-parse] MappingEventLog write failed (non-fatal):', telemetryErr);
+      }
+    }
 
     return NextResponse.json(parsedItems);
   } catch (error) {

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -168,7 +168,29 @@ export type FatsecretMappedIngredient = {
         category?: string;
         detectedIssues?: string[];
     };
+    /**
+     * Gram-resolution branch that billed this result (weight_unit,
+     * label_count_derived, flat_100g_default, ...). Recorded in
+     * MappingEventLog; undefined on the legacy fatsecret/ai serving path.
+     */
+    servingTier?: string;
 };
+
+/**
+ * Telemetry sink for MappingEventLog: the caller passes an empty object via
+ * options and the mapper mutates it with cache-path facts (which cache layer
+ * served the line, or why a cached row was bypassed). Mutation-based so the
+ * facts survive the mapper's many internal return paths without threading
+ * them through every result construction.
+ */
+export interface MappingTelemetry {
+    /** The mapper's own cache-key input (post-normalization), not the segmenter hint. */
+    normalizedForm?: string;
+    /** Set when a FoodMapping row served the line: which cache layer hit. */
+    cacheHit?: 'early' | 'normalized';
+    /** Set when a cached row existed but was bypassed: 'early:grain_cooked', 'normalized:core_token_mismatch', ... */
+    cacheEscape?: string;
+}
 
 /**
  * Returned when skipOnLock is true and the ingredient is currently locked.
@@ -195,6 +217,8 @@ export interface MapIngredientOptions {
     skipOnLock?: boolean;
     brand?: string;
     normalizedForm?: string;
+    /** Optional telemetry sink — mutated with cache-path facts (see MappingTelemetry). */
+    telemetry?: MappingTelemetry;
 }
 
 const ENABLE_MAPPING_ANALYSIS = process.env.ENABLE_MAPPING_ANALYSIS === 'true';
@@ -216,6 +240,7 @@ export async function mapIngredientWithFallback(
         _skipInFlightLock = false,
         _skipFallback = false,
         skipOnLock = false,
+        telemetry,
     } = options;
 
     const trimmed = rawLine.trim();
@@ -541,6 +566,7 @@ export async function mapIngredientWithFallback(
         // ============================================================
         // Check ValidatedMapping for normalized name BEFORE calling AI
         // This is the key optimization: "1 cup chopped onion" → normalized "onion" → cache hit!
+        if (telemetry) telemetry.normalizedForm = normalizedName;
         const earlyCacheHit = skipCache ? null : await getValidatedMappingByNormalizedName(normalizedName, 'fatsecret', trimmed);
         if (earlyCacheHit) {
             logger.info('mapping.early_cache_hit', { rawLine: trimmed, normalizedName, foodName: earlyCacheHit.foodName });
@@ -698,6 +724,14 @@ export async function mapIngredientWithFallback(
                     countLabelEscape: earlyCountLabelEscape,
                     grainCookedEscape: earlyGrainCookedEscape,
                 });
+                if (telemetry) {
+                    telemetry.cacheEscape = 'early:' + (
+                        earlyCoreTokenMismatch ? 'core_token_mismatch'
+                        : earlyNutritionInvalid ? 'nutrition_invalid'
+                        : earlyCountLabelEscape ? 'count_label'
+                        : earlyGrainCookedEscape ? 'grain_cooked'
+                        : 'filter_mismatch');
+                }
                 // Fall through to normal search - don't use stale cached mapping
             } else {
                 // Create synthetic candidate from cached result
@@ -723,6 +757,7 @@ export async function mapIngredientWithFallback(
                 if (hydratedResult) {
                     // Track cache hit for metrics
                     incrementCacheHit();
+                    if (telemetry) telemetry.cacheHit = 'early';
 
                     // Log the early cache hit
                     if (ENABLE_MAPPING_ANALYSIS) {
@@ -911,7 +946,11 @@ export async function mapIngredientWithFallback(
         // Step 1c: Check validated cache for normalized name (User Optimization)
         // "1 cup chopped onion" -> normalized "onion" -> checks cache for "onion"
         if (!winner) {
-            const normalizedCache = await getValidatedMappingByNormalizedName(normalizedName, 'fatsecret', trimmed);
+            if (telemetry) telemetry.normalizedForm = normalizedName;
+            // skipCache must gate this layer too — without it a "cold" (nocache)
+            // run would still serve cached rows via step 1c and parity runs
+            // against the cache would be meaningless.
+            const normalizedCache = skipCache ? null : await getValidatedMappingByNormalizedName(normalizedName, 'fatsecret', trimmed);
             if (normalizedCache) {
                 logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
                 const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);
@@ -1034,6 +1073,14 @@ export async function mapIngredientWithFallback(
                         coreTokenMismatch: normalizedCoreTokenMismatch,
                         nutritionInvalid: normalizedNutritionInvalid,
                     });
+                    if (telemetry) {
+                        telemetry.cacheEscape = 'normalized:' + (
+                            normalizedCoreTokenMismatch ? 'core_token_mismatch'
+                            : normalizedNutritionInvalid ? 'nutrition_invalid'
+                            : normalizedCountLabelEscape ? 'count_label'
+                            : normalizedGrainCookedEscape ? 'grain_cooked'
+                            : 'filter_mismatch');
+                    }
                 } else {
                     winner = {
                         id: normalizedCache.foodId,
@@ -1046,6 +1093,7 @@ export async function mapIngredientWithFallback(
                     };
                     confidence = normalizedCache.confidence;
                     selectionReason = 'normalized_cache_hit';
+                    if (telemetry) telemetry.cacheHit = 'normalized';
                 }
             }
 
@@ -1661,6 +1709,7 @@ export async function mapIngredientWithFallback(
                         confidence: aiResult.confidence * 0.8,  // Penalize slightly vs API matches
                         quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
                         rawLine,
+                        servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
                     };
 
                     if (ENABLE_MAPPING_ANALYSIS) {
@@ -2075,6 +2124,7 @@ export async function mapIngredientWithFallback(
                         confidence: aiResult.confidence * 0.8,
                         quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
                         rawLine,
+                        servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
                     };
 
                     if (ENABLE_MAPPING_ANALYSIS) {
@@ -3441,6 +3491,7 @@ async function buildFdcResult(
                 confidence,
                 quality: confidence >= 0.8 ? 'high' : confidence >= 0.6 ? 'medium' : 'low',
                 rawLine,
+                servingTier: 'fdc_unit_heuristic',
             };
         }
     }
@@ -3504,12 +3555,16 @@ async function buildFdcResult(
 
     let grams: number = 100 * qty;
     let servingDescription: string = `${grams.toFixed(1)}g`;
+    // Telemetry: which branch below billed the grams (MappingEventLog.servingTier).
+    // Starts at the flat default; every resolving branch overwrites it.
+    let servingTier = 'flat_100g_default';
 
     if (unit && weightToGrams[unit]) {
         // Unit is a weight unit - convert qty to grams
         // e.g., "16 oz" → 16 * 28.35 = 453.6g
         grams = qty * weightToGrams[unit];
         servingDescription = `${grams.toFixed(1)}g`;
+        servingTier = 'weight_unit';
     } else if (unit && volumeToGrams[unit]) {
         // Unit is a volume unit - try AI estimation first for food-specific density
         const fdcId = parseInt(candidate.id.replace('fdc_', ''), 10);
@@ -3527,6 +3582,7 @@ async function buildFdcResult(
                     grams = qty * aiResult.grams;
                     servingDescription = `${qty} ${unit}`;
                     aiEstimated = true;
+                    servingTier = 'fdc_volume_ai';
                     logger.info('fdc.volume_ai_estimated', {
                         foodName: candidate.name, unit, gramsPerUnit: aiResult.grams, totalGrams: grams,
                     });
@@ -3540,6 +3596,7 @@ async function buildFdcResult(
             // Fallback to hardcoded density estimate
             grams = qty * volumeToGrams[unit];
             servingDescription = `${qty} ${unit}`;
+            servingTier = 'volume_unit';
             logger.info('fdc.volume_hardcoded_fallback', {
                 foodName: candidate.name, unit, gramsPerUnit: volumeToGrams[unit], totalGrams: grams,
             });
@@ -3554,6 +3611,7 @@ async function buildFdcResult(
             const gramsPerUnit = unit ? sizes[unit] : undefined;
             grams = qty * (gramsPerUnit ?? 100);
             servingDescription = `${qty} ${unit} (${gramsPerUnit}g each)`;
+            servingTier = 'fdc_size_qualifier';
             logger.info('fdc.size_qualifier_resolved', {
                 foodName: candidate.name,
                 size: unit,
@@ -3604,6 +3662,7 @@ async function buildFdcResult(
                         grams = qty * subPieceDefault.grams;
                         servingDescription = `${qty} ${unitHint}s (${subPieceDefault.grams}g each)`;
                         resolved = true;
+                        servingTier = 'fdc_sub_piece_default';
                         logger.info('fdc.sub_piece_default_applied', {
                             foodName: candidate.name,
                             parsedName: cleanItemName,
@@ -3638,6 +3697,7 @@ async function buildFdcResult(
                         grams = qty * gramsPerPiece;
                         servingDescription = `${qty} pieces (${gramsPerPiece}g each)`;
                         resolved = true;
+                        servingTier = 'fdc_piece_ai';
                         logger.info('fdc.unitless_piece_resolved', {
                             foodName: candidate.name,
                             parsedName: itemName,
@@ -3663,6 +3723,7 @@ async function buildFdcResult(
                     const gramsPerUnit = sizes['medium'];
                     grams = qty * gramsPerUnit;
                     servingDescription = `${qty} medium (${gramsPerUnit}g each)`;
+                    servingTier = 'fdc_medium_estimate';
                     logger.info('fdc.unitless_medium_resolved', {
                         foodName: candidate.name,
                         gramsPerUnit,
@@ -3692,6 +3753,7 @@ async function buildFdcResult(
                 
                 grams = qty * gramsPerUnit;
                 servingDescription = `${qty} ${hasMiniModifier ? 'mini' : targetSize} (${gramsPerUnit}g each)`;
+                servingTier = 'fdc_size_estimate';
                 logger.info('fdc.unitless_size_resolved', {
                     foodName: candidate.name,
                     sizeUsed: targetSize,
@@ -3721,6 +3783,7 @@ async function buildFdcResult(
             const gramsPerUnit = ambiguousResult.grams!;
             grams = qty * gramsPerUnit;
             servingDescription = `${qty} ${unit} (${gramsPerUnit}g each)`;
+            servingTier = ambiguousResult.status === 'cached' ? 'count_unit_cached' : 'count_unit_ai';
             logger.info('fdc.ambiguous_unit_resolved', {
                 foodName: candidate.name,
                 unit,
@@ -3757,6 +3820,7 @@ async function buildFdcResult(
                 });
                 grams = bareDefault.grams;
                 servingDescription = bareDefault.description;
+                servingTier = 'bare_query_default';
             }
         } catch (err) {
             // Ignore
@@ -3820,6 +3884,7 @@ async function buildFdcResult(
         confidence,
         quality: confidence >= 0.8 ? 'high' : confidence >= 0.6 ? 'medium' : 'low',
         rawLine,
+        servingTier,
     };
 }
 
@@ -3968,6 +4033,8 @@ async function buildOffResult(
 
     let grams: number | null = null;
     let servingDescription: string | null = null;
+    // Telemetry: which branch below billed the grams (MappingEventLog.servingTier).
+    let servingTier: string | undefined;
     // Set when the item is a unitless integer count ("15 pretzels") for which no
     // per-piece weight could be resolved (no seed, no discrete-unit backfill, no
     // genuine label serving). Such counts must NOT bill the 100g no-serving
@@ -4021,15 +4088,18 @@ async function buildOffResult(
     if (unit && weightToGrams[unit]) {
         grams = qty * weightToGrams[unit];
         servingDescription = `${grams.toFixed(1)}g`;
+        servingTier = 'weight_unit';
     } else if (unit && volumeToGrams[unit]) {
         grams = qty * volumeToGrams[unit];
         servingDescription = `${qty} ${unit}`;
+        servingTier = 'volume_unit';
     } else if (unit && labelUnitWord && perLabelUnitGrams && singularizeUnit(unit) === labelUnitWord) {
         // Requested unit matches the product's OWN label serving unit — the label
         // is authoritative for THIS product. Use per-unit grams (label grams /
         // label unit-count) so a "2 scoops (46g)" tub yields 23g/scoop, not 46g.
         grams = qty * perLabelUnitGrams;
         servingDescription = `${qty} ${unit} (${perLabelUnitGrams.toFixed(1)}g each)`;
+        servingTier = 'label_unit_match';
         logger.info('off.build_result.label_unit_matched', {
             foodId: candidate.id,
             unit,
@@ -4039,6 +4109,7 @@ async function buildOffResult(
     } else if (unit && PACKAGE_LIKE_UNITS.has(unit) && hydrated.servingGrams && hydrated.servingGrams > 0) {
         grams = qty * hydrated.servingGrams;
         servingDescription = `${qty} ${unit} (${hydrated.servingGrams}g each)`;
+        servingTier = 'label_serving_package_unit';
     } else if (unit && PACKAGE_LIKE_UNITS.has(unit) && packageFallbackGrams != null) {
         // Package-like unit with NO label serving ("1 bottle gatorade" on a
         // SKU without servingGrams): the SKU's own net quantity — or the
@@ -4047,6 +4118,7 @@ async function buildOffResult(
         // no-serving default.
         grams = qty * packageFallbackGrams;
         servingDescription = `${qty} ${unit} (${packageFallbackGrams.toFixed(0)}g each)`;
+        servingTier = packageGrams != null ? 'package_quantity_own' : 'package_quantity_sibling';
         logger.info('off.build_result.package_quantity_fallback', {
             foodId: candidate.id,
             unit,
@@ -4063,6 +4135,7 @@ async function buildOffResult(
             && ambiguous.grams && ambiguous.grams > 0) {
             grams = qty * ambiguous.grams;
             servingDescription = `${qty} ${unit} (${ambiguous.grams.toFixed(1)}g each)`;
+            servingTier = ambiguous.status === 'cached' ? 'count_unit_cached' : 'count_unit_ai';
             logger.info('off.build_result.unit_serving_resolved', {
                 foodId: candidate.id,
                 unit,
@@ -4101,6 +4174,7 @@ async function buildOffResult(
         ) {
             grams = qty * perLabelUnitGrams;
             servingDescription = `${qty} ${genericPieceNoun ?? labelUnitWord} (${perLabelUnitGrams.toFixed(1)}g each)`;
+            servingTier = 'label_count_derived';
             logger.info('off.build_result.label_count_derived', {
                 foodId: candidate.id,
                 name: itemNameForCount,
@@ -4120,6 +4194,7 @@ async function buildOffResult(
                 if (countDefault && countDefault.grams > 0) {
                     grams = qty * countDefault.grams;
                     servingDescription = `${qty} each (${countDefault.grams.toFixed(1)}g each)`;
+                    servingTier = 'seed_count_default';
                     logger.info('off.build_result.unitless_count_default', {
                         foodId: candidate.id,
                         name: itemNameForCount,
@@ -4144,6 +4219,7 @@ async function buildOffResult(
                 if ((amb.status === 'success' || amb.status === 'cached') && amb.grams && amb.grams > 0) {
                     grams = qty * amb.grams;
                     servingDescription = `${qty} ${discreteUnit} (${amb.grams.toFixed(1)}g each)`;
+                    servingTier = 'discrete_unit_backfill';
                     logger.info('off.build_result.discrete_unit_backfill', {
                         foodId: candidate.id,
                         unit: discreteUnit,
@@ -4171,6 +4247,7 @@ async function buildOffResult(
             if (pkg != null) {
                 grams = qty * pkg;
                 servingDescription = `${qty} package (${pkg.toFixed(0)}g each)`;
+                servingTier = packageGrams != null ? 'package_count_own' : 'package_count_sibling';
                 logger.info('off.build_result.package_count', {
                     foodId: candidate.id,
                     name: itemNameForCount,
@@ -4195,6 +4272,7 @@ async function buildOffResult(
             // there is NO serving at all (handled below).
             grams = qty * hydrated.servingGrams;
             servingDescription = `${qty} serving (${hydrated.servingGrams}g each)`;
+            servingTier = 'label_serving_default';
         } else if (unitlessCountUnresolved) {
             // Unitless count with NO per-piece weight AND no label serving: we
             // cannot honor the count, so bill ONE bounded 100g serving rather
@@ -4202,6 +4280,7 @@ async function buildOffResult(
             // foods from exploding into kilograms ("15 pretzels" was 1500g).
             grams = 100;
             servingDescription = `1 serving (count unresolved, 100.0g)`;
+            servingTier = 'count_unresolved_floor';
             logger.info('off.build_result.unitless_count_unresolved_capped', {
                 foodId: candidate.id,
                 requestedQty: qty,
@@ -4210,6 +4289,7 @@ async function buildOffResult(
         } else {
             grams = 100 * qty;
             servingDescription = `${grams.toFixed(1)}g`;
+            servingTier = 'flat_100g_default';
         }
     }
 
@@ -4233,6 +4313,7 @@ async function buildOffResult(
             confidence,
             quality: confidence >= 0.8 ? 'high' : confidence >= 0.6 ? 'medium' : 'low',
             rawLine,
+            servingTier,
         };
     }
 
@@ -4266,6 +4347,7 @@ async function buildOffResult(
         confidence: confidence * aiNutrition.confidence,
         quality: 'low',
         rawLine,
+        servingTier,
     };
 }
 


### PR DESCRIPTION
## What

Phase 0 ("Instrument") of the cache-accuracy flywheel — the plan lives in the mobile repo at `sync-docs/cache_warming_accuracy_plan.md`.

- **`MappingEventLog` table + migration**: one row per `/api/nlp/parse` line — cache path (`cacheHit` layer or `cacheEscape` reason), chosen food + source + confidence, **`servingTier`** (which gram-resolution branch billed), billed grams / kcal, mapping latency, `noCache` flag. Written fail-open in one `createMany`; disable with `MAPPING_EVENT_LOG_ENABLED=false` (documented in `.env.example`).
- **Mapper instrumentation**: `servingTier` stamped on every gram-resolution branch of `buildOffResult` / `buildFdcResult` (+ `ai_generated` fallbacks); `MappingTelemetry` sink in `MapIngredientOptions` records `normalizedForm` / `cacheHit` / `cacheEscape` by mutation so the facts survive all internal return paths.
- **`skipCache` gap fix**: the step-1c normalized-cache lookup was not gated by `skipCache` — "cold" runs still served cached rows. Now both cache layers are gated.
- **`nocache` cold-run flag**: `?nocache=1` or `body.nocache` on `/api/nlp/parse`, honored only for dev-bypass auth. Powers cold-vs-warm parity runs.
- **Eval `total` assertion**: bands on `items[0].nutrition` — the **billed totals** for the requested quantity, the end-to-end check per-100g bands are blind to. Five new `n-tot-*` golden cases (olive oil, white rice, quest bar, carb-balance tortilla, 13 tortilla chips).

## Defects found at authoring (documented as knownIssue, non-gating)

The new assertions immediately caught two live defects, proving the approach:

- **n-tot-02**: `white rice` FoodMapping row is poisoned with FDC *"brown parboiled cooked uncle bens rice"* (conf 1.0, stable across runs) — a wrong-record hijack invisible to grams bands (record IS cooked, so the grain-cooked escape correctly stays quiet; white↔brown is not treated as a critical modifier). Phase 2 purge + modifier-guard target.
- **n-tot-04**: carb-balance tortilla grams resolve **correctly** (45g) but the OFF record stores per-serving kcal as per-100g → bills 31.5 kcal (real ~70). The n-mq-20 per-serving-as-100g ingest-corruption class; Phase 2 plausibility-audit target.

## Verification

- typecheck, `lint:ci` (0 errors), `check-env-example` ✅
- 526 unit tests ✅
- `npm run build` (prod) ✅
- Live smoke on the built server: telemetry rows land (warm = `cacheHit:'early'`, cold = `nocache:true`, both `servingTier:'volume_unit'`); nocache bypasses both cache layers ✅
- Full nlp eval vs new code: **192/193** — the single real failure (`n-mq-10`, grams 84 vs [25,80]) reproduces identically against the deployed old code (pre-existing AI serving-estimate drift, not this diff)
- Migration already applied to the Mini-PC DB (`prisma migrate deploy`) — additive table only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu