### PR TITLE
fix(parse): digit-leading brand quantities (7up → 1 can, not 7)

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -3342,6 +3342,50 @@
       "notes": "Pattern 10 (collective word-number 'a dozen' -> 12, article + word consumed). Added 2026-07-18 with the quantity.ts WORD_NUMBERS fix: 'a dozen eggs' = qty 12 -> ~600g (12 x ~50g egg default). Deterministic single-item path. Hard assertion; band widened to tolerate a 44-58g per-egg record serving."
     },
     {
+      "id": "n-qty-08",
+      "category": "quantity_parsing",
+      "text": "7up",
+      "expectItems": 1,
+      "expectName": [
+        [
+          "7up"
+        ],
+        [
+          "7 up"
+        ],
+        [
+          "seven up"
+        ]
+      ],
+      "grams": [
+        240,
+        500
+      ],
+      "notes": "DIGIT-BRAND QUANTITY GUARD (fix 2026-07-21, digit-brands.ts). '7up' must be qty 1 of the soda, NOT qty 7 x 355ml can (~2,485g billed pre-fix). Band = one can/bottle serving (240ml default to 500ml PET), same class as n-serv-46 bare 'coca cola'. Deterministic single-item path (singleItemFromText bypass, no LLM). Hard assertion."
+    },
+    {
+      "id": "n-qty-09",
+      "category": "quantity_parsing",
+      "text": "2 7up",
+      "expectItems": 1,
+      "expectName": [
+        [
+          "7up"
+        ],
+        [
+          "7 up"
+        ],
+        [
+          "seven up"
+        ]
+      ],
+      "grams": [
+        480,
+        1100
+      ],
+      "notes": "DIGIT-BRAND QUANTITY GUARD companion to n-qty-08: an explicit count BEFORE the digit-leading brand must still be honored — '2 7up' = qty 2 -> ~710g (2 x 355ml can), band spans 2x240ml to 2x500ml packages. Guards against the over-correction failure (guard eating the real count -> ~355g) and against flat-100g under-billing (200g, below band). Hard assertion."
+    },
+    {
       "id": "n-supp-16",
       "category": "branded_supplements",
       "item": {

--- a/src/lib/mapping/__tests__/digit-brands.test.ts
+++ b/src/lib/mapping/__tests__/digit-brands.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Digit-leading brand lexicon (digit-brands.ts) + brand-detector integration.
+ *
+ * The lexicon must claim exactly the listed brands (7UP, 5-hour Energy,
+ * 3 Musketeers) and nothing that could shadow a genuine count ("7 almonds").
+ * detectBrandInQuery must flag digit-leading brand lines as branded instead
+ * of stripping the digits as a leading quantity.
+ */
+
+import {
+  isDigitBrandToken,
+  matchDigitBrandTokens,
+  matchDigitBrandPrefix,
+} from '../digit-brands';
+import { detectBrandInQuery } from '../brand-detector';
+
+describe('digit-brands lexicon', () => {
+  test('single tokens: 7up / 7-up / 3musketeers / 5-hour', () => {
+    expect(isDigitBrandToken('7up')).toBe(true);
+    expect(isDigitBrandToken('7UP')).toBe(true);
+    expect(isDigitBrandToken('7-up')).toBe(true);
+    expect(isDigitBrandToken('3musketeers')).toBe(true);
+    expect(isDigitBrandToken('5-hour')).toBe(true);
+    // trailing punctuation tolerated
+    expect(isDigitBrandToken('7up.')).toBe(true);
+  });
+
+  test('non-brand tokens are not claimed', () => {
+    expect(isDigitBrandToken('7')).toBe(false);
+    expect(isDigitBrandToken('200g')).toBe(false);
+    expect(isDigitBrandToken('almonds')).toBe(false);
+    // 9Lives is pet food — deliberately excluded from a food-log lexicon
+    expect(isDigitBrandToken('9lives')).toBe(false);
+  });
+
+  test('phrase matching consumes the right number of tokens', () => {
+    expect(matchDigitBrandTokens(['7up'])).toBe(1);
+    expect(matchDigitBrandTokens(['7', 'up'])).toBe(2);
+    expect(matchDigitBrandTokens(['3', 'musketeers', 'bar'])).toBe(2);
+    expect(matchDigitBrandTokens(['5', 'hour', 'energy'])).toBe(3);
+    // trigram on purpose: bare "5 hour" is NOT claimed
+    expect(matchDigitBrandTokens(['5', 'hour'])).toBe(0);
+    expect(matchDigitBrandTokens(['5', 'hour', 'braise'])).toBe(0);
+    // genuine counts are never claimed
+    expect(matchDigitBrandTokens(['7', 'almonds'])).toBe(0);
+    expect(matchDigitBrandTokens(['2', 'eggs'])).toBe(0);
+    // startIdx offset works ("2 7up" -> brand starts at index 1)
+    expect(matchDigitBrandTokens(['2', '7up'], 1)).toBe(1);
+    expect(matchDigitBrandTokens(['2', '7', 'up'], 1)).toBe(2);
+  });
+
+  test('prefix matcher returns the raw typed prefix', () => {
+    expect(matchDigitBrandPrefix('7up')).toBe('7up');
+    expect(matchDigitBrandPrefix('7 Up zero')).toBe('7 Up');
+    expect(matchDigitBrandPrefix('5 hour energy extra strength')).toBe('5 hour energy');
+    expect(matchDigitBrandPrefix('2 7up')).toBeNull(); // count first -> not a prefix
+    expect(matchDigitBrandPrefix('7 almonds')).toBeNull();
+  });
+});
+
+describe('detectBrandInQuery with digit-leading brands', () => {
+  test('"7up" is branded (leading-qty strip must not eat the brand)', () => {
+    const r = detectBrandInQuery('7up');
+    expect(r.isBranded).toBe(true);
+    expect(r.matchedBrand?.toLowerCase()).toBe('7up');
+  });
+
+  test('"7 up" and "5 hour energy" space forms are branded', () => {
+    expect(detectBrandInQuery('7 up').isBranded).toBe(true);
+    expect(detectBrandInQuery('5 hour energy').isBranded).toBe(true);
+    expect(detectBrandInQuery('3 musketeers bar').isBranded).toBe(true);
+  });
+
+  test('"2 7up" (count + brand) is branded via the n-gram scan', () => {
+    const r = detectBrandInQuery('2 7up');
+    expect(r.isBranded).toBe(true);
+    expect(r.matchedBrand?.toLowerCase()).toBe('7up');
+  });
+
+  test('plain counts stay unbranded', () => {
+    expect(detectBrandInQuery('7 almonds').isBranded).toBe(false);
+    expect(detectBrandInQuery('2 eggs').isBranded).toBe(false);
+  });
+
+  test('existing behavior intact: leading qty stripped, brand still found', () => {
+    const r = detectBrandInQuery('1 cup Heinz ketchup');
+    expect(r.isBranded).toBe(true);
+    expect(r.matchedBrand?.toLowerCase()).toBe('heinz');
+  });
+
+  test('number+unit lines still unbranded', () => {
+    expect(detectBrandInQuery('200g chicken breast').isBranded).toBe(false);
+  });
+});

--- a/src/lib/mapping/brand-detector.ts
+++ b/src/lib/mapping/brand-detector.ts
@@ -344,7 +344,11 @@ const KNOWN_BRANDS: string[] = [
     'sweet baby rays', 'stubbs', 'bulls eye', 'kc masterpiece', 'open pit', 'jack daniels bbq', 'famous daves', 'bone suckin', 'g hughes', 'primal kitchen', 'terrapin ridge', 'stonewall kitchen', 'harry & david', 'rothar', 'a1', 'a.1.', 'heinz 57', 'hp sauce', 'pickapeppa', 'daddies', 'branston', 'colmans', 'pommery', 'maille', 'moutarde de meaux', 'zatarains', 'slap ya mama', 'tony chacheres', 'chef paul prudhommes', 'old bay', 'lawrys', 'cavenders', 'mrs dash', 'badia',
     'de cecco', 'garofalo', 'rummo', 'la molisana', 'rustichella', 'segiano', 'montebello', 'bionaturae', 'jovial', 'tinkyada', 'banza', 'explore cuisine', 'cybeles', 'capello\'s', 'rao\'s', 'raos', 'lucini', 'victoria', 'michalels', 'cucina antica', 'mezetta', 'carbone', 'patsys', 'lidia\'s', 'paesana', 'mid\'s', 'mids', 'silver palate', 'don pepino', 'mutti', 'cento', 'tuttorosso', 'red gold', 'pomi', 'san marzano', 'bianco dinapoli', 'muirglen',
     'frito lay', 'cape cod', 'kettle brand', 'zapps', 'utz', 'wise', 'herrs', 'mikesells', 'chifles', 'plant snacks', 'popchips', 'popcorners', 'snack factory', 'pretzel crisps', 'snyders of hanover', 'snyders', 'rolld gold', 'rold gold', 'dot\'s', 'dots pretzels', 'quinn', 'unique pretzels', 'barkthins', 'brownie brittle', 'stacys', 'stacy\'s', 'toufayan', 'joseph\'s', 'mission', 'guerrero', 'la banderita', 'el milagro', 'cabo chips', 'late july', 'rw garcia', 'garden of eatin', 'xochitl',
-    'coca-cola', 'pepsi', 'dr pepper', 'sprite', 'mountain dew', '7up', 'fanta', 'canada dry', 'schweppes', 'seagrams', 'vernors', 'aw root beer', 'a&w', 'mug root beer', 'barqs', 'fresca', 'squirt', 'crush', 'sunkist', 'welchs', 'ocean spray', 'motts', 'martinelli\'s', 'martinellis', 'langers', 'juicy juice', 'rw knudsen', 'santa cruz organic', 'lakewood', 'pom wonderful', 'naked', 'odwalla', 'suja', 'evolution fresh', 'bolthouse',
+    'coca-cola', 'pepsi', 'dr pepper', 'sprite', 'mountain dew', '7up', '7-up', 'fanta',
+    // Digit-leading brands (see digit-brands.ts for the parser-side qty guard).
+    // NOTE: mid-line n-gram detection filters 1-char tokens, so space forms
+    // ("7 up", "5 hour energy") rely on the digit-brand prefix check instead.
+    '5-hour energy', 'musketeers', 'canada dry', 'schweppes', 'seagrams', 'vernors', 'aw root beer', 'a&w', 'mug root beer', 'barqs', 'fresca', 'squirt', 'crush', 'sunkist', 'welchs', 'ocean spray', 'motts', 'martinelli\'s', 'martinellis', 'langers', 'juicy juice', 'rw knudsen', 'santa cruz organic', 'lakewood', 'pom wonderful', 'naked', 'odwalla', 'suja', 'evolution fresh', 'bolthouse',
     'boar\'s head', 'boars head', 'dietz & watson', 'dietz and watson', 'applegate farms', 'foster farms', 'tyson', 'perdue', 'sanderson farms', 'butterball', 'jennie-o', 'honeysuckle white', 'smithfield', 'hormel', 'jimmy dean', 'johnsonville', 'hillshire farm', 'ball park', 'hebrew national', 'nathan\'s', 'nathans', 'oscar mayer', 'bar-s', 'buddig', 'land o frost', 'carl budding', 'schaller & weber', 'volpi', 'columbus', 'fiorucci', 'creminelli', 'olipop', 'poppi',
     'chobani', 'fage', 'oikos', 'siggis', 'stonyfield', 'dannon', 'yoplait', 'brown cow', 'nancy\'s', 'nancys', 'liberte', 'noosa', 'wallaby', 'kite hill', 'forager project', 'silk', 'almond breeze', 'oatly', 'califia farms', 'planet oat', 'chobani oat', 'elmhurst', 'malk', 'three trees', 'ripple', 'notmilk', 'vital farms', 'pete & gerrys', 'pete and gerrys', 'nellies', 'happy egg', 'handsome brook', 'eggland\'s best', 'egglands best',
     'cava', 'sweetgreen', 'roti', 'nando\'s', 'nandos', 'jollibee', 'halal guys', 'torchy\'s', 'torchys', 'velvet taco', 'hopdoddy', 'freebirds', 'waba grill', 'flame broiler', 'the habit', 'habit burger', 'fatburger', 'fuddruckers', 'johnny rockets', 'baja fresh', 'rubio\'s', 'rubios', 'wahoo\'s', 'wahoos', 'church\'s', 'churchs chicken', 'golden chick', 'bush\'s chicken', 'roy rogers', 'arther treachers', 'long john silvers', 'captain d\'s', 'white castle', 'krystal',
@@ -363,6 +367,7 @@ const KNOWN_BRANDS: string[] = [
  * time by a stoplist + frequency floor so generic food words never slip in.
  */
 import brandLexicon from './brand-lexicon.json';
+import { matchDigitBrandPrefix } from './digit-brands';
 
 /** Set of all brand names (lowercased, trimmed) for O(1) lookup */
 const BRAND_SET = new Set<string>([
@@ -397,11 +402,21 @@ export function detectBrandInQuery(rawLine: string): BrandDetectionResult {
         return { isBranded: false, matchedBrand: null };
     }
 
+    // Digit-leading brand check ("7up", "7 up", "5 hour energy"): the leading-
+    // quantity strip below would eat the brand's digits ("7up" → "up"), so
+    // these are matched against the raw line first.
+    const digitBrand = matchDigitBrandPrefix(rawLine);
+    if (digitBrand) {
+        return { isBranded: true, matchedBrand: digitBrand };
+    }
+
     // Strip leading qty/unit tokens (numbers, fractions, unit abbreviations)
-    // so "1 cup Heinz ketchup" → tokens ["cup", "heinz", "ketchup"]
+    // so "1 cup Heinz ketchup" → tokens ["cup", "heinz", "ketchup"].
+    // Only a STANDALONE leading number is a quantity — digit-leading name
+    // tokens ("7up") must survive to the n-gram scan below.
     const cleaned = rawLine
         .replace(/[⅛¼⅓⅜½⅝⅔¾⅞]/g, '')    // Unicode fractions
-        .replace(/^\s*[\d./]+\s*/g, '')       // Leading qty
+        .replace(/^\s*[\d./]+(?:\s+|$)/g, '')  // Leading qty (whole token only)
         .trim();
 
     const tokens = cleaned

--- a/src/lib/mapping/digit-brands.ts
+++ b/src/lib/mapping/digit-brands.ts
@@ -1,0 +1,98 @@
+/**
+ * Digit-leading brand lexicon.
+ *
+ * A handful of US food brands BEGIN with a digit ("7UP", "5-hour Energy",
+ * "3 Musketeers"). The deterministic quantity extractor treats any leading
+ * numeric token as a count, so "7up" parsed as qty 7 x (355 ml can) and
+ * billed ~2.5 kg of soda. Tokens/phrases listed here are part of the food
+ * NAME: the leading digit is never consumed as a quantity ("7up" -> qty 1),
+ * while an explicit count before the brand still works ("2 7up" -> qty 2).
+ *
+ * Keep this list SMALL, explicit, and US-food-focused. Every entry disables
+ * generic digit parsing for its exact token/phrase, so each addition must be
+ * a real digit-leading HUMAN-food brand, unambiguous against a genuine count
+ * ("7 almonds" must keep qty 7 — that is why bare "5 hour" without "energy"
+ * is deliberately NOT listed). Pet-food brands ("9Lives") are excluded.
+ * The general brand lexicon lives in brand-detector.ts / brand-lexicon.json;
+ * this file covers only the digit-leading subset the parser must know about.
+ */
+
+/**
+ * Single tokens that are a digit-leading brand on their own. These must also
+ * survive the parser's number+unit token splitter ("7up" must NOT become
+ * ["7", "up"] the way "200g" becomes ["200", "g"]).
+ */
+const DIGIT_BRAND_SINGLE_TOKENS = new Set<string>([
+    '7up',          // 7UP soda ("7up")
+    '7-up',         // 7UP soda, hyphenated ("7-up")
+    '5-hour',       // 5-hour Energy shot ("5-hour energy") — hyphen makes it unambiguous
+    '3musketeers',  // 3 Musketeers bar, no-space form
+]);
+
+/**
+ * Multi-token phrases whose leading digit token belongs to the brand name.
+ * Matched against consecutive lowercased tokens. Keep phrases specific enough
+ * that they can never shadow a genuine count of a food ("3 musketeers" is a
+ * candy bar; nobody logs 3 units of a food called "musketeers").
+ */
+const DIGIT_BRAND_PHRASES: ReadonlyArray<ReadonlyArray<string>> = [
+    ['7', 'up'],                // "7 up" (space form of 7UP)
+    ['3', 'musketeers'],        // "3 musketeers bar"
+    ['5', 'hour', 'energy'],    // "5 hour energy" — trigram on purpose: bare
+    //                             "5 hour" without "energy" stays a normal
+    //                             quantity parse (too ambiguous to claim).
+];
+
+/** Longest phrase length, so callers know how far ahead matching may look. */
+const MAX_PHRASE_LEN = DIGIT_BRAND_PHRASES.reduce((m, p) => Math.max(m, p.length), 1);
+
+/** Lowercase a token and strip trailing punctuation ("7up." -> "7up"). */
+function normalizeToken(token: string): string {
+    return token.toLowerCase().replace(/[.,;:!?]+$/, '');
+}
+
+/**
+ * True when a single token IS a digit-leading brand ("7up", "7-up").
+ * Used by the tokenizer to keep the token intact instead of splitting the
+ * digits off as a separate (quantity-looking) token.
+ */
+export function isDigitBrandToken(token: string): boolean {
+    return DIGIT_BRAND_SINGLE_TOKENS.has(normalizeToken(token));
+}
+
+/**
+ * Returns how many tokens starting at `startIdx` form a digit-leading brand
+ * (0 when none do). Single tokens win over phrases; phrases are matched
+ * longest-first so "5 hour energy" beats any shorter overlap.
+ */
+export function matchDigitBrandTokens(tokens: string[], startIdx = 0): number {
+    if (startIdx >= tokens.length) return 0;
+    if (isDigitBrandToken(tokens[startIdx])) return 1;
+
+    for (let len = Math.min(MAX_PHRASE_LEN, tokens.length - startIdx); len >= 2; len--) {
+        for (const phrase of DIGIT_BRAND_PHRASES) {
+            if (phrase.length !== len) continue;
+            let matches = true;
+            for (let k = 0; k < len; k++) {
+                if (normalizeToken(tokens[startIdx + k]) !== phrase[k]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return len;
+        }
+    }
+    return 0;
+}
+
+/**
+ * When `line` STARTS with a digit-leading brand, returns the matched prefix
+ * exactly as the user typed it (e.g. "7 Up", "5 hour energy"); else null.
+ * Used by brand detection, whose leading-quantity strip would otherwise
+ * destroy the digit half of the brand before the lexicon lookup.
+ */
+export function matchDigitBrandPrefix(line: string): string | null {
+    const tokens = line.trim().split(/\s+/);
+    const consumed = matchDigitBrandTokens(tokens, 0);
+    return consumed > 0 ? tokens.slice(0, consumed).join(' ') : null;
+}

--- a/src/lib/parse/__tests__/digit-brand-quantity.test.ts
+++ b/src/lib/parse/__tests__/digit-brand-quantity.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Digit-leading brand quantity guard (fix: "7up" billed as 7 x 355ml can).
+ *
+ * Digit-leading brand names ("7UP", "5-hour Energy", "3 Musketeers") must not
+ * have their leading digit consumed as a quantity by parseIngredientLine.
+ * Explicit counts BEFORE the brand still parse ("2 7up" -> qty 2), and
+ * generic digit-leading lines are untouched ("7 almonds" -> qty 7).
+ *
+ * Lexicon: src/lib/mapping/digit-brands.ts
+ */
+
+import { parseIngredientLine } from '../ingredient-line';
+
+describe('digit-leading brand tokens are not quantities', () => {
+  describe('7UP (single-token brand)', () => {
+    test('"7up" -> qty 1, name keeps the whole brand token', () => {
+      const r = parseIngredientLine('7up');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.multiplier).toBe(1);
+      expect(r!.unit).toBeNull();
+      expect(r!.name.toLowerCase()).toBe('7up');
+    });
+
+    test('"7-up" (hyphen form) -> qty 1, not a 7-to-something range', () => {
+      const r = parseIngredientLine('7-up');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('7-up');
+    });
+
+    test('"7 up" (space form) -> qty 1 via the digit-brand bigram', () => {
+      const r = parseIngredientLine('7 up');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('7 up');
+    });
+
+    test('"2 7up" -> explicit count still wins: qty 2 of 7up', () => {
+      const r = parseIngredientLine('2 7up');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(2);
+      expect(r!.name.toLowerCase()).toContain('7up');
+    });
+
+    test('"2 7up cans" -> qty 2, brand token survives into the name', () => {
+      const r = parseIngredientLine('2 7up cans');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(2);
+      expect(r!.name.toLowerCase()).toContain('7up');
+    });
+
+    test('"7up zero" -> qty 1, flavor suffix kept', () => {
+      const r = parseIngredientLine('7up zero');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toContain('7up');
+    });
+  });
+
+  describe('5-hour Energy (multi-word digit brand)', () => {
+    test('"5 hour energy" -> qty 1, not 5 units', () => {
+      const r = parseIngredientLine('5 hour energy');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('5 hour energy');
+    });
+
+    test('"5-hour energy" (hyphen form) -> qty 1', () => {
+      const r = parseIngredientLine('5-hour energy');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('5-hour energy');
+    });
+
+    test('"2 5 hour energy" -> explicit count: qty 2', () => {
+      const r = parseIngredientLine('2 5 hour energy');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(2);
+      expect(r!.name.toLowerCase()).toContain('hour energy');
+    });
+
+    // Deliberately deferred: bare "5 hour" WITHOUT "energy" is not claimed by
+    // the lexicon (trigram on purpose) — it is too ambiguous against genuine
+    // duration/count phrasings, so it keeps the historical quantity parse.
+    test('bare "5 hour" is NOT claimed by the brand guard', () => {
+      const r = parseIngredientLine('5 hour something');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(5);
+    });
+  });
+
+  describe('3 Musketeers (multi-word digit brand)', () => {
+    test('"3 musketeers bar" -> qty 1, not 3 bars', () => {
+      const r = parseIngredientLine('3 musketeers bar');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toContain('musketeers');
+    });
+
+    test('"3 musketeers" -> qty 1', () => {
+      const r = parseIngredientLine('3 musketeers');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('3 musketeers');
+    });
+
+    test('"2 3 musketeers" -> explicit count: qty 2', () => {
+      const r = parseIngredientLine('2 3 musketeers');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(2);
+      expect(r!.name.toLowerCase()).toContain('musketeers');
+    });
+
+    test('"3musketeers" (no-space form) -> qty 1, token not split', () => {
+      const r = parseIngredientLine('3musketeers');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(1);
+      expect(r!.name.toLowerCase()).toBe('3musketeers');
+    });
+  });
+
+  describe('generic digit-leading parsing is NOT broken', () => {
+    test('"2 eggs" -> qty 2', () => {
+      const r = parseIngredientLine('2 eggs');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(2);
+      expect(r!.name.toLowerCase()).toContain('egg');
+    });
+
+    test('"7 almonds" -> qty 7 (digit + separate word stays a count)', () => {
+      const r = parseIngredientLine('7 almonds');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(7);
+      expect(r!.name.toLowerCase()).toContain('almond');
+    });
+
+    test('"200g chicken breast" -> number+unit token still splits', () => {
+      const r = parseIngredientLine('200g chicken breast');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(200);
+      expect(r!.unit).toBe('g');
+      expect(r!.name.toLowerCase()).toContain('chicken');
+    });
+
+    test('"2-3 eggs" -> range averaging still works', () => {
+      const r = parseIngredientLine('2-3 eggs');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBeCloseTo(2.5);
+    });
+
+    test('"7 oz chicken" -> qty 7 with mass unit', () => {
+      const r = parseIngredientLine('7 oz chicken');
+      expect(r).not.toBeNull();
+      expect(r!.qty).toBe(7);
+      expect(r!.unit).toBe('oz');
+    });
+  });
+
+  // Deliberately deferred (documented, not implemented):
+  // - Word-number brand forms ("seven up") still parse "seven" as qty 7. The
+  //   word-number map predates this fix and "seven up" is a rare way to log
+  //   the soda; claiming it would special-case the WORD_NUMBERS path for one
+  //   brand. Revisit if telemetry ever shows real "seven up" logs.
+  test.skip('"seven up" word-number form (deferred — see comment above)', () => {
+    const r = parseIngredientLine('seven up');
+    expect(r!.qty).toBe(1);
+  });
+});

--- a/src/lib/parse/ingredient-line.ts
+++ b/src/lib/parse/ingredient-line.ts
@@ -2,6 +2,7 @@ import { parseQuantityTokens } from './quantity';
 import { normalizeUnitToken, convertUnit } from './unit';
 import { extractQualifiers, extractQualifiersFromParentheses } from './qualifiers';
 import { extractUnitHint } from './unit-hint';
+import { isDigitBrandToken, matchDigitBrandTokens } from '../mapping/digit-brands';
 
 export type ParsedIngredient = {
   qty: number;
@@ -219,9 +220,11 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
     if (token === '(' || token === ')' || token === ',') {
       tokens.push(token);
     } else {
-      // Check if token is like "200g" (number+unit)
+      // Check if token is like "200g" (number+unit) — but NOT a digit-leading
+      // brand token ("7up"): splitting that would turn the brand's digit into
+      // a quantity ("7up" -> 7 x "up").
       const match = token.match(/^(\d+(?:\.\d+)?)([a-z]+)$/i);
-      if (match) {
+      if (match && !isDigitBrandToken(token)) {
         tokens.push(match[1]); // number
         tokens.push(match[2]); // unit
       } else {
@@ -277,8 +280,16 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
     }
   }
 
-  // Parse quantity (if not starting with unit)
-  if (!startsWithUnit) {
+  // Digit-leading brand guard ("7up", "7 up", "5 hour energy", "3 musketeers"):
+  // when the line STARTS with a known digit-leading brand, the digits are part
+  // of the food name — skip quantity extraction entirely (qty stays 1) and let
+  // the brand tokens flow into the name. An explicit count before the brand
+  // still parses normally ("2 7up" -> qty 2 of "7up"), because then the brand
+  // no longer sits at the quantity position.
+  const startsWithDigitBrand = matchDigitBrandTokens(mergedTokens, i) > 0;
+
+  // Parse quantity (if not starting with unit or a digit-leading brand)
+  if (!startsWithUnit && !startsWithDigitBrand) {
     const qtyResult = parseQuantityTokens(mergedTokens.slice(i));
     if (qtyResult) {
       qty = qtyResult.qty;


### PR DESCRIPTION
## Bug

Logging **"7up"** parsed the leading digit as a quantity: 7 × 355ml can ≈ **2,485g billed** for one soda.

## Root cause

`src/lib/parse/ingredient-line.ts` — the number+unit token splitter (`/^(\d+(?:\.\d+)?)([a-z]+)$/i`) treats "7up" exactly like "200g", splitting it into `["7","up"]`; `parseQuantityTokens` then consumes the `"7"` as a count (and `parseFloat("7up")`/`parseFloat("7-up")` = 7 would do the same even without the split). The hybrid pipeline made it worse: the LLM segmenter correctly hands over name "7up", but qty/unit are deterministic, so the wrong qty 7 was injected regardless.

## Fix

- **NEW `src/lib/mapping/digit-brands.ts`** — small, explicit digit-leading brand lexicon (next to `brand-detector.ts` / `brand-lexicon.json`):
  - single tokens: `7up`, `7-up`, `5-hour`, `3musketeers`
  - phrases: `7 up`, `3 musketeers`, `5 hour energy` (trigram **on purpose** — bare "5 hour" is never claimed, so genuine counts keep their quantity)
  - 9Lives excluded (pet food); US-food-focused and conservative by design.
- **`src/lib/parse/ingredient-line.ts`**: (1) token splitter keeps digit-brand tokens intact; (2) quantity extraction is skipped when the line *starts* with a digit-brand → qty stays 1. Explicit counts before the brand still parse: `"2 7up"` → qty 2.
- **`src/lib/mapping/brand-detector.ts`**: digit-brand prefix check before the leading-qty strip (which previously reduced "7up" → "up"), strip tightened to whole tokens, `7-up` / `5-hour energy` / `musketeers` added for mid-line n-gram detection.

## Behavior

| input | qty | name |
|---|---|---|
| `7up` / `7-up` / `7 up` | 1 | 7up |
| `2 7up` / `2 7up cans` | 2 | 7up (…) |
| `5 hour energy` / `5-hour energy` | 1 | 5 hour energy |
| `3 musketeers bar` | 1 | 3 musketeers bar |
| `2 eggs` / `7 almonds` / `200g chicken` | 2 / 7 / 200g | unchanged |

Deferred: word-number form `"seven up"` (still qty 7 — documented skipped test; WORD_NUMBERS path untouched).

## Golden eval

- `n-qty-08` — `"7up"` grams **[240, 500]** (one can/bottle band, same class as n-serv-46 bare "coca cola"); pre-fix bills ~2,485g, far outside.
- `n-qty-09` — `"2 7up"` grams **[480, 1100]** (doubled band; also catches over-correction to 1 can and flat-100g under-billing).

Live eval NOT run from this branch (no server/DB touched) — merge-time gate as usual.

## Verification

- `npm ci` clean; `lint:ci` 0 errors (431 warnings, cap 700); `typecheck` clean; `next build` OK
- Full jest: **62/62 suites, 881 passed, 1 skipped** (the deliberate "seven up" deferral), 0 pre-existing failures
- New tests: `src/lib/parse/__tests__/digit-brand-quantity.test.ts` (20), `src/lib/mapping/__tests__/digit-brands.test.ts` (10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu