### PR TITLE
fix(mapping): water fast-path only for whole-line beverage queries

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -5391,6 +5391,31 @@
       "notes": "PR D pt3 class (c) KNOWN ISSUE — COOKED-BASIS, rewrite DEFERRED. 'oatmeal' still collapses to rolled-oats and maps DRY oats (~380 kcal/100g); prepared oatmeal is ~70 kcal/100g. Bound expressed as cooked-basis per-100g kcal <=150 (closest expressible form: fails any dry record, passes any prepared one). Ranking/ingest gap — useless to rewrite until a cooked-oats record surfaces. Promote when it does."
     },
     {
+      "id": "n-mq-37",
+      "category": "match_quality",
+      "item": {
+        "rawText": "canned tuna in water",
+        "quantity": 1,
+        "name": "canned tuna in water"
+      },
+      "expectName": [
+        [
+          "tuna"
+        ]
+      ],
+      "macros": {
+        "kcal100": [
+          60,
+          250
+        ],
+        "protein100": [
+          10,
+          35
+        ]
+      },
+      "notes": "WATER FAST-PATH ANCHOR (2026-07-21, HIGH triage). Regression pin for the zero-calorie fast-path bug: ZERO_CALORIE_INGREDIENTS matched 'water' as a suffix/last word of the line, so 'canned tuna in water' short-circuited to the water_default 0-kcal result BEFORE mapping ever ran. Fix anchors the match to the whole line (after qty/unit stripping). This line must map a real tuna record with tuna-like macros (water-packed tuna ~86-130 kcal/100g, ~19-26p); the water_default result (kcal100=0, name 'Water') fails both bands AND expectName. Hard."
+    },
+    {
       "id": "n-dens-01",
       "category": "serving_unit",
       "item": {
@@ -5847,6 +5872,28 @@
         ]
       },
       "notes": "TOTAL-MACRO assertion (Phase 0 flywheel, 2026-07-19). Companion to n-serv-35 (same query, grams band): asserts the BILLED kcal for a 13-count chip line (~28-70g of ~490-530kcal/100g chips → 140-350 kcal; band trimmed to reject edge inflation). The flat-100g failure bills ~500 kcal and the 13x100g count explosion ~6500 — both far outside band. Short text takes the single-item fast path, no LLM segmentation cost."
+    },
+    {
+      "id": "n-tot-06",
+      "category": "total_macros",
+      "item": {
+        "rawText": "16 oz water",
+        "quantity": 16,
+        "unit": "oz",
+        "name": "water"
+      },
+      "expectName": [
+        [
+          "water"
+        ]
+      ],
+      "total": {
+        "calories": [
+          0,
+          1
+        ]
+      },
+      "notes": "WATER FAST-PATH companion to n-mq-37 (2026-07-21): a line that IS entirely a water query (after qty/unit stripping) must still take the zero-calorie fast-path and bill ~0 kcal — guards against over-tightening the whole-line anchor. 16 fl-oz → ~473g water_default, 0 kcal. Hard."
     }
   ]
 }

--- a/src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts
+++ b/src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts
@@ -366,6 +366,134 @@ describe('mapIngredientWithFallback filtering', () => {
         expect(result?.foodName.toLowerCase()).toContain('substitute');
     });
 
