### PR TITLE
Per-field nutrition corruption detector (sodium mg-as-g, impossible kcal/macros, kJ-as-kcal)

### DIFF
--- a/scripts/eval/detect-corrupt-nutrition.ts
+++ b/scripts/eval/detect-corrupt-nutrition.ts
@@ -12,6 +12,9 @@
  *                          live sizing found ~14k unmarked rows, many holding
  *                          mg-scale or per-package junk like 81,818 kcal)
  *   macro-sum-impossible   protein+fat+carbs > 105 g/100g
+ *   fiber-impossible       fiber > 105 g/100g (often paired with kJ-as-kcal
+ *                          on the same row — chicken with "fiber 260")
+ *   sugars-impossible      sugars > 105 g/100g
  *   sodium-impossible      sodium > 39.4 g/100g (pure salt is 39.3 — nothing
  *                          edible exceeds it; jerky at "1285 g" = mg-as-g)
  *   sodium-implausible     sodium in (10, 39.4] g/100g on foods that are NOT
@@ -52,6 +55,7 @@ import {
     CorruptScanFlag,
     MAX_KCAL_100G,
     MAX_MACRO_SUM_100G,
+    MAX_COMPONENT_100G,
     MAX_SODIUM_100G,
     SODIUM_IMPLAUSIBLE_100G,
     KJ_ATWATER_MIN_RATIO,
@@ -176,6 +180,16 @@ async function main() {
                 flagged.push({ ...base, direction: 'macro-sum-impossible', value: macroSum, check: { field: 'macroSum', value: macroSum } });
                 continue;
             }
+            const fiber = readNum(nutrients, 'fiber');
+            if (fiber != null && fiber > MAX_COMPONENT_100G) {
+                flagged.push({ ...base, direction: 'fiber-impossible', value: fiber, check: { field: 'fiber', value: fiber } });
+                continue;
+            }
+            const sugars = readNum(nutrients, 'sugars');
+            if (sugars != null && sugars > MAX_COMPONENT_100G) {
+                flagged.push({ ...base, direction: 'sugars-impossible', value: sugars, check: { field: 'sugars', value: sugars } });
+                continue;
+            }
             if (na != null && na > MAX_SODIUM_100G) {
                 flagged.push({ ...base, direction: 'sodium-impossible', value: na, check: { field: 'sodium', value: na } });
                 continue;
@@ -193,8 +207,11 @@ async function main() {
                 // carries ~2 kcal/g — without the fiber term, psyllium husk /
                 // xanthan / inulin records (kcal ~200, carbs ~0) dominate the
                 // class as false positives. Real kJ slips (4.184x) survive it.
-                const fiber = readNum(nutrients, 'fiber') ?? 0;
-                const atwater = 4 * protein + 9 * fat + 4 * carbs + 2 * fiber;
+                // Only trust fiber that fits in 100g alongside the macros:
+                // multi-field-corrupt rows (chicken with fiber 260) otherwise
+                // launder their kJ kcal through the fiber credit.
+                const fiberCredit = fiber != null && macroSum + fiber <= MAX_MACRO_SUM_100G ? fiber : 0;
+                const atwater = 4 * protein + 9 * fat + 4 * carbs + 2 * fiberCredit;
                 if (atwater > 0 && kcal > KJ_ATWATER_MIN_RATIO * atwater && !ALCOHOL_PATTERN.test(names)) {
                     flagged.push({
                         ...base, direction: 'kj-as-kcal', value: kcal,

--- a/scripts/eval/detect-corrupt-nutrition.ts
+++ b/scripts/eval/detect-corrupt-nutrition.ts
@@ -1,0 +1,253 @@
+/**
+ * detect-corrupt-nutrition.ts — corpus scan for per-FIELD nutrition
+ * impossibilities and scale slips (REPORT-ONLY, writes nothing).
+ *
+ * Companion to detect-corrupt-panel.ts (which catches whole panels stored at
+ * per-serving scale). This scan catches records where individual fields are
+ * physically impossible or off by a unit factor — the classes the 2026-07-21
+ * nutrition re-verify found the panel detector blind to (mayonnaise
+ * off_9348905001434 sodium 5.33 g/100g, a mg-entered-as-g slip):
+ *
+ *   kcal-impossible        kcal/100g > 905 (pure fat is ~900; the 2026-07-21
+ *                          live sizing found ~14k unmarked rows, many holding
+ *                          mg-scale or per-package junk like 81,818 kcal)
+ *   macro-sum-impossible   protein+fat+carbs > 105 g/100g
+ *   sodium-impossible      sodium > 39.4 g/100g (pure salt is 39.3 — nothing
+ *                          edible exceeds it; jerky at "1285 g" = mg-as-g)
+ *   sodium-implausible     sodium in (10, 39.4] g/100g on foods that are NOT
+ *                          salts/bouillon/seasoning concentrates (name guard;
+ *                          guarded rows are reported, never flagged)
+ *   kj-as-kcal             kcal >= 100 with all three macros present and
+ *                          kcal > 3x the Atwater estimate (4P+9F+4C) — the
+ *                          kJ-value-in-the-kcal-field family (n-mq-27 lemon:
+ *                          383 "kcal"/100g vs ~40 real). Alcohol names are
+ *                          exempt (7 kcal/g invisible to Atwater).
+ *   sodium-sibling-outlier sodium >= max(2 g, 6x the same-name sibling
+ *                          median) with >= --min-group siblings whose median
+ *                          is itself sane — the mayo class, where the value
+ *                          is too low for the absolute rules but ~9x its
+ *                          siblings.
+ *
+ * Each row gets at most ONE flag (first matching rule in the order above).
+ * The 4-10 g/100g sodium band (soy/fish-sauce territory) is counted in the
+ * summary but never flagged — that band needs identity-aware triage.
+ *
+ * Output feeds scripts/mark-corrupt-off.ts unchanged: every flag carries a
+ * `check` payload naming the live field the marker must re-verify before
+ * writing, and the shared trust rules (src/lib/mapping/corrupt-mark.ts)
+ * re-verify each threshold from the flag's own value.
+ *
+ * Run (from repo root, read-only):
+ *   npx ts-node -r tsconfig-paths/register --transpile-only --compilerOptions \
+ *     '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/eval/detect-corrupt-nutrition.ts [--min-group 4] [--print 40]
+ */
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PrismaClient } from '@prisma/client';
+import { normalizeNameKey } from '../../src/lib/search/dedupe-candidates';
+import { ALCOHOL_PATTERN } from '../../src/lib/mapping/macro-plausibility';
+import {
+    CorruptScanFlag,
+    MAX_KCAL_100G,
+    MAX_MACRO_SUM_100G,
+    MAX_SODIUM_100G,
+    SODIUM_IMPLAUSIBLE_100G,
+    KJ_ATWATER_MIN_RATIO,
+    KJ_MIN_KCAL,
+    MIN_SODIUM_OUTLIER_GROUP,
+    MIN_SODIUM_OUTLIER_RATIO,
+    MIN_SODIUM_OUTLIER_G,
+} from '../../src/lib/mapping/corrupt-mark';
+
+const prisma = new PrismaClient();
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+const MIN_GROUP = Number(argValue('--min-group') ?? MIN_SODIUM_OUTLIER_GROUP);
+const PRINT = Number(argValue('--print') ?? 40);
+const BATCH = 20000;
+
+/** Foods that legitimately live above SODIUM_IMPLAUSIBLE_100G: pure salts,
+ *  bouillon/stock concentrates, seasoning/gravy powders, electrolyte mixes.
+ *  Word-bounded so "salted caramel" is guarded (conservative skip) but
+ *  "sardines" is not. Guarded rows are reported for later triage, not flagged. */
+const SODIUM_GUARD_PATTERN =
+    /\b(salts?|salted|seasonings?|bouill?[oi]ll?on|broth|stock|base|cubes?|rub|mix|blend|gravy|marinade|sazon|adobo|msg|dashi|miso|electrolytes?|hydration|brine[ds]?|cure[ds]?|curing)\b/i;
+
+/** Sibling sodium medians above this are sauce/seasoning groups where a high
+ *  row is plausible; the outlier rule only trusts clearly-food-like medians. */
+const MAX_OUTLIER_SANE_MEDIAN = 5;
+
+function readNum(nutrients: Record<string, unknown> | null, key: string): number | null {
+    const v = nutrients?.[key];
+    return typeof v === 'number' && isFinite(v) && v >= 0 ? v : null;
+}
+
+function readKcal(nutrients: Record<string, unknown> | null): number | null {
+    return readNum(nutrients, 'calories') ?? readNum(nutrients, 'kcal');
+}
+
+function median(sorted: number[]): number {
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
+
+async function* streamRows(): AsyncGenerator<Row[]> {
+    let cursor: string | undefined;
+    for (;;) {
+        const batch: Row[] = await prisma.offFood.findMany({
+            select: { barcode: true, name: true, brandName: true, servingGrams: true, nutrientsPer100g: true },
+            // Marked and deduped rows are already out of retrieval; skipping
+            // them also keeps the sibling sodium medians clean.
+            where: { nutrientsPer100g: { not: undefined }, corruptReason: null, duplicateOfBarcode: null },
+            orderBy: { barcode: 'asc' },
+            take: BATCH,
+            ...(cursor ? { cursor: { barcode: cursor }, skip: 1 } : {}),
+        });
+        if (!batch.length) return;
+        yield batch;
+        cursor = batch[batch.length - 1].barcode;
+    }
+}
+
+async function main() {
+    // Pass 1: sibling sodium distributions per name key (for the outlier rule).
+    console.log('Pass 1: building sibling sodium medians...');
+    const groups = new Map<string, number[]>();
+    let scanned = 0;
+    for await (const batch of streamRows()) {
+        for (const r of batch) {
+            const nutrients = r.nutrientsPer100g as Record<string, unknown> | null;
+            const na = readNum(nutrients, 'sodium');
+            if (na == null) continue;
+            const key = normalizeNameKey(r.name);
+            if (!key) continue;
+            let g = groups.get(key);
+            if (!g) { g = []; groups.set(key, g); }
+            g.push(na);
+        }
+        scanned += batch.length;
+        if (scanned % 200000 === 0) console.log(`  ${scanned} rows...`);
+    }
+    const sodiumMedians = new Map<string, { med: number; n: number }>();
+    for (const [key, values] of groups) {
+        if (values.length < MIN_GROUP) continue;
+        values.sort((a, b) => a - b);
+        sodiumMedians.set(key, { med: median(values), n: values.length });
+    }
+    groups.clear();
+    console.log(`  ${scanned} rows, ${sodiumMedians.size} name groups with >=${MIN_GROUP} sodium values`);
+
+    // Pass 2: per-row rules, first match wins.
+    console.log('Pass 2: testing per-field rules...');
+    const flagged: CorruptScanFlag[] = [];
+    const guarded: Array<{ barcode: string; name: string; brandName: string | null; sodium: number }> = [];
+    let sauceBand = 0;
+    for await (const batch of streamRows()) {
+        for (const r of batch) {
+            const nutrients = r.nutrientsPer100g as Record<string, unknown> | null;
+            const kcal = readKcal(nutrients);
+            const protein = readNum(nutrients, 'protein');
+            const fat = readNum(nutrients, 'fat');
+            const carbs = readNum(nutrients, 'carbs');
+            const na = readNum(nutrients, 'sodium');
+            const macroSum = (protein ?? 0) + (fat ?? 0) + (carbs ?? 0);
+            const names = `${r.name} ${r.brandName ?? ''}`;
+
+            const base = {
+                barcode: r.barcode, name: r.name, brandName: r.brandName,
+                kcal100: kcal ?? 0, servingGrams: r.servingGrams,
+                tier: 'direct' as const, rescaled: 0, siblingMedian: 0, groupSize: 0,
+                triageConfirmed: false,
+            };
+
+            if (kcal != null && kcal > MAX_KCAL_100G) {
+                flagged.push({ ...base, direction: 'kcal-impossible', value: kcal, check: { field: 'calories', value: kcal } });
+                continue;
+            }
+            if (macroSum > MAX_MACRO_SUM_100G) {
+                flagged.push({ ...base, direction: 'macro-sum-impossible', value: macroSum, check: { field: 'macroSum', value: macroSum } });
+                continue;
+            }
+            if (na != null && na > MAX_SODIUM_100G) {
+                flagged.push({ ...base, direction: 'sodium-impossible', value: na, check: { field: 'sodium', value: na } });
+                continue;
+            }
+            if (na != null && na > SODIUM_IMPLAUSIBLE_100G) {
+                if (SODIUM_GUARD_PATTERN.test(names)) {
+                    guarded.push({ barcode: r.barcode, name: r.name, brandName: r.brandName, sodium: na });
+                } else {
+                    flagged.push({ ...base, direction: 'sodium-implausible', value: na, check: { field: 'sodium', value: na } });
+                }
+                continue;
+            }
+            if (kcal != null && kcal >= KJ_MIN_KCAL && protein != null && fat != null && carbs != null) {
+                const atwater = 4 * protein + 9 * fat + 4 * carbs;
+                if (atwater > 0 && kcal > KJ_ATWATER_MIN_RATIO * atwater && !ALCOHOL_PATTERN.test(names)) {
+                    flagged.push({
+                        ...base, direction: 'kj-as-kcal', value: kcal,
+                        ratio: kcal / atwater, check: { field: 'calories', value: kcal },
+                    });
+                    continue;
+                }
+            }
+            if (na != null && na > 4) sauceBand++;
+            if (na != null && na >= MIN_SODIUM_OUTLIER_G) {
+                const m = sodiumMedians.get(normalizeNameKey(r.name));
+                if (m && m.med > 0 && m.med <= MAX_OUTLIER_SANE_MEDIAN && na >= MIN_SODIUM_OUTLIER_RATIO * m.med) {
+                    flagged.push({
+                        ...base, direction: 'sodium-sibling-outlier', value: na,
+                        ratio: na / m.med, siblingMedian: m.med, groupSize: m.n,
+                        check: { field: 'sodium', value: na },
+                    });
+                }
+            }
+        }
+    }
+
+    const byDirection: Record<string, number> = {};
+    for (const f of flagged) byDirection[f.direction] = (byDirection[f.direction] ?? 0) + 1;
+
+    const outDir = path.join(__dirname, 'results');
+    fs.mkdirSync(outDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = path.join(outDir, `corrupt-nutrition-scan-${ts}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({
+        at: new Date().toISOString(),
+        params: { minGroup: MIN_GROUP },
+        summary: {
+            scanned,
+            flagged: flagged.length,
+            byDirection,
+            guardedSkipped: guarded.length,
+            sodiumSauceBandUnflagged: sauceBand,
+        },
+        flagged,
+        guarded: guarded.slice(0, 1000),
+    }, null, 1));
+
+    console.log(`\nFlagged ${flagged.length} rows (of ${scanned} scanned): ${JSON.stringify(byDirection)}`);
+    console.log(`Guarded (seasoning-class names, sodium > ${SODIUM_IMPLAUSIBLE_100G}g, NOT flagged): ${guarded.length}`);
+    console.log(`Sauce band (sodium 4-${SODIUM_IMPLAUSIBLE_100G}g, NOT flagged — needs identity-aware triage): ${sauceBand}`);
+    const bySeverity = [...flagged].sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+    for (const f of bySeverity.slice(0, PRINT)) {
+        const extra = f.direction === 'sodium-sibling-outlier'
+            ? ` (${(f.ratio ?? 0).toFixed(1)}x sibling median ${f.siblingMedian.toFixed(2)}g, n=${f.groupSize})`
+            : f.direction === 'kj-as-kcal' ? ` (${(f.ratio ?? 0).toFixed(1)}x Atwater)` : '';
+        console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''} (${f.direction}): ${f.value}${extra}`);
+    }
+    if (flagged.length > PRINT) console.log(`  ... ${flagged.length - PRINT} more in the report file`);
+    console.log(`\nReport written to ${path.relative(process.cwd(), outPath)}`);
+    console.log('Next: scripts/mark-corrupt-off.ts --file <report> (dry-run first, then --apply after approval).');
+}
+
+main()
+    .catch(err => { console.error(err); process.exit(2); })
+    .finally(() => prisma.$disconnect());

--- a/scripts/eval/detect-corrupt-nutrition.ts
+++ b/scripts/eval/detect-corrupt-nutrition.ts
@@ -77,7 +77,7 @@ const BATCH = 20000;
  *  Word-bounded so "salted caramel" is guarded (conservative skip) but
  *  "sardines" is not. Guarded rows are reported for later triage, not flagged. */
 const SODIUM_GUARD_PATTERN =
-    /\b(salts?|salted|seasonings?|bouill?[oi]ll?on|broth|stock|base|cubes?|rub|mix|blend|gravy|marinade|sazon|adobo|msg|dashi|miso|electrolytes?|hydration|brine[ds]?|cure[ds]?|curing)\b/i;
+    /\b(salts?|salted|seasonings?|bouillon|bouillion|boullion|bullion|bouilion|broth|stock|base|cubes?|rub|mix|blend|gravy|marinade|sazon|adobo|msg|dashi|miso|electrolytes?|hydration|hydrate|brine[ds]?|cure[ds]?|curing)\b/i;
 
 /** Sibling sodium medians above this are sauce/seasoning groups where a high
  *  row is plausible; the outlier rule only trusts clearly-food-like medians. */
@@ -189,7 +189,12 @@ async function main() {
                 continue;
             }
             if (kcal != null && kcal >= KJ_MIN_KCAL && protein != null && fat != null && carbs != null) {
-                const atwater = 4 * protein + 9 * fat + 4 * carbs;
+                // EU-style labels exclude fiber from carbs, and fiber still
+                // carries ~2 kcal/g — without the fiber term, psyllium husk /
+                // xanthan / inulin records (kcal ~200, carbs ~0) dominate the
+                // class as false positives. Real kJ slips (4.184x) survive it.
+                const fiber = readNum(nutrients, 'fiber') ?? 0;
+                const atwater = 4 * protein + 9 * fat + 4 * carbs + 2 * fiber;
                 if (atwater > 0 && kcal > KJ_ATWATER_MIN_RATIO * atwater && !ALCOHOL_PATTERN.test(names)) {
                     flagged.push({
                         ...base, direction: 'kj-as-kcal', value: kcal,
@@ -202,11 +207,17 @@ async function main() {
             if (na != null && na >= MIN_SODIUM_OUTLIER_G) {
                 const m = sodiumMedians.get(normalizeNameKey(r.name));
                 if (m && m.med > 0 && m.med <= MAX_OUTLIER_SANE_MEDIAN && na >= MIN_SODIUM_OUTLIER_RATIO * m.med) {
-                    flagged.push({
-                        ...base, direction: 'sodium-sibling-outlier', value: na,
-                        ratio: na / m.med, siblingMedian: m.med, groupSize: m.n,
-                        check: { field: 'sodium', value: na },
-                    });
+                    // Dry gravy/soup mixes legitimately sit 10-20x above their
+                    // prepared same-name siblings — same guard as the band rule.
+                    if (SODIUM_GUARD_PATTERN.test(names)) {
+                        guarded.push({ barcode: r.barcode, name: r.name, brandName: r.brandName, sodium: na });
+                    } else {
+                        flagged.push({
+                            ...base, direction: 'sodium-sibling-outlier', value: na,
+                            ratio: na / m.med, siblingMedian: m.med, groupSize: m.n,
+                            check: { field: 'sodium', value: na },
+                        });
+                    }
                 }
             }
         }

--- a/scripts/mark-corrupt-off.ts
+++ b/scripts/mark-corrupt-off.ts
@@ -66,6 +66,8 @@ function checkValueOf(nutrients: unknown, field: CorruptScanCheck['field']): num
     const num = (v: unknown) => (typeof v === 'number' && isFinite(v) ? v : null);
     if (field === 'calories') return num(n.calories ?? n.energy ?? n.kcal);
     if (field === 'sodium') return num(n.sodium);
+    if (field === 'fiber') return num(n.fiber);
+    if (field === 'sugars') return num(n.sugars ?? n.sugar);
     return (num(n.protein) ?? 0) + (num(n.fat) ?? 0) + (num(n.carbs) ?? 0);
 }
 

--- a/scripts/mark-corrupt-off.ts
+++ b/scripts/mark-corrupt-off.ts
@@ -1,15 +1,18 @@
 /**
- * mark-corrupt-off.ts — write OffFood.corruptReason from a corrupt-panel scan.
+ * mark-corrupt-off.ts — write OffFood.corruptReason from a corrupt-record scan.
  *
  * Input: a results/corrupt-panel-scan-*.json produced by
- * scripts/eval/detect-corrupt-panel.ts. Each flagged entry is passed through
- * the shared trust rules (src/lib/mapping/corrupt-mark.ts):
+ * scripts/eval/detect-corrupt-panel.ts, or a results/corrupt-nutrition-scan-*.json
+ * produced by scripts/eval/detect-corrupt-nutrition.ts. Each flagged entry is
+ * passed through the shared trust rules (src/lib/mapping/corrupt-mark.ts):
  *   - panel-low flags whose sibling median exceeds the physical ceiling are
  *     skipped (the SIBLING group is the corrupt one — kJ-as-kcal family);
- *   - panel-inflated flags from groups smaller than 8 are skipped.
+ *   - panel-inflated flags from groups smaller than 8 are skipped;
+ *   - nutrition-scale flags are re-verified against their own thresholds.
  * Surviving flags are re-checked against the live row (barcode still exists,
- * stored kcal/100g still matches the scan within 0.5 — the corpus may have
- * changed since the scan) and then written as corruptReason = "<direction>:<tier>".
+ * stored value of the flag's check field still matches the scan within 0.5 —
+ * the corpus may have changed since the scan) and then written as
+ * corruptReason = "<direction>:<tier>".
  *
  * corruptReason is a SEPARATE column from duplicateOfBarcode on purpose:
  * dedupe-off-mark.ts clears and recomputes duplicate marks on every run.
@@ -38,7 +41,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { PrismaClient, Prisma } from '@prisma/client';
-import { decideMark, CorruptScanFlag } from '../src/lib/mapping/corrupt-mark';
+import { decideMark, CorruptScanFlag, CorruptScanCheck } from '../src/lib/mapping/corrupt-mark';
 
 const prisma = new PrismaClient();
 
@@ -55,11 +58,15 @@ const FILE = argValue('--file');
 const FETCH_CHUNK = 1000;
 const WRITE_BATCH = 5000;
 
-function kcalOf(nutrients: unknown): number | null {
+/** Live value of the field a flag's staleness re-check compares against.
+ *  Panel-scan flags carry no `check` payload — they default to calories. */
+function checkValueOf(nutrients: unknown, field: CorruptScanCheck['field']): number | null {
     if (!nutrients || typeof nutrients !== 'object') return null;
     const n = nutrients as Record<string, unknown>;
-    const v = n.calories ?? n.energy ?? n.kcal;
-    return typeof v === 'number' ? v : null;
+    const num = (v: unknown) => (typeof v === 'number' && isFinite(v) ? v : null);
+    if (field === 'calories') return num(n.calories ?? n.energy ?? n.kcal);
+    if (field === 'sodium') return num(n.sodium);
+    return (num(n.protein) ?? 0) + (num(n.fat) ?? 0) + (num(n.carbs) ?? 0);
 }
 
 async function clearMarks(): Promise<void> {
@@ -128,8 +135,10 @@ async function main(): Promise<void> {
             const entry = markable.get(barcode)!;
             if (!row) { missing++; continue; }
             if (row.corruptReason != null) { alreadyMarked++; continue; }
-            const liveKcal = kcalOf(row.nutrientsPer100g);
-            if (liveKcal == null || Math.abs(liveKcal - entry.flag.kcal100) > 0.5) {
+            const check: CorruptScanCheck =
+                entry.flag.check ?? { field: 'calories', value: entry.flag.kcal100 };
+            const live = checkValueOf(row.nutrientsPer100g, check.field);
+            if (live == null || Math.abs(live - check.value) > 0.5) {
                 stale++;
                 continue;
             }

--- a/src/lib/mapping/__tests__/corrupt-mark.test.ts
+++ b/src/lib/mapping/__tests__/corrupt-mark.test.ts
@@ -103,6 +103,15 @@ describe('decideMark — nutrition-scale directions (detect-corrupt-nutrition.ts
         expect(d).toEqual({ mark: true, reason: 'macro-sum-impossible:direct' });
     });
 
+    it('marks impossible single components (fiber 260, sugars 2000)', () => {
+        expect(decideMark(flag({ direction: 'fiber-impossible', value: 260 })))
+            .toEqual({ mark: true, reason: 'fiber-impossible:direct' });
+        expect(decideMark(flag({ direction: 'sugars-impossible', value: 2000 })))
+            .toEqual({ mark: true, reason: 'sugars-impossible:direct' });
+        expect(decideMark(flag({ direction: 'fiber-impossible', value: 90 })))
+            .toEqual({ mark: false, skip: 'value_below_threshold' });
+    });
+
     it('marks sodium above pure salt (mg-entered-as-g family)', () => {
         // Real case: beef jerky storing "1285.71 g" sodium — the mg value.
         const d = decideMark(flag({ direction: 'sodium-impossible', value: 1285.71 }));

--- a/src/lib/mapping/__tests__/corrupt-mark.test.ts
+++ b/src/lib/mapping/__tests__/corrupt-mark.test.ts
@@ -9,6 +9,15 @@ import {
     CorruptScanFlag,
     MAX_TRUSTABLE_SIBLING_MEDIAN,
     MIN_INFLATED_GROUP_SIZE,
+    MAX_KCAL_100G,
+    MAX_MACRO_SUM_100G,
+    MAX_SODIUM_100G,
+    SODIUM_IMPLAUSIBLE_100G,
+    KJ_ATWATER_MIN_RATIO,
+    KJ_MIN_KCAL,
+    MIN_SODIUM_OUTLIER_GROUP,
+    MIN_SODIUM_OUTLIER_RATIO,
+    MIN_SODIUM_OUTLIER_G,
 } from '../corrupt-mark';
 
 function flag(overrides: Partial<CorruptScanFlag>): CorruptScanFlag {
@@ -74,6 +83,82 @@ describe('decideMark', () => {
     it('does NOT apply the group-size floor to panel-low flags (direct serving evidence)', () => {
         const d = decideMark(flag({ direction: 'panel-low', groupSize: 4 }));
         expect(d.mark).toBe(true);
+    });
+});
+
+describe('decideMark — nutrition-scale directions (detect-corrupt-nutrition.ts)', () => {
+    it('marks kcal above the physical ceiling', () => {
+        // Real case from the 2026-07-21 sizing: "Bomb Burrito" at 81,818 kcal/100g.
+        const d = decideMark(flag({ direction: 'kcal-impossible', value: 81818 }));
+        expect(d).toEqual({ mark: true, reason: 'kcal-impossible:direct' });
+    });
+
+    it('re-verifies the kcal threshold from the flag value (stale/hand-edited scan defense)', () => {
+        const d = decideMark(flag({ direction: 'kcal-impossible', value: MAX_KCAL_100G }));
+        expect(d).toEqual({ mark: false, skip: 'value_below_threshold' });
+    });
+
+    it('marks macro sums over 100g/100g', () => {
+        const d = decideMark(flag({ direction: 'macro-sum-impossible', value: MAX_MACRO_SUM_100G + 1 }));
+        expect(d).toEqual({ mark: true, reason: 'macro-sum-impossible:direct' });
+    });
+
+    it('marks sodium above pure salt (mg-entered-as-g family)', () => {
+        // Real case: beef jerky storing "1285.71 g" sodium — the mg value.
+        const d = decideMark(flag({ direction: 'sodium-impossible', value: 1285.71 }));
+        expect(d).toEqual({ mark: true, reason: 'sodium-impossible:direct' });
+    });
+
+    it('marks unguarded sodium in the implausible band', () => {
+        // Real case: "Banoffee Pie" at 12.6 g sodium/100g (= 31 g salt).
+        const d = decideMark(flag({ direction: 'sodium-implausible', value: 12.6 }));
+        expect(d).toEqual({ mark: true, reason: 'sodium-implausible:direct' });
+    });
+
+    it('skips sodium-implausible at or below the band floor', () => {
+        const d = decideMark(flag({ direction: 'sodium-implausible', value: SODIUM_IMPLAUSIBLE_100G }));
+        expect(d).toEqual({ mark: false, skip: 'value_below_threshold' });
+    });
+
+    it('marks kJ-as-kcal Atwater mismatches', () => {
+        // The n-mq-27 lemon class: 383 "kcal"/100g vs ~40 from macros (~9.6x).
+        const d = decideMark(flag({ direction: 'kj-as-kcal', value: 383, ratio: 9.6 }));
+        expect(d).toEqual({ mark: true, reason: 'kj-as-kcal:direct' });
+    });
+
+    it('skips kj-as-kcal below the ratio or kcal floors', () => {
+        expect(decideMark(flag({ direction: 'kj-as-kcal', value: 383, ratio: KJ_ATWATER_MIN_RATIO - 0.1 })))
+            .toEqual({ mark: false, skip: 'value_below_threshold' });
+        expect(decideMark(flag({ direction: 'kj-as-kcal', value: KJ_MIN_KCAL - 1, ratio: 9.6 })))
+            .toEqual({ mark: false, skip: 'value_below_threshold' });
+    });
+
+    it('marks the mayo-class sodium sibling outlier', () => {
+        // off_9348905001434: mayonnaise sodium 5.33 g/100g vs sibling median ~0.6 (~8.9x).
+        const d = decideMark(flag({
+            direction: 'sodium-sibling-outlier', value: 5.33, ratio: 8.9,
+            siblingMedian: 0.6, groupSize: 12,
+        }));
+        expect(d).toEqual({ mark: true, reason: 'sodium-sibling-outlier:direct' });
+    });
+
+    it('skips sibling outliers from small groups', () => {
+        const d = decideMark(flag({
+            direction: 'sodium-sibling-outlier', value: 5.33, ratio: 8.9,
+            groupSize: MIN_SODIUM_OUTLIER_GROUP - 1,
+        }));
+        expect(d).toEqual({ mark: false, skip: 'outlier_group_too_small' });
+    });
+
+    it('skips sibling outliers below the ratio or absolute floors', () => {
+        expect(decideMark(flag({
+            direction: 'sodium-sibling-outlier', value: 5.33,
+            ratio: MIN_SODIUM_OUTLIER_RATIO - 0.5, groupSize: 12,
+        }))).toEqual({ mark: false, skip: 'outlier_below_thresholds' });
+        expect(decideMark(flag({
+            direction: 'sodium-sibling-outlier', value: MIN_SODIUM_OUTLIER_G - 0.1,
+            ratio: 8.9, groupSize: 12,
+        }))).toEqual({ mark: false, skip: 'outlier_below_thresholds' });
     });
 });
 

--- a/src/lib/mapping/corrupt-mark.ts
+++ b/src/lib/mapping/corrupt-mark.ts
@@ -39,6 +39,8 @@ export type CorruptDirection =
     // detect-corrupt-nutrition.ts
     | 'kcal-impossible'
     | 'macro-sum-impossible'
+    | 'fiber-impossible'
+    | 'sugars-impossible'
     | 'sodium-impossible'
     | 'sodium-implausible'
     | 'kj-as-kcal'
@@ -48,7 +50,7 @@ export type CorruptDirection =
  *  against the scan-time value before writing (the corpus may have changed).
  *  'macroSum' is computed as protein + fat + carbs from the live row. */
 export interface CorruptScanCheck {
-    field: 'calories' | 'sodium' | 'macroSum';
+    field: 'calories' | 'sodium' | 'macroSum' | 'fiber' | 'sugars';
     value: number;
 }
 
@@ -94,6 +96,8 @@ export const MIN_INFLATED_GROUP_SIZE = 8;
 export const MAX_KCAL_100G = 905;
 /** Protein + fat + carbs cannot exceed 100 g per 100 g; 105 allows label rounding. */
 export const MAX_MACRO_SUM_100G = 105;
+/** No single gram-basis component (fiber, sugars) can exceed 100 g per 100 g. */
+export const MAX_COMPONENT_100G = 105;
 /** Pure salt is 39.3 g sodium/100g; no food can exceed it. */
 export const MAX_SODIUM_100G = 39.4;
 /** Only salts, bouillon/stock concentrates, and seasoning powders live above
@@ -148,6 +152,12 @@ export function decideMark(flag: CorruptScanFlag): MarkDecision {
             return { mark: true, reason: `${flag.direction}:${flag.tier}` };
         case 'macro-sum-impossible':
             if ((flag.value ?? 0) <= MAX_MACRO_SUM_100G) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'fiber-impossible':
+        case 'sugars-impossible':
+            if ((flag.value ?? 0) <= MAX_COMPONENT_100G) {
                 return { mark: false, skip: 'value_below_threshold' };
             }
             return { mark: true, reason: `${flag.direction}:${flag.tier}` };

--- a/src/lib/mapping/corrupt-mark.ts
+++ b/src/lib/mapping/corrupt-mark.ts
@@ -1,13 +1,19 @@
 /**
  * corrupt-mark.ts — shared logic for the OffFood.corruptReason marking system.
  *
- * The corpus scan (scripts/eval/detect-corrupt-panel.ts) flags records whose
- * stored per-100g panel is really a per-serving panel (rescaling by
- * 100/servingGrams lands on the same-name sibling median). The marker
- * (scripts/mark-corrupt-off.ts) writes corruptReason for the trustworthy
- * subset of those flags; retrieval then excludes marked rows (Typesense sync
- * WHERE clause + live-index purge + PG fallback filter) and the mapper escapes
- * cache rows that point at them.
+ * Two corpus scans feed the marker (scripts/mark-corrupt-off.ts):
+ *   - scripts/eval/detect-corrupt-panel.ts — records whose stored per-100g
+ *     panel is really a per-serving panel (rescaling by 100/servingGrams
+ *     lands on the same-name sibling median);
+ *   - scripts/eval/detect-corrupt-nutrition.ts — per-field impossibilities
+ *     and scale slips: kcal above the physical ceiling, macro sums over
+ *     100 g/100g, sodium above pure salt (the mg-entered-as-g family),
+ *     kJ-values-in-the-kcal-field Atwater mismatches, and sodium sibling
+ *     outliers (the mayonnaise 5.33 g/100g class from the 2026-07-21
+ *     nutrition re-verify).
+ * Retrieval then excludes marked rows (Typesense sync WHERE clause +
+ * live-index purge + PG fallback filter) and the mapper escapes cache rows
+ * that point at them.
  *
  * This module holds the pure decision rules so the marker script and jest can
  * share them, plus the runtime kill-switch used by the exclusion sites.
@@ -26,7 +32,32 @@ export function isCorruptExclusionEnabled(): boolean {
     return process.env.CORRUPT_RECORD_EXCLUSION !== '0';
 }
 
-/** One entry of detect-corrupt-panel.ts scan output (results/corrupt-panel-scan-*.json). */
+export type CorruptDirection =
+    // detect-corrupt-panel.ts
+    | 'panel-low'
+    | 'panel-inflated'
+    // detect-corrupt-nutrition.ts
+    | 'kcal-impossible'
+    | 'macro-sum-impossible'
+    | 'sodium-impossible'
+    | 'sodium-implausible'
+    | 'kj-as-kcal'
+    | 'sodium-sibling-outlier';
+
+/** Staleness re-check payload: which live field the marker must compare
+ *  against the scan-time value before writing (the corpus may have changed).
+ *  'macroSum' is computed as protein + fat + carbs from the live row. */
+export interface CorruptScanCheck {
+    field: 'calories' | 'sodium' | 'macroSum';
+    value: number;
+}
+
+/** One entry of a detect-corrupt-*.ts scan output (results/corrupt-*-scan-*.json).
+ *  Panel flags fill kcal100/rescaled/siblingMedian/groupSize; nutrition-scale
+ *  flags carry the offending value in `value` (plus `ratio` where the rule is
+ *  ratio-based) and always provide `check`. For sodium-sibling-outlier,
+ *  siblingMedian/groupSize describe the sibling SODIUM distribution (g/100g),
+ *  not kcal. */
 export interface CorruptScanFlag {
     barcode: string;
     name: string;
@@ -34,11 +65,14 @@ export interface CorruptScanFlag {
     kcal100: number;
     servingGrams: number | null;
     tier: 'direct' | 'sibling-serving';
-    direction: 'panel-low' | 'panel-inflated';
+    direction: CorruptDirection;
     rescaled: number;
     siblingMedian: number;
     groupSize: number;
     triageConfirmed: boolean;
+    value?: number;
+    ratio?: number;
+    check?: CorruptScanCheck;
 }
 
 /** Physical ceiling for a trustworthy sibling median. Pure fat is ~900 kcal/100g;
@@ -50,21 +84,95 @@ export const MAX_TRUSTABLE_SIBLING_MEDIAN = 920;
  *  are dominated by a few bad rows. Triage review set this floor. */
 export const MIN_INFLATED_GROUP_SIZE = 8;
 
+// ---- detect-corrupt-nutrition.ts thresholds (corpus-mark tier) ----
+// These sit deliberately ABOVE the rank/save-time gate bounds in
+// macro-plausibility.ts (kcal 900, macro sum 105): a corruptReason mark
+// permanently removes the record from the index, so the corpus tier takes
+// extra label-rounding slack where the physics allows it.
+
+/** Pure fat is ~900 kcal/100g; nothing edible exceeds it. 905 allows rounding. */
+export const MAX_KCAL_100G = 905;
+/** Protein + fat + carbs cannot exceed 100 g per 100 g; 105 allows label rounding. */
+export const MAX_MACRO_SUM_100G = 105;
+/** Pure salt is 39.3 g sodium/100g; no food can exceed it. */
+export const MAX_SODIUM_100G = 39.4;
+/** Only salts, bouillon/stock concentrates, and seasoning powders live above
+ *  this; the detector name-guards those and flags the rest. */
+export const SODIUM_IMPLAUSIBLE_100G = 10;
+/** kJ-as-kcal stores 4.184x the true value; 3x keeps margin over fiber noise. */
+export const KJ_ATWATER_MIN_RATIO = 3;
+/** Below this kcal the Atwater ratio is dominated by rounding on tiny macros. */
+export const KJ_MIN_KCAL = 100;
+/** sodium-sibling-outlier trust floors (mayo class: 5.33 vs sibling ~0.6). */
+export const MIN_SODIUM_OUTLIER_GROUP = 4;
+export const MIN_SODIUM_OUTLIER_RATIO = 6;
+export const MIN_SODIUM_OUTLIER_G = 2;
+
 export type MarkDecision =
     | { mark: true; reason: string }
-    | { mark: false; skip: 'sibling_median_implausible' | 'inflated_group_too_small' };
+    | {
+          mark: false;
+          skip:
+              | 'sibling_median_implausible'
+              | 'inflated_group_too_small'
+              | 'value_below_threshold'
+              | 'outlier_group_too_small'
+              | 'outlier_below_thresholds';
+      };
 
 /**
  * Decide whether a scan flag is trustworthy enough to mark.
  * Reason strings are stable identifiers ("panel-low:direct" etc.) so later
  * sweeps can distinguish mark generations by prefix match.
+ *
+ * The nutrition-scale directions re-verify their threshold against the flag's
+ * own `value` — a defense in depth so a hand-edited or stale scan file can
+ * never mark a row the rule would not flag today.
  */
 export function decideMark(flag: CorruptScanFlag): MarkDecision {
-    if (flag.direction === 'panel-low' && flag.siblingMedian > MAX_TRUSTABLE_SIBLING_MEDIAN) {
-        return { mark: false, skip: 'sibling_median_implausible' };
+    switch (flag.direction) {
+        case 'panel-low':
+            if (flag.siblingMedian > MAX_TRUSTABLE_SIBLING_MEDIAN) {
+                return { mark: false, skip: 'sibling_median_implausible' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'panel-inflated':
+            if (flag.groupSize < MIN_INFLATED_GROUP_SIZE) {
+                return { mark: false, skip: 'inflated_group_too_small' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'kcal-impossible':
+            if ((flag.value ?? 0) <= MAX_KCAL_100G) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'macro-sum-impossible':
+            if ((flag.value ?? 0) <= MAX_MACRO_SUM_100G) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'sodium-impossible':
+            if ((flag.value ?? 0) <= MAX_SODIUM_100G) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'sodium-implausible':
+            if ((flag.value ?? 0) <= SODIUM_IMPLAUSIBLE_100G) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'kj-as-kcal':
+            if ((flag.value ?? 0) < KJ_MIN_KCAL || (flag.ratio ?? 0) < KJ_ATWATER_MIN_RATIO) {
+                return { mark: false, skip: 'value_below_threshold' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'sodium-sibling-outlier':
+            if (flag.groupSize < MIN_SODIUM_OUTLIER_GROUP) {
+                return { mark: false, skip: 'outlier_group_too_small' };
+            }
+            if ((flag.value ?? 0) < MIN_SODIUM_OUTLIER_G || (flag.ratio ?? 0) < MIN_SODIUM_OUTLIER_RATIO) {
+                return { mark: false, skip: 'outlier_below_thresholds' };
+            }
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
     }
-    if (flag.direction === 'panel-inflated' && flag.groupSize < MIN_INFLATED_GROUP_SIZE) {
-        return { mark: false, skip: 'inflated_group_too_small' };
-    }
-    return { mark: true, reason: `${flag.direction}:${flag.tier}` };
 }

--- a/src/lib/mapping/macro-plausibility.ts
+++ b/src/lib/mapping/macro-plausibility.ts
@@ -143,8 +143,9 @@ const LEAN_PROTEIN_CUT_PATTERN =
 /** g protein/100g floor: below raw breast (~22) and cooked (~31), above deli rolls (~14-16). */
 const LEAN_CUT_PROTEIN_FLOOR = 18;
 
-/** Alcohol carries 7 kcal/g that never shows up in P/C/F — exempt from the high-side Atwater check. */
-const ALCOHOL_PATTERN =
+/** Alcohol carries 7 kcal/g that never shows up in P/C/F — exempt from the high-side Atwater check.
+ *  Exported for detect-corrupt-nutrition.ts, whose kJ-as-kcal rule needs the same exemption. */
+export const ALCOHOL_PATTERN =
     /\b(beer|wine|vodka|whiske?y|rum|gin|tequila|liqueur|brandy|cognac|sake|cider|cocktail|margarita|sangria|champagne|prosecco|bourbon|scotch|mead|soju|alcoholic?|spirits?|ale|lager|stout|ipa)\b/i;
 
 // ============================================================


### PR DESCRIPTION
## What

Second corpus detector for the corrupt-marking system (follow-up to #116): `scripts/eval/detect-corrupt-nutrition.ts` catches per-FIELD impossibilities and unit-scale slips that the per-serving-panel detector is structurally blind to. This is the "detector extension (search-side nutrition, mayo-sodium class)" item from the PR E handoff.

## Classes (live sizing against prod DB, 2026-07-21, unmarked non-dup rows)

| direction | rule | ~rows |
|---|---|---|
| `kcal-impossible` | kcal > 905/100g (pure fat ≈ 900) | ~14,000 |
| `macro-sum-impossible` | P+F+C > 105 g/100g | ~20,300 |
| `sodium-impossible` | Na > 39.4 g/100g (pure salt = 39.3) — the mg-entered-as-g family | ~800 |
| `sodium-implausible` | Na 10–39.4 g/100g, name-guarded (salts/bouillon/seasoning skip) | ≤2,000 |
| `kj-as-kcal` | kcal ≥ 100, all macros present, kcal > 3× Atwater, alcohol-exempt | ~27 |
| `sodium-sibling-outlier` | Na ≥ max(2 g, 6× same-name sibling median) | TBD (mayo class) |

Union of the three impossible tiers ≈ **21.5k rows (~2% of corpus)**. Examples: "Bomb Burrito" 81,818 kcal/100g; beef jerky sodium "1285 g"/100g (the mg value); Knorr bouillon 21,142 (mg-as-g of a legit 21 g). The 4–10 g sodium band (soy/fish-sauce territory, ~7.3k rows) is **counted but never flagged** — identity-aware triage only.

## How it plugs in

- `mark-corrupt-off.ts` consumes either scan file unchanged. Flags now carry a `check: {field, value}` payload; the live staleness re-check compares that field (was hardcoded kcal). Old panel-scan JSONs still work (default to calories).
- `decideMark` re-verifies every nutrition-scale threshold from the flag's own value — a stale or hand-edited scan file can never mark a row the rule wouldn't flag today.
- Exclusion path unchanged: `corruptReason` → Typesense sync WHERE + `purge-corrupt-typesense.ts` + PG fallback filter + cache-row escape.
- `ALCOHOL_PATTERN` exported from `macro-plausibility.ts` (shared exemption).

## Safety

- Scan is read-only; marking stays dry-run-by-default behind `--apply`.
- 21 jest tests (14 new) on the trust rules; typecheck clean.
- Apply plan (separate, after merge + approval): scan → dry-run marker → review byReason + affected-cache report → apply → purge → eval gate must stay at exact parity (allow-fail n-mq-10 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu