### PR TITLE
feat(nlp): segmentation-result cache (SegmentationCache + segCacheHit telemetry)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "eval": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register eval/run.ts",
         "eval:analyze": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register eval/analyze.ts",
         "flywheel:sweep": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/flywheel-sweep.ts",
+        "seg:replay-diff": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/seg-replay-diff.ts",
         "similar:build": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/build-similar.ts",
         "test:fdc-api": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/test-fdc-api.ts",
         "verify:seeding": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/verify-seeding.ts",

--- a/prisma/migrations/20260721190000_add_segmentation_cache/migration.sql
+++ b/prisma/migrations/20260721190000_add_segmentation_cache/migration.sql
@@ -1,0 +1,29 @@
+-- Segmentation-result cache (magic-log): repeat free-text lines skip the ~2-4s
+-- LLM split. Keyed by canonicalized line (src/lib/nlp/seg-line-key.ts) plus
+-- SEG_PARSER_VERSION (src/lib/nlp/ai-segmenter.ts) — a version bump orphans old
+-- rows (never read again); the sliding 30d TTL on "lastUsedAt" garbage-collects
+-- them (opportunistic sweep in src/lib/nlp/segmentation-cache.ts). Only
+-- successful, complete LLM segmentations are ever written.
+
+-- CreateTable
+CREATE TABLE "SegmentationCache" (
+    "lineKey" TEXT NOT NULL,
+    "parserVersion" TEXT NOT NULL,
+    "segmentsJson" JSONB NOT NULL,
+    "hitCount" INTEGER NOT NULL DEFAULT 0,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SegmentationCache_pkey" PRIMARY KEY ("lineKey","parserVersion")
+);
+
+-- CreateIndex
+CREATE INDEX "SegmentationCache_lastUsedAt_idx" ON "SegmentationCache"("lastUsedAt");
+
+-- CreateIndex
+CREATE INDEX "SegmentationCache_hitCount_idx" ON "SegmentationCache"("hitCount");
+
+-- AlterTable: per-request segmentation-cache outcome on telemetry rows
+-- (true = served from cache, false = AI segmentation ran, NULL = the line
+-- never reached AI segmentation — item-form input or single-item fast path).
+ALTER TABLE "MappingEventLog" ADD COLUMN "segCacheHit" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -680,12 +680,34 @@ model MappingEventLog {
   totalKcal      Float?
   latencyMs      Int?
   noCache        Boolean  @default(false) // request ran with the admin nocache flag (cold run)
+  segCacheHit    Boolean? // true = segmentation served from SegmentationCache; false = AI segmentation ran; null = line never reached AI segmentation (item-form input or single-item fast path)
   createdAt      DateTime @default(now())
 
   @@index([createdAt])
   @@index([normalizedForm])
   @@index([cacheHit])
   @@index([servingTier])
+}
+
+// AI segmentation-result cache (magic-log): repeat free-text lines skip the
+// ~2-4s LLM split. Keyed by canonicalized line (src/lib/nlp/seg-line-key.ts)
+// + SEG_PARSER_VERSION (src/lib/nlp/ai-segmenter.ts — bump on any prompt/
+// model/schema change; old-version rows are simply never read again).
+// Rows are written ONLY for successful, complete LLM segmentations — the
+// heuristic fast path and fallback-degraded splits are never cached.
+// Sliding 30d TTL on lastUsedAt (opportunistic throttled sweep in
+// src/lib/nlp/segmentation-cache.ts).
+model SegmentationCache {
+  lineKey       String
+  parserVersion String   // SEG_PARSER_VERSION at write time
+  segmentsJson  Json     // SegmentedItem[]: { rawText, mealType, brand, normalizedForm }
+  hitCount      Int      @default(0) // times served from cache (not counted on write)
+  lastUsedAt    DateTime @default(now()) // sliding-TTL anchor: bumped on every hit
+  createdAt     DateTime @default(now())
+
+  @@id([lineKey, parserVersion])
+  @@index([lastUsedAt])
+  @@index([hitCount])
 }
 
 // ============================================================================

--- a/scripts/seg-replay-diff.ts
+++ b/scripts/seg-replay-diff.ts
@@ -1,0 +1,189 @@
+/**
+ * seg-replay-diff.ts — drift defense for the SegmentationCache.
+ *
+ * A cached segmentation is served verbatim forever (within SEG_PARSER_VERSION
+ * and the 30d TTL), so silent drift between cached splits and what the LLM
+ * would say TODAY is invisible in production. This script takes the top-N
+ * cached lines by hitCount (the rows doing the most serving), re-runs AI
+ * segmentation for each while BYPASSING the cache (direct segmentTextWithAi
+ * call — no route, no lookup, no write-back), and diffs the outputs on item
+ * count + normalized item names (src/lib/nlp/segmentation-diff.ts; multiset
+ * compare, order-insensitive).
+ *
+ * Statuses per line:
+ *   - match:    fresh split agrees with the cached one
+ *   - drift:    count or name multiset changed — model/prompt behavior moved;
+ *               investigate, and if real, bump SEG_PARSER_VERSION
+ *   - ai_error: the fresh LLM call failed/timed out — NOT drift, retry later
+ *
+ * The script never mutates SegmentationCache. It is read-only on the DB and
+ * paid on the LLM (~$0.0003/line) — keep --top modest.
+ *
+ * Wiring into the nightly flywheel sweep (scripts/eval/flywheel-sweep.ts) is a
+ * follow-up PR; runReplayDiff() is importable and pure of CLI state for that.
+ *
+ * Run (from repo root; needs DATABASE_URL + OPENROUTER_API_KEY):
+ *   npm run seg:replay-diff -- [--top 50] [--out <file>]
+ * or:
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register \
+ *     scripts/seg-replay-diff.ts --top 50
+ *
+ * Writes scripts/eval/results/seg-replay-diff-<timestamp>.json:
+ *   { generatedAt, parserVersion, topN, replayed, matches, drifts, aiErrors,
+ *     driftRate, entries: [{ lineKey, hitCount, status, cachedCount,
+ *     freshCount, onlyCached, onlyFresh, cachedNames, freshNames }] }
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { PrismaClient } from '@prisma/client';
+import {
+    SEG_PARSER_VERSION,
+    SegmentedItem,
+    isSegmentedItemArray,
+    segmentTextWithAi,
+} from '../src/lib/nlp/ai-segmenter';
+import { diffSegments, segmentNames } from '../src/lib/nlp/segmentation-diff';
+
+export interface ReplayDiffEntry {
+    lineKey: string;
+    hitCount: number;
+    status: 'match' | 'drift' | 'ai_error';
+    cachedCount: number;
+    freshCount: number | null;
+    onlyCached: string[];
+    onlyFresh: string[];
+    cachedNames: string[];
+    freshNames: string[] | null;
+}
+
+export interface ReplayDiffReport {
+    generatedAt: string;
+    parserVersion: string;
+    topN: number;
+    replayed: number;
+    skippedMalformed: number;
+    matches: number;
+    drifts: number;
+    aiErrors: number;
+    /** drifts / (matches + drifts) — ai_error rows are excluded. */
+    driftRate: number;
+    entries: ReplayDiffEntry[];
+}
+
+/**
+ * Replay the top-N cached lines through fresh AI segmentation and diff.
+ * Sequential on purpose: N is small (nightly top-50) and the 'parse' purpose
+ * shares a concurrency semaphore with live traffic.
+ */
+export async function runReplayDiff(prisma: PrismaClient, topN: number): Promise<ReplayDiffReport> {
+    const rows = await prisma.segmentationCache.findMany({
+        where: { parserVersion: SEG_PARSER_VERSION },
+        orderBy: { hitCount: 'desc' },
+        take: topN,
+    });
+    console.log(`[seg-replay] ${rows.length} cached lines (parserVersion=${SEG_PARSER_VERSION}, top ${topN} by hitCount)`);
+
+    const entries: ReplayDiffEntry[] = [];
+    let skippedMalformed = 0;
+
+    for (const [i, row] of rows.entries()) {
+        const cached: unknown = row.segmentsJson;
+        if (!isSegmentedItemArray(cached)) {
+            // Route-side validation already treats these as misses; just report.
+            console.warn(`[seg-replay] malformed segmentsJson for "${row.lineKey}" — skipping`);
+            skippedMalformed += 1;
+            continue;
+        }
+
+        const fresh = await segmentTextWithAi(row.lineKey);
+        if (fresh === null) {
+            entries.push({
+                lineKey: row.lineKey,
+                hitCount: row.hitCount,
+                status: 'ai_error',
+                cachedCount: cached.length,
+                freshCount: null,
+                onlyCached: [],
+                onlyFresh: [],
+                cachedNames: segmentNames(cached),
+                freshNames: null,
+            });
+        } else {
+            const diff = diffSegments(cached, fresh as SegmentedItem[]);
+            entries.push({
+                lineKey: row.lineKey,
+                hitCount: row.hitCount,
+                status: diff.same ? 'match' : 'drift',
+                cachedCount: diff.cachedCount,
+                freshCount: diff.freshCount,
+                onlyCached: diff.onlyCached,
+                onlyFresh: diff.onlyFresh,
+                cachedNames: segmentNames(cached),
+                freshNames: segmentNames(fresh as SegmentedItem[]),
+            });
+        }
+        if ((i + 1) % 10 === 0) console.log(`[seg-replay]   ${i + 1}/${rows.length}`);
+    }
+
+    const matches = entries.filter((e) => e.status === 'match').length;
+    const drifts = entries.filter((e) => e.status === 'drift').length;
+    const aiErrors = entries.filter((e) => e.status === 'ai_error').length;
+    const compared = matches + drifts;
+
+    return {
+        generatedAt: new Date().toISOString(),
+        parserVersion: SEG_PARSER_VERSION,
+        topN,
+        replayed: entries.length,
+        skippedMalformed,
+        matches,
+        drifts,
+        aiErrors,
+        driftRate: compared > 0 ? Number((drifts / compared).toFixed(4)) : 0,
+        entries,
+    };
+}
+
+function argValue(args: string[], flag: string): string | undefined {
+    const idx = args.indexOf(flag);
+    return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+    const args = process.argv.slice(2);
+    const topN = Number.parseInt(argValue(args, '--top') ?? '50', 10);
+    if (!Number.isFinite(topN) || topN <= 0) {
+        console.error('--top must be a positive integer');
+        process.exit(2);
+    }
+
+    const prisma = new PrismaClient();
+    try {
+        const report = await runReplayDiff(prisma, topN);
+
+        const outDir = path.join(__dirname, 'eval', 'results');
+        fs.mkdirSync(outDir, { recursive: true });
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const outPath = argValue(args, '--out') ?? path.join(outDir, `seg-replay-diff-${ts}.json`);
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+
+        console.log(`[seg-replay] replayed ${report.replayed}: ${report.matches} match / ${report.drifts} drift / ${report.aiErrors} ai_error (driftRate ${(report.driftRate * 100).toFixed(1)}%)`);
+        for (const e of report.entries.filter((x) => x.status === 'drift')) {
+            console.log(`[seg-replay]   DRIFT "${e.lineKey}" (hits ${e.hitCount}): ${e.cachedCount}→${e.freshCount} items; -[${e.onlyCached.join(', ')}] +[${e.onlyFresh.join(', ')}]`);
+        }
+        console.log(`[seg-replay] report: ${outPath}`);
+        if (report.drifts > 0) {
+            console.log('[seg-replay] drift detected — review; if the new splits are correct/intended, bump SEG_PARSER_VERSION');
+        }
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+if (require.main === module) {
+    main().catch((err) => {
+        console.error('[seg-replay] fatal:', err);
+        process.exit(1);
+    });
+}

--- a/src/app/api/nlp/parse/route.seg-cache.test.ts
+++ b/src/app/api/nlp/parse/route.seg-cache.test.ts
@@ -1,0 +1,230 @@
+/**
+ * /api/nlp/parse — segmentation-cache flow tests.
+ *
+ * Covers: cache hit skips the LLM entirely; miss runs AI + writes through;
+ * failed AI parse falls back to the heuristic and is NEVER cached; cache
+ * errors are fail-open (request still succeeds via the AI path); and
+ * segCacheHit telemetry stamping (true / false / null).
+ *
+ * The AI client (structured-client) and prisma are mocked; the segmentation
+ * cache module, canonicalizer, ai-segmenter, and heuristic segmenter run real.
+ */
+
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { SEG_PARSER_VERSION } from '@/lib/nlp/ai-segmenter';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ auth: { getUser: jest.fn() } })),
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    nlpRequestLog: { count: jest.fn(), create: jest.fn() },
+    mappingEventLog: { createMany: jest.fn() },
+    segmentationCache: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      upsert: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/ai/structured-client', () => ({
+  callStructuredLlm: jest.fn(),
+}));
+
+jest.mock('@/lib/mapping/map-ingredient-with-fallback', () => ({
+  mapIngredientWithFallback: jest.fn().mockResolvedValue({ status: 'no_match' }),
+}));
+
+jest.mock('@/lib/nlp/resolve-payload', () => ({
+  resolveFoodDetails: jest.fn(),
+}));
+
+const validItems = [
+  { rawText: '2 eggs', mealType: 'breakfast', brand: '', normalizedForm: 'eggs' },
+  { rawText: 'wheat toast', mealType: 'breakfast', brand: '', normalizedForm: 'wheat toast' },
+];
+
+const MULTI_ITEM_TEXT = '2 Eggs and wheat toast for breakfast.';
+const MULTI_ITEM_KEY = '2 eggs and wheat toast for breakfast';
+
+function parseRequest(body: object): NextRequest {
+  return new NextRequest('http://localhost:3000/api/nlp/parse', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': 'adminAPI_dev_key_bypass', // dev bypass: skips Supabase auth + rate limiting
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/nlp/parse segmentation cache', () => {
+  const { prisma } = require('@/lib/db');
+  const { callStructuredLlm } = require('@/lib/ai/structured-client');
+
+  const telemetryRows = () => prisma.mappingEventLog.createMany.mock.calls[0][0].data;
+
+  beforeAll(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/test';
+    delete process.env.DEV_API_KEY;
+    delete process.env.MAPPING_EVENT_LOG_ENABLED;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    prisma.segmentationCache.findUnique.mockResolvedValue(null);
+    prisma.segmentationCache.update.mockResolvedValue({});
+    prisma.segmentationCache.upsert.mockResolvedValue({});
+    prisma.mappingEventLog.createMany.mockResolvedValue({ count: 0 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('cache HIT serves cached segments, skips the LLM, stamps segCacheHit=true', async () => {
+    prisma.segmentationCache.findUnique.mockResolvedValue({
+      lineKey: MULTI_ITEM_KEY,
+      parserVersion: SEG_PARSER_VERSION,
+      segmentsJson: validItems,
+      hitCount: 7,
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT }));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveLength(2);
+    expect(data.map((d: { rawText: string }) => d.rawText)).toEqual(['2 eggs', 'wheat toast']);
+
+    // The whole point: no LLM call on a hit.
+    expect(callStructuredLlm).not.toHaveBeenCalled();
+    // Canonicalized key + current version were used for the read.
+    expect(prisma.segmentationCache.findUnique).toHaveBeenCalledWith({
+      where: { lineKey_parserVersion: { lineKey: MULTI_ITEM_KEY, parserVersion: SEG_PARSER_VERSION } },
+    });
+    // Usage bump fired; no write-through on a hit.
+    expect(prisma.segmentationCache.update).toHaveBeenCalledTimes(1);
+    expect(prisma.segmentationCache.upsert).not.toHaveBeenCalled();
+
+    const rows = telemetryRows();
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(row.segCacheHit).toBe(true);
+  });
+
+  test('cache MISS runs AI, writes through on success, stamps segCacheHit=false', async () => {
+    callStructuredLlm.mockResolvedValue({
+      status: 'success',
+      content: { items: validItems },
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveLength(2);
+
+    expect(callStructuredLlm).toHaveBeenCalledTimes(1);
+    expect(callStructuredLlm).toHaveBeenCalledWith(expect.objectContaining({ purpose: 'parse' }));
+    expect(prisma.segmentationCache.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { lineKey_parserVersion: { lineKey: MULTI_ITEM_KEY, parserVersion: SEG_PARSER_VERSION } },
+        create: expect.objectContaining({ segmentsJson: validItems }),
+      }),
+    );
+
+    for (const row of telemetryRows()) expect(row.segCacheHit).toBe(false);
+  });
+
+  test('failed AI parse falls back to heuristic split and is NEVER cached', async () => {
+    callStructuredLlm.mockResolvedValue({
+      status: 'error',
+      error: 'provider exploded',
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT }));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.length).toBeGreaterThan(0); // heuristic forceSegmentText result
+
+    expect(prisma.segmentationCache.upsert).not.toHaveBeenCalled();
+    // AI ran (and failed) — still a seg-cache miss for telemetry.
+    for (const row of telemetryRows()) expect(row.segCacheHit).toBe(false);
+  });
+
+  test('empty AI item list is treated as failure: heuristic fallback, no write-through', async () => {
+    callStructuredLlm.mockResolvedValue({
+      status: 'success',
+      content: { items: [] },
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT }));
+    expect(response.status).toBe(200);
+    expect(prisma.segmentationCache.upsert).not.toHaveBeenCalled();
+  });
+
+  test('fail-open: cache read AND write both throwing still yields a successful AI-path response', async () => {
+    prisma.segmentationCache.findUnique.mockRejectedValue(new Error('db down'));
+    prisma.segmentationCache.upsert.mockRejectedValue(new Error('db still down'));
+    callStructuredLlm.mockResolvedValue({
+      status: 'success',
+      content: { items: validItems },
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveLength(2);
+    for (const row of telemetryRows()) expect(row.segCacheHit).toBe(false);
+  });
+
+  test('single-item fast path never touches the seg cache, stamps segCacheHit=null', async () => {
+    const response = await POST(parseRequest({ text: 'apple' }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveLength(1);
+
+    expect(prisma.segmentationCache.findUnique).not.toHaveBeenCalled();
+    expect(callStructuredLlm).not.toHaveBeenCalled();
+    for (const row of telemetryRows()) expect(row.segCacheHit).toBeNull();
+  });
+
+  test('item-form input never touches the seg cache, stamps segCacheHit=null', async () => {
+    const response = await POST(parseRequest({ items: ['apple', 'banana'] }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveLength(2);
+
+    expect(prisma.segmentationCache.findUnique).not.toHaveBeenCalled();
+    expect(callStructuredLlm).not.toHaveBeenCalled();
+    for (const row of telemetryRows()) expect(row.segCacheHit).toBeNull();
+  });
+
+  test('admin nocache cold-run bypasses the seg cache in both directions', async () => {
+    callStructuredLlm.mockResolvedValue({
+      status: 'success',
+      content: { items: validItems },
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+    });
+
+    const response = await POST(parseRequest({ text: MULTI_ITEM_TEXT, nocache: true }));
+    expect(response.status).toBe(200);
+
+    expect(prisma.segmentationCache.findUnique).not.toHaveBeenCalled();
+    expect(prisma.segmentationCache.upsert).not.toHaveBeenCalled();
+    expect(callStructuredLlm).toHaveBeenCalledTimes(1);
+    for (const row of telemetryRows()) {
+      expect(row.segCacheHit).toBe(false);
+      expect(row.noCache).toBe(true);
+    }
+  });
+});

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -154,7 +154,9 @@ export async function POST(req: NextRequest) {
       }, { status: 500 });
     }
 
-    const { callStructuredLlm } = await import('@/lib/ai/structured-client');
+    const { segmentTextWithAi } = await import('@/lib/nlp/ai-segmenter');
+    const { canonicalizeSegLine } = await import('@/lib/nlp/seg-line-key');
+    const { lookupSegmentationCache, writeSegmentationCache } = await import('@/lib/nlp/segmentation-cache');
     const { forceSegmentText } = await import('@/lib/nlp/heuristic-segmenter');
     const { parseIngredientLine } = await import('@/lib/parse/ingredient-line');
     const { mapIngredientWithFallback } = await import('@/lib/mapping/map-ingredient-with-fallback');
@@ -173,6 +175,11 @@ export async function POST(req: NextRequest) {
       (req.nextUrl.searchParams.get('nocache') === '1' || body.nocache === true);
 
     let items: Array<{ rawText: string; mealType: 'breakfast' | 'lunch' | 'dinner' | 'snacks'; brand?: string; normalizedForm?: string }> = [];
+
+    // Segmentation-cache outcome for telemetry: true = split served from
+    // SegmentationCache, false = AI segmentation ran, null = this request
+    // never reached AI segmentation (item-form input / single-item fast path).
+    let segCacheHit: boolean | null = null;
 
     if (inputItems && Array.isArray(inputItems)) {
       items = inputItems.map(item => {
@@ -194,90 +201,43 @@ export async function POST(req: NextRequest) {
       // return it unchanged after ~1-5s. Skip straight to mapping.
       items = [singleItemFromText(text)!];
     } else {
-      // AI-first segmentation: the cheap LLM splitter (CHEAP_AI_MODEL_PRIMARY
-      // via OpenRouter — gpt-4o-mini, ~$0.0003/call, magic-log is
-      // rate-capped) is the
-      // unconditional first step for any multi-token / delimited log. The
-      // deterministic heuristic is deliberately NOT on the primary path — it
-      // survives only as forceSegmentText, the fallback used when the LLM
-      // errors or exceeds its deadline. This removes the class of silent
-      // heuristic mis-splits (flavor "and" like "cookies and cream", ambiguous
-      // "with" attachments) that a static phrase whitelist could never keep up
-      // with. The mapper is then fed clean, AI-segmented food names while
-      // quantity/units stay deterministic — the goal being fewer AI guesses in
-      // the *mapping* stage, not the (cheap) segmentation stage.
-      {
-        console.log('[nlp-parse] AI-first segmentation');
+      // AI-first segmentation (prompt/model/schema live in
+      // src/lib/nlp/ai-segmenter.ts, versioned by SEG_PARSER_VERSION): the
+      // cheap LLM splitter is the unconditional first step for any
+      // multi-token / delimited log; the deterministic heuristic survives
+      // only as forceSegmentText, the fallback when the LLM errors or
+      // exceeds its deadline.
+      //
+      // SegmentationCache sits in front of the LLM: an identical repeat line
+      // (canonicalized: case/whitespace/trailing-punctuation only — digits
+      // preserved) serves the cached split in ~ms instead of re-paying the
+      // ~2-4s LLM call. Fail-open: any cache error behaves as a miss. Only
+      // successful, complete LLM parses are written back — heuristic
+      // fallback splits are never cached. The admin nocache cold-run flag
+      // bypasses the cache in BOTH directions (no read, no write) so parity
+      // runs measure the full pipeline without mutating cache state.
+      console.log('[nlp-parse] AI-first segmentation');
 
-        const NLP_SPLIT_SCHEMA = {
-          name: 'nlp_split',
-          schema: {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-              items: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  additionalProperties: false,
-                  properties: {
-                    rawText: { type: 'string' },
-                    mealType: { type: 'string', enum: ['breakfast', 'lunch', 'dinner', 'snacks'] },
-                    brand: { type: 'string' },
-                    normalizedForm: { type: 'string' }
-                  },
-                  required: ['rawText', 'mealType', 'brand', 'normalizedForm']
-                }
-              }
-            },
-            required: ['items']
-          },
-          strict: true
-        };
+      const lineKey = canonicalizeSegLine(text);
+      const cachedSegments = noCache ? null : await lookupSegmentationCache(lineKey);
 
-        // Minimal prompt: the JSON schema already constrains the output shape,
-        // so the prompt only needs the field semantics and one example.
-        const SYSTEM_PROMPT = `Split the food-log text into individual food items. Per item:
-- rawText: original chunk incl. quantity/unit (e.g. "2 scrambled eggs")
-- mealType: breakfast|lunch|dinner|snacks (default "snacks")
-- brand: explicit brand name, else ""
-- normalizedForm: base food name without quantity/unit, keep prep modifiers ("2 scrambled eggs" -> "scrambled eggs", "1 tbsp Heinz ketchup" -> "ketchup")
-Attached condiments stay with their item ("toast with butter" = 1 item); distinct foods are separate items.
-Two distinct whole foods joined by "and" are SEPARATE items ("chicken and rice" -> 2, "eggs and bacon" -> 2, "rice and beans" -> 2). Keep "and" together ONLY when the whole phrase names ONE product or a single flavor ("cookies and cream", "peaches and cream", "mac and cheese", "peanut butter and jelly" = 1 item).
-Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs","mealType":"breakfast","brand":"","normalizedForm":"eggs"},{"rawText":"wheat toast","mealType":"breakfast","brand":"","normalizedForm":"wheat toast"}]}`;
-
-        // Per-attempt timeout 6s, overall deadline 8s: a hung provider chain
-        // (previously up to 15s+) now degrades to the lenient heuristic split
-        // instead of stalling the request or returning a 500.
-        const LLM_ATTEMPT_TIMEOUT_MS = 6000;
-        const LLM_OVERALL_DEADLINE_MS = 8000;
-
-        let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-        const llmResult = await Promise.race([
-          callStructuredLlm({
-            schema: NLP_SPLIT_SCHEMA,
-            systemPrompt: SYSTEM_PROMPT,
-            userPrompt: `Unstructured text: "${text}"`,
-            purpose: 'parse',
-            timeout: LLM_ATTEMPT_TIMEOUT_MS,
-            maxTokens: 600,
-          }),
-          new Promise<null>((resolve) => {
-            deadlineTimer = setTimeout(() => resolve(null), LLM_OVERALL_DEADLINE_MS);
-          }),
-        ]);
-        if (deadlineTimer) clearTimeout(deadlineTimer);
-
-        if (!llmResult || llmResult.status === 'error') {
-          console.warn(
-            `[nlp-parse] LLM segmentation ${llmResult ? `failed: ${llmResult.error}` : `deadline exceeded (${LLM_OVERALL_DEADLINE_MS}ms)`} — using lenient heuristic split`
-          );
-          items = forceSegmentText(text);
-        } else {
-          items = (llmResult.content?.items as Array<{ rawText: string; mealType: 'breakfast' | 'lunch' | 'dinner' | 'snacks'; brand: string; normalizedForm: string }>) || [];
-          if (items.length === 0) {
-            items = forceSegmentText(text);
+      if (cachedSegments) {
+        segCacheHit = true;
+        items = cachedSegments;
+        console.log(`[nlp-parse] segmentation cache HIT (${cachedSegments.length} items) — LLM skipped`);
+      } else {
+        segCacheHit = false;
+        const aiItems = await segmentTextWithAi(text);
+        if (aiItems) {
+          items = aiItems;
+          if (!noCache) {
+            // Write-through (fail-open inside; a few ms before mapping starts).
+            await writeSegmentationCache(lineKey, aiItems);
           }
+        } else {
+          // LLM failed/timed out/returned nothing usable — degraded split,
+          // deliberately NOT cached.
+          items = forceSegmentText(text);
         }
       }
     }
@@ -288,7 +248,7 @@ Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs"
       cacheEscape: string | null; foodId: string | null; foodName: string | null;
       brandName: string | null; source: string | null; confidence: number | null;
       servingTier: string | null; grams: number | null; totalKcal: number | null;
-      latencyMs: number; noCache: boolean;
+      latencyMs: number; noCache: boolean; segCacheHit: boolean | null;
     };
     const eventRows: EventRow[] = [];
     const telemetryEnabled = process.env.MAPPING_EVENT_LOG_ENABLED !== 'false';
@@ -331,6 +291,7 @@ Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs"
           totalKcal: isMapped ? (mapped as any).kcal : null,
           latencyMs: mapLatencyMs,
           noCache,
+          segCacheHit,
         });
       }
 

--- a/src/lib/nlp/__tests__/seg-line-key.test.ts
+++ b/src/lib/nlp/__tests__/seg-line-key.test.ts
@@ -1,0 +1,53 @@
+import { canonicalizeSegLine } from '../seg-line-key';
+
+describe('canonicalizeSegLine', () => {
+  test('lowercases', () => {
+    expect(canonicalizeSegLine('Two Eggs AND Toast')).toBe('two eggs and toast');
+  });
+
+  test('collapses internal whitespace runs (spaces, tabs, newlines)', () => {
+    expect(canonicalizeSegLine('2  eggs\tand   toast')).toBe('2 eggs and toast');
+    expect(canonicalizeSegLine('eggs\nbacon')).toBe('eggs bacon');
+  });
+
+  test('trims leading/trailing whitespace', () => {
+    expect(canonicalizeSegLine('  2 eggs and toast  ')).toBe('2 eggs and toast');
+  });
+
+  test('strips trailing punctuation', () => {
+    expect(canonicalizeSegLine('2 eggs and toast.')).toBe('2 eggs and toast');
+    expect(canonicalizeSegLine('2 eggs and toast!?')).toBe('2 eggs and toast');
+    expect(canonicalizeSegLine('2 eggs and toast;')).toBe('2 eggs and toast');
+  });
+
+  test('strips trailing punctuation separated by whitespace', () => {
+    expect(canonicalizeSegLine('2 eggs and toast .')).toBe('2 eggs and toast');
+  });
+
+  test('equivalent variants of the same line collapse to one key', () => {
+    const key = canonicalizeSegLine('2 eggs and toast for breakfast');
+    expect(canonicalizeSegLine('  2 Eggs  AND toast for Breakfast. ')).toBe(key);
+    expect(canonicalizeSegLine('2 eggs and toast for breakfast!!')).toBe(key);
+  });
+
+  test('preserves internal punctuation (list separators are load-bearing)', () => {
+    expect(canonicalizeSegLine('eggs, toast; bacon')).toBe('eggs, toast; bacon');
+    expect(canonicalizeSegLine('eggs, toast')).not.toBe(canonicalizeSegLine('eggs toast'));
+  });
+
+  test('NEVER strips digits/quantities — different quantities are different keys', () => {
+    expect(canonicalizeSegLine('2 eggs and toast')).toBe('2 eggs and toast');
+    expect(canonicalizeSegLine('2 eggs and toast')).not.toBe(canonicalizeSegLine('3 eggs and toast'));
+    expect(canonicalizeSegLine('1.5 cups rice')).toBe('1.5 cups rice');
+  });
+
+  test('preserves decimal quantities at end of line (only punctuation runs stripped)', () => {
+    // trailing "." after a digit is still trailing punctuation; the digit itself survives
+    expect(canonicalizeSegLine('rice 1.5')).toBe('rice 1.5');
+  });
+
+  test('empty and whitespace-only input yield empty key', () => {
+    expect(canonicalizeSegLine('')).toBe('');
+    expect(canonicalizeSegLine('   ')).toBe('');
+  });
+});

--- a/src/lib/nlp/__tests__/segmentation-cache.test.ts
+++ b/src/lib/nlp/__tests__/segmentation-cache.test.ts
@@ -1,0 +1,181 @@
+/**
+ * segmentation-cache unit tests: hit path, version keying, write-through,
+ * fail-open on every prisma error, and the throttled TTL sweep.
+ *
+ * jest.resetModules() per test: the TTL sweep throttle is module state
+ * (writesSinceSweep), so each test gets a fresh module + fresh prisma mocks.
+ */
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    segmentationCache: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      upsert: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  },
+}));
+
+const validItems = [
+  { rawText: '2 eggs', mealType: 'breakfast', brand: '', normalizedForm: 'eggs' },
+  { rawText: 'wheat toast', mealType: 'breakfast', brand: '', normalizedForm: 'wheat toast' },
+];
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('segmentation-cache', () => {
+  let segCache: typeof import('../segmentation-cache');
+  let SEG_PARSER_VERSION: string;
+  let prisma: {
+    segmentationCache: {
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      upsert: jest.Mock;
+      deleteMany: jest.Mock;
+    };
+  };
+  let warnSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    segCache = require('../segmentation-cache');
+    SEG_PARSER_VERSION = require('../ai-segmenter').SEG_PARSER_VERSION;
+    prisma = require('@/lib/db').prisma;
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    prisma.segmentationCache.update.mockResolvedValue({});
+    prisma.segmentationCache.upsert.mockResolvedValue({});
+    prisma.segmentationCache.deleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  afterEach(async () => {
+    await flush(); // settle fire-and-forget promises before restoring spies
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  describe('lookupSegmentationCache', () => {
+    test('hit returns cached segments and bumps hitCount/lastUsedAt fire-and-forget', async () => {
+      prisma.segmentationCache.findUnique.mockResolvedValue({
+        lineKey: '2 eggs and toast',
+        parserVersion: SEG_PARSER_VERSION,
+        segmentsJson: validItems,
+        hitCount: 3,
+        lastUsedAt: new Date(),
+        createdAt: new Date(),
+      });
+
+      const result = await segCache.lookupSegmentationCache('2 eggs and toast');
+      expect(result).toEqual(validItems);
+      expect(prisma.segmentationCache.update).toHaveBeenCalledWith({
+        where: {
+          lineKey_parserVersion: { lineKey: '2 eggs and toast', parserVersion: SEG_PARSER_VERSION },
+        },
+        data: { hitCount: { increment: 1 }, lastUsedAt: expect.any(Date) },
+      });
+    });
+
+    test('lookup is keyed by CURRENT parser version (old-version rows are unreachable)', async () => {
+      prisma.segmentationCache.findUnique.mockResolvedValue(null);
+      const result = await segCache.lookupSegmentationCache('2 eggs and toast');
+      expect(result).toBeNull();
+      expect(prisma.segmentationCache.findUnique).toHaveBeenCalledWith({
+        where: {
+          lineKey_parserVersion: { lineKey: '2 eggs and toast', parserVersion: SEG_PARSER_VERSION },
+        },
+      });
+      expect(prisma.segmentationCache.update).not.toHaveBeenCalled();
+    });
+
+    test('malformed segmentsJson reads as a miss (no bump, warning logged)', async () => {
+      prisma.segmentationCache.findUnique.mockResolvedValue({
+        segmentsJson: [{ rawText: '', mealType: 'brunch' }],
+      });
+      const result = await segCache.lookupSegmentationCache('weird row');
+      expect(result).toBeNull();
+      expect(prisma.segmentationCache.update).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('malformed segmentsJson'));
+    });
+
+    test('fail-open: prisma read throwing yields a miss, never a throw', async () => {
+      prisma.segmentationCache.findUnique.mockRejectedValue(new Error('db down'));
+      await expect(segCache.lookupSegmentationCache('2 eggs and toast')).resolves.toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('lookup failed (fail-open'),
+        expect.any(Error),
+      );
+    });
+
+    test('fail-open: a failing hit bump does not affect the returned segments', async () => {
+      prisma.segmentationCache.findUnique.mockResolvedValue({ segmentsJson: validItems });
+      prisma.segmentationCache.update.mockRejectedValue(new Error('bump failed'));
+      const result = await segCache.lookupSegmentationCache('2 eggs and toast');
+      expect(result).toEqual(validItems);
+      await flush();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('hit bump failed'), expect.any(Error));
+    });
+  });
+
+  describe('writeSegmentationCache', () => {
+    test('upserts under the CURRENT parser version', async () => {
+      await segCache.writeSegmentationCache('2 eggs and toast', validItems as never);
+      expect(prisma.segmentationCache.upsert).toHaveBeenCalledWith({
+        where: {
+          lineKey_parserVersion: { lineKey: '2 eggs and toast', parserVersion: SEG_PARSER_VERSION },
+        },
+        create: {
+          lineKey: '2 eggs and toast',
+          parserVersion: SEG_PARSER_VERSION,
+          segmentsJson: validItems,
+          lastUsedAt: expect.any(Date),
+        },
+        update: { segmentsJson: validItems, lastUsedAt: expect.any(Date) },
+      });
+    });
+
+    test('fail-open: upsert throwing resolves quietly and skips the sweep counter', async () => {
+      prisma.segmentationCache.upsert.mockRejectedValue(new Error('db down'));
+      await expect(segCache.writeSegmentationCache('k', validItems as never)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('write-through failed'),
+        expect.any(Error),
+      );
+      expect(prisma.segmentationCache.deleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('opportunistic TTL sweep', () => {
+    test(`sweeps expired rows exactly once per ${'TTL_SWEEP_EVERY_N_WRITES'} successful writes`, async () => {
+      const n = segCache.TTL_SWEEP_EVERY_N_WRITES;
+      for (let i = 0; i < n - 1; i++) {
+        await segCache.writeSegmentationCache(`line ${i}`, validItems as never);
+      }
+      expect(prisma.segmentationCache.deleteMany).not.toHaveBeenCalled();
+
+      await segCache.writeSegmentationCache('the nth line', validItems as never);
+      expect(prisma.segmentationCache.deleteMany).toHaveBeenCalledTimes(1);
+
+      const arg = prisma.segmentationCache.deleteMany.mock.calls[0][0];
+      const cutoff: Date = arg.where.lastUsedAt.lt;
+      const expectedCutoff = Date.now() - segCache.SEG_CACHE_TTL_DAYS * 24 * 60 * 60 * 1000;
+      expect(Math.abs(cutoff.getTime() - expectedCutoff)).toBeLessThan(60 * 1000);
+
+      // counter reset: next write does not sweep again
+      await segCache.writeSegmentationCache('one more', validItems as never);
+      expect(prisma.segmentationCache.deleteMany).toHaveBeenCalledTimes(1);
+    });
+
+    test('fail-open: sweep errors are swallowed', async () => {
+      prisma.segmentationCache.deleteMany.mockRejectedValue(new Error('sweep failed'));
+      for (let i = 0; i < segCache.TTL_SWEEP_EVERY_N_WRITES; i++) {
+        await segCache.writeSegmentationCache(`line ${i}`, validItems as never);
+      }
+      await flush();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TTL sweep failed'), expect.any(Error));
+    });
+  });
+});

--- a/src/lib/nlp/__tests__/segmentation-diff.test.ts
+++ b/src/lib/nlp/__tests__/segmentation-diff.test.ts
@@ -1,0 +1,74 @@
+import { SegmentedItem } from '../ai-segmenter';
+import { diffSegments, normalizeSegName, segmentNames } from '../segmentation-diff';
+
+const item = (rawText: string, normalizedForm = '', mealType: SegmentedItem['mealType'] = 'snacks'): SegmentedItem => ({
+  rawText,
+  mealType,
+  brand: '',
+  normalizedForm,
+});
+
+describe('normalizeSegName', () => {
+  test('lowercases, collapses whitespace, trims', () => {
+    expect(normalizeSegName('  Wheat   Toast ')).toBe('wheat toast');
+  });
+});
+
+describe('segmentNames', () => {
+  test('prefers normalizedForm, falls back to rawText when empty', () => {
+    expect(segmentNames([item('2 eggs', 'eggs'), item('wheat toast')])).toEqual(['eggs', 'wheat toast']);
+  });
+
+  test('returns sorted names (multiset form)', () => {
+    expect(segmentNames([item('toast', 'toast'), item('2 eggs', 'eggs')])).toEqual(['eggs', 'toast']);
+  });
+});
+
+describe('diffSegments', () => {
+  const eggsAndToast = [item('2 eggs', 'eggs', 'breakfast'), item('wheat toast', 'wheat toast', 'breakfast')];
+
+  test('identical segmentations match', () => {
+    const d = diffSegments(eggsAndToast, [...eggsAndToast]);
+    expect(d.same).toBe(true);
+    expect(d.countChanged).toBe(false);
+    expect(d.onlyCached).toEqual([]);
+    expect(d.onlyFresh).toEqual([]);
+  });
+
+  test('re-ordered items are NOT drift (multiset compare)', () => {
+    const reordered = [eggsAndToast[1], eggsAndToast[0]];
+    expect(diffSegments(eggsAndToast, reordered).same).toBe(true);
+  });
+
+  test('case/whitespace variation in names is NOT drift', () => {
+    const variant = [item('2 eggs', 'Eggs', 'breakfast'), item('wheat toast', ' Wheat  Toast ', 'breakfast')];
+    expect(diffSegments(eggsAndToast, variant).same).toBe(true);
+  });
+
+  test('item-count change is drift', () => {
+    const merged = [item('2 eggs and wheat toast', 'eggs and wheat toast', 'breakfast')];
+    const d = diffSegments(eggsAndToast, merged);
+    expect(d.same).toBe(false);
+    expect(d.countChanged).toBe(true);
+    expect(d.cachedCount).toBe(2);
+    expect(d.freshCount).toBe(1);
+  });
+
+  test('same count but renamed item is drift, reported both ways', () => {
+    const renamed = [item('2 eggs', 'eggs', 'breakfast'), item('white toast', 'white toast', 'breakfast')];
+    const d = diffSegments(eggsAndToast, renamed);
+    expect(d.same).toBe(false);
+    expect(d.countChanged).toBe(false);
+    expect(d.onlyCached).toEqual(['wheat toast']);
+    expect(d.onlyFresh).toEqual(['white toast']);
+  });
+
+  test('duplicates count as a multiset (2x eggs vs 1x eggs + toast is drift)', () => {
+    const twoEggs = [item('egg', 'eggs'), item('egg', 'eggs')];
+    const eggAndToast = [item('egg', 'eggs'), item('toast', 'toast')];
+    const d = diffSegments(twoEggs, eggAndToast);
+    expect(d.same).toBe(false);
+    expect(d.onlyCached).toEqual(['eggs']);
+    expect(d.onlyFresh).toEqual(['toast']);
+  });
+});

--- a/src/lib/nlp/ai-segmenter.ts
+++ b/src/lib/nlp/ai-segmenter.ts
@@ -1,0 +1,146 @@
+/**
+ * ai-segmenter.ts — the LLM text→items splitter for magic-log parsing.
+ *
+ * Extracted from app/api/nlp/parse/route.ts so the segmentation prompt, output
+ * schema, timeouts, and the SegmentationCache version stamp live in ONE place.
+ *
+ * AI-first segmentation: the cheap LLM splitter (CHEAP_AI_MODEL_PRIMARY via
+ * OpenRouter — gpt-4o-mini, ~$0.0003/call, magic-log is rate-capped) is the
+ * unconditional first step for any multi-token / delimited log. The
+ * deterministic heuristic is deliberately NOT on the primary path — it
+ * survives only as forceSegmentText, the fallback used when the LLM errors or
+ * exceeds its deadline. This removes the class of silent heuristic mis-splits
+ * (flavor "and" like "cookies and cream", ambiguous "with" attachments) that a
+ * static phrase whitelist could never keep up with. The mapper is then fed
+ * clean, AI-segmented food names while quantity/units stay deterministic — the
+ * goal being fewer AI guesses in the *mapping* stage, not the (cheap)
+ * segmentation stage.
+ */
+
+import { callStructuredLlm } from '@/lib/ai/structured-client';
+
+/**
+ * ⚠️⚠️ SEGMENTATION PARSER VERSION — BUMP THIS ON ANY CHANGE TO: ⚠️⚠️
+ *   - SEGMENT_SYSTEM_PROMPT (split semantics, examples, meal-type rules)
+ *   - NLP_SPLIT_SCHEMA (output shape / fields)
+ *   - the model or provider serving purpose 'parse' (structured-client
+ *     provider chain, CHEAP_AI_MODEL_PRIMARY, Ollama routing)
+ *
+ * SegmentationCache rows are keyed [lineKey, parserVersion]; rows written
+ * under an old version are simply never read again (the sliding 30d TTL
+ * garbage-collects them). Bumping is always safe and cheap — forgetting to
+ * bump serves STALE segmentations for up to 30 days.
+ */
+export const SEG_PARSER_VERSION = 'seg-v1';
+
+export type SegmentedMealType = 'breakfast' | 'lunch' | 'dinner' | 'snacks';
+
+export interface SegmentedItem {
+  rawText: string;
+  mealType: SegmentedMealType;
+  brand: string;
+  normalizedForm: string;
+}
+
+const MEAL_TYPES: ReadonlySet<string> = new Set(['breakfast', 'lunch', 'dinner', 'snacks']);
+
+/**
+ * Shape guard for SegmentedItem[] — used to validate LLM output before
+ * caching and cached segmentsJson blobs before serving (a malformed cached
+ * row must read as a miss, never crash the request).
+ */
+export function isSegmentedItemArray(value: unknown): value is SegmentedItem[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every((it) => {
+    if (!it || typeof it !== 'object') return false;
+    const item = it as Record<string, unknown>;
+    return (
+      typeof item.rawText === 'string' && item.rawText.trim() !== '' &&
+      typeof item.mealType === 'string' && MEAL_TYPES.has(item.mealType) &&
+      typeof item.brand === 'string' &&
+      typeof item.normalizedForm === 'string'
+    );
+  });
+}
+
+const NLP_SPLIT_SCHEMA = {
+  name: 'nlp_split',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      items: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            rawText: { type: 'string' },
+            mealType: { type: 'string', enum: ['breakfast', 'lunch', 'dinner', 'snacks'] },
+            brand: { type: 'string' },
+            normalizedForm: { type: 'string' }
+          },
+          required: ['rawText', 'mealType', 'brand', 'normalizedForm']
+        }
+      }
+    },
+    required: ['items']
+  },
+  strict: true
+};
+
+// Minimal prompt: the JSON schema already constrains the output shape,
+// so the prompt only needs the field semantics and one example.
+const SEGMENT_SYSTEM_PROMPT = `Split the food-log text into individual food items. Per item:
+- rawText: original chunk incl. quantity/unit (e.g. "2 scrambled eggs")
+- mealType: breakfast|lunch|dinner|snacks (default "snacks")
+- brand: explicit brand name, else ""
+- normalizedForm: base food name without quantity/unit, keep prep modifiers ("2 scrambled eggs" -> "scrambled eggs", "1 tbsp Heinz ketchup" -> "ketchup")
+Attached condiments stay with their item ("toast with butter" = 1 item); distinct foods are separate items.
+Two distinct whole foods joined by "and" are SEPARATE items ("chicken and rice" -> 2, "eggs and bacon" -> 2, "rice and beans" -> 2). Keep "and" together ONLY when the whole phrase names ONE product or a single flavor ("cookies and cream", "peaches and cream", "mac and cheese", "peanut butter and jelly" = 1 item).
+Example: "2 eggs and wheat toast for breakfast" -> {"items":[{"rawText":"2 eggs","mealType":"breakfast","brand":"","normalizedForm":"eggs"},{"rawText":"wheat toast","mealType":"breakfast","brand":"","normalizedForm":"wheat toast"}]}`;
+
+// Per-attempt timeout 6s, overall deadline 8s: a hung provider chain
+// (previously up to 15s+) now degrades to the lenient heuristic split
+// instead of stalling the request or returning a 500.
+const LLM_ATTEMPT_TIMEOUT_MS = 6000;
+const LLM_OVERALL_DEADLINE_MS = 8000;
+
+/**
+ * Run AI segmentation on a raw log line.
+ *
+ * Returns the segmented items on a SUCCESSFUL, complete parse; returns null
+ * when the LLM errored, exceeded the deadline, or returned an empty/invalid
+ * item list — callers fall back to forceSegmentText and must NOT cache the
+ * degraded result.
+ */
+export async function segmentTextWithAi(text: string): Promise<SegmentedItem[] | null> {
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const llmResult = await Promise.race([
+    callStructuredLlm({
+      schema: NLP_SPLIT_SCHEMA,
+      systemPrompt: SEGMENT_SYSTEM_PROMPT,
+      userPrompt: `Unstructured text: "${text}"`,
+      purpose: 'parse',
+      timeout: LLM_ATTEMPT_TIMEOUT_MS,
+      maxTokens: 600,
+    }),
+    new Promise<null>((resolve) => {
+      deadlineTimer = setTimeout(() => resolve(null), LLM_OVERALL_DEADLINE_MS);
+    }),
+  ]);
+  if (deadlineTimer) clearTimeout(deadlineTimer);
+
+  if (!llmResult || llmResult.status === 'error') {
+    console.warn(
+      `[nlp-parse] LLM segmentation ${llmResult ? `failed: ${llmResult.error}` : `deadline exceeded (${LLM_OVERALL_DEADLINE_MS}ms)`} — caller falls back to lenient heuristic split`
+    );
+    return null;
+  }
+
+  const items = llmResult.content?.items;
+  if (!isSegmentedItemArray(items)) {
+    return null;
+  }
+  return items;
+}

--- a/src/lib/nlp/seg-line-key.ts
+++ b/src/lib/nlp/seg-line-key.ts
@@ -1,0 +1,30 @@
+/**
+ * seg-line-key.ts — canonicalizer for SegmentationCache lookup keys.
+ *
+ * Maps a raw magic-log line to the key under which its AI segmentation result
+ * is cached (model SegmentationCache, keyed [lineKey, parserVersion]).
+ *
+ * Deliberately CONSERVATIVE: only normalizations that cannot change what the
+ * segmenter would return are applied —
+ *   - lowercase
+ *   - collapse internal whitespace runs (incl. tabs/newlines) to one space
+ *   - trim
+ *   - strip TRAILING punctuation ("2 eggs and toast." == "2 eggs and toast")
+ *
+ * Digits and quantities are load-bearing and are NEVER touched:
+ * "2 eggs and toast" and "3 eggs and toast" MUST produce different keys.
+ * Internal punctuation is also preserved — commas/semicolons are list
+ * separators the segmenter splits on ("eggs, toast" != "eggs toast").
+ */
+
+/** Trailing punctuation that never carries meaning at end-of-line. */
+const TRAILING_PUNCT = /[.,;:!?]+$/;
+
+export function canonicalizeSegLine(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(TRAILING_PUNCT, '')
+    .trim();
+}

