### PR TITLE
fix(ai): strict-mode-valid structured output schemas (ingredient_parse 400 on primary model)

### DIFF
--- a/src/lib/ai/__tests__/structured-schema-invariant.test.ts
+++ b/src/lib/ai/__tests__/structured-schema-invariant.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Structured-output schema invariant (OpenAI/Azure strict mode).
+ *
+ * Strict json_schema mode rejects any schema whose object nodes do not list
+ * EVERY key of `properties` in `required`:
+ *
+ *   HTTP 400 "Invalid schema for response_format '<name>': In context=(),
+ *   'required' is required to be supplied and to be an array including every
+ *   key in properties. Missing '<key>'."
+ *
+ * The failure is silent in production: the structured client falls back to
+ * the secondary model on every call, paying a failed round-trip in latency
+ * and losing the intended primary model (this is exactly how the
+ * 'ingredient_parse' schema shipped broken — `notes` was in `properties`
+ * but not in `required`).
+ *
+ * Optional fields must instead be REQUIRED with a nullable type union
+ * (e.g. type: ['string', 'null']) — never omitted from `required`.
+ *
+ * This test enforces the invariant mechanically for every structured-output
+ * schema in the codebase, recursively (nested objects, array items,
+ * anyOf/oneOf/allOf). A registry-completeness check counts `strict: true`
+ * schema declarations under src/ so that adding a new schema without
+ * registering it here fails the suite.
+ */
+
+// Several schema modules transitively import the Prisma client at module
+// scope (via '@/lib/db'); stub it so importing them stays side-effect free.
+jest.mock('@/lib/db', () => ({ prisma: {} }));
+// ai-nutrition-backfill → modifier-constraints → gather-candidates calls
+// warmupEmbedder() at module scope, which starts an async ONNX model load
+// that leaves an open handle after the run; stub the embedding module.
+jest.mock('@/lib/search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn(),
+}));
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { RESPONSE_SCHEMA as INGREDIENT_PARSE_SCHEMA } from '@/lib/mapping/ai-parse';
+import { JSON_SCHEMA as SIMPLIFY_SCHEMA } from '@/lib/mapping/ai-simplify';
+import { RESPONSE_SCHEMA as NORMALIZE_SCHEMA } from '@/lib/mapping/ai-normalize';
+import { BATCH_RESPONSE_SCHEMA } from '@/lib/mapping/ai-batch-normalize';
+import { RESPONSE_SCHEMA as RERANK_SCHEMA } from '@/lib/mapping/ai-rerank';
+import { RESPONSE_SCHEMA as SYNONYM_SCHEMA } from '@/lib/mapping/ai-synonym-generator';
+import { RESPONSE_SCHEMA as SEARCH_REFINE_SCHEMA } from '@/lib/mapping/ai-search-refine';
+import { NUTRITION_RESPONSE_SCHEMA } from '@/lib/mapping/ai-nutrition-backfill';
+import { VALIDATION_SCHEMA } from '@/lib/mapping/ai-validation';
+import { RESPONSE_SCHEMA as SERVING_SCHEMA } from '@/lib/ai/serving-estimator';
+import {
+    RESPONSE_SCHEMA as AMBIGUOUS_SERVING_SCHEMA,
+    PRODUCE_SIZE_RESPONSE_SCHEMA,
+} from '@/lib/ai/ambiguous-serving-estimator';
+import { RESPONSE_SCHEMA as SIMPLE_SERVING_SCHEMA } from '@/lib/ai/simple-serving-estimator';
+import { NLP_SPLIT_SCHEMA } from '@/lib/nlp/ai-segmenter';
+
+type StructuredSchema = {
+    name: string;
+    schema: Record<string, unknown>;
+    strict?: boolean;
+};
+
+/**
+ * Registry of every structured-output schema in the codebase.
+ * When you add a new schema (the { name, schema, strict: true } object passed
+ * as response_format json_schema / to callStructuredLlm), export it from its
+ * module and add it here — the completeness check below fails otherwise.
+ */
+const ALL_SCHEMAS: StructuredSchema[] = [
+    INGREDIENT_PARSE_SCHEMA,
+    SIMPLIFY_SCHEMA,
+    NORMALIZE_SCHEMA,
+    BATCH_RESPONSE_SCHEMA,
+    RERANK_SCHEMA,
+    SYNONYM_SCHEMA,
+    SEARCH_REFINE_SCHEMA,
+    NUTRITION_RESPONSE_SCHEMA,
+    VALIDATION_SCHEMA,
+    SERVING_SCHEMA,
+    AMBIGUOUS_SERVING_SCHEMA,
+    PRODUCE_SIZE_RESPONSE_SCHEMA,
+    SIMPLE_SERVING_SCHEMA,
+    NLP_SPLIT_SCHEMA,
+];
+
+// ============================================================
+// Invariant walker
+// ============================================================
+
+type Violation = { path: string; message: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nodeTypes(node: Record<string, unknown>): string[] {
+    const t = node.type;
+    if (typeof t === 'string') return [t];
+    if (Array.isArray(t)) return t.filter((x): x is string => typeof x === 'string');
+    return [];
+}
+
+/**
+ * Recursively walk a JSON schema node, collecting strict-mode violations:
+ * every node with `properties` must have a `required` array that includes
+ * every key of `properties`.
+ */
+function collectViolations(node: unknown, nodePath: string, out: Violation[]): void {
+    if (!isPlainObject(node)) return;
+
+    const hasProperties = isPlainObject(node.properties);
+    const isObjectNode = nodeTypes(node).includes('object') || hasProperties;
+
+    if (isObjectNode && hasProperties) {
+        const propKeys = Object.keys(node.properties as Record<string, unknown>);
+        const required = node.required;
+        if (!Array.isArray(required)) {
+            out.push({
+                path: nodePath,
+                message: `'required' is missing (must be an array including every key in properties: [${propKeys.join(', ')}])`,
+            });
+        } else {
+            const missing = propKeys.filter((k) => !required.includes(k));
+            if (missing.length > 0) {
+                out.push({
+                    path: nodePath,
+                    message: `'required' is missing key(s): ${missing.join(', ')} — optional fields must be required with a nullable type (e.g. type: ['string', 'null'])`,
+                });
+            }
+            const unknown = required.filter((k) => !propKeys.includes(k as string));
+            if (unknown.length > 0) {
+                out.push({
+                    path: nodePath,
+                    message: `'required' lists key(s) not present in properties: ${unknown.join(', ')}`,
+                });
+            }
+        }
+    }
+
+    // Recurse: nested object properties
+    if (hasProperties) {
+        for (const [key, child] of Object.entries(node.properties as Record<string, unknown>)) {
+            collectViolations(child, `${nodePath}.properties.${key}`, out);
+        }
+    }
+
+    // Recurse: array items (single schema or tuple form)
+    if (isPlainObject(node.items)) {
+        collectViolations(node.items, `${nodePath}.items`, out);
+    } else if (Array.isArray(node.items)) {
+        node.items.forEach((child, i) => collectViolations(child, `${nodePath}.items[${i}]`, out));
+    }
+
+    // Recurse: composition keywords
+    for (const keyword of ['anyOf', 'oneOf', 'allOf'] as const) {
+        const branches = node[keyword];
+        if (Array.isArray(branches)) {
+            branches.forEach((child, i) =>
+                collectViolations(child, `${nodePath}.${keyword}[${i}]`, out));
+        }
+    }
+
+    // Recurse: $defs / definitions
+    for (const keyword of ['$defs', 'definitions'] as const) {
+        const defs = node[keyword];
+        if (isPlainObject(defs)) {
+            for (const [key, child] of Object.entries(defs)) {
+                collectViolations(child, `${nodePath}.${keyword}.${key}`, out);
+            }
+        }
+    }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('structured-output schemas are valid under OpenAI strict mode', () => {
+    it('registry has no duplicate schema names', () => {
+        const names = ALL_SCHEMAS.map((s) => s.name);
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    it.each(ALL_SCHEMAS.map((s) => [s.name, s] as const))(
+        "'%s': required includes every key in properties (recursively)",
+        (_name, schemaDef) => {
+            expect(schemaDef.strict).toBe(true);
+            expect(isPlainObject(schemaDef.schema)).toBe(true);
+
+            const violations: Violation[] = [];
+            collectViolations(schemaDef.schema, 'schema', violations);
+
+            const report = violations
+                .map((v) => `  at ${v.path}: ${v.message}`)
+                .join('\n');
+            expect(
+                violations.length === 0
+                    ? ''
+                    : `Schema '${schemaDef.name}' violates strict mode:\n${report}`,
+            ).toBe('');
+        },
+    );
+});
+
+describe('schema registry completeness', () => {
+    it('every `strict: true` structured-output schema in src/ is registered in this test', () => {
+        const srcRoot = path.resolve(__dirname, '../../..');
+        const matches: string[] = [];
+
+        const walk = (dir: string): void => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+                    walk(full);
+                } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.(ts|tsx)$/.test(entry.name)) {
+                    const source = fs.readFileSync(full, 'utf8');
+                    const count = (source.match(/\bstrict:\s*true\b/g) ?? []).length;
+                    for (let i = 0; i < count; i++) matches.push(full);
+                }
+            }
+        };
+        walk(srcRoot);
+
+        // One `strict: true` per schema object. If this fails because you added
+        // a new structured-output schema, export it from its module and add it
+        // to ALL_SCHEMAS above so the strict-mode invariant covers it.
+        expect(matches.length).toBe(ALL_SCHEMAS.length);
+    });
+});

