### PR TITLE
fix(ai): retire dead gemini-2.0-flash parse primary, align model config, add cache parity sweep tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,11 +142,18 @@ OLLAMA_MODEL=qwen2.5:14b
 OLLAMA_TIMEOUT_MS=15000
 
 # AI Model Configuration
-# Primary and fallback models used for cheap structured tasks (normalization, serving estimation)
-CHEAP_AI_MODEL_PRIMARY=google/gemini-2.0-flash
-CHEAP_AI_MODEL_FALLBACK=gpt-4o-mini
+# Primary and fallback models used for cheap structured tasks (segmentation,
+# normalization, serving estimation). Must be VALID OpenRouter model IDs —
+# an invalid slug fails HTTP 400 on every call and silently burns a round
+# trip before the fallback serves it (google/gemini-2.0-flash died this way
+# when OpenRouter retired the model; verify against /api/v1/models).
+# gpt-4o-mini beat gemini-2.5-flash/-lite on multi-item segmentation in the
+# 2026-07-20 golden-eval bake-off (0 vs 2 real seg failures) and is cheaper
+# than 2.5-flash.
+CHEAP_AI_MODEL_PRIMARY=openai/gpt-4o-mini
+CHEAP_AI_MODEL_FALLBACK=google/gemini-2.5-flash
 # Model for AI nutrition estimation (last-resort fallback)
-NUTRITION_AI_MODEL=google/gemini-2.0-flash
+NUTRITION_AI_MODEL=openai/gpt-4o-mini
 # Structured LLM client timeout and retry config
 STRUCTURED_LLM_TIMEOUT_MS=30000
 STRUCTURED_LLM_MAX_RETRIES=2

--- a/scripts/eval/cache-parity-sweep.ts
+++ b/scripts/eval/cache-parity-sweep.ts
@@ -1,0 +1,139 @@
+/**
+ * cache-parity-sweep.ts — replay every cached FoodMapping key through the full
+ * pipeline cold (nocache=1) and diff what fresh retrieval resolves vs what the
+ * cache row held. Divergences = cache rows that disagree with the current
+ * pipeline (stale ranking-era picks, pre-dedupe records, plausibility misses).
+ *
+ * NOTE (intended side effect): the pipeline's saveValidatedMapping is NOT
+ * gated by skipCache, so each cold run OVERWRITES its cache row with the
+ * fresh result. Snapshot the table first (pg_dump -t '"FoodMapping"').
+ *
+ * Run (from repo root):
+ *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/eval/cache-parity-sweep.ts --before scripts/eval/results/foodmapping-before-2026-07-20.json \
+ *     [--base http://192.168.1.21:3000] [--concurrency 4]
+ *
+ * The --before file is a JSON array of FoodMapping rows:
+ *   select json_agg(row_to_json(t)) from (select "normalizedForm","foodName",
+ *   "brandName",source,"offBarcode","fdcId","aiConfidence","usedCount"
+ *   from "FoodMapping" order by "normalizedForm") t;
+ *
+ * Writes results/cache-parity-<timestamp>.json (full) and prints a summary +
+ * the changed-record list to stdout.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+
+const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.21:3000';
+const API_KEY = process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
+const CONCURRENCY = Number(argValue('--concurrency') ?? 4);
+const TIMEOUT_MS = Number(argValue('--timeout') ?? 30000);
+const beforePath = argValue('--before');
+if (!beforePath) {
+    console.error('missing --before <foodmapping-rows.json>');
+    process.exit(1);
+}
+
+interface BeforeRow {
+    normalizedForm: string;
+    foodName: string;
+    brandName: string | null;
+    source: string;
+    offBarcode: string | null;
+    fdcId: number | null;
+    aiConfidence: number;
+    usedCount: number;
+}
+
+const before: BeforeRow[] = JSON.parse(fs.readFileSync(beforePath, 'utf8'));
+const results: any[] = [];
+let done = 0;
+
+async function sweepOne(row: BeforeRow) {
+    const name = row.normalizedForm;
+    // 100 g weight unit → grams resolution is trivial and identical for every
+    // record, so per-100g nutrition compares apples-to-apples.
+    const body = { items: [{ rawText: `100g ${name}`, quantity: 100, unit: 'g', name }] };
+    const t0 = Date.now();
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            const ctrl = new AbortController();
+            const to = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+            const res = await fetch(`${BASE}/api/nlp/parse?nocache=1`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'x-api-key': API_KEY },
+                body: JSON.stringify(body),
+                signal: ctrl.signal,
+            });
+            clearTimeout(to);
+            const items: any = await res.json();
+            const it = Array.isArray(items) ? items[0] : null;
+            return {
+                key: name,
+                before: row,
+                cold: it ? {
+                    foodId: it.foodId ?? null,
+                    foodName: it.foodName ?? null,
+                    brandName: it.brandName ?? null,
+                    source: it.source ?? null,
+                    confidence: it.matchConfidence ?? null,
+                    kcal100: it.nutritionPer100g?.kcal100 ?? null,
+                    protein100: it.nutritionPer100g?.protein100 ?? null,
+                } : { error: `no item (HTTP ${res.status})` },
+                ms: Date.now() - t0,
+            };
+        } catch (e) {
+            if (attempt === 1) return { key: name, before: row, cold: { error: String(e).slice(0, 120) }, ms: Date.now() - t0 };
+        }
+    }
+}
+
+async function main() {
+    const queue = [...before];
+    const workers = Array.from({ length: CONCURRENCY }, async () => {
+        while (queue.length) {
+            const row = queue.shift()!;
+            results.push(await sweepOne(row));
+            done++;
+            if (done % 25 === 0) console.error(`progress: ${done}/${before.length}`);
+        }
+    });
+    await Promise.all(workers);
+
+    const beforeId = (b: BeforeRow) => b.offBarcode ? `off_${b.offBarcode}` : (b.fdcId != null ? `fdc_${b.fdcId}` : null);
+    let same = 0, changedId = 0, changedSource = 0, errors = 0;
+    const changes: any[] = [];
+    for (const r of results) {
+        if (r.cold.error) { errors++; changes.push({ key: r.key, error: r.cold.error }); continue; }
+        const oldId = beforeId(r.before);
+        if (r.cold.foodId === oldId) { same++; continue; }
+        changedId++;
+        if (r.cold.source !== r.before.source) changedSource++;
+        changes.push({
+            key: r.key,
+            was: `${oldId} "${r.before.foodName}" (${r.before.source}, used=${r.before.usedCount})`,
+            now: `${r.cold.foodId} "${r.cold.foodName}" (${r.cold.source}, conf=${r.cold.confidence?.toFixed?.(2)})`,
+            kcal100: r.cold.kcal100,
+        });
+    }
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = path.join(__dirname, 'results', `cache-parity-${stamp}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({ base: BASE, ranAt: stamp, summary: { total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors }, changes, results }, null, 1));
+
+    console.log(JSON.stringify({ total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors }, null, 1));
+    for (const c of changes) {
+        if (c.error) console.log(`  ⚠️ [${c.key}] ERROR: ${c.error}`);
+        else console.log(`  ↻ [${c.key}]\n      was ${c.was}\n      now ${c.now}`);
+    }
+    console.log(`\nResults written to ${outPath}`);
+}
+
+main();

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -194,8 +194,9 @@ export async function POST(req: NextRequest) {
       // return it unchanged after ~1-5s. Skip straight to mapping.
       items = [singleItemFromText(text)!];
     } else {
-      // AI-first segmentation: the cheap LLM splitter (gemini-2.0-flash via
-      // OpenRouter, ~$0.0003/call, magic-log is rate-capped) is the
+      // AI-first segmentation: the cheap LLM splitter (CHEAP_AI_MODEL_PRIMARY
+      // via OpenRouter — gpt-4o-mini, ~$0.0003/call, magic-log is
+      // rate-capped) is the
       // unconditional first step for any multi-token / delimited log. The
       // deterministic heuristic is deliberately NOT on the primary path — it
       // survives only as forceSegmentText, the fallback used when the LLM

--- a/src/lib/mapping/config.ts
+++ b/src/lib/mapping/config.ts
@@ -45,8 +45,8 @@ export const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL ?? 'https://a
 // OpenRouter configuration for cheap-first LLM fallback (Jan 2026)
 export const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? '';
 export const OPENROUTER_BASE_URL = process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1';
-export const CHEAP_AI_MODEL_PRIMARY = process.env.CHEAP_AI_MODEL_PRIMARY ?? 'qwen/qwen-turbo';
-export const CHEAP_AI_MODEL_FALLBACK = process.env.CHEAP_AI_MODEL_FALLBACK ?? 'mistralai/mistral-nemo';
+export const CHEAP_AI_MODEL_PRIMARY = process.env.CHEAP_AI_MODEL_PRIMARY ?? 'openai/gpt-4o-mini';
+export const CHEAP_AI_MODEL_FALLBACK = process.env.CHEAP_AI_MODEL_FALLBACK ?? 'google/gemini-2.5-flash';
 export const STRUCTURED_LLM_TIMEOUT_MS = Number.parseInt(process.env.STRUCTURED_LLM_TIMEOUT_MS ?? '15000', 10);
 export const STRUCTURED_LLM_MAX_RETRIES = Number.parseInt(process.env.STRUCTURED_LLM_MAX_RETRIES ?? '3', 10);
 


### PR DESCRIPTION
## Problem

\`google/gemini-2.0-flash\` — the configured cheap-tier primary — was removed from OpenRouter. Every cheap-tier structured-LLM call (segmentation, normalization, serving estimation) has been burning an HTTP 400 round trip on the dead model before falling through to \`openai/gpt-4o-mini\` (329 logged failures on the prod box). This resolves the "parse-model config three-way mismatch" follow-up in \`docs/eval-hardening-plan.md\`.

## Bake-off (2026-07-20, full nlp golden suite per candidate)

| primary | real seg failures | seg p50 | seg max |
|---|---|---|---|
| gpt-4o-mini (after dead hop) | 0 across 3 runs | 1569ms | 15.6s |
| gemini-2.5-flash-lite | 2 (under-segmentation) | 863ms | 9.6s |
| gemini-2.5-flash | 2 (under-segmentation) | 1065ms | 6.3s |
| **gpt-4o-mini (direct, final)** | **0** | — | — |

\`n-seg-30\` ("oatmeal with 2 tbsp peanut butter") failed on both gemini tiers and passed all gpt-4o-mini runs — model-correlated, not flake. gpt-4o-mini is also cheaper than 2.5-flash ($0.15/$0.60 vs $0.30/$2.50 per M).

## Changes

- **Primary → \`openai/gpt-4o-mini\`**, **fallback → \`google/gemini-2.5-flash\`** (live-validated as primary during the bake-off; replaces the dead slug with a working tier). Deployed \`.env\` on the prod box updated + service restarted; final eval: 1 real failure (n-mq-10, pre-existing) = baseline parity.
- \`config.ts\` defaults aligned (were \`qwen/qwen-turbo\` + \`mistral-nemo\`, matching no deployed env); stale gemini-2.0-flash comment in the parse route fixed; \`.env.example\` now documents the invalid-slug 400 failure mode.
- **New tool**: \`scripts/eval/cache-parity-sweep.ts\` — replays every cached FoodMapping key cold (\`nocache=1\`) and diffs fresh retrieval vs the cache row. First run found 184/267 (69%) stale rows; 14 bad fresh picks selectively restored from snapshot.

No new env vars (values only), no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu