### PR TITLE
feat(site): global footer with official fatsecret attribution badge

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { AuthHeader } from '@/components/auth/AuthHeader';
 import { WelcomeNotification } from '@/components/WelcomeNotification';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { SignupGuard } from '@/components/SignupGuard';
+import { SiteFooter } from '@/components/SiteFooter';
 import ThemeScript from '@/components/ThemeScript';
 import { Suspense } from 'react';
 import { ThemeProvider } from 'next-themes';
@@ -45,6 +46,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <AuthHeader />
               </Suspense>
               <main className="min-h-screen pt-20">{children}</main>
+              <SiteFooter />
               <Suspense fallback={null}>
                 <WelcomeNotification />
               </Suspense>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,22 @@
+// Global site footer. Carries the fatsecret attribution required by the
+// fatsecret Platform API Terms of Use (Premier Free tier): the official Web
+// Badge, unmodified, linked to platform.fatsecret.com. Do not edit the badge
+// markup — the snippet must match https://platform.fatsecret.com/attribution
+// exactly, and "fatsecret" must always be written in lowercase.
+const FATSECRET_BADGE_HTML = `<a href="https://platform.fatsecret.com"><img alt="Nutrition information provided by fatsecret Platform API" src="https://platform.fatsecret.com/api/static/images/powered_by_fatsecret_horizontal_brand.svg" border="0"/></a>`;
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border mt-12">
+      <div className="container mx-auto px-4 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
+        <div className="text-sm text-muted-foreground text-center sm:text-left">
+          <p>&copy; {new Date().getFullYear()} Mealspire</p>
+          <p className="mt-1">Nutrition data provided in part by fatsecret.</p>
+        </div>
+        <div dangerouslySetInnerHTML={{ __html: FATSECRET_BADGE_HTML }} />
+      </div>
+    </footer>
+  );
+}
+
+export default SiteFooter;


### PR DESCRIPTION
## Why
fatsecret requires the official Web Badge (unmodified, linked to platform.fatsecret.com) on the product website to reinstate Premier Free access. The site had no footer and no attribution.

## What
- New `SiteFooter` server component: © Mealspire + the exact badge markup from the [fatsecret attribution page](https://platform.fatsecret.com/attribution), injected verbatim via `dangerouslySetInnerHTML` so the snippet stays byte-identical to the official one.
- Rendered site-wide from `layout.tsx` (public homepage requires no login, satisfying the no-login placement rule).

All text mentions use lowercase "fatsecret" per their branding rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y