--- a/src/lib/ai/ambiguous-serving-estimator.ts
+++ b/src/lib/ai/ambiguous-serving-estimator.ts
@@ -113,7 +113,7 @@ export interface AmbiguousServingResult {
     error?: string;
 }
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
     name: 'ambiguous_serving_estimate',
     schema: {
         type: 'object',
@@ -499,7 +499,7 @@ export interface BatchedProduceSizeResult {
     error?: string;
 }
 
-const PRODUCE_SIZE_RESPONSE_SCHEMA = {
+export const PRODUCE_SIZE_RESPONSE_SCHEMA = {
     name: 'produce_size_estimates',
     schema: {
         type: 'object',

--- a/src/lib/ai/serving-estimator.ts
+++ b/src/lib/ai/serving-estimator.ts
@@ -74,7 +74,7 @@ export type AiServingResult =
     raw?: unknown;
   };
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
   name: 'fatsecret_serving_suggestion',
   schema: {
     type: 'object',

--- a/src/lib/ai/simple-serving-estimator.ts
+++ b/src/lib/ai/simple-serving-estimator.ts
@@ -31,7 +31,7 @@ export interface SimpleServingEstimateResult {
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? '';
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
     name: 'simple_serving_estimate',
     schema: {
         type: 'object',

--- a/src/lib/mapping/ai-batch-normalize.ts
+++ b/src/lib/mapping/ai-batch-normalize.ts
@@ -38,7 +38,7 @@ export interface BatchNormalizeResult {
 // Response Schema
 // ============================================================
 
-const BATCH_RESPONSE_SCHEMA = {
+export const BATCH_RESPONSE_SCHEMA = {
     name: 'batch_fatsecret_normalize',
     schema: {
         type: 'object',

--- a/src/lib/mapping/ai-normalize.ts
+++ b/src/lib/mapping/ai-normalize.ts
@@ -33,7 +33,7 @@ type AiNormalizeError = {
 
 export type AiNormalizeResult = AiNormalizeSuccess | AiNormalizeError;
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
   name: 'fatsecret_normalize',
   schema: {
     type: 'object',

--- a/src/lib/mapping/ai-nutrition-backfill.ts
+++ b/src/lib/mapping/ai-nutrition-backfill.ts
@@ -88,7 +88,7 @@ export function getNutritionBatchCount(): number {
 // JSON Schema for LLM response
 // ============================================================
 
-const NUTRITION_RESPONSE_SCHEMA = {
+export const NUTRITION_RESPONSE_SCHEMA = {
     name: 'ai_nutrition_estimate',
     strict: true,
     schema: {

--- a/src/lib/mapping/ai-parse.ts
+++ b/src/lib/mapping/ai-parse.ts
@@ -40,7 +40,12 @@ export type AiParseResult = AiParseSuccess | AiParseError;
 // Schema
 // ============================================================
 
-const RESPONSE_SCHEMA = {
+// OpenAI/Azure strict mode requires `required` to list EVERY key in
+// `properties`; optionality is expressed via the nullable type union on
+// `notes` (['string', 'null']), not by omitting it from `required`.
+// (Omitting it caused an HTTP 400 on the primary model and a silent
+// fallback to the secondary model on every call.)
+export const RESPONSE_SCHEMA = {
     name: 'ingredient_parse',
     schema: {
         type: 'object',
@@ -53,7 +58,7 @@ const RESPONSE_SCHEMA = {
             confidence: { type: 'number' },
             error: { type: ['string', 'null'] },
         },
-        required: ['qty', 'unit', 'name', 'confidence', 'error'],
+        required: ['qty', 'unit', 'name', 'notes', 'confidence', 'error'],
     },
     strict: true,
 };

--- a/src/lib/mapping/ai-rerank.ts
+++ b/src/lib/mapping/ai-rerank.ts
@@ -26,7 +26,7 @@ type AiPick =
     reason: string;
   };
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
   name: 'fatsecret_candidate_pick',
   schema: {
     type: 'object',

--- a/src/lib/mapping/ai-search-refine.ts
+++ b/src/lib/mapping/ai-search-refine.ts
@@ -7,7 +7,7 @@ import type { FatSecretFoodSummary } from './client';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? '';
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
     name: 'fatsecret_refine_search',
     schema: {
         type: 'object',

--- a/src/lib/mapping/ai-simplify.ts
+++ b/src/lib/mapping/ai-simplify.ts
@@ -42,7 +42,7 @@ const SYSTEM_PROMPT = [
     '6. OUTPUT JSON: { simplified: string, rationale: string }',
 ].join('\n');
 
-const JSON_SCHEMA = {
+export const JSON_SCHEMA = {
     name: 'simplify_ingredient',
     schema: {
         type: 'object',

--- a/src/lib/mapping/ai-synonym-generator.ts
+++ b/src/lib/mapping/ai-synonym-generator.ts
@@ -113,7 +113,7 @@ for (const [british, americans] of Object.entries(BRITISH_TO_AMERICAN)) {
 // Schema & Prompts (Very Conservative)
 // ============================================================
 
-const RESPONSE_SCHEMA = {
+export const RESPONSE_SCHEMA = {
     name: 'synonym_generation',
     schema: {
         type: 'object',

--- a/src/lib/mapping/ai-validation.ts
+++ b/src/lib/mapping/ai-validation.ts
@@ -25,7 +25,7 @@ export type AIValidationResult = {
     };
 };
 
-const VALIDATION_SCHEMA = {
+export const VALIDATION_SCHEMA = {
     name: 'ingredient_validation',
     strict: true,
     schema: {

--- a/src/lib/nlp/ai-segmenter.ts
+++ b/src/lib/nlp/ai-segmenter.ts
@@ -63,7 +63,7 @@ export function isSegmentedItemArray(value: unknown): value is SegmentedItem[] {
   });
 }
 
-const NLP_SPLIT_SCHEMA = {
+export const NLP_SPLIT_SCHEMA = {
   name: 'nlp_split',
   schema: {
     type: 'object',


### PR DESCRIPTION
## Problem

Captured live from production-equivalent server logs — every call using the `ingredient_parse` structured-output schema fails on the primary model with:

```
HTTP 400 ... "Invalid schema for response_format 'ingredient_parse': In context=(),
'required' is required to be supplied and to be an array including every key in
properties. Missing 'notes'."
```

Both OpenAI and Azure backends reject the schema, so the structured client silently falls back to the secondary model (gemini-2.5-flash) on EVERY `aiParseIngredient` call — paying a failed round-trip in latency and never using the intended primary model.

Root cause: OpenAI strict mode requires `required` to list **every** key in `properties`. The schema had `notes` in `properties` but not in `required` — optionality in strict mode must be expressed via a nullable type union (`type: ["string", "null"]`), never by omitting the key from `required`.

## Fix

- **`src/lib/mapping/ai-parse.ts`** — added `notes` to `required`. Its type was already `['string', 'null']`, and the consumer already coerces non-string `notes` to `undefined` (`typeof parsed.notes === 'string' ? parsed.notes : undefined`), so `null` is handled and behavior is unchanged.

## Audit of all other structured-output schemas

All 13 other `strict: true` schemas in `src/` were audited (top-level, nested objects, and array items) — **every one already satisfies the invariant**:

| Schema | File | Verdict |
|---|---|---|
| `ingredient_parse` | `src/lib/mapping/ai-parse.ts` | **fixed** (missing `notes`) |
| `simplify_ingredient` | `src/lib/mapping/ai-simplify.ts` | valid |
| `fatsecret_normalize` | `src/lib/mapping/ai-normalize.ts` | valid (incl. nested `nutrition_estimate`) |
| `batch_fatsecret_normalize` | `src/lib/mapping/ai-batch-normalize.ts` | valid (incl. array items) |
| `fatsecret_candidate_pick` | `src/lib/mapping/ai-rerank.ts` | valid |
| `synonym_generation` | `src/lib/mapping/ai-synonym-generator.ts` | valid |
| `fatsecret_refine_search` | `src/lib/mapping/ai-search-refine.ts` | valid |
| `ai_nutrition_estimate` | `src/lib/mapping/ai-nutrition-backfill.ts` | valid (16/16 keys) |
| `ingredient_validation` | `src/lib/mapping/ai-validation.ts` | valid |
| `fatsecret_serving_suggestion` | `src/lib/ai/serving-estimator.ts` | valid |
| `ambiguous_serving_estimate` | `src/lib/ai/ambiguous-serving-estimator.ts` | valid |
| `produce_size_estimates` | `src/lib/ai/ambiguous-serving-estimator.ts` | valid |
| `simple_serving_estimate` | `src/lib/ai/simple-serving-estimator.ts` | valid |
| `nlp_split` | `src/lib/nlp/ai-segmenter.ts` | valid (untouched — other feature) |

## Recurrence prevention

New test `src/lib/ai/__tests__/structured-schema-invariant.test.ts`:

- Recursively walks every schema (nested `properties`, `items`, `anyOf`/`oneOf`/`allOf`, `$defs`) and asserts `required` exists and includes every key of `properties` (and no unknown keys).
- Registry-completeness check: counts `strict: true` schema declarations under `src/` and fails if a new schema is added without registering it in the test.
- Verified the test catches the original bug: reverting the one-line fix makes it fail with `at schema: 'required' is missing key(s): notes`.

Schema consts are now exported from their modules so the test can import them — export-only refactors, no behavioral changes to calling code.

## Verification

- `npm run typecheck` — clean
- `npm run lint:ci` — 0 errors, 434 warnings (under the 700 cap)
- `npm run build` — success
- `npx jest` — 68/68 suites, 955 passed, 1 skipped, 0 failures

Live-testing the LLM call isn't possible from this environment; the invariant test plus the captured 400 error message is the evidence. The 400s should disappear from server logs post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu