### PR TITLE
feat(mapping): corrupt-record marking — OffFood.corruptReason + retrieval exclusion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,14 @@ RANK_PLAUSIBILITY_PARTITION=1
 # (nutrition-invalid and serving-shape escapes stay active). Kill-switch: "0".
 HUMAN_ROW_TRUST=1
 
+# Corrupt-record exclusion (mark-corrupt PR): OffFood rows with a non-null
+# corruptReason (written by scripts/mark-corrupt-off.ts) are filtered from the
+# Postgres fallback search, and FoodMapping cache rows pointing at them escape
+# at read time ('corrupt_record') so they re-resolve. Index-level exclusion
+# (sync-typesense WHERE + purge script) is data-level and unaffected by this
+# flag. Kill-switch: "0".
+CORRUPT_RECORD_EXCLUSION=1
+
 # OpenFoodFacts Configuration
 # Enable/disable OpenFoodFacts candidate search (default: true)
 OFF_ENABLED=true

--- a/prisma/migrations/20260721160000_add_offfood_corrupt_reason/migration.sql
+++ b/prisma/migrations/20260721160000_add_offfood_corrupt_reason/migration.sql
@@ -1,0 +1,9 @@
+-- Corrupt-record marking for OffFood (per-serving-panel-as-per-100g family and kin,
+-- detected by scripts/eval/detect-corrupt-panel.ts, written by scripts/mark-corrupt-off.ts).
+-- NULL means the row is clean or not yet evaluated. Non-null rows are excluded from the
+-- Typesense sync (scripts/sync-typesense.ts) and the Postgres fallback search; direct
+-- barcode lookups still resolve so existing references keep working.
+-- Deliberately a separate column from "duplicateOfBarcode": dedupe-off-mark.ts clears and
+-- recomputes that column on every run, so it can never carry corrupt marks.
+ALTER TABLE "OffFood" ADD COLUMN "corruptReason" TEXT;
+CREATE INDEX "OffFood_corruptReason_idx" ON "OffFood"("corruptReason");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -381,6 +381,7 @@ model OffFood {
   packageQuantity  Float?                      // OFF product_quantity: net package quantity (see packageQuantityUnit)
   packageQuantityUnit String?                  // 'g' | 'ml', inferred from the OFF quantity label string; null when unknown
   duplicateOfBarcode String?                   // Near-dup marking (scripts/dedupe-off-mark.ts): barcode of the surviving representative; null = representative/unique. Search paths filter marked rows; direct barcode lookups don't.
+  corruptReason        String?   // corrupt-panel mark (scripts/mark-corrupt-off.ts); non-null rows excluded from Typesense sync + PG fallback search
   imageUrl         String?                     // Product image from OFF
   categories       String?                     // OFF categories CSV
   syncedAt         DateTime      @default(now())
@@ -394,6 +395,7 @@ model OffFood {
   @@index([brandName])
   @@index([syncedAt])
   @@index([duplicateOfBarcode])
+  @@index([corruptReason])
 }
 
 model OffServing {

--- a/scripts/eval/detect-corrupt-panel.ts
+++ b/scripts/eval/detect-corrupt-panel.ts
@@ -1,0 +1,209 @@
+/**
+ * detect-corrupt-panel.ts — corpus scan for the "per-serving panel stored as
+ * per-100g" OFF corruption family (REPORT-ONLY, writes nothing).
+ *
+ * The 2026-07-20 warm-cache triage confirmed 17 OFF records whose per-100g
+ * nutrition fields actually hold the label's per-SERVING panel (oreo at
+ * 143 kcal/100g = the 2-cookie serving, monster at 140 = the can, etc.).
+ * The mechanical signature: the stored kcal100 is far BELOW the same-name
+ * sibling median, and rescaling it by 100/servingGrams lands ON the median.
+ *
+ * Detection (sibling groups keyed by normalizeNameKey(name), the query-time
+ * dedupe key, with >= --min-group members for a robust median):
+ *   flag when kcal100 < 0.6 * siblingMedian
+ *        and |kcal100 * 100/serving - siblingMedian| <= 0.3 * siblingMedian
+ *   where serving is the row's own servingGrams in [2, 95] (tier "direct"),
+ *   falling back to the group's median servingGrams (tier "sibling-serving")
+ *   when the corrupt row carries none — corrupt rows often do.
+ *
+ * Groups whose MEDIAN exceeds 950 kcal/100g (physical max ~900 for pure fat)
+ * are excluded from the signature test and reported separately: those are a
+ * different corruption family (mass-INFLATED per-100g values — e.g. whole
+ * maraschino-cherry name groups with medians of 3200), where the plausible-
+ * looking row is the healthy one, not the corrupt one.
+ *
+ * The 17 triage-confirmed barcodes are cross-checked at the end; misses are
+ * reported with the reason so the marking PR can carry them explicitly.
+ *
+ * NOTE ON MARKING: duplicateOfBarcode is NOT a safe vehicle for corrupt marks —
+ * dedupe-off-mark.ts clears and recomputes all marks on every run. Exclusion
+ * needs its own column (planned with PR D pt3); this scan produces the input.
+ *
+ * Run (from repo root, read-only):
+ *   npx ts-node -r tsconfig-paths/register --transpile-only --compilerOptions \
+ *     '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/eval/detect-corrupt-panel.ts [--min-group 4] [--print 40]
+ */
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PrismaClient } from '@prisma/client';
+import { normalizeNameKey } from '../../src/lib/search/dedupe-candidates';
+
+const prisma = new PrismaClient();
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+const MIN_GROUP = Number(argValue('--min-group') ?? 4);
+const PRINT = Number(argValue('--print') ?? 40);
+const BATCH = 20000;
+
+/** Confirmed corrupt in the 2026-07-20 warm-cache triage (adversarial verify vs live corpus). */
+const TRIAGE_CONFIRMED = [
+    'off_0001424435577', 'off_0033864074825', 'off_0062020001849', 'off_0070847030607',
+    'off_0074734129207', 'off_0080000515568', 'off_0234794000001', 'off_0643843714903',
+    'off_0876063004619', 'off_5099839070778', 'off_6915917000460', 'off_7622201779160',
+    'off_8683036407634', 'off_9201070382107', 'off_9300675012089', 'off_9300675031226',
+    'off_9339687445134',
+].map(b => b.slice(4));
+
+function readKcal(nutrients: unknown): number | null {
+    const n = nutrients as { calories?: number; kcal?: number } | null;
+    const v = n?.calories ?? n?.kcal;
+    return typeof v === 'number' && isFinite(v) && v > 0 ? v : null;
+}
+
+function median(sorted: number[]): number {
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
+
+async function* streamRows(): AsyncGenerator<Row[]> {
+    let cursor: string | undefined;
+    for (;;) {
+        const batch: Row[] = await prisma.offFood.findMany({
+            select: { barcode: true, name: true, brandName: true, servingGrams: true, nutrientsPer100g: true },
+            where: { nutrientsPer100g: { not: undefined } },
+            orderBy: { barcode: 'asc' },
+            take: BATCH,
+            ...(cursor ? { cursor: { barcode: cursor }, skip: 1 } : {}),
+        });
+        if (!batch.length) return;
+        yield batch;
+        cursor = batch[batch.length - 1].barcode;
+    }
+}
+
+async function main() {
+    // Pass 1: sibling kcal + serving distributions per name key
+    console.log('Pass 1: building sibling kcal/serving medians...');
+    const groups = new Map<string, { kcals: number[]; servings: number[] }>();
+    let scanned = 0;
+    for await (const batch of streamRows()) {
+        for (const r of batch) {
+            const kcal = readKcal(r.nutrientsPer100g);
+            if (kcal == null) continue;
+            const key = normalizeNameKey(r.name);
+            if (!key) continue;
+            let g = groups.get(key);
+            if (!g) { g = { kcals: [], servings: [] }; groups.set(key, g); }
+            g.kcals.push(kcal);
+            if (r.servingGrams != null && r.servingGrams >= 2 && r.servingGrams <= 600) {
+                g.servings.push(r.servingGrams);
+            }
+        }
+        scanned += batch.length;
+        if (scanned % 200000 === 0) console.log(`  ${scanned} rows...`);
+    }
+    const MAX_SANE_MEDIAN = 950; // physical ceiling ~900 kcal/100g (pure fat)
+    const medians = new Map<string, { med: number; n: number; medServing: number | null }>();
+    const inflatedGroups: Array<{ key: string; med: number; n: number }> = [];
+    for (const [key, g] of groups) {
+        if (g.kcals.length < MIN_GROUP) continue;
+        g.kcals.sort((a, b) => a - b);
+        const med = median(g.kcals);
+        if (med > MAX_SANE_MEDIAN) {
+            inflatedGroups.push({ key, med: Math.round(med), n: g.kcals.length });
+            continue; // mass-inflated family — the low rows here are the healthy ones
+        }
+        g.servings.sort((a, b) => a - b);
+        medians.set(key, {
+            med, n: g.kcals.length,
+            medServing: g.servings.length >= 2 ? median(g.servings) : null,
+        });
+    }
+    groups.clear();
+    console.log(`  ${scanned} rows, ${medians.size} sane name groups with >=${MIN_GROUP} members, ${inflatedGroups.length} mass-inflated groups (median > ${MAX_SANE_MEDIAN}) excluded`);
+
+    // Pass 2: test the panel-as-100g signature
+    console.log('Pass 2: testing serving-rescale signature...');
+    const flagged: Array<{
+        barcode: string; name: string; brandName: string | null;
+        kcal100: number; servingGrams: number; tier: 'direct' | 'sibling-serving';
+        direction: 'panel-low' | 'panel-inflated';
+        rescaled: number; siblingMedian: number; groupSize: number; triageConfirmed: boolean;
+    }> = [];
+    for await (const batch of streamRows()) {
+        for (const r of batch) {
+            const kcal = readKcal(r.nutrientsPer100g);
+            if (kcal == null) continue;
+            const m = medians.get(normalizeNameKey(r.name));
+            if (!m || m.med <= 0) continue;
+            const own = r.servingGrams != null && r.servingGrams >= 2 && r.servingGrams <= 600;
+            const s = own ? r.servingGrams! : m.medServing;
+            // Servings near 100g can't distinguish panel-as-100g from correct data
+            if (s == null || (s > 90 && s < 110)) continue;
+            const rescaled = kcal * (100 / s);
+            // Serving < 100g stores the panel LOW (oil at 120), > 100g stores it
+            // INFLATED (a 473ml Monster can panel at 140 vs ~47 real density).
+            const direction = kcal <= 0.6 * m.med ? 'panel-low'
+                : kcal >= 1.6 * m.med ? 'panel-inflated' : null;
+            if (direction && Math.abs(rescaled - m.med) <= 0.3 * m.med) {
+                flagged.push({
+                    barcode: r.barcode, name: r.name, brandName: r.brandName,
+                    kcal100: kcal, servingGrams: s, tier: own ? 'direct' : 'sibling-serving',
+                    direction,
+                    rescaled: Math.round(rescaled), siblingMedian: Math.round(m.med), groupSize: m.n,
+                    triageConfirmed: TRIAGE_CONFIRMED.includes(r.barcode),
+                });
+            }
+        }
+    }
+
+    flagged.sort((a, b) => b.siblingMedian - a.siblingMedian);
+    const outDir = path.join(__dirname, 'results');
+    fs.mkdirSync(outDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = path.join(outDir, `corrupt-panel-scan-${ts}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({
+        at: new Date().toISOString(),
+        params: { minGroup: MIN_GROUP },
+        summary: { scanned, flagged: flagged.length },
+        flagged,
+    }, null, 1));
+
+    const low = flagged.filter(f => f.direction === 'panel-low').length;
+    const inflated = flagged.filter(f => f.direction === 'panel-inflated').length;
+    console.log(`\nFlagged ${flagged.length} rows (of ${scanned} scanned): ${low} panel-low, ${inflated} panel-inflated`);
+    for (const f of flagged.slice(0, PRINT)) {
+        const tag = f.triageConfirmed ? ' [TRIAGE-CONFIRMED]' : '';
+        console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''} (${f.direction}/${f.tier}): ${f.kcal100} kcal/100g, serving ${f.servingGrams}g -> rescaled ${f.rescaled} vs sibling median ${f.siblingMedian} (n=${f.groupSize})${tag}`);
+    }
+    if (flagged.length > PRINT) console.log(`  ... ${flagged.length - PRINT} more in the report file`);
+
+    // Cross-check: which triage-confirmed records did the scan catch?
+    console.log('\nTriage-confirmed cross-check:');
+    const flaggedSet = new Set(flagged.map(f => f.barcode));
+    for (const b of TRIAGE_CONFIRMED) {
+        if (flaggedSet.has(b)) { console.log(`  CAUGHT  off_${b}`); continue; }
+        const row = await prisma.offFood.findUnique({
+            where: { barcode: b },
+            select: { name: true, servingGrams: true, nutrientsPer100g: true },
+        });
+        if (!row) { console.log(`  MISSING off_${b}: not in DB`); continue; }
+        const kcal = readKcal(row.nutrientsPer100g);
+        const m = medians.get(normalizeNameKey(row.name));
+        console.log(`  MISSED  off_${b} "${row.name}": kcal=${kcal}, servingGrams=${row.servingGrams}, siblingGroup=${m ? `${m.n} med ${Math.round(m.med)}` : 'none/too-small'}`);
+    }
+
+    console.log(`\nReport written to ${path.relative(process.cwd(), outPath)}`);
+}
+
+main()
+    .catch(err => { console.error(err); process.exit(2); })
+    .finally(() => prisma.$disconnect());

--- a/scripts/mark-corrupt-off.ts
+++ b/scripts/mark-corrupt-off.ts
@@ -1,0 +1,204 @@
+/**
+ * mark-corrupt-off.ts — write OffFood.corruptReason from a corrupt-panel scan.
+ *
+ * Input: a results/corrupt-panel-scan-*.json produced by
+ * scripts/eval/detect-corrupt-panel.ts. Each flagged entry is passed through
+ * the shared trust rules (src/lib/mapping/corrupt-mark.ts):
+ *   - panel-low flags whose sibling median exceeds the physical ceiling are
+ *     skipped (the SIBLING group is the corrupt one — kJ-as-kcal family);
+ *   - panel-inflated flags from groups smaller than 8 are skipped.
+ * Surviving flags are re-checked against the live row (barcode still exists,
+ * stored kcal/100g still matches the scan within 0.5 — the corpus may have
+ * changed since the scan) and then written as corruptReason = "<direction>:<tier>".
+ *
+ * corruptReason is a SEPARATE column from duplicateOfBarcode on purpose:
+ * dedupe-off-mark.ts clears and recomputes duplicate marks on every run.
+ * This script never touches rows it did not decide about, and re-runs are
+ * idempotent (already-marked rows are counted, not rewritten).
+ *
+ * DRY-RUN BY DEFAULT — nothing is written without --apply.
+ *
+ * Run (from repo root; DATABASE_URL must point at the target DB):
+ *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/mark-corrupt-off.ts --file scripts/eval/results/corrupt-panel-scan-<ts>.json [--apply]
+ *
+ * Flags:
+ *   --file <path>   scan JSON (required)
+ *   --apply         actually write marks (default: dry-run report only)
+ *   --clear         instead of marking, set corruptReason = NULL on every row
+ *                   whose reason matches --clear-prefix (default: all rows);
+ *                   requires --apply to take effect
+ *   --clear-prefix <p>  with --clear: only clear reasons starting with <p>
+ *
+ * After applying: run scripts/purge-corrupt-typesense.ts to drop the marked
+ * docs from the live off_foods index (full rebuilds via sync-typesense.ts
+ * exclude them automatically).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { decideMark, CorruptScanFlag } from '../src/lib/mapping/corrupt-mark';
+
+const prisma = new PrismaClient();
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+const APPLY = args.includes('--apply');
+const CLEAR = args.includes('--clear');
+const CLEAR_PREFIX = argValue('--clear-prefix');
+const FILE = argValue('--file');
+
+const FETCH_CHUNK = 1000;
+const WRITE_BATCH = 5000;
+
+function kcalOf(nutrients: unknown): number | null {
+    if (!nutrients || typeof nutrients !== 'object') return null;
+    const n = nutrients as Record<string, unknown>;
+    const v = n.calories ?? n.energy ?? n.kcal;
+    return typeof v === 'number' ? v : null;
+}
+
+async function clearMarks(): Promise<void> {
+    const where = CLEAR_PREFIX
+        ? Prisma.sql`"corruptReason" LIKE ${CLEAR_PREFIX + '%'}`
+        : Prisma.sql`"corruptReason" IS NOT NULL`;
+    const count = await prisma.$queryRaw<Array<{ n: bigint }>>(
+        Prisma.sql`SELECT count(*)::bigint AS n FROM "OffFood" WHERE ${where}`
+    );
+    const n = Number(count[0]?.n ?? 0);
+    if (!APPLY) {
+        console.log(`[dry-run] --clear would null corruptReason on ${n} rows` +
+            (CLEAR_PREFIX ? ` (prefix "${CLEAR_PREFIX}")` : ''));
+        return;
+    }
+    const res = await prisma.$executeRaw(
+        Prisma.sql`UPDATE "OffFood" SET "corruptReason" = NULL WHERE ${where}`
+    );
+    console.log(`Cleared corruptReason on ${res} rows` +
+        (CLEAR_PREFIX ? ` (prefix "${CLEAR_PREFIX}")` : ''));
+}
+
+async function main(): Promise<void> {
+    if (CLEAR) {
+        await clearMarks();
+        return;
+    }
+
+    if (!FILE) {
+        console.error('Usage: mark-corrupt-off.ts --file <corrupt-panel-scan.json> [--apply]');
+        process.exit(1);
+    }
+    const scan = JSON.parse(fs.readFileSync(FILE, 'utf8')) as {
+        at: string;
+        summary: { scanned: number; flagged: number };
+        flagged: CorruptScanFlag[];
+    };
+    console.log(`Scan ${scan.at}: ${scan.flagged.length} flagged of ${scan.summary.scanned} scanned`);
+
+    // 1. Trust rules (pure, shared with jest).
+    const skips: Record<string, number> = {};
+    const markable = new Map<string, { flag: CorruptScanFlag; reason: string }>();
+    for (const flag of scan.flagged) {
+        const decision = decideMark(flag);
+        if (!decision.mark) {
+            skips[decision.skip] = (skips[decision.skip] ?? 0) + 1;
+            continue;
+        }
+        markable.set(flag.barcode, { flag, reason: decision.reason });
+    }
+    console.log(`Trust rules: ${markable.size} markable, skipped ${JSON.stringify(skips)}`);
+
+    // 2. Staleness re-check against the live rows.
+    const barcodes = [...markable.keys()];
+    const toWrite: Array<{ barcode: string; reason: string }> = [];
+    let missing = 0, stale = 0, alreadyMarked = 0;
+    for (let i = 0; i < barcodes.length; i += FETCH_CHUNK) {
+        const chunk = barcodes.slice(i, i + FETCH_CHUNK);
+        const rows = await prisma.offFood.findMany({
+            where: { barcode: { in: chunk } },
+            select: { barcode: true, nutrientsPer100g: true, corruptReason: true },
+        });
+        const byBarcode = new Map(rows.map(r => [r.barcode, r]));
+        for (const barcode of chunk) {
+            const row = byBarcode.get(barcode);
+            const entry = markable.get(barcode)!;
+            if (!row) { missing++; continue; }
+            if (row.corruptReason != null) { alreadyMarked++; continue; }
+            const liveKcal = kcalOf(row.nutrientsPer100g);
+            if (liveKcal == null || Math.abs(liveKcal - entry.flag.kcal100) > 0.5) {
+                stale++;
+                continue;
+            }
+            toWrite.push({ barcode, reason: entry.reason });
+        }
+    }
+    console.log(`Live check: ${toWrite.length} to write ` +
+        `(${alreadyMarked} already marked, ${stale} stale panels, ${missing} missing rows)`);
+    const byReason: Record<string, number> = {};
+    for (const w of toWrite) byReason[w.reason] = (byReason[w.reason] ?? 0) + 1;
+    console.log(`By reason: ${JSON.stringify(byReason)}`);
+
+    // 3. Cache rows pointing at soon-to-be-marked records (they will escape
+    //    at read time as 'corrupt_record'; human-triage rows deserve eyes).
+    const markSet = new Set(toWrite.map(w => w.barcode));
+    const cacheRows = await prisma.foodMapping.findMany({
+        where: { offBarcode: { not: null } },
+        select: { normalizedForm: true, offBarcode: true, foodName: true, validatedBy: true },
+    });
+    const affected = cacheRows.filter(r => r.offBarcode && markSet.has(r.offBarcode));
+    if (affected.length) {
+        console.log(`\nFoodMapping rows pointing at marked records (${affected.length}) — these escape+re-resolve on next hit:`);
+        for (const r of affected) {
+            const tag = r.validatedBy === 'human-triage' ? '  ** HUMAN-TRIAGE **' : '';
+            console.log(`  ${r.normalizedForm} -> off_${r.offBarcode} (${r.foodName})${tag}`);
+        }
+    } else {
+        console.log('\nNo FoodMapping rows point at the records being marked.');
+    }
+
+    if (!APPLY) {
+        console.log('\n[dry-run] no writes performed. Re-run with --apply to mark.');
+        return;
+    }
+
+    // 4. Batched writes.
+    let written = 0;
+    for (let i = 0; i < toWrite.length; i += WRITE_BATCH) {
+        const batch = toWrite.slice(i, i + WRITE_BATCH);
+        const values = Prisma.join(
+            batch.map(w => Prisma.sql`(${w.barcode}, ${w.reason})`)
+        );
+        written += await prisma.$executeRaw(Prisma.sql`
+            UPDATE "OffFood" AS f
+            SET "corruptReason" = v.reason
+            FROM (VALUES ${values}) AS v(barcode, reason)
+            WHERE f.barcode = v.barcode AND f."corruptReason" IS NULL
+        `);
+        console.log(`  wrote ${Math.min(i + WRITE_BATCH, toWrite.length)}/${toWrite.length}`);
+    }
+    console.log(`\nMarked ${written} rows. Next: scripts/purge-corrupt-typesense.ts to drop them from the live index.`);
+
+    const outPath = path.join('scripts', 'eval', 'results',
+        `corrupt-mark-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({
+        at: new Date().toISOString(),
+        scanFile: FILE,
+        scanAt: scan.at,
+        written,
+        skips,
+        stale,
+        missing,
+        alreadyMarked,
+        byReason,
+        affectedCacheRows: affected,
+    }, null, 2));
+    console.log(`Audit record: ${outPath}`);
+}
+
+main()
+    .catch((err) => { console.error(err); process.exit(1); })
+    .finally(() => prisma.$disconnect());

--- a/scripts/purge-corrupt-typesense.ts
+++ b/scripts/purge-corrupt-typesense.ts
@@ -1,0 +1,91 @@
+/**
+ * purge-corrupt-typesense.ts — Remove corrupt-marked OffFood rows from the
+ * live off_foods Typesense collection without a full resync.
+ *
+ * Companion to mark-corrupt-off.ts: reads every barcode with
+ * corruptReason IS NOT NULL and issues batched
+ * DELETE /collections/off_foods/documents?filter_by=barcode:[...] requests —
+ * the same mechanics as dedupe-off-purge-typesense.ts.
+ *
+ * Fully recoverable: a normal scripts/sync-typesense.ts rebuild restores the
+ * index from Postgres (and skips corrupt-marked rows anyway). To un-exclude a
+ * record: clear its corruptReason, then reindex or upsert it.
+ *
+ * Usage: npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *          -r tsconfig-paths/register scripts/purge-corrupt-typesense.ts [--dry-run]
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const HOST = process.env.TYPESENSE_HOST ?? 'http://localhost:8108';
+const KEY = process.env.TYPESENSE_API_KEY ?? '';
+const COLLECTION = 'off_foods';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// Keep the filter_by URL comfortably under typical 8KB request-line limits.
+const BATCH = 250;
+
+async function typesenseReq(endpoint: string, options: RequestInit = {}): Promise<any> {
+    const res = await fetch(`${HOST}${endpoint}`, {
+        headers: { 'X-TYPESENSE-API-KEY': KEY },
+        ...options,
+    });
+    if (!res.ok) {
+        throw new Error(`Typesense ${endpoint} failed ${res.status}: ${await res.text()}`);
+    }
+    return res.json();
+}
+
+async function docCount(): Promise<number> {
+    const info = await typesenseReq(`/collections/${COLLECTION}`);
+    return info.num_documents as number;
+}
+
+async function main() {
+    console.log(`🚀 purge-corrupt-typesense ${DRY_RUN ? '(DRY RUN)' : ''} → ${HOST}`);
+
+    const marked: Array<{ barcode: string }> = await prisma.offFood.findMany({
+        where: { corruptReason: { not: null } },
+        select: { barcode: true },
+    });
+    console.log(`Corrupt-marked rows in Postgres: ${marked.length.toLocaleString()}`);
+
+    const before = await docCount();
+    console.log(`off_foods docs before  : ${before.toLocaleString()}`);
+
+    if (DRY_RUN) {
+        console.log('🔍 Dry run — no deletes. Done.');
+        return;
+    }
+
+    let deleted = 0;
+    for (let i = 0; i < marked.length; i += BATCH) {
+        const batch = marked.slice(i, i + BATCH).map(m => m.barcode);
+        const filterBy = encodeURIComponent(`barcode:[${batch.join(',')}]`);
+        const res = await typesenseReq(
+            `/collections/${COLLECTION}/documents?filter_by=${filterBy}`,
+            { method: 'DELETE' }
+        );
+        deleted += res.num_deleted ?? 0;
+        if ((i / BATCH) % 40 === 0) {
+            console.log(`  processed ${Math.min(i + BATCH, marked.length).toLocaleString()} / ${marked.length.toLocaleString()} barcodes (${deleted.toLocaleString()} docs deleted)`);
+        }
+    }
+
+    const after = await docCount();
+    console.log('──────────────────────────────────────────────');
+    console.log(`  Docs deleted : ${deleted.toLocaleString()}`);
+    console.log(`  off_foods    : ${before.toLocaleString()} → ${after.toLocaleString()}`);
+    console.log('✅ Done.');
+}
+
+main()
+    .catch(err => {
+        console.error('❌ Crashed:', err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/scripts/sync-typesense.ts
+++ b/scripts/sync-typesense.ts
@@ -135,6 +135,7 @@ async function main() {
             FROM "OffFood"
             WHERE barcode > ${lastBarcode}
               AND "duplicateOfBarcode" IS NULL
+              AND "corruptReason" IS NULL
             ORDER BY barcode ASC
             LIMIT ${batchSize}
         `;

--- a/src/lib/mapping/__tests__/corrupt-mark.test.ts
+++ b/src/lib/mapping/__tests__/corrupt-mark.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the corrupt-mark trust rules (corrupt-mark.ts) — the pure
+ * decision layer between detect-corrupt-panel.ts scan output and the
+ * corruptReason writes performed by scripts/mark-corrupt-off.ts.
+ */
+import {
+    decideMark,
+    isCorruptExclusionEnabled,
+    CorruptScanFlag,
+    MAX_TRUSTABLE_SIBLING_MEDIAN,
+    MIN_INFLATED_GROUP_SIZE,
+} from '../corrupt-mark';
+
+function flag(overrides: Partial<CorruptScanFlag>): CorruptScanFlag {
+    return {
+        barcode: '0000000000000',
+        name: 'Test Food',
+        brandName: null,
+        kcal100: 160,
+        servingGrams: 30,
+        tier: 'direct',
+        direction: 'panel-low',
+        rescaled: 533,
+        siblingMedian: 540,
+        groupSize: 12,
+        triageConfirmed: false,
+        ...overrides,
+    };
+}
+
+describe('decideMark', () => {
+    it('marks a classic per-serving-panel-as-per-100g record (panel-low, sane siblings)', () => {
+        const d = decideMark(flag({ direction: 'panel-low', siblingMedian: 540, tier: 'direct' }));
+        expect(d).toEqual({ mark: true, reason: 'panel-low:direct' });
+    });
+
+    it('marks panel-inflated records from large groups', () => {
+        const d = decideMark(flag({
+            direction: 'panel-inflated', tier: 'sibling-serving',
+            kcal100: 900, rescaled: 270, siblingMedian: 265, groupSize: MIN_INFLATED_GROUP_SIZE,
+        }));
+        expect(d).toEqual({ mark: true, reason: 'panel-inflated:sibling-serving' });
+    });
+
+    it('reason string encodes direction and tier', () => {
+        const d = decideMark(flag({ direction: 'panel-low', tier: 'sibling-serving' }));
+        expect(d).toEqual({ mark: true, reason: 'panel-low:sibling-serving' });
+    });
+
+    it('skips panel-low flags whose sibling median is physically impossible (kJ-corrupt group)', () => {
+        // Real case from the 2026-07-21 scan: "Honey mustard dressing & dip"
+        // group median 939 kcal/100g — above pure fat. The SIBLINGS are the
+        // corrupt rows; the flagged 300 kcal/100g record is the sane one.
+        const d = decideMark(flag({
+            direction: 'panel-low', kcal100: 300, servingGrams: 30,
+            rescaled: 1000, siblingMedian: MAX_TRUSTABLE_SIBLING_MEDIAN + 19,
+        }));
+        expect(d).toEqual({ mark: false, skip: 'sibling_median_implausible' });
+    });
+
+    it('trusts panel-low at exactly the sibling-median ceiling', () => {
+        const d = decideMark(flag({ direction: 'panel-low', siblingMedian: MAX_TRUSTABLE_SIBLING_MEDIAN }));
+        expect(d.mark).toBe(true);
+    });
+
+    it('skips panel-inflated flags from small sibling groups', () => {
+        const d = decideMark(flag({
+            direction: 'panel-inflated', groupSize: MIN_INFLATED_GROUP_SIZE - 1,
+            kcal100: 900, rescaled: 270, siblingMedian: 265,
+        }));
+        expect(d).toEqual({ mark: false, skip: 'inflated_group_too_small' });
+    });
+
+    it('does NOT apply the group-size floor to panel-low flags (direct serving evidence)', () => {
+        const d = decideMark(flag({ direction: 'panel-low', groupSize: 4 }));
+        expect(d.mark).toBe(true);
+    });
+});
+
+describe('isCorruptExclusionEnabled', () => {
+    const saved = process.env.CORRUPT_RECORD_EXCLUSION;
+    afterEach(() => {
+        if (saved === undefined) delete process.env.CORRUPT_RECORD_EXCLUSION;
+        else process.env.CORRUPT_RECORD_EXCLUSION = saved;
+    });
+
+    it('defaults ON when unset', () => {
+        delete process.env.CORRUPT_RECORD_EXCLUSION;
+        expect(isCorruptExclusionEnabled()).toBe(true);
+    });
+
+    it('kill-switch: "0" disables', () => {
+        process.env.CORRUPT_RECORD_EXCLUSION = '0';
+        expect(isCorruptExclusionEnabled()).toBe(false);
+    });
+
+    it('any other value stays ON', () => {
+        process.env.CORRUPT_RECORD_EXCLUSION = '1';
+        expect(isCorruptExclusionEnabled()).toBe(true);
+    });
+});

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -147,6 +147,40 @@ describe('serving-downgrade save guard', () => {
         expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
     });
 
+    it('bypasses the guard when the incumbent record is corrupt-marked', async () => {
+        // Zombie-row fix (mark-corrupt PR): live-verified on "beans" — the
+        // marked record 8681820101348 had serving shape, the clean re-pick
+        // didn't, and the guard kept re-protecting the corrupt row forever.
+        setupExistingRow(
+            { servingGrams: 250, packageQuantity: null, corruptReason: 'panel-inflated:direct' } as any,
+            { servingGrams: null, packageQuantity: null },
+        );
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the guard when corrupt exclusion is kill-switched off', async () => {
+        process.env.CORRUPT_RECORD_EXCLUSION = '0';
+        try {
+            setupExistingRow(
+                { servingGrams: 250, packageQuantity: null, corruptReason: 'panel-inflated:direct' } as any,
+                { servingGrams: null, packageQuantity: null },
+            );
+            await saveValidatedMapping(
+                'red bull',
+                makeMapping({ foodId: `off_${NEW_BARCODE}`, foodName: 'Red Bull Energy Drink' }),
+                validation,
+            );
+            expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+        } finally {
+            delete process.env.CORRUPT_RECORD_EXCLUSION;
+        }
+    });
+
     it('allows the swap when the old record had no serving data either', async () => {
         setupExistingRow(
             { servingGrams: null, packageQuantity: null },

--- a/src/lib/mapping/corrupt-mark.ts
+++ b/src/lib/mapping/corrupt-mark.ts
@@ -1,0 +1,70 @@
+/**
+ * corrupt-mark.ts — shared logic for the OffFood.corruptReason marking system.
+ *
+ * The corpus scan (scripts/eval/detect-corrupt-panel.ts) flags records whose
+ * stored per-100g panel is really a per-serving panel (rescaling by
+ * 100/servingGrams lands on the same-name sibling median). The marker
+ * (scripts/mark-corrupt-off.ts) writes corruptReason for the trustworthy
+ * subset of those flags; retrieval then excludes marked rows (Typesense sync
+ * WHERE clause + live-index purge + PG fallback filter) and the mapper escapes
+ * cache rows that point at them.
+ *
+ * This module holds the pure decision rules so the marker script and jest can
+ * share them, plus the runtime kill-switch used by the exclusion sites.
+ *
+ * Layering note: the curated 25-barcode denylist (corrupt-denylist.ts) stays a
+ * separate rank-time layer. Several of its entries are current golden winners
+ * for SEARCH cases (s-brand-05/08, n-sem-02 replacement, n-supp-10 twins), so
+ * they must remain in the Typesense index for manual search; corruptReason
+ * rows, by contrast, are removed from the index entirely.
+ */
+
+/** Kill-switch: set CORRUPT_RECORD_EXCLUSION=0 to stop filtering marked rows
+ *  at the PG fallback and to disable the cache-row escape. Index-level
+ *  exclusion (sync WHERE + purge) is data-level and not affected. */
+export function isCorruptExclusionEnabled(): boolean {
+    return process.env.CORRUPT_RECORD_EXCLUSION !== '0';
+}
+
+/** One entry of detect-corrupt-panel.ts scan output (results/corrupt-panel-scan-*.json). */
+export interface CorruptScanFlag {
+    barcode: string;
+    name: string;
+    brandName: string | null;
+    kcal100: number;
+    servingGrams: number | null;
+    tier: 'direct' | 'sibling-serving';
+    direction: 'panel-low' | 'panel-inflated';
+    rescaled: number;
+    siblingMedian: number;
+    groupSize: number;
+    triageConfirmed: boolean;
+}
+
+/** Physical ceiling for a trustworthy sibling median. Pure fat is ~900 kcal/100g;
+ *  a group median above this means the SIBLINGS are corrupt (kJ-as-kcal family)
+ *  and a panel-low flag against them is inverted — the flagged row is the sane one. */
+export const MAX_TRUSTABLE_SIBLING_MEDIAN = 920;
+
+/** panel-inflated flags lean entirely on the sibling distribution; small groups
+ *  are dominated by a few bad rows. Triage review set this floor. */
+export const MIN_INFLATED_GROUP_SIZE = 8;
+
+export type MarkDecision =
+    | { mark: true; reason: string }
+    | { mark: false; skip: 'sibling_median_implausible' | 'inflated_group_too_small' };
+
+/**
+ * Decide whether a scan flag is trustworthy enough to mark.
+ * Reason strings are stable identifiers ("panel-low:direct" etc.) so later
+ * sweeps can distinguish mark generations by prefix match.
+ */
+export function decideMark(flag: CorruptScanFlag): MarkDecision {
+    if (flag.direction === 'panel-low' && flag.siblingMedian > MAX_TRUSTABLE_SIBLING_MEDIAN) {
+        return { mark: false, skip: 'sibling_median_implausible' };
+    }
+    if (flag.direction === 'panel-inflated' && flag.groupSize < MIN_INFLATED_GROUP_SIZE) {
+        return { mark: false, skip: 'inflated_group_too_small' };
+    }
+    return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+}

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -53,6 +53,7 @@ import { hydrateOffCandidate } from '../openfoodfacts/hydrate';
 import { detectBrandInQuery } from './brand-detector';
 import { assessMacroPlausibility, assessRankTimePlausibility } from './macro-plausibility';
 import { isDenylistedOffRecord } from './corrupt-denylist';
+import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { deriveCacheKeyName } from './cache-key';
 import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
 
@@ -758,6 +759,7 @@ export async function mapIngredientWithFallback(
             const earlyCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, earlyCacheHit.foodName, earlyCacheHit.brandName);
 
             let earlyNutritionInvalid = false;
+            let earlyCorruptMarked = false;
             let loadedFdcNutrition: any = null;
             let cachedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
             let cachedKcal100: number | null = null;
@@ -797,11 +799,12 @@ export async function mapIngredientWithFallback(
                         const barcode = earlyCacheHit.foodId.replace('off_', '');
                         const off = await prisma.offFood.findUnique({
                             where: { barcode },
-                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true }
+                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true, corruptReason: true }
                         });
                         nutrients = off?.nutrientsPer100g;
                         if (off) {
                             cachedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
+                            earlyCorruptMarked = off.corruptReason != null && isCorruptExclusionEnabled();
                         }
                     } else {
                         const ai = await prisma.aiGeneratedFood.findUnique({
@@ -885,7 +888,8 @@ export async function mapIngredientWithFallback(
             // former catch-all 'filter_mismatch' into per-condition labels).
             // Same predicates, same evaluation order as the former || chain.
             let earlyEscapeReason =
-                earlyCoreTokenMismatch ? 'core_token_mismatch'
+                earlyCorruptMarked ? 'corrupt_record'
+                : earlyCoreTokenMismatch ? 'core_token_mismatch'
                 : earlyNutritionInvalid ? 'nutrition_invalid'
                 : earlyCountLabelEscape ? 'count_label'
                 : earlyGrainCookedEscape ? 'grain_cooked'
@@ -906,9 +910,9 @@ export async function mapIngredientWithFallback(
             // Read-time trust (PR D pt3, HUMAN_ROW_TRUST): human-triage rows
             // are deliberate identity repoints — the five NAME-heuristic
             // escapes must not evict them (see isTrustedHumanRow). Kept
-            // active for ALL rows: core_token_mismatch, nutrition_invalid,
-            // count_label and grain_cooked — a repoint fixes identity, not
-            // per-piece/cooked serving shape.
+            // active for ALL rows: corrupt_record, core_token_mismatch,
+            // nutrition_invalid, count_label and grain_cooked — a repoint
+            // fixes identity, not data validity or serving shape.
             if (earlyEscapeReason
                 && isHumanTrustSkippableEscape(earlyEscapeReason)
                 && isTrustedHumanRow(earlyCacheHit.validatedBy)) {
@@ -1160,6 +1164,7 @@ export async function mapIngredientWithFallback(
 
                 // Validate nutrition data - reject cached mappings to foods with zero/null nutrition
                 let normalizedNutritionInvalid = false;
+                let normalizedCorruptMarked = false;
                 let normalizedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
                 let normalizedCachedKcal100: number | null = null;
                 let normalizedCachedCarbs100: number | null = null;
@@ -1177,11 +1182,12 @@ export async function mapIngredientWithFallback(
                         const barcode = normalizedCache.foodId.replace('off_', '');
                         const off = await prisma.offFood.findUnique({
                             where: { barcode },
-                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true }
+                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true, corruptReason: true }
                         });
                         nutrients = off?.nutrientsPer100g;
                         if (off) {
                             normalizedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
+                            normalizedCorruptMarked = off.corruptReason != null && isCorruptExclusionEnabled();
                         }
                     } else {
                         const ai = await prisma.aiGeneratedFood.findUnique({
@@ -1247,7 +1253,8 @@ export async function mapIngredientWithFallback(
                 // the former catch-all 'filter_mismatch' into per-condition
                 // labels). Same predicates, same order as the former || chain.
                 let normalizedEscapeReason =
-                    normalizedCoreTokenMismatch ? 'core_token_mismatch'
+                    normalizedCorruptMarked ? 'corrupt_record'
+                    : normalizedCoreTokenMismatch ? 'core_token_mismatch'
                     : normalizedNutritionInvalid ? 'nutrition_invalid'
                     : normalizedCountLabelEscape ? 'count_label'
                     : normalizedGrainCookedEscape ? 'grain_cooked'
@@ -1277,8 +1284,9 @@ export async function mapIngredientWithFallback(
 
                 // Read-time trust (PR D pt3, HUMAN_ROW_TRUST) — same rationale
                 // as the early-cache block: name-heuristic escapes skipped for
-                // human-triage rows; core-token, nutrition-invalid and
-                // serving-shape escapes stay active for all rows.
+                // human-triage rows; corrupt-record, core-token,
+                // nutrition-invalid and serving-shape escapes stay active for
+                // all rows.
                 if (normalizedEscapeReason
                     && isHumanTrustSkippableEscape(normalizedEscapeReason)
                     && isTrustedHumanRow(normalizedCache.validatedBy)) {

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -14,6 +14,7 @@ import type { AIValidationResult } from './ai-validation';
 import { normalizeQuery } from '../search/normalize';
 import { logger } from '../logger';
 import { hasCoreTokenMismatch } from './filter-candidates';
+import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { assessSaveTimePlausibility } from './macro-plausibility';
 import type { MacroPlausibilityInput, ExpectedNutritionPer100g } from './macro-plausibility';
 import { detectBrandInQuery } from './brand-detector';
@@ -509,7 +510,7 @@ export async function saveValidatedMapping(
                 const [oldOff, newOff] = await Promise.all([
                     prisma.offFood.findUnique({
                         where: { barcode: existing.offBarcode },
-                        select: { servingGrams: true, packageQuantity: true },
+                        select: { servingGrams: true, packageQuantity: true, corruptReason: true },
                     }),
                     prisma.offFood.findUnique({
                         where: { barcode: offBarcode },
@@ -518,7 +519,19 @@ export async function saveValidatedMapping(
                 ]);
                 const hasServingShape = (f: { servingGrams: number | null; packageQuantity: number | null } | null) =>
                     !!f && ((f.servingGrams ?? 0) > 0 || (f.packageQuantity ?? 0) > 0);
-                if (hasServingShape(oldOff) && !hasServingShape(newOff)) {
+                // A corrupt-marked incumbent forfeits the guard: keeping it
+                // would zombie the row — every hit escapes ('corrupt_record'),
+                // re-resolves, and lands right back here. Serving shape on a
+                // corrupt panel is not worth preserving.
+                const incumbentCorrupt = oldOff?.corruptReason != null && isCorruptExclusionEnabled();
+                if (incumbentCorrupt) {
+                    logger.info('validated_mapping.downgrade_guard_bypassed_corrupt_incumbent', {
+                        normalizedForm,
+                        keptBarcode: offBarcode,
+                        evictedBarcode: existing.offBarcode,
+                        corruptReason: oldOff?.corruptReason,
+                    });
+                } else if (hasServingShape(oldOff) && !hasServingShape(newOff)) {
                     logger.warn('validated_mapping.save_rejected_serving_downgrade', {
                         rawIngredient,
                         normalizedForm,

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -61,9 +61,9 @@ export function isTrustedHumanRow(validatedBy?: string | null): boolean {
  * belongs here: human repoints routinely cross naming conventions (key
  * 'prawns' → FDC "Crustaceans, shrimp, ..."), and the helper-side core-token
  * skip would be moot if the mapper twin still escaped the row. Deliberately
- * excludes nutrition_invalid, count_label and grain_cooked: those escapes
- * fire for every row regardless of provenance (a repoint fixes identity,
- * not nutrition validity or serving shape).
+ * excludes corrupt_record, nutrition_invalid, count_label and grain_cooked:
+ * those escapes fire for every row regardless of provenance (a repoint fixes
+ * identity, not data validity or serving shape).
  */
 const HUMAN_TRUST_SKIPPABLE_ESCAPES = new Set([
     'category_mismatch',

--- a/src/lib/openfoodfacts/search.ts
+++ b/src/lib/openfoodfacts/search.ts
@@ -8,6 +8,7 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
+import { isCorruptExclusionEnabled } from '../mapping/corrupt-mark';
 import type { UnifiedCandidate } from '../mapping/gather-candidates';
 
 // ============================================================
@@ -306,6 +307,7 @@ export async function searchOffSimple(
             where: {
                 nutrientsPer100g: { not: Prisma.DbNull },
                 duplicateOfBarcode: null,
+                ...(isCorruptExclusionEnabled() ? { corruptReason: null } : {}),
                 OR: [
                     { name:      { contains: queryLower, mode: 'insensitive' } },
                     { brandName: { contains: queryLower, mode: 'insensitive' } },


### PR DESCRIPTION
## What

DB-backed corrupt-record layer for the OFF corpus (mark-corrupt PR planned since PR D pt3). The 2026-07-21 corpus scan flagged **7,266 records** in the per-serving-panel-as-per-100g family; after trust rules ~6,800 get marked and excluded from retrieval.

## How

- **Schema**: `OffFood.corruptReason` (nullable TEXT) + index. Deliberately separate from `duplicateOfBarcode` — `dedupe-off-mark.ts` clears that column on every run, so it can never carry corrupt marks.
- **Trust rules** (`src/lib/mapping/corrupt-mark.ts`, unit-tested): skip panel-low flags whose sibling median exceeds 920 kcal/100g (physically impossible — the *siblings* are the kJ-corrupt rows, 3 cases); skip panel-inflated flags from sibling groups < 8 (441 cases).
- **Exclusion sites**:
  - `scripts/sync-typesense.ts`: `AND "corruptReason" IS NULL` (full rebuilds stay clean)
  - `scripts/purge-corrupt-typesense.ts` (new): removes marked docs from the live index, mirrors the dedupe purge
  - PG fallback search (`searchOffSimple`): `corruptReason: null` filter
  - Mapper cache layers: new `corrupt_record` read-time escape (data-level — fires for human-triage rows too, same class as `nutrition_invalid`)
- **Kill-switch**: `CORRUPT_RECORD_EXCLUSION` (default ON) gates the runtime sites; index-level exclusion is data-level.
- **Marker** (`scripts/mark-corrupt-off.ts`): dry-run by default, re-checks each flag against the live row (staleness), reports FoodMapping rows that point at marked records, writes an audit JSON.
- Also commits the previously untracked `scripts/eval/detect-corrupt-panel.ts` scanner that produces the input.

## Deliberate deviation from the pt3 seam plan

The curated 25-barcode JSON denylist **stays** as the rank-time layer instead of being replaced by the DB flag: `isDenylistedOffRecord` is sync in hot rerank paths, and several denylist entries are current golden winners for *search* cases (s-brand-05/08, n-supp-10) that must remain in the Typesense index. DB-marked rows, by contrast, are removed from the index entirely.

## Verification

- jest: 60 suites / 838 tests green (incl. 10 new)
- tsc, lint:ci, check-env-example green
- Deploy gate before merge: migrate on OptiPlex → marker dry-run → apply (user-approved) → purge → eval ×2 parity (exactly n-mq-10) + warm-diff spot checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu