### PR TITLE
feat(flywheel): stuck-key report (sub-gate keys that never cache)

### DIFF
--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -9,6 +9,10 @@
  *      (become extra warm seeds — real demand replaces guesswork corpora),
  *      never-cache-hit "attention" keys, cache-escape reasons, thrash keys
  *      (≥2 distinct foodIds resolved for one key), servingTier distribution.
+ *      1b. STUCK KEYS — sub-gate keys (all-miss, max confidence < 0.85) that
+ *      the cache can never save and so never surface for review; writes
+ *      results/stuck-keys-<ts>.json (triage-batch input) + a trend line vs the
+ *      previous stuck-keys report. Logic: src/lib/ops/stuck-keys.ts.
  *   2. WARM       — standard warm-cache corpus + telemetry seeds through
  *      /api/nlp/parse on the normal cache-first path (save gates apply).
  *   3. DIFF       — compare against the previous warm-*.json report: identity
@@ -28,6 +32,9 @@
  *     scripts/eval/flywheel-sweep.ts --base http://localhost:3000 \
  *     [--days 7] [--top 100] [--concurrency 4] [--allow-fail n-mq-10] \
  *     [--skip-warm] [--skip-eval] [--publish-dir sync-docs]
+ *
+ * --stuck-keys-only runs JUST the stuck-key report (read-only against the DB,
+ * writes only results/stuck-keys-<ts>.json) — no warm, no eval, no publish.
  */
 
 import * as fs from 'fs';
@@ -35,6 +42,10 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { PrismaClient } from '@prisma/client';
 import { assembleSeeds, runWarm, WarmResult, WarmRunReport } from './warm-cache';
+import {
+    collectStuckKeys, computeStuckTrend, findPreviousStuckReport, formatStuckKeysSection,
+    StuckKeysReport, StuckTrend,
+} from '../../src/lib/ops/stuck-keys';
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
@@ -49,6 +60,7 @@ const CONCURRENCY = Number(argValue('--concurrency') ?? 4);
 const ALLOW_FAIL = (argValue('--allow-fail') ?? 'n-mq-10').split(',').map(s => s.trim()).filter(Boolean);
 const SKIP_WARM = args.includes('--skip-warm');
 const SKIP_EVAL = args.includes('--skip-eval');
+const STUCK_ONLY = args.includes('--stuck-keys-only');
 const PUBLISH_DIR = argValue('--publish-dir');
 
 const RESULTS_DIR = path.join(__dirname, 'results');
@@ -129,6 +141,49 @@ async function collectTelemetry(): Promise<Telemetry> {
     } finally {
         await prisma.$disconnect().catch(() => {});
     }
+}
+
+// ---------------------------------------------------------------------------
+// 1b. Stuck keys (sub-gate, never cached) — logic in src/lib/ops/stuck-keys.ts
+// ---------------------------------------------------------------------------
+
+interface StuckKeysRun {
+    report: StuckKeysReport;
+    trend: StuckTrend;
+    /** results/stuck-keys-<ts>.json (triage-batch input); null when the query failed. */
+    outPath: string | null;
+}
+
+async function runStuckKeysReport(ranAt: string, stamp: string): Promise<StuckKeysRun> {
+    const prisma = new PrismaClient();
+    const since = new Date(Date.now() - DAYS * 24 * 3600 * 1000);
+    let report: StuckKeysReport;
+    try {
+        report = await collectStuckKeys(prisma, { since, windowDays: DAYS });
+    } finally {
+        await prisma.$disconnect().catch(() => {});
+    }
+
+    // Locate the previous report BEFORE writing this run's file (trend input).
+    const prev = findPreviousStuckReport(RESULTS_DIR);
+    const trend = computeStuckTrend(report.count, prev);
+
+    let outPath: string | null = null;
+    if (report.ok) {
+        // Zero rows is a valid (great) result and still worth a trend datapoint;
+        // a failed query writes nothing so it can't fake an empty population.
+        fs.mkdirSync(RESULTS_DIR, { recursive: true });
+        outPath = path.join(RESULTS_DIR, `stuck-keys-${stamp}.json`);
+        fs.writeFileSync(outPath, JSON.stringify({
+            ranAt,
+            windowDays: report.windowDays,
+            confidenceGate: report.confidenceGate,
+            count: report.count,
+            trend,
+            rows: report.rows,
+        }, null, 1));
+    }
+    return { report, trend, outPath };
 }
 
 // ---------------------------------------------------------------------------