--- a/src/lib/nlp/segmentation-cache.ts
+++ b/src/lib/nlp/segmentation-cache.ts
@@ -1,0 +1,118 @@
+/**
+ * segmentation-cache.ts — DB-backed cache of AI segmentation results.
+ *
+ * Biggest felt-latency lever on the magic-log path: an identical repeat line
+ * ("2 eggs and toast for breakfast") used to re-pay the ~2-4s LLM split every
+ * time; only the per-food mapping was cached. This module serves the split
+ * from Postgres (SegmentationCache, keyed [lineKey, parserVersion]) in
+ * single-digit ms instead.
+ *
+ * Contract (see route.ts caller):
+ *   - Only lines that would hit the LLM consult this cache. The heuristic
+ *     single-item fast path and item-form requests never touch it (no LLM
+ *     cost to save there).
+ *   - Only SUCCESSFUL, complete LLM segmentations are written. Heuristic
+ *     fallback splits (LLM error/deadline) and empty/invalid parses are NEVER
+ *     cached — a degraded result must not be replayed forever.
+ *   - FAIL-OPEN everywhere: any cache read/write error logs a warning and the
+ *     request proceeds exactly as a miss. The cache can never fail a request.
+ *   - Invalidation is by version: bump SEG_PARSER_VERSION (ai-segmenter.ts)
+ *     on any prompt/model/schema change; old-version rows are never read.
+ *
+ * TTL: sliding 30 days on lastUsedAt. Implemented as an opportunistic,
+ * throttled deleteMany after write-throughs (at most once per
+ * TTL_SWEEP_EVERY_N_WRITES writes per process) rather than a standalone cron —
+ * consistent with the codebase's in-process opportunistic maintenance style
+ * (cf. fire-and-forget telemetry, alias-cache refresh) and avoids another
+ * systemd unit for a table this small. Misses only delay cleanup, never
+ * correctness: stale rows for old parser versions are unreachable by design.
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/db';
+import { SEG_PARSER_VERSION, SegmentedItem, isSegmentedItemArray } from './ai-segmenter';
+
+export const SEG_CACHE_TTL_DAYS = 30;
+export const TTL_SWEEP_EVERY_N_WRITES = 50;
+
+/** Per-process write counter for the opportunistic TTL sweep throttle. */
+let writesSinceSweep = 0;
+
+/**
+ * Look up a cached segmentation for a canonicalized line key under the
+ * CURRENT parser version. On a hit, bumps hitCount/lastUsedAt fire-and-forget
+ * (never blocks the request). Fail-open: any error → null (treated as miss).
+ */
+export async function lookupSegmentationCache(lineKey: string): Promise<SegmentedItem[] | null> {
+  try {
+    const row = await prisma.segmentationCache.findUnique({
+      where: { lineKey_parserVersion: { lineKey, parserVersion: SEG_PARSER_VERSION } },
+    });
+    if (!row) return null;
+
+    const segments: unknown = row.segmentsJson;
+    if (!isSegmentedItemArray(segments)) {
+      console.warn(`[seg-cache] malformed segmentsJson for key "${lineKey}" — treating as miss`);
+      return null;
+    }
+
+    // Usage bump is fire-and-forget: a failed bump costs a stat, not a request.
+    prisma.segmentationCache
+      .update({
+        where: { lineKey_parserVersion: { lineKey, parserVersion: SEG_PARSER_VERSION } },
+        data: { hitCount: { increment: 1 }, lastUsedAt: new Date() },
+      })
+      .catch((err) => console.warn('[seg-cache] hit bump failed (non-fatal):', err));
+
+    return segments;
+  } catch (err) {
+    console.warn('[seg-cache] lookup failed (fail-open, treating as miss):', err);
+    return null;
+  }
+}
+
+/**
+ * Write-through after a SUCCESSFUL AI segmentation. Upsert so a concurrent
+ * duplicate request (or a re-parse after a malformed-row miss) replaces
+ * rather than conflicts. Fail-open: errors are logged and swallowed.
+ */
+export async function writeSegmentationCache(lineKey: string, segments: SegmentedItem[]): Promise<void> {
+  try {
+    const segmentsJson = segments as unknown as Prisma.InputJsonValue;
+    await prisma.segmentationCache.upsert({
+      where: { lineKey_parserVersion: { lineKey, parserVersion: SEG_PARSER_VERSION } },
+      create: {
+        lineKey,
+        parserVersion: SEG_PARSER_VERSION,
+        segmentsJson,
+        lastUsedAt: new Date(),
+      },
+      update: { segmentsJson, lastUsedAt: new Date() },
+    });
+  } catch (err) {
+    console.warn('[seg-cache] write-through failed (non-fatal):', err);
+    return;
+  }
+  maybeSweepExpired();
+}
+
+/**
+ * Opportunistic sliding-TTL sweep: at most once per TTL_SWEEP_EVERY_N_WRITES
+ * successful write-throughs, delete rows idle for >SEG_CACHE_TTL_DAYS.
+ * Fire-and-forget — never blocks or fails the triggering request.
+ */
+function maybeSweepExpired(): void {
+  writesSinceSweep += 1;
+  if (writesSinceSweep < TTL_SWEEP_EVERY_N_WRITES) return;
+  writesSinceSweep = 0;
+
+  const cutoff = new Date(Date.now() - SEG_CACHE_TTL_DAYS * 24 * 60 * 60 * 1000);
+  prisma.segmentationCache
+    .deleteMany({ where: { lastUsedAt: { lt: cutoff } } })
+    .then((res) => {
+      if (res.count > 0) {
+        console.log(`[seg-cache] TTL sweep deleted ${res.count} rows idle >${SEG_CACHE_TTL_DAYS}d`);
+      }
+    })
+    .catch((err) => console.warn('[seg-cache] TTL sweep failed (non-fatal):', err));
+}

--- a/src/lib/nlp/segmentation-diff.ts
+++ b/src/lib/nlp/segmentation-diff.ts
@@ -1,0 +1,70 @@
+/**
+ * segmentation-diff.ts — pure diff core for the seg-replay drift defense
+ * (scripts/seg-replay-diff.ts). Lives under src/ so jest covers it.
+ *
+ * Compares a cached segmentation against a fresh AI re-run on two axes:
+ *   1. item COUNT — a count change is always drift (split semantics moved);
+ *   2. normalized item NAMES — compared as a multiset (order-insensitive:
+ *      the LLM re-ordering "eggs, toast" → toast-first is not drift; the
+ *      mapper handles items independently).
+ *
+ * Names are taken from normalizedForm (the mapper's food-name input) and
+ * fall back to rawText when the model left normalizedForm empty. Grams/
+ * quantities are NOT diffed here — quantity resolution is deterministic
+ * downstream of segmentation (parseIngredientLine), so segment-name parity
+ * implies billing parity.
+ */
+
+import { SegmentedItem } from './ai-segmenter';
+
+/** Same conservative normalization family as seg-line-key: case/whitespace only. */
+export function normalizeSegName(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/** Normalized comparison names for a segmentation, sorted (multiset form). */
+export function segmentNames(items: SegmentedItem[]): string[] {
+  return items
+    .map((it) => normalizeSegName(it.normalizedForm.trim() !== '' ? it.normalizedForm : it.rawText))
+    .sort();
+}
+
+export interface SegDiffResult {
+  /** True when count and name multiset both match — no drift. */
+  same: boolean;
+  countChanged: boolean;
+  cachedCount: number;
+  freshCount: number;
+  /** Names present in the cached split but missing from the fresh one. */
+  onlyCached: string[];
+  /** Names present in the fresh split but missing from the cached one. */
+  onlyFresh: string[];
+}
+
+export function diffSegments(cached: SegmentedItem[], fresh: SegmentedItem[]): SegDiffResult {
+  const cachedNames = segmentNames(cached);
+  const freshNames = segmentNames(fresh);
+
+  // Multiset difference: consume matches pairwise so duplicates count.
+  const freshPool = [...freshNames];
+  const onlyCached: string[] = [];
+  for (const name of cachedNames) {
+    const idx = freshPool.indexOf(name);
+    if (idx === -1) {
+      onlyCached.push(name);
+    } else {
+      freshPool.splice(idx, 1);
+    }
+  }
+  const onlyFresh = freshPool;
+
+  const countChanged = cached.length !== fresh.length;
+  return {
+    same: !countChanged && onlyCached.length === 0 && onlyFresh.length === 0,
+    countChanged,
+    cachedCount: cached.length,
+    freshCount: fresh.length,
+    onlyCached,
+    onlyFresh,
+  };
+}


### PR DESCRIPTION
## What

Biggest felt-latency lever left on the magic-log path: an identical repeat free-text line ("2 eggs and toast for breakfast") re-paid the ~2–4s AI segmentation LLM call on every request — only the per-food mapping was cached. This PR adds a **segmentation-result cache** so repeat lines skip the LLM entirely and go straight to mapping.

## Design

- **New model `SegmentationCache`** keyed `@@id([lineKey, parserVersion])` with `segmentsJson` (the AI split), `hitCount`, `lastUsedAt`, `createdAt`. Migration `20260721190000_add_segmentation_cache` (hand-authored, Prisma SQL conventions; `migrate-smoke` validates it).
- **Canonicalizer** (`src/lib/nlp/seg-line-key.ts`): lowercase, collapse whitespace, trim, strip *trailing* punctuation only. Digits/quantities are never touched ("2 eggs and toast" ≠ "3 eggs and toast") and internal punctuation is preserved (commas are list separators the segmenter splits on).
- **AI segmenter extracted** to `src/lib/nlp/ai-segmenter.ts`: the prompt, `nlp_split` schema, timeouts, and `SEG_PARSER_VERSION` now live in ONE place, with a loud bump-on-any-change comment. The route's segmentation behavior is byte-for-byte the same prompt/model/deadline as before (purpose `'parse'`, `CHEAP_AI_MODEL_PRIMARY` via OpenRouter, 6s attempt / 8s overall deadline, heuristic `forceSegmentText` fallback).
- **Flow** (route `else`-branch only — the single-item fast path and item-form requests never touch the cache; there is no LLM cost to save there):
  - canonicalize → lookup `(lineKey, SEG_PARSER_VERSION)`
  - **HIT**: serve cached segments, fire-and-forget `hitCount`/`lastUsedAt` bump, LLM skipped
  - **MISS**: AI runs as today; on a **successful, complete** parse → write-through upsert. Failed/deadline/empty parses (heuristic-fallback splits) are **never** cached.
  - The admin `nocache` cold-run flag bypasses the seg cache in **both** directions (no read, no write) so parity runs measure the full pipeline without mutating cache state.

## Fail-open guarantees

Every cache touch is wrapped: read errors, malformed `segmentsJson` (shape-validated before serving), write errors, bump errors, and TTL-sweep errors all log a warning and behave exactly as a miss. The request can never fail — or even slow past one extra `findUnique` — because of the cache. Covered by tests (prisma throwing on read *and* write still returns 200 via the AI path).

## Invalidation story

1. **`SEG_PARSER_VERSION`** (`'seg-v1'`, colocated with the prompt/schema in `ai-segmenter.ts`): bump on ANY change to segmentation prompt, model/provider routing, or output schema. Rows are keyed by version, so old rows are structurally unreachable — no flush needed.
2. **Drift defense**: new `scripts/seg-replay-diff.ts` (`npm run seg:replay-diff -- [--top 50]`) takes the top-N cached lines by `hitCount`, re-runs AI segmentation bypassing the cache, and diffs item count + normalized names (multiset, order-insensitive — diff core in `src/lib/nlp/segmentation-diff.ts`, unit-tested with fixtures). Writes a JSON report to `scripts/eval/results/seg-replay-diff-<ts>.json`. Read-only on the DB; wiring into the nightly flywheel sweep is a follow-up PR (deliberately not touching `flywheel-sweep.ts` here — another branch owns it).

## TTL

Sliding 30 days on `lastUsedAt` (bumped on every hit). Implemented as an opportunistic, throttled `deleteMany` — at most once per 50 successful write-throughs per process, fire-and-forget — rather than a standalone cron: consistent with the codebase's in-process maintenance style and avoids another systemd unit for a table this small. Missed sweeps only delay cleanup, never correctness.

## Telemetry

`MappingEventLog.segCacheHit Boolean?` (same migration), stamped on every per-line telemetry row exactly like `cacheHit`/`servingTier`: `true` = split served from cache, `false` = AI segmentation ran (including AI-failed→heuristic-fallback requests), `null` = the request never reached AI segmentation (item-form input / single-item fast path). Gives hit-rate and latency-win measurement for free from the existing sink.

## Tests (36 new, all green)

- canonicalizer: case/whitespace/trailing-punctuation collapse; digits + internal punctuation preserved
- cache module: hit + bump, version-keyed lookup, malformed-row = miss, fail-open on read/write/bump/sweep errors, write-through payload, TTL sweep throttle + cutoff
- route: hit skips `callStructuredLlm`; miss writes through; failed/empty AI parse → heuristic fallback + **no** write; fail-open end-to-end; `segCacheHit` true/false/null stamping; `nocache` two-way bypass
- diff core: match/reorder/case = no drift; count change + rename + multiset duplicates = drift

## Verification

`prisma generate` ✓, `prisma validate` ✓, `lint:ci` ✓ (0 errors), `typecheck` ✓, `next build` ✓, full jest suite **888/888 across 64 suites** (no pre-existing failures encountered). No new env vars, no new dependencies. No database was touched — the migration applies at deploy time / in `migrate-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu
