### PR TITLE
feat(site): Duolingo-style landing page matching the mobile app design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,103 @@
   }
 }
 
+@layer components {
+  /* "Chunky" surfaces — web port of the mobile app's ChunkyCard/ChunkyButton
+     (2px border, 20px radius, 4px darker depth lip below). */
+  .chunky-card {
+    border-radius: 20px;
+    border: 2px solid hsl(var(--border));
+    background-color: hsl(var(--card));
+    box-shadow: 0 4px 0 hsl(var(--border-dark));
+  }
+
+  .chunky-card-primary {
+    border-radius: 20px;
+    border: 2px solid hsl(var(--primary));
+    background-color: hsl(var(--card));
+    box-shadow: 0 4px 0 hsl(var(--primary-depth));
+  }
+
+  .chunky-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    padding: 0.875rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 800;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #fff;
+    background-color: hsl(var(--primary));
+    border: 2px solid hsl(var(--primary-depth));
+    box-shadow: 0 4px 0 hsl(var(--primary-depth));
+    transition: transform 0.1s ease, box-shadow 0.1s ease, filter 0.15s ease;
+  }
+  .chunky-btn:hover {
+    filter: brightness(1.06);
+  }
+  .chunky-btn:active {
+    transform: translateY(4px);
+    box-shadow: 0 0 0 hsl(var(--primary-depth));
+  }
+
+  .chunky-btn-gray {
+    color: hsl(var(--text));
+    background-color: hsl(var(--surface));
+    border-color: hsl(var(--border-dark));
+    box-shadow: 0 4px 0 hsl(var(--border-dark));
+  }
+  .chunky-btn-gray:active {
+    box-shadow: 0 0 0 hsl(var(--border-dark));
+  }
+
+  /* Progress bar with the mobile app's glossy top sheen */
+  .chunky-bar {
+    position: relative;
+    height: 12px;
+    border-radius: 9999px;
+    background-color: hsl(var(--track));
+    overflow: hidden;
+  }
+  .chunky-bar-fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: 9999px;
+  }
+  .chunky-bar-fill::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2%;
+    width: 96%;
+    height: 25%;
+    border-radius: 9999px;
+    background-color: rgba(255, 255, 255, 0.35);
+  }
+
+  /* Official fatsecret badge wrapper: sizes the (unmodified) badge snippet
+     and swaps brand/dark variants with the theme. */
+  .fatsecret-badge {
+    display: inline-flex;
+  }
+  .fatsecret-badge img {
+    height: var(--fs-badge-h, 20px);
+    width: auto;
+  }
+  .fatsecret-badge .fs-dark {
+    display: none;
+  }
+  .dark .fatsecret-badge .fs-dark {
+    display: inline-flex;
+  }
+  .dark .fatsecret-badge .fs-brand {
+    display: none;
+  }
+}
+
 @layer utilities {
   .filter {
     filter: invert(1) brightness(2);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,20 @@
 import "./globals.css";
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
+import { Nunito } from 'next/font/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/react';
 import ThemeScript from '@/components/ThemeScript';
 import { SiteFooter } from '@/components/SiteFooter';
 import { ThemeProvider } from 'next-themes';
+
+// Rounded, chunky typeface to match the mobile app's playful design language.
+const nunito = Nunito({
+  subsets: ['latin'],
+  weight: ['400', '600', '700', '800', '900'],
+  variable: '--font-nunito',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'Mealspire',
@@ -18,11 +27,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={nunito.variable}>
       <head>
         <ThemeScript />
       </head>
-      <body className="min-h-screen bg-background text-foreground">
+      <body className="min-h-screen bg-background font-sans text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <main className="min-h-screen">{children}</main>
           <SiteFooter />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,29 @@
-import { FATSECRET_BADGE_HTML } from '@/components/SiteFooter';
+import { FatsecretBadge } from '@/components/FatsecretBadge';
+import { PhoneMock } from '@/components/landing/PhoneMock';
+import { FoodCard } from '@/components/landing/FoodCard';
 
-// Fully static marketing landing page. The web recipe app is parked (see git
-// history) while the product focus is the mobile app; this page must never
-// depend on the database or auth so it cannot break.
+// Fully static marketing landing page styled after the mobile app's chunky
+// Duolingo-like design system (see src/styles/tokens.css). The web recipe app
+// is parked (see git history) while the product focus is the mobile app; this
+// page must never depend on the database or auth so it cannot break.
 export const dynamic = 'force-static';
 
 const FEATURES = [
   {
+    emoji: '🪄',
+    tint: 'bg-tint-green',
     title: 'Magic Log',
-    body: 'Type "chicken breast and a banana" and it’s logged. Natural-language food logging that understands portions, brands, and servings.',
+    body: 'Type what you ate in plain English. Portions, brands, and servings are parsed and logged in seconds.',
   },
   {
+    emoji: '🔎',
+    tint: 'bg-tint-blue',
     title: 'Data you can trust',
-    body: 'Nutrition sourced from fatsecret, USDA FoodData Central, and Open Food Facts — with per-item source attribution right in the app.',
+    body: 'Nutrition sourced from fatsecret, USDA FoodData Central, and Open Food Facts — with per-item source attribution right on the card.',
   },
   {
+    emoji: '📱',
+    tint: 'bg-tint-orange',
     title: 'Coming soon',
     body: 'Barcode scanning, meal photos, recipes, and sharing. iOS first, Android next. Currently in private development.',
   },
@@ -22,29 +31,107 @@ const FEATURES = [
 
 export default function HomePage() {
   return (
-    <div className="mx-auto max-w-4xl px-4">
+    <div className="mx-auto max-w-5xl px-4">
       {/* Hero */}
-      <section className="flex flex-col items-center text-center pt-20 pb-14">
-        <img src="/logo.svg" alt="Mealspire" className="logo-dark-mode h-16 w-auto mb-6" />
-        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">Mealspire</h1>
-        <p className="mt-3 text-lg text-foreground/70 max-w-xl">
-          Food tracking that keeps it real. Log meals in plain English, scan what you eat, and
-          see nutrition you can actually trust.
+      <section className="grid items-center gap-12 pb-16 pt-16 lg:grid-cols-2">
+        <div className="flex flex-col items-center text-center lg:items-start lg:text-left">
+          <img src="/logo.svg" alt="Mealspire" className="logo-dark-mode mb-6 h-14 w-auto" />
+          <h1 className="text-5xl font-black tracking-tight sm:text-6xl">Mealspire</h1>
+          <p className="mt-4 max-w-xl text-xl font-bold text-muted">
+            Food tracking that keeps it real.
+          </p>
+          <p className="mt-2 max-w-xl text-base font-semibold text-muted">
+            Log meals in plain English, scan what you eat, and see nutrition you can actually
+            trust — coming soon to the App Store.
+          </p>
+          <a href="#magic-log" className="chunky-btn mt-8">
+            See the magic
+          </a>
+          <FatsecretBadge height={24} className="mt-8" />
+        </div>
+        <PhoneMock />
+      </section>
+
+      {/* Magic Log demo */}
+      <section id="magic-log" className="pb-16 text-center">
+        <h2 className="text-3xl font-black tracking-tight sm:text-4xl">
+          Just type it. <span aria-hidden="true">✨</span>
+        </h2>
+        <p className="mx-auto mt-3 max-w-lg text-base font-semibold text-muted">
+          No database spelunking, no serving-size math. Magic Log turns a sentence into logged
+          food — real records, real labels, real macros.
         </p>
-        <p className="mt-2 text-sm text-foreground/60">
-          A mobile nutrition app, currently in development — coming soon to the App Store.
-        </p>
-        <div className="mt-6" dangerouslySetInnerHTML={{ __html: FATSECRET_BADGE_HTML }} />
+
+        <div className="mx-auto mt-8 max-w-md">
+          {/* Input mock */}
+          <div className="chunky-card flex items-center gap-3 p-3.5">
+            <span className="text-lg" aria-hidden="true">
+              ✨
+            </span>
+            <p className="flex-1 truncate text-left font-bold text-muted">
+              grilled chicken breast and a banana
+            </p>
+            <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full border-2 border-primary-depth bg-primary text-base font-black text-white">
+              ↑
+            </span>
+          </div>
+
+          <p className="my-4 text-2xl font-black text-muted" aria-hidden="true">
+            ↓
+          </p>
+
+          <div className="space-y-4">
+            <FoodCard
+              name="Grilled Chicken Breast"
+              serving="1 × 100g"
+              kcal={165}
+              protein={31}
+              carbs={0}
+              fat={4}
+              confidence="exact"
+              badge
+            />
+            <FoodCard
+              name="Banana"
+              serving="1 × medium (118g)"
+              kcal={105}
+              protein={1}
+              carbs={27}
+              fat={0}
+              confidence="exact"
+              badge
+            />
+          </div>
+        </div>
       </section>
 
       {/* Features */}
-      <section className="grid gap-4 sm:grid-cols-3 pb-20">
+      <section className="grid gap-5 pb-16 sm:grid-cols-3">
         {FEATURES.map((f) => (
-          <div key={f.title} className="bg-card border border-border rounded-xl p-6">
-            <h2 className="font-semibold text-lg">{f.title}</h2>
-            <p className="mt-2 text-sm text-foreground/70 leading-relaxed">{f.body}</p>
+          <div key={f.title} className="chunky-card p-6">
+            <span
+              className={`grid h-12 w-12 place-items-center rounded-2xl text-2xl ${f.tint}`}
+              aria-hidden="true"
+            >
+              {f.emoji}
+            </span>
+            <h3 className="mt-4 text-lg font-extrabold">{f.title}</h3>
+            <p className="mt-2 text-sm font-semibold leading-relaxed text-muted">{f.body}</p>
           </div>
         ))}
+      </section>
+
+      {/* CTA */}
+      <section className="pb-20">
+        <div className="chunky-card-primary px-6 py-10 text-center">
+          <h2 className="text-2xl font-black tracking-tight sm:text-3xl">
+            Coming soon to the App Store
+          </h2>
+          <p className="mx-auto mt-3 max-w-md text-base font-semibold text-muted">
+            Mealspire is in private development. iOS first, Android next — follow along as the
+            kitchen heats up. <span aria-hidden="true">🔥</span>
+          </p>
+        </div>
       </section>
     </div>
   );

--- a/src/components/FatsecretBadge.tsx
+++ b/src/components/FatsecretBadge.tsx
@@ -1,0 +1,33 @@
+import type { CSSProperties } from 'react';
+
+// Official fatsecret attribution badge, required by the fatsecret Platform
+// API Terms of Use (Premier Free tier). The two snippets below are the
+// UNMODIFIED badge HTML from https://platform.fatsecret.com/attribution —
+// brand for light backgrounds, dark for dark backgrounds (the same pairing
+// the mobile app uses). Do not edit the snippet markup, and "fatsecret" must
+// always be written in lowercase in any text mention.
+export const FATSECRET_BADGE_HTML = `<a href="https://platform.fatsecret.com"><img alt="Nutrition information provided by fatsecret Platform API" src="https://platform.fatsecret.com/api/static/images/powered_by_fatsecret_horizontal_brand.svg" border="0"/></a>`;
+export const FATSECRET_BADGE_HTML_DARK = `<a href="https://platform.fatsecret.com"><img alt="Nutrition information provided by fatsecret Platform API" src="https://platform.fatsecret.com/api/static/images/powered_by_fatsecret_horizontal_dark.svg" border="0"/></a>`;
+
+// Renders both official variants; CSS (.fatsecret-badge in globals.css)
+// shows the one matching the active theme and sizes the image via
+// --fs-badge-h. The badge markup itself is injected verbatim.
+export function FatsecretBadge({
+  height = 20,
+  className,
+}: {
+  height?: number;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`fatsecret-badge ${className ?? ''}`}
+      style={{ '--fs-badge-h': `${height}px` } as CSSProperties}
+    >
+      <span className="fs-brand" dangerouslySetInnerHTML={{ __html: FATSECRET_BADGE_HTML }} />
+      <span className="fs-dark" dangerouslySetInnerHTML={{ __html: FATSECRET_BADGE_HTML_DARK }} />
+    </span>
+  );
+}
+
+export default FatsecretBadge;

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,19 +1,18 @@
+import { FatsecretBadge } from '@/components/FatsecretBadge';
+
 // Global site footer. Carries the fatsecret attribution required by the
 // fatsecret Platform API Terms of Use (Premier Free tier): the official Web
-// Badge, unmodified, linked to platform.fatsecret.com. Do not edit the badge
-// markup — the snippet must match https://platform.fatsecret.com/attribution
-// exactly, and "fatsecret" must always be written in lowercase.
-export const FATSECRET_BADGE_HTML = `<a href="https://platform.fatsecret.com"><img alt="Nutrition information provided by fatsecret Platform API" src="https://platform.fatsecret.com/api/static/images/powered_by_fatsecret_horizontal_brand.svg" border="0"/></a>`;
-
+// Badge, unmodified, linked to platform.fatsecret.com (see FatsecretBadge).
+// "fatsecret" must always be written in lowercase.
 export function SiteFooter() {
   return (
-    <footer className="border-t border-border mt-12">
-      <div className="container mx-auto px-4 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
-        <div className="text-sm text-muted-foreground text-center sm:text-left">
+    <footer className="mt-12 border-t-2 border-border">
+      <div className="container mx-auto flex flex-col items-center justify-between gap-4 px-4 py-8 sm:flex-row">
+        <div className="text-center text-sm font-semibold text-muted sm:text-left">
           <p>&copy; {new Date().getFullYear()} Mealspire</p>
           <p className="mt-1">Nutrition data provided in part by fatsecret.</p>
         </div>
-        <div dangerouslySetInnerHTML={{ __html: FATSECRET_BADGE_HTML }} />
+        <FatsecretBadge height={22} />
       </div>
     </footer>
   );

--- a/src/components/landing/DailySummaryCard.tsx
+++ b/src/components/landing/DailySummaryCard.tsx
@@ -1,0 +1,107 @@
+// Static replica of the mobile app's daily summary card
+// (KindaHealthyMobile src/components/food-log/daily-summary-card.tsx):
+// green chunky card, calorie progress ring with "kcal left" center, consumed/
+// target stats, and glossy macro progress bars in the app's macro colors.
+
+const TARGET = 2200;
+const CONSUMED = 1390;
+const REMAINING = TARGET - CONSUMED;
+
+const RING_SIZE = 110;
+const RING_STROKE = 12;
+const RING_R = (RING_SIZE - RING_STROKE) / 2;
+const RING_C = 2 * Math.PI * RING_R;
+const RING_OFFSET = RING_C * (1 - CONSUMED / TARGET);
+
+const MACROS = [
+  { emoji: '🍗', label: 'Protein', eaten: 96, goal: 140, color: 'hsl(var(--macro-protein))' },
+  { emoji: '🍚', label: 'Carbs', eaten: 180, goal: 220, color: 'hsl(var(--macro-carbs))' },
+  { emoji: '🥑', label: 'Fat', eaten: 48, goal: 70, color: 'hsl(var(--macro-fat))' },
+];
+
+export function DailySummaryCard() {
+  return (
+    <div className="chunky-card-primary p-4 text-left">
+      <p className="text-lg font-extrabold">Today&rsquo;s Summary</p>
+
+      <div className="mt-3 flex items-center justify-center gap-6">
+        {/* Calorie ring */}
+        <div className="relative" style={{ width: RING_SIZE, height: RING_SIZE }}>
+          <svg
+            width={RING_SIZE}
+            height={RING_SIZE}
+            viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
+            className="-rotate-90"
+            aria-hidden="true"
+          >
+            <circle
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              r={RING_R}
+              fill="none"
+              stroke="hsl(var(--track))"
+              strokeWidth={RING_STROKE}
+            />
+            <circle
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              r={RING_R}
+              fill="none"
+              stroke="hsl(var(--primary))"
+              strokeWidth={RING_STROKE}
+              strokeLinecap="round"
+              strokeDasharray={RING_C}
+              strokeDashoffset={RING_OFFSET}
+            />
+          </svg>
+          <div className="absolute inset-0 grid place-items-center text-center">
+            <div>
+              <p className="text-2xl font-black leading-none">{REMAINING}</p>
+              <p className="mt-0.5 text-[11px] font-bold text-muted">kcal left</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Consumed / Target stats */}
+        <div className="flex items-center gap-4">
+          <div className="text-center">
+            <p className="text-lg font-extrabold leading-tight">{CONSUMED.toLocaleString('en-US')}</p>
+            <p className="text-xs font-semibold text-muted">Consumed</p>
+          </div>
+          <div className="h-14 w-px bg-border" />
+          <div className="text-center">
+            <p className="text-lg font-extrabold leading-tight">{TARGET.toLocaleString('en-US')}</p>
+            <p className="text-xs font-semibold text-muted">Target</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Macro bars */}
+      <div className="mt-4 space-y-3.5 border-t border-border pt-3">
+        {MACROS.map((m) => (
+          <div key={m.label}>
+            <div className="mb-1.5 flex items-center justify-between">
+              <p className="text-sm font-bold">
+                {m.emoji} {m.label}
+              </p>
+              <p className="text-xs font-semibold text-muted">
+                {m.eaten}g / {m.goal}g
+              </p>
+            </div>
+            <div className="chunky-bar">
+              <div
+                className="chunky-bar-fill"
+                style={{
+                  width: `${Math.round((m.eaten / m.goal) * 100)}%`,
+                  backgroundColor: m.color,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default DailySummaryCard;

--- a/src/components/landing/FoodCard.tsx
+++ b/src/components/landing/FoodCard.tsx
@@ -1,0 +1,78 @@
+import { FatsecretBadge } from '@/components/FatsecretBadge';
+
+// Static replica of the mobile app's logged-food card
+// (KindaHealthyMobile src/components/food-log/food-item-card.tsx):
+// name → serving line → confidence chip (+ fatsecret badge), calories on the
+// right at weight 900, and the colored P/C/F macro line under a divider.
+
+const CONFIDENCE = {
+  exact: { label: 'Exact Match', icon: '✓', color: '#58CC02' },
+  good: { label: 'Good Estimate', icon: '≈', color: '#FF9600' },
+  ai: { label: 'AI Estimated', icon: '?', color: '#EA2B2B' },
+} as const;
+
+export type FoodCardProps = {
+  name: string;
+  serving: string;
+  brand?: string;
+  kcal: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  confidence?: keyof typeof CONFIDENCE;
+  /** Show the official fatsecret badge under the serving line. */
+  badge?: boolean;
+};
+
+export function FoodCard({
+  name,
+  serving,
+  brand,
+  kcal,
+  protein,
+  carbs,
+  fat,
+  confidence = 'exact',
+  badge = false,
+}: FoodCardProps) {
+  const conf = CONFIDENCE[confidence];
+  return (
+    <div className="chunky-card p-4 text-left">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-base font-bold leading-tight">{name}</p>
+          <p className="mt-0.5 truncate text-[13px] font-semibold text-muted">
+            {serving}
+            {brand ? ` • ${brand}` : ''}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            <span
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold"
+              style={{
+                color: conf.color,
+                border: `1.5px solid ${conf.color}`,
+                backgroundColor: `${conf.color}18`,
+              }}
+            >
+              {conf.icon} {conf.label}
+            </span>
+          </div>
+          {badge ? <FatsecretBadge height={16} className="mt-1.5" /> : null}
+        </div>
+        <div className="shrink-0 text-center">
+          <p className="text-[22px] font-black leading-none">{kcal}</p>
+          <p className="text-[11px] font-bold text-muted">kcal</p>
+        </div>
+      </div>
+      <div className="mt-2.5 border-t border-border pt-2 text-xs font-semibold text-muted">
+        P: <span className="font-bold text-macro-protein">{protein}g</span>
+        <span className="mx-1.5">•</span>
+        C: <span className="font-bold text-macro-carbs">{carbs}g</span>
+        <span className="mx-1.5">•</span>
+        F: <span className="font-bold text-macro-fat">{fat}g</span>
+      </div>
+    </div>
+  );
+}
+
+export default FoodCard;

--- a/src/components/landing/PhoneMock.tsx
+++ b/src/components/landing/PhoneMock.tsx
@@ -1,0 +1,53 @@
+import { DailySummaryCard } from './DailySummaryCard';
+import { FoodCard } from './FoodCard';
+
+// A stylized phone frame showing the mobile app's home tab: date header,
+// daily summary card, and a logged meal with a real food card (including the
+// official fatsecret attribution badge, exactly as it appears in-app).
+export function PhoneMock() {
+  return (
+    <div className="mx-auto w-full max-w-[340px]">
+      <div className="rounded-[44px] border-[6px] border-border-dark bg-background p-3 shadow-2xl">
+        {/* Dynamic island */}
+        <div className="mx-auto mb-3 h-6 w-28 rounded-full bg-surface" />
+
+        {/* Date header */}
+        <div className="flex items-center justify-between border-b border-border px-2 pb-2">
+          <span className="text-lg font-black text-muted" aria-hidden="true">
+            ‹
+          </span>
+          <p className="font-extrabold">Today</p>
+          <span className="text-lg font-black text-muted" aria-hidden="true">
+            ›
+          </span>
+        </div>
+
+        <div className="space-y-3 px-1 pb-2 pt-3">
+          <DailySummaryCard />
+
+          <div className="flex items-center justify-between px-1 pt-1">
+            <p className="font-extrabold">🥩 Dinner</p>
+            <p className="text-sm font-bold text-muted">619 kcal</p>
+          </div>
+
+          <FoodCard
+            name="Grilled Chicken Breast"
+            serving="1 × 100g"
+            kcal={165}
+            protein={31}
+            carbs={0}
+            fat={4}
+            confidence="exact"
+            badge
+          />
+
+          <div className="chunky-btn chunky-btn-gray w-full py-2.5 text-sm normal-case tracking-normal">
+            + Add Food
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PhoneMock;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,49 +1,75 @@
 :root {
-  /* FitFuel light tokens derived from Figma */
-  --bg: 180 29% 98%;            /* #F7FAFA / #F8FBFA */
+  /* Mealspire light tokens — mirrors the mobile app palette
+     (KindaHealthyMobile src/constants/theme.ts). Cards share the page
+     background; 2px borders + 4px "chunky" depth lips define surfaces. */
+  --bg: 0 0% 100%;               /* #FFFFFF */
   --card: 0 0% 100%;
   --popover: 0 0% 100%;
-  --text: 150 30% 8%;            /* #0D1A12 */
-  --muted: 143 29% 45%;          /* #52946B */
-  --primary: 144 73% 55%;        /* #38E07B */
+  --text: 0 0% 0%;               /* #000000 */
+  --muted: 220 6% 40%;           /* #60646C textSecondary */
+  --primary: 94 98% 40%;         /* #58CC02 foodLogPrimary */
   --primary-foreground: 0 0% 100%;
-  --secondary: 150 20% 94%;      /* light mint grays (e8f2ed/e5e8eb) */
-  --secondary-foreground: 150 30% 8%;
-  --accent: 144 73% 55%;
+  --primary-depth: 95 98% 32%;   /* #46A302 foodLogDark — depth lip */
+  --secondary: 240 12% 95%;      /* #F0F0F3 backgroundElement */
+  --secondary-foreground: 0 0% 0%;
+  --accent: 199 92% 54%;         /* #1CB0F6 profilePrimary (blue) */
   --accent-foreground: 0 0% 100%;
-  --destructive: 0 84% 60%;
+  --destructive: 0 82% 54%;      /* #EA2B2B */
   --destructive-foreground: 0 0% 100%;
-  --border: 147 28% 86%;         /* #D1E5D9 */
-  --ring: 144 73% 55%;           /* match primary */
-  --radius-xl: 1.25rem;          /* ~20px for inputs */
+  --border: 0 0% 90%;            /* #E5E5E5 */
+  --border-dark: 0 0% 75%;       /* #C0C0C0 neutral depth lip */
+  --surface: 240 12% 95%;        /* #F0F0F3 chips / inputs */
+  --track: 0 0% 90%;             /* #E5E5E5 progress track */
+  --ring: 94 98% 40%;
+  --macro-protein: 258 90% 66%;  /* #8B5CF6 */
+  --macro-carbs: 189 94% 43%;    /* #06B6D4 */
+  --macro-fat: 350 89% 60%;      /* #F43F5E */
+  --macro-calories: 38 92% 50%;  /* #F59E0B */
+  --tint-green: 89 77% 90%;      /* #E5F9D0 foodLogLight */
+  --tint-blue: 199 100% 93%;     /* #DDF4FF profileLight */
+  --tint-orange: 38 100% 92%;    /* #FFF0D6 recipesLight */
+  --radius-xl: 1.25rem;          /* ~20px for cards */
   --radius-lg: 1rem;
   --radius-md: 0.75rem;
   --radius-sm: 0.5rem;
-  --shadow: 150 3% 30%;
+  --shadow: 0 0% 75%;
+  --search-bg: 240 12% 95%;
+  --search-text: 0 0% 0%;
+  --search-placeholder: 220 6% 40%;
+  --light-gray: 210 20% 90%;
 }
 
 .dark {
-  /* New FitFood dark mode palette from Figma */
-  --bg: 15 50% 10%;              /* #211412 - very dark brown/black */
-  --card: 15 33% 15%;            /* slightly lighter than bg */
-  --popover: 15 33% 15%;         /* same as card */
-  --text: 0 0% 100%;             /* #FFFFFF - white text */
-  --muted: 15 25% 70%;           /* #C99E91 - light brown/orange */
-  --primary: 144 73% 55%;        /* Keep green accent for buttons */
+  /* Mobile app dark palette — neutral near-black, green accent kept */
+  --bg: 220 7% 8%;               /* #131416 */
+  --card: 220 7% 8%;
+  --popover: 225 6% 14%;
+  --text: 0 0% 100%;             /* #FFFFFF */
+  --muted: 216 7% 71%;           /* #B0B4BA */
+  --primary: 94 98% 40%;         /* #58CC02 — same green both modes */
   --primary-foreground: 0 0% 100%;
-  --secondary: 15 33% 22%;       /* #472B24 - dark brown */
+  --primary-depth: 96 97% 28%;   /* #3A8C02 */
+  --secondary: 225 6% 14%;       /* #212225 */
   --secondary-foreground: 0 0% 100%;
-  --accent: 144 73% 55%;         /* Keep green accent */
+  --accent: 199 92% 54%;
   --accent-foreground: 0 0% 100%;
-  --destructive: 0 84% 60%;
+  --destructive: 0 82% 54%;
   --destructive-foreground: 0 0% 100%;
-  --border: 15 33% 22%;           /* #472B24 - dark brown */
-  --ring: 144 73% 55%;           /* Keep green accent for focus rings */
-  --shadow: 15 50% 5%;           /* Very dark shadow */
-  
-  /* Additional FitFood dark mode colors from Figma */
-  --search-bg: 15 33% 22%;       /* #472B24 - dark brown for search bars */
-  --search-text: 0 0% 100%;      /* #FFFFFF - white text in search */
-  --search-placeholder: 15 25% 70%; /* #C99E91 - light brown/orange for placeholder */
-  --light-gray: 210 20% 90%;     /* #E5E8EB - light gray for subtle elements */
+  --border: 220 6% 21%;          /* #333539 */
+  --border-dark: 210 6% 13%;     /* #1E2022 */
+  --surface: 225 6% 14%;         /* #212225 */
+  --track: 225 6% 14%;
+  --ring: 94 98% 40%;
+  --macro-protein: 255 92% 76%;  /* #A78BFA */
+  --macro-carbs: 187 86% 53%;    /* #22D3EE */
+  --macro-fat: 351 95% 71%;      /* #FB7185 */
+  --macro-calories: 43 96% 56%;  /* #FBBF24 */
+  --tint-green: 96 47% 12%;      /* #1B2C10 */
+  --tint-blue: 203 55% 12%;      /* #0E2330 */
+  --tint-orange: 33 58% 11%;     /* #2D1E0C */
+  --shadow: 210 6% 13%;
+  --search-bg: 225 6% 14%;
+  --search-text: 0 0% 100%;
+  --search-placeholder: 216 7% 71%;
+  --light-gray: 210 20% 90%;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -7,6 +8,19 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: [
+          'var(--font-nunito)',
+          'ui-sans-serif',
+          'system-ui',
+          '-apple-system',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif',
+        ],
+      },
       colors: {
         background: 'hsl(var(--bg))',
         foreground: 'hsl(var(--text))',
@@ -21,6 +35,7 @@ module.exports = {
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',
+          depth: 'hsl(var(--primary-depth))',
         },
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',
@@ -39,7 +54,23 @@ module.exports = {
           foreground: 'hsl(var(--destructive-foreground))',
         },
         border: 'hsl(var(--border))',
+        'border-dark': 'hsl(var(--border-dark))',
+        surface: 'hsl(var(--surface))',
+        track: 'hsl(var(--track))',
         ring: 'hsl(var(--ring))',
+        // Mobile-app macro colors (P/C/F + calories)
+        macro: {
+          protein: 'hsl(var(--macro-protein))',
+          carbs: 'hsl(var(--macro-carbs))',
+          fat: 'hsl(var(--macro-fat))',
+          calories: 'hsl(var(--macro-calories))',
+        },
+        // Soft section tints (foodLogLight / profileLight / recipesLight)
+        tint: {
+          green: 'hsl(var(--tint-green))',
+          blue: 'hsl(var(--tint-blue))',
+          orange: 'hsl(var(--tint-orange))',
+        },
         // FitFood dark mode specific colors
         'search-bg': 'hsl(var(--search-bg))',
         'search-text': 'hsl(var(--search-text))',


### PR DESCRIPTION
## Summary
Rethemes the static marketing site to the mobile app's actual design system (KindaHealthyMobile `src/constants/theme.ts`) and adds app-faithful showcase components, so the site looks like the product instead of a placeholder:

- **Palette swap** (`tokens.css`): #58CC02 Duolingo green, neutral near-black dark mode, app macro colors (P/C/F), section tints; new `primary-depth`/`surface`/`track`/`border-dark` vars
- **Chunky design language** (`globals.css` + Tailwind config): web port of ChunkyCard/ChunkyButton/ChunkyProgressBar — 2px borders, 20px radii, 4px depth lips, glossy bar sheen, press animation; Nunito via `next/font` for the rounded feel; `darkMode: 'class'` now matches the ThemeScript/next-themes wiring
- **Landing components**: static `FoodCard` (serving line, confidence chip, kcal at weight 900, colored P/C/F line), `DailySummaryCard` (calorie ring + macro bars), `PhoneMock` (home-tab replica)
- **Page**: hero with phone mockup, Magic Log demo (typed sentence → resolved food cards), tinted feature cards, App Store CTA
- **fatsecret attribution**: new `FatsecretBadge` renders the official unmodified badge snippets (brand + dark variants from platform.fatsecret.com/attribution), theme-swapped via CSS — now shown in hero, on demo food cards, in the phone mockup, and in the footer

The page remains `force-static` with zero DB/auth dependencies.

## Verification
- `npm run build` green locally
- Headless-Chrome visual QA: light/dark × desktop/390px mobile — all pass; all 5 badge instances load (naturalWidth 212) and swap variants with the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y