@@ -256,7 +311,8 @@ function fmtTable(rows: string[][], header: string[]): string {
 }
 
 function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport | null,
-    seedCount: number, telemetrySeedCount: number, diff: WarmDiff | null, gate: EvalGate | null): string {
+    seedCount: number, telemetrySeedCount: number, diff: WarmDiff | null, gate: EvalGate | null,
+    stuck: StuckKeysRun | null): string {
     const lines: string[] = [];
     lines.push(`# Flywheel sweep — ${ranAt}`);
     lines.push('');
@@ -341,6 +397,12 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
             [t.reason, String(t.n), `${(100 * t.n / totalTier).toFixed(1)}%`]), ['tier', 'events', 'share']));
     }
     lines.push('');
+
+    if (stuck) {
+        lines.push(...formatStuckKeysSection(stuck.report, stuck.trend));
+        if (stuck.outPath) lines.push('', `Triage input: \`${path.basename(stuck.outPath)}\``);
+        lines.push('');
+    }
     return lines.join('\n');
 }
 
@@ -349,6 +411,16 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
 async function main() {
     const ranAt = new Date().toISOString();
     const stamp = ranAt.replace(/[:.]/g, '-');
+
+    if (STUCK_ONLY) {
+        console.log(`Stuck-keys-only report @ ${ranAt} (window ${DAYS}d)`);
+        const stuck = await runStuckKeysReport(ranAt, stamp);
+        console.log('');
+        console.log(formatStuckKeysSection(stuck.report, stuck.trend).join('\n'));
+        if (stuck.outPath) console.log(`\nJSON: ${stuck.outPath}`);
+        return;
+    }
+
     console.log(`Flywheel sweep @ ${ranAt} → ${BASE} (window ${DAYS}d)`);
 
     console.log('\n[1/4] Telemetry…');
@@ -356,6 +428,14 @@ async function main() {
     console.log(telemetry.ok
         ? `  ${telemetry.events} events, ${telemetry.topKeys.length} traffic keys, ${telemetry.thrash.length} thrash, ${telemetry.attentionKeys.length} attention`
         : `  unavailable: ${telemetry.error}`);
+
+    console.log('\n[1b] Stuck keys (sub-gate, never cached)…');
+    const stuck = await runStuckKeysReport(ranAt, stamp);
+    console.log(stuck.report.ok
+        ? `  ${stuck.report.count} stuck keys (${stuck.trend.previous === null
+            ? 'first run'
+            : `prev ${stuck.trend.previousCount}, Δ ${stuck.trend.delta}`})`
+        : `  unavailable: ${stuck.report.error}`);
 
     let warm: WarmRunReport | null = null;
     let diff: WarmDiff | null = null;
@@ -391,9 +471,15 @@ async function main() {
         ranAt, base: BASE, days: DAYS, allowFail: ALLOW_FAIL,
         telemetry, warmSummary: warm?.summary ?? null, warmReport: warm?.outPath ?? null,
         diff, gate,
+        // Rows live in the dedicated stuck-keys-<ts>.json (triage-batch input);
+        // the sweep JSON carries the summary + pointer, like warmReport.
+        stuckKeys: {
+            ok: stuck.report.ok, error: stuck.report.error,
+            count: stuck.report.count, trend: stuck.trend, report: stuck.outPath,
+        },
     }, null, 1));
 
-    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate);
+    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate, stuck);
     const mdPath = path.join(RESULTS_DIR, `flywheel-${stamp}.md`);
     fs.writeFileSync(mdPath, md);
     console.log(`\nReport: ${mdPath}`);

--- a/src/lib/ops/__tests__/stuck-keys.test.ts
+++ b/src/lib/ops/__tests__/stuck-keys.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    collectStuckKeys,
+    computeStuckTrend,
+    findPreviousStuckReport,
+    formatStuckKeysSection,
+    RawQueryClient,
+    StuckKeyRow,
+    StuckKeysReport,
+    StuckTrend,
+    STUCK_KEY_CONFIDENCE_GATE,
+    STUCK_KEY_MIN_EVENTS,
+    STUCK_KEY_ROW_LIMIT,
+} from '../stuck-keys';
+
+/**
+ * Tests for the flywheel sweep's stuck-key report (sub-gate keys that the
+ * FoodMapping cache never saves — served forever off the full pipeline).
+ * The DB is mocked; live-shape validation happened against MappingEventLog
+ * on the OptiPlex ("mac and cheese" 26 events / max conf 0.61, dup-token
+ * "canned canned kidney beans", etc).
+ */
+
+function mockDb(result: StuckKeyRow[] | Error): { db: RawQueryClient; spy: jest.Mock } {
+    const spy = result instanceof Error
+        ? jest.fn().mockRejectedValue(result)
+        : jest.fn().mockResolvedValue(result);
+    return { db: { $queryRaw: spy } as unknown as RawQueryClient, spy };
+}
+
+const ROWS: StuckKeyRow[] = [
+    {
+        key: 'mac and cheese', events: 26, maxConfidence: 0.612, avgLatencyMs: 102.4,
+        sampleRawLine: 'mac and cheese',
+        foods: [{ foodId: 'cmrr3yk1k0000e3peumv609wd', foodName: 'Mac and Cheese (Cooked)', n: 26 }],
+    },
+    {
+        key: 'canned canned kidney beans', events: 7, maxConfidence: 0.8214, avgLatencyMs: 52,
+        sampleRawLine: 'kidney beans | canned',
+        foods: [
+            { foodId: 'off_0041188290241', foodName: 'Canned White Kidney Beans', n: 6 },
+            { foodId: 'off_0671635706546', foodName: null, n: 1 },
+        ],
+    },
+    {
+        key: 'mystery snack', events: 2, maxConfidence: null, avgLatencyMs: null,
+        sampleRawLine: null, foods: [],
+    },
+];
+
+describe('collectStuckKeys', () => {
+    const since = new Date('2026-07-14T00:00:00Z');
+
+    it('returns ok report with rows passed through and count set', async () => {
+        const { db } = mockDb(ROWS);
+        const report = await collectStuckKeys(db, { since, windowDays: 7 });
+        expect(report.ok).toBe(true);
+        expect(report.error).toBeUndefined();
+        expect(report.count).toBe(3);
+        expect(report.rows).toEqual(ROWS);
+        expect(report.windowDays).toBe(7);
+        expect(report.confidenceGate).toBe(STUCK_KEY_CONFIDENCE_GATE);
+    });
+
+    it('issues a single query carrying the full stuck-key definition', async () => {
+        const { db, spy } = mockDb([]);
+        await collectStuckKeys(db, { since, windowDays: 7 });
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        const [strings, ...values] = spy.mock.calls[0];
+        const sql = (strings as string[]).join('¤');
+        // Window + exclusions
+        expect(sql).toContain('"createdAt" >=');
+        expect(sql).toContain('"noCache" = false');
+        expect(sql).toContain('"cacheEscape" IS NULL');
+        expect(sql).toContain('"normalizedForm" IS NOT NULL');
+        // Per-key all-miss condition (computed per key, not per event)
+        expect(sql).toContain('count(*) FILTER (WHERE "cacheHit" IS NOT NULL) = 0');
+        // NULL-only confidence still counts as stuck
+        expect(sql).toContain('coalesce(max("confidence"), 0) <');
+        expect(sql).toContain('ORDER BY s.events DESC');
+        // Parameters: since date, min events, gate, foods-per-key, row limit
+        expect(values[0]).toBe(since);
+        expect(values).toContain(STUCK_KEY_MIN_EVENTS);
+        expect(values).toContain(STUCK_KEY_CONFIDENCE_GATE);
+        expect(values).toContain(STUCK_KEY_ROW_LIMIT);
+    });
+
+    it('zero rows is a valid ok report, not a failure', async () => {
+        const { db } = mockDb([]);
+        const report = await collectStuckKeys(db, { since, windowDays: 7 });
+        expect(report.ok).toBe(true);
+        expect(report.count).toBe(0);
+        expect(report.rows).toEqual([]);
+    });
+
+    it('a query failure is captured, never thrown (sweep must not die)', async () => {
+        const { db } = mockDb(new Error('connection refused'));
+        const report = await collectStuckKeys(db, { since, windowDays: 7 });
+        expect(report.ok).toBe(false);
+        expect(report.error).toBe('connection refused');
+        expect(report.count).toBe(0);
+        expect(report.rows).toEqual([]);
+    });
+
+    it('honors a custom limit', async () => {
+        const { db, spy } = mockDb([]);
+        await collectStuckKeys(db, { since, windowDays: 7, limit: 10 });
+        const values = spy.mock.calls[0].slice(1);
+        expect(values).toContain(10);
+        expect(values).not.toContain(STUCK_KEY_ROW_LIMIT);
+    });
+});
+
+describe('computeStuckTrend', () => {
+    it('first run: no previous report', () => {
+        expect(computeStuckTrend(13, null)).toEqual({ previous: null, previousCount: null, delta: null });
+    });
+
+    it('delta vs previous count (growth, shrink, flat)', () => {
+        const prev = { path: '/x/results/stuck-keys-2026-07-20.json', count: 10 };
+        expect(computeStuckTrend(13, prev)).toEqual({
+            previous: 'stuck-keys-2026-07-20.json', previousCount: 10, delta: 3,
+        });
+        expect(computeStuckTrend(4, prev).delta).toBe(-6);
+        expect(computeStuckTrend(10, prev).delta).toBe(0);
+    });
+});
+
+describe('findPreviousStuckReport', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stuck-keys-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    function writeReport(name: string, content: unknown, mtimeSec: number): string {
+        const p = path.join(dir, name);
+        fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content));
+        fs.utimesSync(p, mtimeSec, mtimeSec);
+        return p;
+    }
+
+    it('returns null when the dir does not exist or holds no stuck-keys files', () => {
+        expect(findPreviousStuckReport(path.join(dir, 'nope'))).toBeNull();
+        writeReport('flywheel-2026-07-20.json', { count: 99 }, 1000);
+        expect(findPreviousStuckReport(dir)).toBeNull();
+    });
+
+    it('picks the most recent stuck-keys-*.json by mtime and reads its count', () => {
+        writeReport('stuck-keys-2026-07-19.json', { count: 20, rows: [] }, 1000);
+        const newest = writeReport('stuck-keys-2026-07-20.json', { count: 13, rows: [] }, 2000);
+        const prev = findPreviousStuckReport(dir);
+        expect(prev).toEqual({ path: newest, count: 13 });
+    });
+
+    it('falls back to rows.length when count is missing, skips unparseable files and excludePath', () => {
+        writeReport('stuck-keys-a.json', { rows: [{}, {}, {}] }, 1000);
+        writeReport('stuck-keys-b.json', '{not json', 2000);
+        const excluded = writeReport('stuck-keys-c.json', { count: 7 }, 3000);
+        const prev = findPreviousStuckReport(dir, excluded);
+        expect(prev).toEqual({ path: path.join(dir, 'stuck-keys-a.json'), count: 3 });
+    });
+});
+
+describe('formatStuckKeysSection', () => {
+    const okReport = (rows: StuckKeyRow[]): StuckKeysReport => ({
+        ok: true, windowDays: 7, confidenceGate: 0.85, count: rows.length, rows,
+    });
+    const firstRun: StuckTrend = { previous: null, previousCount: null, delta: null };
+
+    it('renders the section header, definition line and table', () => {
+        const md = formatStuckKeysSection(okReport(ROWS), firstRun).join('\n');
+        expect(md).toContain('## Stuck keys (sub-gate, never cached)');
+        expect(md).toContain('3 stuck keys in the 7d window');
+        expect(md).toContain('0.85 cache-save gate');
+        expect(md).toContain('Trend: first run (no previous stuck-keys report).');
+        expect(md).toContain('### Keys (3 of 3 shown, by events)');
+        expect(md).toContain('| mac and cheese | 26 | 0.612 | 102ms | mac and cheese |');
+        expect(md).toContain('cmrr3yk1k0000e3peumv609wd "Mac and Cheese (Cooked)" ×26');
+    });
+
+    it('escapes pipes in raw lines and renders null fields as em-dash / placeholders', () => {
+        const lines = formatStuckKeysSection(okReport(ROWS), firstRun);
+        const beans = lines.find(l => l.includes('canned canned kidney beans'))!;
+        expect(beans).toContain('kidney beans \\| canned');
+        expect(beans).toContain('"?" ×1'); // null foodName
+        const mystery = lines.find(l => l.includes('mystery snack'))!;
+        expect(mystery).toContain('| — | — |');
+        expect(mystery).toContain('(never resolved)');
+    });
+
+    it('zero rows: section still renders with count 0 and an empty table', () => {
+        const md = formatStuckKeysSection(okReport([]), firstRun).join('\n');
+        expect(md).toContain('0 stuck keys in the 7d window');
+        expect(md).toContain('_none_');
+    });
+
+    it('trend line reports the delta against the previous report', () => {
+        const grow: StuckTrend = { previous: 'stuck-keys-2026-07-20.json', previousCount: 1, delta: 2 };
+        expect(formatStuckKeysSection(okReport(ROWS), grow).join('\n'))
+            .toContain('Trend: 1 → 3 (+2) vs `stuck-keys-2026-07-20.json`.');
+        const shrink: StuckTrend = { previous: 'stuck-keys-2026-07-20.json', previousCount: 5, delta: -2 };
+        expect(formatStuckKeysSection(okReport(ROWS), shrink).join('\n')).toContain('(-2)');
+        const flat: StuckTrend = { previous: 'stuck-keys-2026-07-20.json', previousCount: 3, delta: 0 };
+        expect(formatStuckKeysSection(okReport(ROWS), flat).join('\n')).toContain('(±0)');
+    });
+
+    it('caps the table at maxRows but reports the full count', () => {
+        const many = Array.from({ length: 40 }, (_, i) => ({
+            key: `key ${i}`, events: 40 - i, maxConfidence: 0.5, avgLatencyMs: 10,
+            sampleRawLine: `raw ${i}`, foods: [],
+        }));
+        const md = formatStuckKeysSection(okReport(many), firstRun, 30).join('\n');
+        expect(md).toContain('### Keys (30 of 40 shown, by events)');
+        expect(md).toContain('| key 29 |');
+        expect(md).not.toContain('| key 30 |');
+    });
+
+    it('failed report renders as unavailable, without a table', () => {
+        const md = formatStuckKeysSection(
+            { ok: false, error: 'boom', windowDays: 7, confidenceGate: 0.85, count: 0, rows: [] },
+            firstRun,
+        ).join('\n');
+        expect(md).toContain('_unavailable: boom_');
+        expect(md).not.toContain('### Keys');
+    });
+});

--- a/src/lib/ops/stuck-keys.ts
+++ b/src/lib/ops/stuck-keys.ts
@@ -1,0 +1,233 @@
+/**
+ * stuck-keys.ts — "stuck key" detection + report formatting for the nightly
+ * flywheel sweep (scripts/eval/flywheel-sweep.ts).
+ *
+ * The FoodMapping cache only saves results with confidence >= 0.85 (the
+ * cache-save gate in map-ingredient-with-fallback.ts). Sub-gate results are
+ * served to users but never cached and never reviewed — those keys re-run the
+ * full mapping pipeline on every request, forever, invisibly. This module
+ * makes that population visible so triage batches can clear it.
+ *
+ * A key (normalizedForm) is STUCK when, over the telemetry window:
+ *   - events with noCache = true are excluded (eval cold-run traffic), and
+ *   - events with cacheEscape set are excluded (escapes are deliberate), and
+ *   - NO remaining event has cacheHit set (all-miss, computed per key), and
+ *   - MAX(confidence) < 0.85 (a key with only NULL confidence is stuck too —
+ *     it certainly never passed the save gate), and
+ *   - the key was demanded at least twice.
+ *
+ * Lives in src/lib (not scripts/) so the aggregation/formatting logic is
+ * jest-coverable — the jest projects only match tests under src/**.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Mirrors the FoodMapping cache-save gate (map-ingredient-with-fallback.ts, `confidence >= 0.85`). */
+export const STUCK_KEY_CONFIDENCE_GATE = 0.85;
+
+/** Minimum events in the window for a key to count as stuck (1-offs are noise). */
+export const STUCK_KEY_MIN_EVENTS = 2;
+
+/** Safety cap on rows returned (the sub-gate population is small; this only guards runaway telemetry). */
+export const STUCK_KEY_ROW_LIMIT = 500;
+
+/** Distinct resolved records reported per key, by frequency. */
+export const STUCK_KEY_FOODS_PER_KEY = 3;
+
+/** Structural slice of PrismaClient we need — keeps the module trivially mockable. */
+export interface RawQueryClient {
+    $queryRaw<T = unknown>(strings: TemplateStringsArray, ...values: unknown[]): Promise<T>;
+}
+
+export interface StuckKeyFood {
+    foodId: string;
+    foodName: string | null;
+    n: number;
+}
+
+export interface StuckKeyRow {
+    key: string;
+    events: number;
+    maxConfidence: number | null;
+    avgLatencyMs: number | null;
+    sampleRawLine: string | null;
+    foods: StuckKeyFood[];
+}
+
+export interface StuckKeysReport {
+    ok: boolean;
+    error?: string;
+    windowDays: number;
+    confidenceGate: number;
+    count: number;
+    rows: StuckKeyRow[];
+}
+
+export interface StuckTrend {
+    /** Basename of the previous stuck-keys-*.json compared against; null = first run. */
+    previous: string | null;
+    previousCount: number | null;
+    /** current count − previous count; null on first run. */
+    delta: number | null;
+}
+
+/**
+ * Single-query aggregation over MappingEventLog. Never throws — a failure (or
+ * zero rows) comes back as a report the sweep can render without dying,
+ * mirroring collectTelemetry() in flywheel-sweep.ts.
+ */
+export async function collectStuckKeys(
+    db: RawQueryClient,
+    opts: { since: Date; windowDays: number; limit?: number },
+): Promise<StuckKeysReport> {
+    const limit = opts.limit ?? STUCK_KEY_ROW_LIMIT;
+    const base: StuckKeysReport = {
+        ok: false, windowDays: opts.windowDays,
+        confidenceGate: STUCK_KEY_CONFIDENCE_GATE, count: 0, rows: [],
+    };
+    try {
+        const rows = await db.$queryRaw<StuckKeyRow[]>`
+            WITH sub_gate_events AS (
+                SELECT "normalizedForm", "rawLine", "cacheHit", "confidence", "latencyMs", "foodId", "foodName"
+                FROM "MappingEventLog"
+                WHERE "createdAt" >= ${opts.since}
+                  AND "noCache" = false
+                  AND "cacheEscape" IS NULL
+                  AND "normalizedForm" IS NOT NULL
+            ),
+            stuck AS (
+                SELECT "normalizedForm" AS key,
+                       count(*)::int AS events,
+                       max("confidence")::float AS "maxConfidence",
+                       avg("latencyMs")::float AS "avgLatencyMs",
+                       min("rawLine") AS "sampleRawLine"
+                FROM sub_gate_events
+                GROUP BY 1
+                HAVING count(*) FILTER (WHERE "cacheHit" IS NOT NULL) = 0
+                   AND count(*) >= ${STUCK_KEY_MIN_EVENTS}
+                   AND coalesce(max("confidence"), 0) < ${STUCK_KEY_CONFIDENCE_GATE}
+            )
+            SELECT s.key, s.events, s."maxConfidence", s."avgLatencyMs", s."sampleRawLine",
+                   coalesce(f.foods, '[]'::jsonb) AS foods
+            FROM stuck s
+            LEFT JOIN LATERAL (
+                SELECT jsonb_agg(jsonb_build_object('foodId', t."foodId", 'foodName', t."foodName", 'n', t.n)
+                                 ORDER BY t.n DESC) AS foods
+                FROM (
+                    SELECT e."foodId", min(e."foodName") AS "foodName", count(*)::int AS n
+                    FROM sub_gate_events e
+                    WHERE e."normalizedForm" = s.key AND e."foodId" IS NOT NULL
+                    GROUP BY e."foodId"
+                    ORDER BY n DESC
+                    LIMIT ${STUCK_KEY_FOODS_PER_KEY}
+                ) t
+            ) f ON true
+            ORDER BY s.events DESC, s.key ASC
+            LIMIT ${limit}`;
+        return { ...base, ok: true, count: rows.length, rows };
+    } catch (err) {
+        return { ...base, error: (err as Error).message };
+    }
+}
+
+/**
+ * Most recent previous stuck-keys-*.json in resultsDir (by mtime), skipping
+ * excludePath and unparseable files. Returns its stuck-key count for the trend
+ * line, or null when this is the first run.
+ */
+export function findPreviousStuckReport(
+    resultsDir: string,
+    excludePath?: string,
+): { path: string; count: number } | null {
+    if (!fs.existsSync(resultsDir)) return null;
+    const files = fs.readdirSync(resultsDir)
+        .filter(f => f.startsWith('stuck-keys-') && f.endsWith('.json'))
+        .map(f => path.join(resultsDir, f))
+        .filter(f => f !== excludePath)
+        .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+    for (const file of files) {
+        try {
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const count = typeof data?.count === 'number' ? data.count
+                : Array.isArray(data?.rows) ? data.rows.length : null;
+            if (count !== null) return { path: file, count };
+        } catch {
+            // unparseable previous report — skip it, keep looking
+        }
+    }
+    return null;
+}
+
+export function computeStuckTrend(
+    currentCount: number,
+    prev: { path: string; count: number } | null,
+): StuckTrend {
+    if (!prev) return { previous: null, previousCount: null, delta: null };
+    return { previous: path.basename(prev.path), previousCount: prev.count, delta: currentCount - prev.count };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatting (mirrors flywheel-sweep's fmtTable conventions)
+// ---------------------------------------------------------------------------
+
+/** Markdown-table cell safety: collapse newlines, escape pipes. */
+function cell(s: string): string {
+    return s.replace(/\s*\n\s*/g, ' ').replace(/\|/g, '\\|');
+}
+
+function mdTable(rows: string[][], header: string[]): string {
+    if (rows.length === 0) return '_none_';
+    return [
+        `| ${header.join(' | ')} |`,
+        `| ${header.map(() => '---').join(' | ')} |`,
+        ...rows.map(r => `| ${r.join(' | ')} |`),
+    ].join('\n');
+}
+
+function fmtDelta(delta: number): string {
+    if (delta > 0) return `+${delta}`;
+    if (delta < 0) return `${delta}`;
+    return '±0';
+}
+
+function fmtFoods(foods: StuckKeyFood[]): string {
+    if (!foods.length) return '(never resolved)';
+    return foods.map(f => `${f.foodId} "${f.foodName ?? '?'}" ×${f.n}`).join('; ');
+}
+
+/**
+ * The "## Stuck keys (sub-gate, never cached)" report section, as markdown
+ * lines ready for flywheel-sweep's buildMarkdown (or console output).
+ */
+export function formatStuckKeysSection(
+    report: StuckKeysReport,
+    trend: StuckTrend,
+    maxRows = 30,
+): string[] {
+    const lines: string[] = [];
+    lines.push('## Stuck keys (sub-gate, never cached)');
+    if (!report.ok) {
+        lines.push(`_unavailable: ${report.error ?? 'unknown'}_`);
+        return lines;
+    }
+    lines.push(`${report.count} stuck keys in the ${report.windowDays}d window — all-miss demand whose max `
+        + `confidence stayed under the ${report.confidenceGate} cache-save gate (≥${STUCK_KEY_MIN_EVENTS} events; `
+        + 'noCache + cacheEscape events excluded). These re-run the full pipeline on every request.');
+    lines.push(trend.previous === null
+        ? 'Trend: first run (no previous stuck-keys report).'
+        : `Trend: ${trend.previousCount} → ${report.count} (${fmtDelta(trend.delta ?? 0)}) vs \`${trend.previous}\`.`);
+    lines.push('');
+    const shown = report.rows.slice(0, maxRows);
+    lines.push(`### Keys (${shown.length} of ${report.count} shown, by events)`);
+    lines.push(mdTable(shown.map(r => [
+        cell(r.key),
+        String(r.events),
+        // 3 decimals: at 2, 0.8473 renders as "0.85" and looks like it beat the gate
+        r.maxConfidence == null ? '—' : r.maxConfidence.toFixed(3),
+        r.avgLatencyMs == null ? '—' : `${Math.round(r.avgLatencyMs)}ms`,
+        cell(r.sampleRawLine ?? ''),
+        cell(fmtFoods(r.foods)),
+    ]), ['key', 'events', 'max conf', 'avg latency', 'sample raw line', 'records seen (top)']));
+    return lines;
+}


### PR DESCRIPTION
## Why

The FoodMapping cache only saves results with **confidence ≥ 0.85**. Sub-gate results are served to users but never cached and never reviewed — they re-run the full mapping pipeline forever, invisibly. This adds a nightly report that makes the population visible so triage batches can clear it.

## What

- **New sweep section "Stuck keys (sub-gate, never cached)"** in `scripts/eval/flywheel-sweep.ts` (step 1b, after telemetry). Definition per key (`normalizedForm`) over the `--days` window:
  - `noCache` events excluded (eval cold-run traffic), `cacheEscape` events excluded (escapes are deliberate)
  - ALL remaining events are misses (`count(*) FILTER (WHERE "cacheHit" IS NOT NULL) = 0` — per key, not per event; `cacheHit` is text `'early' | 'normalized' | NULL`)
  - `coalesce(max(confidence), 0) < 0.85` (NULL-only confidence counts as stuck) and `count(*) >= 2`
  - Per key: events, max confidence, avg latency, sample rawLine, top 3 resolved records by frequency; ordered by events desc
- **`results/stuck-keys-<ts>.json`** written next to the existing `flywheel-<ts>.{json,md}` artifacts — machine-readable rows, the input for future triage batches. The sweep JSON carries a summary + pointer (same pattern as `warmReport`).
- **Trend line** vs the most recent previous `stuck-keys-*.json` (mtime, same convention as `latestWarmReport`); "first run" when none exists.
- **`--stuck-keys-only`** flag runs just this report (read-only against the DB, writes only the JSON) — no warm, no eval, no publish.
- **Purely additive**: single `$queryRaw` CTE; zero rows or a failed query render in the report but never fail the sweep; warm/eval gating and exit codes untouched. No new deps, no new env vars.
- Logic factored into `src/lib/ops/stuck-keys.ts` so jest covers it (the jest projects only match `src/**`): **16 tests, mocked prisma** — SQL-shape assertions, error/zero-row resilience, trend math, previous-report discovery (mtime + unparseable fallback), markdown formatting (pipe escaping, null fields, row cap).

## Live smoke (`--stuck-keys-only` against the OptiPlex DB, 7d window)

13 stuck keys; top rows:

| key | events | max conf | avg latency | sample raw line |
| --- | --- | --- | --- | --- |
| ghost vegan protein powder chocolate flavor | 33 | 0.789 | 100ms | 1 scoop ghost vegan protein powder chocolate flavor |
| instant rolled oats | 33 | 0.813 | 55ms | 1 packet instant oatmeal |
| bang cotton candy | 26 | 0.808 | 405ms | bang cotton candy |
| ghugh's sugar free honey mustard | 26 | 0.840 | 66ms | 2 tbsp ghugh's sugar free honey mustard |
| mac and cheese | 26 | 0.612 | 102ms | mac and cheese |
| canned canned kidney beans | 7 | 0.821 | 52ms | kidney beans |
| dry rolled rolled oats | 7 | 0.808 | 441ms | dry rolled oats |
| Potato Salad | 2 | 0.612 | 31720ms | potato salad |

(The staples from the original capture — eggs, salt, white rice — no longer qualify: the 2026-07-21 triage batches gave them cache hits, verified live. The report correctly drops them and keeps the still-stuck ones.)

## Validation

- `npm run typecheck`, `npm run lint:ci` (431 warnings, unchanged files clean), `npm run build` — all green locally
- Full jest suite: 61/61 suites, 868/868 tests pass (16 new)
- SQL shape validated read-only via `psql` against the live `MappingEventLog` before wiring up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu