### PR TITLE
feat(mapping): serving-shape preference + brand-mismatch/serving-downgrade save gates (PR D pt2)

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -4746,6 +4746,26 @@
       "notes": "DEFECT (found 2026-07-19) — GENERIC MATCH QUALITY. PARTIALLY IMPROVED 2026-07-19: shipped lean-cut protein FLOOR (18g/100g, macro-plausibility.ts) which demoted the worst deli 'roll' (14.6p) -> now 'sliced chicken breast' 16.8p, but STILL below [25,38] because the real ~30g grilled-breast record is NOT retrieved for this phrasing (word-order-sensitive candidate gathering; 'chicken breast grilled' finds 29.5p but 'grilled chicken breast' does not). 'white rice' still resolves to 45g DRY vs ~150g cooked. REMAINING (deferred, own PR behind full eval): (a) cooked-default for bare staples [HIGH risk — cook-state-detector.ts is dead code, gather-candidates.ts:~516 auto-bypasses bare 'rice' to dry top1], (b) retrieval/rerank so the grilled-breast record enters the pool order-independently."
     },
     {
+      "id": "n-mq-23",
+      "category": "match_quality",
+      "item": {
+        "rawText": "1 scoop ryse protein",
+        "quantity": 1,
+        "unit": "scoop",
+        "name": "ryse protein",
+        "brand": "ryse",
+        "normalizedForm": "protein powder",
+        "mealType": "snacks"
+      },
+      "expectName": [
+        [
+          "ryse"
+        ]
+      ],
+      "knownIssue": true,
+      "notes": "IDENTITY-HIJACK GUARD (PR D pt2, 2026-07-20). The parity sweep's cold re-resolution mapped 'protein ryse' to 'Protein Rice' (ryse fuzzy->rice). The save-time brand-mismatch gate now refuses to CACHE a cross-brand pick for a decisive brand query, but retrieval can still SERVE one when no Ryse SKU surfaces. Promote to hard once retrieval reliably surfaces Ryse protein SKUs."
+    },
+    {
       "id": "n-dens-01",
       "category": "serving_unit",
       "item": {

--- a/src/lib/mapping/__tests__/simple-rerank.test.ts
+++ b/src/lib/mapping/__tests__/simple-rerank.test.ts
@@ -242,3 +242,78 @@ describe('count-labeled SKU preference (Cluster A pt2)', () => {
         expect(result.winner!.id).toBe('off_exact');
     });
 });
+
+describe('serving-labeled record preference (PR D pt2)', () => {
+    it('prefers the serving-labeled record between identically-named branded candidates', () => {
+        // The parity-sweep "red bull" class: same name, same score — only the
+        // serving label distinguishes them, and losing it bills 100g flat.
+        const candidates: RerankCandidate[] = [
+            {
+                id: 'off_no_serving',
+                name: 'Red Bull',
+                brandName: 'BrandA',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+            },
+            {
+                id: 'off_can_label',
+                name: 'Red Bull',
+                brandName: 'BrandB',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+                servingLabelMatch: true,
+            },
+        ];
+        const result = simpleRerank('red bull', candidates, undefined, '1 red bull');
+        expect(result.winner).not.toBeNull();
+        expect(result.winner!.id).toBe('off_can_label');
+    });
+
+    it('does not overcome a clearly better name match', () => {
+        const candidates: RerankCandidate[] = [
+            {
+                id: 'off_exact',
+                name: 'Red Bull',
+                brandName: 'BrandA',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+            },
+            {
+                id: 'off_bloated_with_label',
+                name: 'Zesty Tropical Energy Drink Party Variety Pack',
+                brandName: 'BrandB',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+                servingLabelMatch: true,
+            },
+        ];
+        const result = simpleRerank('red bull', candidates, undefined, '1 red bull');
+        expect(result.winner).not.toBeNull();
+        expect(result.winner!.id).toBe('off_exact');
+    });
+
+    it('does not override the generic-record preference on its own', () => {
+        // Boost (+0.05) exactly matches NO_BRAND (+0.05): a branded record's
+        // serving label alone must not beat an equally-good generic record —
+        // the score ties and the brand tiebreaker keeps the generic winner.
+        const candidates: RerankCandidate[] = [
+            {
+                id: 'off_generic',
+                name: 'Peanut Butter',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+            },
+            {
+                id: 'off_branded_with_label',
+                name: 'Peanut Butter',
+                brandName: 'BrandB',
+                score: 1.0,
+                source: 'openfoodfacts' as const,
+                servingLabelMatch: true,
+            },
+        ];
+        const result = simpleRerank('peanut butter', candidates, undefined, 'peanut butter');
+        expect(result.winner).not.toBeNull();
+        expect(result.winner!.id).toBe('off_generic');
+    });
+});

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Save-time identity/serving gates on saveValidatedMapping (PR D pt2).
+ *
+ * - Brand-mismatch gate: a decisively-named brand query ("ryse protein")
+ *   must not cache a food that carries neither the brand in its brand field
+ *   nor its name ("Protein Rice").
+ * - Serving-downgrade guard: an OFF→OFF barcode overwrite must not replace
+ *   a record with real serving data with one that has none.
+ *
+ * Uses the real brand detector (lexicon includes "ryse"/"red bull") so the
+ * tests exercise production matching behavior, and mocks only the db.
+ */
+
+const mockFoodMappingFindUnique = jest.fn();
+const mockFoodMappingUpsert = jest.fn();
+const mockOffFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        foodMapping: {
+            findUnique: (...args: unknown[]) => mockFoodMappingFindUnique(...args),
+            upsert: (...args: unknown[]) => mockFoodMappingUpsert(...args),
+        },
+        offFood: {
+            findUnique: (...args: unknown[]) => mockOffFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { saveValidatedMapping } from '../validated-mapping-helpers';
+import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+import type { AIValidationResult } from '../ai-validation';
+
+const validation = { confidence: 0.95 } as AIValidationResult;
+
+function makeMapping(overrides: Partial<FatsecretMappedIngredient>): FatsecretMappedIngredient {
+    return {
+        foodId: 'off_1111111111111',
+        foodName: 'Test Food',
+        brandName: undefined,
+        grams: 100,
+        kcal: 100,
+        protein: 5,
+        carbs: 10,
+        fat: 3,
+        ...overrides,
+    } as FatsecretMappedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFoodMappingFindUnique.mockResolvedValue(null);
+    mockFoodMappingUpsert.mockResolvedValue({});
+    mockOffFoodFindUnique.mockResolvedValue(null);
+});
+
+describe('brand-mismatch save gate', () => {
+    it('rejects "ryse protein" mapped to "Protein Rice" (no brand carried)', async () => {
+        await saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Protein Rice' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('saves when the mapped food carries the brand in its brand field', async () => {
+        await saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Loaded Protein Powder', brandName: 'RYSE' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('saves when the mapped food embeds the brand token in its name', async () => {
+        await saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Ryse Loaded Protein' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire without decisive brand context', async () => {
+        // "ghost" is a lexicon brand, but adjacent to a non-product word the
+        // reading is coincidental English — the gate must stay out of the way.
+        await saveValidatedMapping(
+            'ghost berry smoothie',
+            makeMapping({ foodName: 'Berry Smoothie' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('serving-downgrade save guard', () => {
+    const OLD_BARCODE = '9002490100070';
+    const NEW_BARCODE = '5099839628986';
+
+    function setupExistingRow(oldServing: { servingGrams: number | null; packageQuantity: number | null },
+        newServing: { servingGrams: number | null; packageQuantity: number | null }) {
+        mockFoodMappingFindUnique.mockResolvedValue({ offBarcode: OLD_BARCODE });
+        mockOffFoodFindUnique.mockImplementation((args: any) =>
+            Promise.resolve(args?.where?.barcode === OLD_BARCODE ? oldServing : newServing));
+    }
+
+    it('refuses to replace a serving-labeled record with a label-less one', async () => {
+        setupExistingRow(
+            { servingGrams: 250, packageQuantity: null },
+            { servingGrams: null, packageQuantity: null },
+        );
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('allows the swap when the new record also has serving data', async () => {
+        setupExistingRow(
+            { servingGrams: 250, packageQuantity: null },
+            { servingGrams: 355, packageQuantity: null },
+        );
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats package quantity as serving shape on the new record', async () => {
+        setupExistingRow(
+            { servingGrams: 250, packageQuantity: null },
+            { servingGrams: null, packageQuantity: 473 },
+        );
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows the swap when the old record had no serving data either', async () => {
+        setupExistingRow(
+            { servingGrams: null, packageQuantity: null },
+            { servingGrams: null, packageQuantity: null },
+        );
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not query serving data for a first-time save', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue(null);
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockOffFoodFindUnique).not.toHaveBeenCalled();
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the guard when the barcode is unchanged', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({ offBarcode: NEW_BARCODE });
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockOffFoodFindUnique).not.toHaveBeenCalled();
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -1404,6 +1404,7 @@ export async function mapIngredientWithFallback(
                             }
                         }
 
+                        const billsByServing = requestBillsByServing(parsed);
                         const rerankCandidates = candidatesForRerank.map(c => toRerankCandidate({
                             id: c.id,
                             name: c.name,
@@ -1413,6 +1414,7 @@ export async function mapIngredientWithFallback(
                             source: c.source,
                             nutrition: c.nutrition,  // Include for Route C macro sanity check + nutrition tiebreaker
                             countLabelMatch: countedNoun ? candidateHasCountLabel(c, countedNoun) : undefined,
+                            servingLabelMatch: billsByServing ? candidateHasServingData(c) : undefined,
                         }));
 
                         // Hybrid prep stripping: prefer AI canonicalBase (strips prep but preserves
@@ -2029,6 +2031,7 @@ export async function mapIngredientWithFallback(
 
                 // Run reranker to ensure anomaly penalties (e.g. canned beans) are applied
                 const countedNounFB = countedPieceNoun(parsed);
+                const billsByServingFB = requestBillsByServing(parsed);
                 const rerankCandidates = searchFilterResult.filtered.map(c => toRerankCandidate({
                     id: c.id,
                     name: c.name,
@@ -2038,6 +2041,7 @@ export async function mapIngredientWithFallback(
                     source: c.source,
                     nutrition: c.nutrition,
                     countLabelMatch: countedNounFB ? candidateHasCountLabel(c, countedNounFB) : undefined,
+                    servingLabelMatch: billsByServingFB ? candidateHasServingData(c) : undefined,
                 }));
                 const rerankQuery = aiCanonicalBase || stripPrepModifiers(normalizedName);
                 const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNounFB != null);
@@ -3939,6 +3943,36 @@ function candidateHasCountLabel(candidate: UnifiedCandidate, pieceNoun: string):
     if (candidate.source !== 'openfoodfacts') return false;
     const raw = candidate.rawData as { servingSize?: string | null; servingGrams?: number | null } | undefined;
     return servingLabelCountsPiece(raw?.servingSize, raw?.servingGrams, pieceNoun);
+}
+
+/**
+ * Explicit weight/volume units bill deterministically from grams/ml, so a
+ * record's serving-label richness is irrelevant to those requests. Everything
+ * else — unitless ("1 red bull"), counts, container words ("can", "bar",
+ * "sleeve") — resolves through the record's own serving data, where a
+ * label-less winner falls to flat_100g_default and mis-bills.
+ */
+const EXPLICIT_MEASURE_UNIT_RE = /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|ml|milliliter|milliliters|l|liter|liters|floz|fl\s*oz|fluid\s*ounces?|pint|pints|quart|quarts|gallon|gallons)$/i;
+function requestBillsByServing(parsed: ParsedIngredient | null): boolean {
+    return !(parsed?.unit && EXPLICIT_MEASURE_UNIT_RE.test(parsed.unit.trim()));
+}
+
+/**
+ * True when the candidate carries genuine gram-quantified serving data:
+ * an OFF label servingGrams, or any FDC serving with grams. Feeds the
+ * rerank SERVING_LABEL_BOOST tie-break (PR D pt2) so a serving-less record
+ * can't win a near-tie and flatten a serving-billed request to 100g —
+ * the parity sweep's "red bull lost its can" class.
+ */
+function candidateHasServingData(candidate: UnifiedCandidate): boolean {
+    if (candidate.source === 'openfoodfacts') {
+        const raw = candidate.rawData as { servingGrams?: number | null } | undefined;
+        return typeof raw?.servingGrams === 'number' && raw.servingGrams > 0;
+    }
+    if (candidate.source === 'fdc') {
+        return !!candidate.servings?.some(s => typeof s.grams === 'number' && s.grams > 0);
+    }
+    return false;
 }
 
 // Plausible single-retail-unit bands for package quantities. 'ml' is the

--- a/src/lib/mapping/simple-rerank.ts
+++ b/src/lib/mapping/simple-rerank.ts
@@ -30,6 +30,15 @@ export interface RerankCandidate {
      * when the caller passes preferCountLabeled.
      */
     countLabelMatch?: boolean;
+    /**
+     * True when this candidate carries genuine gram-quantified serving data
+     * (OFF label servingGrams, or FDC servings with grams) AND the request's
+     * shape would actually bill by serving (unitless / count / container —
+     * not an explicit weight or volume). Precomputed by the mapper; earns
+     * SERVING_LABEL_BOOST so a serving-less record can't win a near-tie and
+     * silently flatten a can/bar/sleeve request to 100g.
+     */
+    servingLabelMatch?: boolean;
 }
 
 export interface AiNutritionEstimate {
@@ -78,6 +87,8 @@ const WEIGHTS = {
     MISSING_COOKING_STATE_PENALTY: 0.40, // Penalty when query says "fried" but candidate doesn't
     // Count-labeled SKU preference (Cluster A pt2, Jul 2026)
     COUNT_LABEL_BOOST: 0.08,  // Tie-break toward SKUs whose label declares a per-piece count when the user is counting pieces. Deliberately small: must not beat EXACT_MATCH or token penalties.
+    // Serving-shape preference (PR D pt2, Jul 2026)
+    SERVING_LABEL_BOOST: 0.05,  // Tie-break toward records with real serving data when the request bills by serving. Smaller than COUNT_LABEL_BOOST: it must only break near-ties (equal-name "Red Bull" with vs without a 250ml label), never override identity signals.
     // Decisive same-brand preference (brand-hijack fix, Jul 2026)
     DECISIVE_BRAND_BOOST: 0.35,  // Only fires behind hasDecisiveBrandContext + non-brand token coverage; a cross-brand candidate must not win on flavor-token coverage alone when the user named a brand unambiguously.
     // Cooked-grain preference for volume-unit lines (cooked-vs-dry fix, Jul 2026)
@@ -1342,7 +1353,7 @@ const BRAND_PRODUCT_CONTEXT_TOKENS = new Set([
  * Single-word brands that double as common English words ("ghost", "one",
  * "built") never qualify on their own.
  */
-function hasDecisiveBrandContext(text: string, targetBrand: string): boolean {
+export function hasDecisiveBrandContext(text: string, targetBrand: string): boolean {
     const brandTokens = targetBrand.toLowerCase().trim().split(/\s+/).filter(Boolean);
     if (brandTokens.length === 0) return false;
     if (brandTokens.length >= 2) return true;
@@ -1363,7 +1374,7 @@ function hasDecisiveBrandContext(text: string, targetBrand: string): boolean {
  * match "Toblerone"); requiring every detected token is too strict because
  * lexicon entries can be brand+form ("one bar" vs brand "ONE Brands").
  */
-function candidateMatchesTargetBrand(brandName: string | undefined, candidateName: string, targetBrand: string): boolean {
+export function candidateMatchesTargetBrand(brandName: string | undefined, candidateName: string, targetBrand: string): boolean {
     const brandTokens = targetBrand.toLowerCase().trim().split(/\s+/).filter(Boolean);
     if (brandTokens.length === 0) return false;
     const candTokens = `${candidateName} ${brandName ?? ''}`.toLowerCase()
@@ -1528,12 +1539,13 @@ export function simpleRerank(
             const constraintPenalty = constraintResult.penalty * 0.5; // Scale penalty to reasonable range
 
             const countLabelBoost = (preferCountLabeled && c.countLabelMatch) ? WEIGHTS.COUNT_LABEL_BOOST : 0;
+            const servingLabelBoost = c.servingLabelMatch ? WEIGHTS.SERVING_LABEL_BOOST : 0;
             const decisiveBrandBoost = isDecisiveBrandCandidate(c) ? WEIGHTS.DECISIVE_BRAND_BOOST : 0;
             const grainCookedBoost = isCookedGrainCandidate(c) ? WEIGHTS.GRAIN_COOKED_VOLUME_BOOST : 0;
 
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score - constraintPenalty + countLabelBoost + decisiveBrandBoost + grainCookedBoost,
+                score: baseScore + nutritionResult.score - constraintPenalty + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
@@ -1563,11 +1575,12 @@ export function simpleRerank(
             const baseScore = computeSimpleScore(c, query, isBranded, targetBrand);
             const nutritionResult = computeNutritionScore(c, aiNutritionEstimate);
             const countLabelBoost = (preferCountLabeled && c.countLabelMatch) ? WEIGHTS.COUNT_LABEL_BOOST : 0;
+            const servingLabelBoost = c.servingLabelMatch ? WEIGHTS.SERVING_LABEL_BOOST : 0;
             const decisiveBrandBoost = isDecisiveBrandCandidate(c) ? WEIGHTS.DECISIVE_BRAND_BOOST : 0;
             const grainCookedBoost = isCookedGrainCandidate(c) ? WEIGHTS.GRAIN_COOKED_VOLUME_BOOST : 0;
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score + countLabelBoost + decisiveBrandBoost + grainCookedBoost,
+                score: baseScore + nutritionResult.score + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
@@ -1815,6 +1828,7 @@ export function toRerankCandidate(candidate: {
         per100g: boolean;
     };
     countLabelMatch?: boolean;
+    servingLabelMatch?: boolean;
 }): RerankCandidate {
     // Some FDC entries have doubled descriptions (a known FDC data quality issue).
     // e.g. "peeled plum tomatoes peeled plum tomatoes" → "peeled plum tomatoes"
@@ -1838,5 +1852,6 @@ export function toRerankCandidate(candidate: {
         source: candidate.source,
         nutrition: candidate.nutrition,
         countLabelMatch: candidate.countLabelMatch,
+        servingLabelMatch: candidate.servingLabelMatch,
     };
 }

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -17,6 +17,7 @@ import { hasCoreTokenMismatch } from './filter-candidates';
 import { assessSaveTimePlausibility } from './macro-plausibility';
 import type { MacroPlausibilityInput, ExpectedNutritionPer100g } from './macro-plausibility';
 import { detectBrandInQuery } from './brand-detector';
+import { hasDecisiveBrandContext, candidateMatchesTargetBrand } from './simple-rerank';
 import { parseIngredientLine } from '../parse/ingredient-line';
 import { normalizeIngredientName, canonicalizeCacheKey } from './normalization-rules';
 
@@ -273,6 +274,29 @@ export async function saveValidatedMapping(
     // Canonicalize: lowercase + singularize + sort tokens
     const normalizedForm = canonicalizeCacheKey(rawForm);
 
+    const detectedBrand = detectBrandInQuery(rawIngredient).matchedBrand;
+
+    // Brand-mismatch save gate (PR D pt2, Jul 2026): the parity sweep cached
+    // "protein ryse" as "Protein Rice". When the query names a brand
+    // decisively (multi-word brand, or brand token adjacent to a product-form
+    // word like "protein") and the mapped food carries that brand in neither
+    // its brand field nor its name, the identity is wrong — or a generic
+    // substitute that shouldn't answer a brand query from cache. Reuses the
+    // rerank's decisive-context + whole-token matching so ranking and caching
+    // agree on what "named a brand" means. The pick still serves THIS request.
+    if (detectedBrand
+        && hasDecisiveBrandContext(rawIngredient, detectedBrand)
+        && !candidateMatchesTargetBrand(mapping.brandName ?? undefined, mapping.foodName, detectedBrand)) {
+        logger.warn('validated_mapping.save_rejected_brand_mismatch', {
+            rawIngredient,
+            normalizedForm,
+            foodName: mapping.foodName,
+            brandName: mapping.brandName,
+            namedBrand: detectedBrand,
+        });
+        return;
+    }
+
     // Pre-save validation: Reject mappings where core tokens from normalizedForm are missing from foodName
     if (hasCoreTokenMismatch(normalizedForm, mapping.foodName, mapping.brandName)) {
         // Brand rescue (mirrors the runtime core-token brand rescue): when the
@@ -280,7 +304,7 @@ export async function saveValidatedMapping(
         // field or embedded in its name — the "missing" core token is usually
         // a flavor the brand spells differently ("cinnamon" vs "Cinnabon").
         // Rejecting the save forces a full re-resolution on every request.
-        const rescueBrand = detectBrandInQuery(rawIngredient).matchedBrand?.toLowerCase().trim();
+        const rescueBrand = detectedBrand?.toLowerCase().trim();
         const carriesBrand = !!rescueBrand && (
             mapping.brandName?.toLowerCase().includes(rescueBrand) ||
             new RegExp(`\\b${rescueBrand.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(mapping.foodName.toLowerCase())
@@ -339,6 +363,44 @@ export async function saveValidatedMapping(
 
         const mappingSource = offBarcode ? 'openfoodfacts' : fdcId ? 'fdc' : 'ai_generated';
         const clampedConfidence = Math.max(0, Math.min(1, validation.confidence));
+
+        // Serving-shape downgrade guard (PR D pt2, Jul 2026): the parity sweep
+        // showed record swaps silently replacing a cache row whose OFF record
+        // carries real serving data ("red bull" with its 250ml can label) with
+        // a record that has none — every later serving-billed request then
+        // falls to flat_100g_default. When an overwrite would change the OFF
+        // barcode, keep the old row if the new record would lose all serving
+        // shape. The new pick still serves THIS request, it just isn't cached.
+        if (offBarcode) {
+            const existing = await prisma.foodMapping.findUnique({
+                where: { normalizedForm },
+                select: { offBarcode: true },
+            });
+            if (existing?.offBarcode && existing.offBarcode !== offBarcode) {
+                const [oldOff, newOff] = await Promise.all([
+                    prisma.offFood.findUnique({
+                        where: { barcode: existing.offBarcode },
+                        select: { servingGrams: true, packageQuantity: true },
+                    }),
+                    prisma.offFood.findUnique({
+                        where: { barcode: offBarcode },
+                        select: { servingGrams: true, packageQuantity: true },
+                    }),
+                ]);
+                const hasServingShape = (f: { servingGrams: number | null; packageQuantity: number | null } | null) =>
+                    !!f && ((f.servingGrams ?? 0) > 0 || (f.packageQuantity ?? 0) > 0);
+                if (hasServingShape(oldOff) && !hasServingShape(newOff)) {
+                    logger.warn('validated_mapping.save_rejected_serving_downgrade', {
+                        rawIngredient,
+                        normalizedForm,
+                        foodName: mapping.foodName,
+                        keptBarcode: existing.offBarcode,
+                        rejectedBarcode: offBarcode,
+                    });
+                    return;
+                }
+            }
+        }
 
         await prisma.foodMapping.upsert({
             where: {


### PR DESCRIPTION
## Summary

Closes defects **3 + 4** from the 2026-07-20 cache parity sweep hardening list (follow-up to #109 / PR D pt1):

1. **Serving-shape rerank preference** — rerank candidates now carry `servingLabelMatch` (OFF label `servingGrams` / FDC servings with grams), earning `SERVING_LABEL_BOOST` (0.05, tie-break scale) when the request bills by serving (unitless / count / container — not explicit weight/volume). A serving-less record can no longer win a near-tie and flatten "1 red bull" to `flat_100g_default`.
2. **Serving-downgrade save guard** — an OFF→OFF cache overwrite that would replace a record with real serving shape (`servingGrams`/`packageQuantity`) with one carrying none is refused (`save_rejected_serving_downgrade`). The pick still serves the current request; the richer cache row survives.
3. **Brand-mismatch save gate** — a decisive brand query ("ryse protein") whose winner carries the brand in neither brand field nor name is refused a cache write (`save_rejected_brand_mismatch`). Reuses the rerank's decisive-context + whole-token brand matching (now exported) so ranking and caching agree.

New golden knownIssue `n-mq-23` tracks the remaining *retrieval-side* ryse identity gap; `n-serv-27/28` stay hard regression guards for the serving-shape class.

## Live verification (OptiPlex)

- Cold `nocache=1` "1 red bull" → fresh pick is the 250g-can record (`off_0611269333572`), conf 0.98.
- Cold "protein ryse" (sweep's exact failing form) → still serves "Protein Rice" (Muller) but `save_rejected_brand_mismatch` fired and the cache row stayed **"Ryse Clear Protein"** — the poisoning path is closed.
- Cold "1 scoop ryse protein" / "ryse preworkout" → correct Ryse SKUs, saved normally.

## Testing

- 558/558 unit tests (10 new: 3 rerank boost, 7 save gates), typecheck clean, lint 0 errors.
- Full golden eval vs OptiPlex: **baseline parity** — 1 real failure (`n-mq-10`, pre-existing), 14 knownIssues; `n-serv-06` and new `n-mq-23` now in the passing-knownIssue column (`eval-2026-07-20T20-58-39-708Z.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu