### PR TITLE
fix(home): render homepage without trending rail when its query fails

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,9 +20,15 @@ export default async function HomePage() {
   // which rewrites them to /auth/callback route handler
   // This page should never receive a code parameter due to the middleware rewrite
   
-  // Parallelize data fetching for better performance
+  // Parallelize data fetching for better performance.
+  // Trending must not take down the whole page: the Vercel deployment's
+  // database can lag behind the self-hosted schema (e.g. missing Like/Comment
+  // tables → P2021), and the homepage still needs to render without it.
   const [trending, currentUser] = await Promise.all([
-    getTrendingRecipes({ limit: 12 }),
+    getTrendingRecipes({ limit: 12 }).catch((err) => {
+      console.error('getTrendingRecipes failed; rendering homepage without trending rail:', err);
+      return [];
+    }),
     getCurrentUser().catch(() => null), // Don't fail if user fetch fails
   ]);
 
@@ -31,19 +37,21 @@ export default async function HomePage() {
       {/* Search bar */}
       <SearchBar />
 
-      <HomeSection title="Trending Recipes" href="/recipes?sort=new">
-        <TrendingRail>
-          {trending.map((r, index) => (
-            <div key={r.id} className="min-w-[280px] max-w-[320px] snap-start">
-              <RecipeCard
-                recipe={r}
-                currentUserId={currentUser?.id || null}
-                isPriority={index < 3}
-              />
-            </div>
-          ))}
-        </TrendingRail>
-      </HomeSection>
+      {trending.length > 0 && (
+        <HomeSection title="Trending Recipes" href="/recipes?sort=new">
+          <TrendingRail>
+            {trending.map((r, index) => (
+              <div key={r.id} className="min-w-[280px] max-w-[320px] snap-start">
+                <RecipeCard
+                  recipe={r}
+                  currentUserId={currentUser?.id || null}
+                  isPriority={index < 3}
+                />
+              </div>
+            ))}
+          </TrendingRail>
+        </HomeSection>
+      )}
 
       {currentUser && (
         <HomeSection title="Suggested Creators">


### PR DESCRIPTION
## Why
The production homepage (recipe-app-henna-nine.vercel.app) has been rendering an empty shell that crashes into the error boundary on every visit. Vercel runtime logs show the cause: `getTrendingRecipes` throws Prisma `P2021` — **the Vercel deployment's Supabase database is missing the `Like`/`Comment` tables** (schema drift vs the self-hosted OptiPlex DB where migrations actually run). One unguarded await took down the whole page, including the fatsecret attribution footer needed for the Premier Free audit (#113).

## What
- `getTrendingRecipes` failure is caught and logged; the page renders without the trending section instead of dying.
- Trending section is hidden when empty.

Proper schema reconciliation for the Vercel DB is a separate decision (migrate it or repoint it); this just stops one query from blanking the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y