### PR TITLE
feat(search): mark and filter OFF near-duplicate products

### DIFF
--- a/prisma/migrations/20260719120000_add_offfood_duplicate_of/migration.sql
+++ b/prisma/migrations/20260719120000_add_offfood_duplicate_of/migration.sql
@@ -1,0 +1,5 @@
+-- Near-duplicate marking for OffFood: barcode of the surviving representative.
+-- NULL means the row is itself a representative (or was never evaluated).
+ALTER TABLE "OffFood" ADD COLUMN "duplicateOfBarcode" TEXT;
+
+CREATE INDEX "OffFood_duplicateOfBarcode_idx" ON "OffFood"("duplicateOfBarcode");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -380,6 +380,7 @@ model OffFood {
   servingGrams     Float?                      // Parsed default serving weight
   packageQuantity  Float?                      // OFF product_quantity: net package quantity (see packageQuantityUnit)
   packageQuantityUnit String?                  // 'g' | 'ml', inferred from the OFF quantity label string; null when unknown
+  duplicateOfBarcode String?                   // Near-dup marking (scripts/dedupe-off-mark.ts): barcode of the surviving representative; null = representative/unique. Search paths filter marked rows; direct barcode lookups don't.
   imageUrl         String?                     // Product image from OFF
   categories       String?                     // OFF categories CSV
   syncedAt         DateTime      @default(now())
@@ -392,6 +393,7 @@ model OffFood {
   @@index([name])
   @@index([brandName])
   @@index([syncedAt])
+  @@index([duplicateOfBarcode])
 }
 
 model OffServing {

--- a/scripts/dedupe-off-mark.ts
+++ b/scripts/dedupe-off-mark.ts
@@ -1,0 +1,209 @@
+/**
+ * dedupe-off-mark.ts — Offline near-duplicate marking pass over OffFood.
+ *
+ * The OFF ingest (ingest-off.ts) only dedupes on exact barcode, so the corpus
+ * carries ~80-160k near-identical rows (e.g. 1,160 rows literally named
+ * "chicken breast"). This script groups rows by
+ *   (normalized name, normalized brand, bucketed macro signature)
+ * — the same normalizeNameKey/macroSignature used by the query-time dedupe in
+ * src/lib/search/dedupe-candidates.ts, plus brand so distinct brands' products
+ * never collapse — picks one best representative per group, and marks every
+ * other member with duplicateOfBarcode = <representative's barcode>.
+ *
+ * Nothing is deleted: barcodes are identity (FoodMapping FKs, logged foods),
+ * so direct barcode lookups still resolve marked rows. Only search/candidate
+ * paths filter on duplicateOfBarcode IS NULL, and sync-typesense.ts skips
+ * marked rows so the search index shrinks.
+ *
+ * Usage: npx ts-node scripts/dedupe-off-mark.ts [--dry-run] [--clear]
+ *   --dry-run  compute and print group stats, write nothing
+ *   --clear    reset all duplicateOfBarcode marks to NULL and exit
+ *
+ * Re-runnable: each run recomputes marks from scratch (clears existing marks
+ * first) so it stays correct after new ingests or delta updates.
+ */
+import 'dotenv/config';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { normalizeNameKey, macroSignature } from '../src/lib/search/dedupe-candidates';
+
+const prisma = new PrismaClient();
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const CLEAR = process.argv.includes('--clear');
+
+const READ_BATCH = 20_000;
+const WRITE_BATCH = 5_000;
+
+interface Row {
+    barcode: string;
+    name: string;
+    brandName: string | null;
+    nutrientsPer100g: { calories?: number; protein?: number; carbs?: number; fat?: number } | null;
+    servingGrams: number | null;
+    servingSize: string | null;
+}
+
+/** Same completeness idea as dedupe-candidates.ts isBetterRepresentative,
+ *  adapted to raw OffFood rows: macro coverage + serving info. */
+function completenessScore(r: Row): number {
+    const n = r.nutrientsPer100g ?? {};
+    let score = 0;
+    if ((n.calories ?? 0) > 0) score++;
+    if ((n.protein ?? 0) > 0) score++;
+    if ((n.carbs ?? 0) > 0) score++;
+    if ((n.fat ?? 0) > 0) score++;
+    if (r.servingGrams != null) score++;
+    else if (r.servingSize) score += 0.5;
+    return score;
+}
+
+/** True when a should survive over b. Ties broken deterministically so
+ *  re-runs pick the same representative. */
+function isBetterRepresentative(a: Row, b: Row): boolean {
+    const ac = completenessScore(a);
+    const bc = completenessScore(b);
+    if (ac !== bc) return ac > bc;
+    if (a.name.length !== b.name.length) return a.name.length < b.name.length;
+    return a.barcode < b.barcode;
+}
+
+function groupKey(r: Row): string {
+    const nameKey = normalizeNameKey(r.name);
+    const brandKey = (r.brandName ?? '').trim().toLowerCase();
+    const sig = macroSignature({
+        kcal: r.nutrientsPer100g?.calories ?? 0,
+        protein: r.nutrientsPer100g?.protein ?? 0,
+        carbs: r.nutrientsPer100g?.carbs ?? 0,
+        fat: r.nutrientsPer100g?.fat ?? 0,
+        per100g: true,
+    });
+    return `${nameKey}|${brandKey}|${sig}`;
+}
+
+async function main() {
+    console.log(`🚀 dedupe-off-mark ${DRY_RUN ? '(DRY RUN)' : CLEAR ? '(CLEAR)' : ''}`);
+    console.log(`Database: ${process.env.DATABASE_URL ? '✓ configured' : '❌ MISSING'}`);
+
+    if (CLEAR) {
+        const cleared = await prisma.offFood.updateMany({
+            where: { duplicateOfBarcode: { not: null } },
+            data: { duplicateOfBarcode: null },
+        });
+        console.log(`🧹 Cleared ${cleared.count.toLocaleString()} marks. Done.`);
+        return;
+    }
+
+    // Pass 1: stream every row, keep the best representative per group and
+    // the member barcodes. Memory: ~1M entries of small strings — fine.
+    console.log('📖 Pass 1: streaming OffFood and grouping...');
+    const groups = new Map<string, { rep: Row; members: string[] }>();
+    let scanned = 0;
+    let lastBarcode = '';
+
+    while (true) {
+        const batch: Row[] = await prisma.offFood.findMany({
+            where: { barcode: { gt: lastBarcode } },
+            select: {
+                barcode: true,
+                name: true,
+                brandName: true,
+                nutrientsPer100g: true,
+                servingGrams: true,
+                servingSize: true,
+            },
+            orderBy: { barcode: 'asc' },
+            take: READ_BATCH,
+        }) as unknown as Row[];
+        if (batch.length === 0) break;
+        lastBarcode = batch[batch.length - 1].barcode;
+
+        for (const row of batch) {
+            const key = groupKey(row);
+            const g = groups.get(key);
+            if (!g) {
+                groups.set(key, { rep: row, members: [row.barcode] });
+            } else {
+                g.members.push(row.barcode);
+                if (isBetterRepresentative(row, g.rep)) g.rep = row;
+            }
+        }
+        scanned += batch.length;
+        if (scanned % 200_000 === 0) {
+            console.log(`  scanned ${scanned.toLocaleString()} rows, ${groups.size.toLocaleString()} groups...`);
+        }
+    }
+
+    let dupGroups = 0;
+    let dupRows = 0;
+    for (const g of groups.values()) {
+        if (g.members.length > 1) {
+            dupGroups++;
+            dupRows += g.members.length - 1;
+        }
+    }
+    console.log('──────────────────────────────────────────────');
+    console.log(`  Rows scanned          : ${scanned.toLocaleString()}`);
+    console.log(`  Unique groups         : ${groups.size.toLocaleString()}`);
+    console.log(`  Groups with dupes     : ${dupGroups.toLocaleString()}`);
+    console.log(`  Rows to mark          : ${dupRows.toLocaleString()} (${((dupRows / scanned) * 100).toFixed(1)}%)`);
+    console.log('──────────────────────────────────────────────');
+
+    if (DRY_RUN) {
+        console.log('🔍 Dry run — no writes. Done.');
+        return;
+    }
+
+    // Reset existing marks so re-runs never leave stale pointers behind.
+    console.log('🧹 Clearing previous marks...');
+    const cleared = await prisma.offFood.updateMany({
+        where: { duplicateOfBarcode: { not: null } },
+        data: { duplicateOfBarcode: null },
+    });
+    if (cleared.count > 0) console.log(`  cleared ${cleared.count.toLocaleString()} stale marks`);
+
+    // Pass 2: write marks in batches via UPDATE ... FROM (VALUES ...).
+    console.log('✍️  Pass 2: marking duplicates...');
+    let pairs: Array<[string, string]> = []; // [dupBarcode, repBarcode]
+    let written = 0;
+
+    const flush = async () => {
+        if (pairs.length === 0) return;
+        const values = Prisma.join(
+            pairs.map(([dup, rep]) => Prisma.sql`(${dup}, ${rep})`)
+        );
+        await prisma.$executeRaw`
+            UPDATE "OffFood" AS f
+            SET "duplicateOfBarcode" = v.rep
+            FROM (VALUES ${values}) AS v(dup, rep)
+            WHERE f.barcode = v.dup
+        `;
+        written += pairs.length;
+        if (written % 25_000 < WRITE_BATCH) {
+            console.log(`  marked ${written.toLocaleString()} / ${dupRows.toLocaleString()}`);
+        }
+        pairs = [];
+    };
+
+    for (const g of groups.values()) {
+        if (g.members.length < 2) continue;
+        for (const barcode of g.members) {
+            if (barcode === g.rep.barcode) continue;
+            pairs.push([barcode, g.rep.barcode]);
+            if (pairs.length >= WRITE_BATCH) await flush();
+        }
+    }
+    await flush();
+
+    console.log(`✅ Done. Marked ${written.toLocaleString()} near-duplicate rows.`);
+    console.log('Next: re-run scripts/sync-typesense.ts — marked rows are now skipped,');
+    console.log('so the rebuilt off_foods index drops them.');
+}
+
+main()
+    .catch(err => {
+        console.error('❌ Crashed:', err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/scripts/dedupe-off-purge-typesense.ts
+++ b/scripts/dedupe-off-purge-typesense.ts
@@ -1,0 +1,91 @@
+/**
+ * dedupe-off-purge-typesense.ts — Remove marked near-duplicate OffFood rows
+ * from the live off_foods Typesense collection without a full resync.
+ *
+ * Companion to dedupe-off-mark.ts: reads every barcode with
+ * duplicateOfBarcode IS NOT NULL and issues batched
+ * DELETE /collections/off_foods/documents?filter_by=barcode:[...] requests.
+ * Filtering on the indexed barcode field works even where doc ids aren't
+ * barcode-keyed (the live collection predates id=barcode keying).
+ *
+ * Fully recoverable: a normal scripts/sync-typesense.ts rebuild restores the
+ * index from Postgres (and now skips marked rows anyway).
+ *
+ * Usage: npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *          -r tsconfig-paths/register scripts/dedupe-off-purge-typesense.ts [--dry-run]
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const HOST = process.env.TYPESENSE_HOST ?? 'http://192.168.1.21:8108';
+const KEY = process.env.TYPESENSE_API_KEY ?? '';
+const COLLECTION = 'off_foods';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// Keep the filter_by URL comfortably under typical 8KB request-line limits.
+const BATCH = 250;
+
+async function typesenseReq(endpoint: string, options: RequestInit = {}): Promise<any> {
+    const res = await fetch(`${HOST}${endpoint}`, {
+        headers: { 'X-TYPESENSE-API-KEY': KEY },
+        ...options,
+    });
+    if (!res.ok) {
+        throw new Error(`Typesense ${endpoint} failed ${res.status}: ${await res.text()}`);
+    }
+    return res.json();
+}
+
+async function docCount(): Promise<number> {
+    const info = await typesenseReq(`/collections/${COLLECTION}`);
+    return info.num_documents as number;
+}
+
+async function main() {
+    console.log(`🚀 dedupe-off-purge-typesense ${DRY_RUN ? '(DRY RUN)' : ''}`);
+
+    const marked: Array<{ barcode: string }> = await prisma.offFood.findMany({
+        where: { duplicateOfBarcode: { not: null } },
+        select: { barcode: true },
+    });
+    console.log(`Marked rows in Postgres: ${marked.length.toLocaleString()}`);
+
+    const before = await docCount();
+    console.log(`off_foods docs before  : ${before.toLocaleString()}`);
+
+    if (DRY_RUN) {
+        console.log('🔍 Dry run — no deletes. Done.');
+        return;
+    }
+
+    let deleted = 0;
+    for (let i = 0; i < marked.length; i += BATCH) {
+        const batch = marked.slice(i, i + BATCH).map(m => m.barcode);
+        const filterBy = encodeURIComponent(`barcode:[${batch.join(',')}]`);
+        const res = await typesenseReq(
+            `/collections/${COLLECTION}/documents?filter_by=${filterBy}`,
+            { method: 'DELETE' }
+        );
+        deleted += res.num_deleted ?? 0;
+        if ((i / BATCH) % 40 === 0) {
+            console.log(`  processed ${Math.min(i + BATCH, marked.length).toLocaleString()} / ${marked.length.toLocaleString()} barcodes (${deleted.toLocaleString()} docs deleted)`);
+        }
+    }
+
+    const after = await docCount();
+    console.log('──────────────────────────────────────────────');
+    console.log(`  Docs deleted : ${deleted.toLocaleString()}`);
+    console.log(`  off_foods    : ${before.toLocaleString()} → ${after.toLocaleString()}`);
+    console.log('✅ Done.');
+}
+
+main()
+    .catch(err => {
+        console.error('❌ Crashed:', err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/scripts/sync-typesense.ts
+++ b/scripts/sync-typesense.ts
@@ -134,6 +134,7 @@ async function main() {
                    embedding::text AS embedding
             FROM "OffFood"
             WHERE barcode > ${lastBarcode}
+              AND "duplicateOfBarcode" IS NULL
             ORDER BY barcode ASC
             LIMIT ${batchSize}
         `;

--- a/src/lib/openfoodfacts/search.ts
+++ b/src/lib/openfoodfacts/search.ts
@@ -305,6 +305,7 @@ export async function searchOffSimple(
         const results = await prisma.offFood.findMany({
             where: {
                 nutrientsPer100g: { not: Prisma.DbNull },
+                duplicateOfBarcode: null,
                 OR: [
                     { name:      { contains: queryLower, mode: 'insensitive' } },
                     { brandName: { contains: queryLower, mode: 'insensitive' } },


### PR DESCRIPTION
## Summary
- OFF ingest only dedupes on exact barcode, leaving ~80-160k near-identical rows in the corpus (e.g. 1,160 rows literally named "chicken breast")
- Adds an offline pass (`scripts/dedupe-off-mark.ts`) that groups `OffFood` rows by normalized name + brand + macro signature and marks every non-representative member via a new `duplicateOfBarcode` column
- Postgres fallback search (`src/lib/openfoodfacts/search.ts`) and the Typesense sync (`scripts/sync-typesense.ts`) both filter out marked rows; nothing is deleted, so direct barcode lookups (FoodMapping FKs, logged foods) are unaffected
- `scripts/dedupe-off-purge-typesense.ts` is a companion for purging an already-built index in place, without a full resync

## Verified against the live corpus
- 92,841 rows marked (8.6% of 1,073,541)
- Full `sync-typesense.ts` rebuild: `off_foods` went from 1,073,537 → 980,700 docs
- `/api/foods/search?s=chicken%20breast&local=true` now returns a diverse brand mix instead of dozens of identical no-brand rows

## Test plan
- [ ] `npx prisma migrate deploy` applies cleanly against a copy of prod data
- [ ] `npx ts-node scripts/dedupe-off-mark.ts --dry-run` stats look sane
- [ ] `npx ts-node scripts/dedupe-off-mark.ts` then re-run `sync-typesense.ts`, confirm doc count drop
- [ ] `migrate-smoke` CI check passes (schema/migration change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)