+    it('fires the zero-calorie fast-path only when the whole line is a water query', async () => {
+        // Positive: plain water and water with qty/unit prefixes (qty/unit are
+        // stripped by parsing, so baseName is exactly "water").
+        for (const line of ['water', '2 cups water', '16 oz water']) {
+            const result = await mapIngredientWithFallback(line, {
+                minConfidence: 0,
+                skipFdc: true,
+            });
+            expect(result).not.toBeNull();
+            expect(result?.foodId).toBe('water_default');
+            expect(result?.kcal).toBe(0);
+        }
+    });
+
+    it('fires the zero-calorie fast-path for whole-line water beverage variants', async () => {
+        for (const line of ['sparkling water', 'ice water', 'still water']) {
+            const result = await mapIngredientWithFallback(line, {
+                minConfidence: 0,
+                skipFdc: true,
+            });
+            expect(result).not.toBeNull();
+            expect(result?.foodId).toBe('water_default');
+            expect(result?.kcal).toBe(0);
+        }
+    });
+
+    it('does NOT fast-path "canned tuna in water"', async () => {
+        // "canned tuna in water" billed 0 kcal because the old check matched
+        // "water" as a suffix/last word of the line. It must map normally.
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            { id: 'tuna-water', source: 'ai_generated', name: 'Tuna in Water, Canned', brandName: null, score: 0.9, rawData: {} }
+        ]);
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'tuna-water',
+            displayName: 'Tuna in Water, Canned',
+            ingredientName: 'canned tuna in water',
+            caloriesPer100g: 90,
+            proteinPer100g: 20,
+            carbsPer100g: 0,
+            fatPer100g: 1,
+            servings: [{ id: 'srv-tuna', label: '1 can', grams: 120 }]
+        });
+
+        const result = await mapIngredientWithFallback('100g canned tuna in water', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+        expect(result).not.toBeNull();
+        expect(result?.foodId).not.toBe('water_default');
+        expect(result?.foodName.toLowerCase()).toContain('tuna');
+        expect(result?.kcal).toBeGreaterThan(0);
+    });
+
+    it('does NOT fast-path "tuna in spring water"', async () => {
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            { id: 'tuna-spring', source: 'ai_generated', name: 'Tuna in Spring Water', brandName: null, score: 0.9, rawData: {} }
+        ]);
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'tuna-spring',
+            displayName: 'Tuna in Spring Water',
+            ingredientName: 'tuna in spring water',
+            caloriesPer100g: 99,
+            proteinPer100g: 23,
+            carbsPer100g: 0,
+            fatPer100g: 0.8,
+            servings: [{ id: 'srv-tuna-sp', label: '1 can', grams: 120 }]
+        });
+
+        const result = await mapIngredientWithFallback('100g tuna in spring water', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+        expect(result).not.toBeNull();
+        expect(result?.foodId).not.toBe('water_default');
+        expect(result?.foodName.toLowerCase()).toContain('tuna');
+        expect(result?.kcal).toBeGreaterThan(0);
+    });
+
+    it('does NOT fast-path "chicken packed in water"', async () => {
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            { id: 'chicken-water', source: 'ai_generated', name: 'Chicken Breast, Canned in Water', brandName: null, score: 0.9, rawData: {} }
+        ]);
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'chicken-water',
+            displayName: 'Chicken Breast, Canned in Water',
+            ingredientName: 'chicken packed in water',
+            caloriesPer100g: 105,
+            proteinPer100g: 22,
+            carbsPer100g: 0,
+            fatPer100g: 2,
+            servings: [{ id: 'srv-chx', label: '1 can', grams: 140 }]
+        });
+
+        const result = await mapIngredientWithFallback('100g chicken packed in water', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+        expect(result).not.toBeNull();
+        expect(result?.foodId).not.toBe('water_default');
+        expect(result?.foodName.toLowerCase()).toContain('chicken');
+        expect(result?.kcal).toBeGreaterThan(0);
+    });
+
+    it('does NOT treat watermelon as water', async () => {
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            { id: 'melon-1', source: 'ai_generated', name: 'Watermelon', brandName: null, score: 0.9, rawData: {} }
+        ]);
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'melon-1',
+            displayName: 'Watermelon',
+            ingredientName: 'watermelon',
+            caloriesPer100g: 30,
+            proteinPer100g: 0.6,
+            carbsPer100g: 7.6,
+            fatPer100g: 0.2,
+            servings: [{ id: 'srv-melon', label: '1 cup', grams: 152 }]
+        });
+
+        const result = await mapIngredientWithFallback('100g watermelon', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+        expect(result).not.toBeNull();
+        expect(result?.foodId).not.toBe('water_default');
+        expect(result?.foodName.toLowerCase()).toContain('watermelon');
+        expect(result?.kcal).toBeGreaterThan(0);
+    });
+
     it('enforces low-fat modifiers in candidate selection', async () => {
         (gatherCandidates as jest.Mock).mockResolvedValue([
             { id: 'cream-cheese', source: 'ai_generated', name: 'Cream Cheese', brandName: null, score: 0.9, rawData: {} },

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -554,17 +554,21 @@ export async function mapIngredientWithFallback(
     // ============================================================
     // Step 1-WATER: Early exit for ice/water - always zero calories
     // ============================================================
-    // These ingredients have no nutritional value and should never map to food
+    // These ingredients have no nutritional value and should never map to food.
+    // IMPORTANT: the match is anchored to the WHOLE line (after qty/unit stripping) —
+    // the old suffix/last-word matching made "canned tuna in water" bill 0 kcal.
+    // Lines that merely CONTAIN water phrasing must proceed through normal mapping.
     // Note: "liquid" added to handle ambiguous inputs like "100% liquid" that normalize to just "liquid"
-    const ZERO_CALORIE_INGREDIENTS = ['ice', 'ice cubes', 'crushed ice', 'shaved ice', 'water', 'tap water', 'cold water', 'hot water', 'ice water', 'liquid'];
-    const baseNameLowerForWaterCheck = baseName.toLowerCase().trim();
-    // Also extract the last word to handle "100% liquid" → "liquid"
-    const lastWordForWaterCheck = baseNameLowerForWaterCheck.split(/\s+/).pop() || '';
-    if (ZERO_CALORIE_INGREDIENTS.some(term =>
-        baseNameLowerForWaterCheck === term ||
-        baseNameLowerForWaterCheck.endsWith(' ' + term) ||
-        lastWordForWaterCheck === term  // <-- NEW: Handles "100% liquid"
-    )) {
+    const ZERO_CALORIE_INGREDIENTS = [
+        'ice', 'ice cubes', 'crushed ice', 'shaved ice',
+        'water', 'tap water', 'cold water', 'hot water', 'warm water', 'ice water', 'iced water',
+        'still water', 'sparkling water', 'mineral water', 'spring water', 'carbonated water',
+        'filtered water', 'drinking water',
+        'liquid',
+    ];
+    // Strip leading "100%"-style prefixes so "100% liquid" → "liquid" still matches whole-line
+    const baseNameLowerForWaterCheck = baseName.toLowerCase().trim().replace(/^\d+(?:\.\d+)?\s*%\s*/, '');
+    if (ZERO_CALORIE_INGREDIENTS.includes(baseNameLowerForWaterCheck)) {
         logger.info('mapping.zero_calorie_default', { rawLine: trimmed, baseName });
 
         // Calculate grams from parsed quantity using standard conversions


### PR DESCRIPTION
## Bug

The query **"canned tuna in water"** billed **0 kcal** (HIGH, flagged in the big-warm triage as the water fast-path bug, map:565).

## Root cause

The Step 1-WATER zero-calorie fast-path in `src/lib/mapping/map-ingredient-with-fallback.ts` matched `ZERO_CALORIE_INGREDIENTS` terms as a **suffix** (`endsWith(' ' + term)`) or **last word** of the parsed line. Any line ending in "water" — "canned tuna in water", "chicken packed in water", "tuna in spring water" — short-circuited to the `water_default` 0-kcal result before candidate retrieval ever ran, and did so at confidence 1.0.

## Fix

Anchor the match to the **whole line**: after qty/unit stripping, the base name must exactly equal a term in the list (plus a leading `N%` prefix strip that preserves the old `"100% liquid"` handling). The list gains the whole-line water-beverage variants the suffix match used to legitimately cover (`sparkling/still/mineral/spring/carbonated/filtered/drinking/warm/iced water`), so plain water queries still fast-path to 0 kcal. Lines that merely *contain* water phrasing now proceed through normal mapping. Side benefit: "coconut water" (caloric) no longer bills 0.

## Tests

- **Unit** (`src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts`, follows the file's existing mock pattern):
  - Positive: `water`, `2 cups water`, `16 oz water`, `sparkling water`, `ice water`, `still water` → `water_default`, 0 kcal
  - Negative: `canned tuna in water`, `tuna in spring water`, `chicken packed in water` map to real records with kcal > 0; `watermelon` is not treated as water
- **Golden eval** (`scripts/eval/golden-set.json`, hard/gating):
  - `n-mq-37` — "canned tuna in water" must map a tuna record (kcal100 [60,250], protein100 [10,35]); the old water_default result fails name + both bands
  - `n-tot-06` — "16 oz water" must still fast-path and bill ~0 kcal (guards against over-tightening)
- Full local gate: `lint:ci` 0 errors, `typecheck` clean, `next build` clean, jest **858/858** (60 suites, no pre-existing failures)

Live eval gate to be run by the orchestrator at merge time (not run here — requires the running server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu