### PR TITLE
fix(cache): read/write key symmetry + malformed-key cleanup script

### DIFF
--- a/scripts/fix-malformed-cache-keys.ts
+++ b/scripts/fix-malformed-cache-keys.ts
@@ -1,0 +1,181 @@
+/**
+ * fix-malformed-cache-keys.ts — find (and optionally delete) FoodMapping rows
+ * whose normalizedForm was mangled by the pre-Track-1c write path.
+ *
+ * The defect (fixed in src/lib/mapping/cache-key.ts deriveMappingCacheKey):
+ * the save site prepended the detected brand with a substring includes()
+ * guard that singularization defeats — querying "oikos" wrote "oiko oiko"
+ * while reads derived "oiko" — and composed keys over already-doubled
+ * normalized names ("canned canned kidney beans"). canonicalizeCacheKey
+ * sorts + singularizes but never dedupes, so every such key is stored with
+ * the same token twice. These rows are DEAD: no read path can ever derive
+ * their key, so the row occupies the table while its query re-runs the full
+ * pipeline forever.
+ *
+ * Detection (two classes, both reported):
+ *   1. adjacent-dup — the stored key literally repeats a token back-to-back
+ *      ("oiko oiko", "bean canned canned kidney").
+ *   2. stem-dup — after re-canonicalizing the stored key (sort + singularize)
+ *      two tokens collapse onto the same stem ("oiko oikos", legacy unsorted
+ *      "oikos greek oiko yogurt"). Doubled brand prefixes whose copies differ
+ *      only by plurality land here.
+ *   Rows whose duplicated stem matches a known brand are labeled
+ *   doubled-brand-prefix for the report.
+ *
+ * Deletion is safe: the next query for that food re-resolves through the
+ * fixed pipeline and re-caches under the correct symmetric key.
+ *
+ * Usage:
+ *   npx ts-node scripts/fix-malformed-cache-keys.ts            # dry-run (default): report only
+ *   npx ts-node scripts/fix-malformed-cache-keys.ts --dry-run  # same, explicit
+ *   npx ts-node scripts/fix-malformed-cache-keys.ts --apply    # DELETE the malformed rows
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { canonicalizeCacheKey } from '../src/lib/mapping/normalization-rules';
+import { collapseAdjacentDuplicateTokens } from '../src/lib/mapping/cache-key';
+import { isBrandedIngredient } from '../src/lib/mapping/brand-detector';
+
+const prisma = new PrismaClient();
+
+const APPLY = process.argv.includes('--apply');
+
+interface Finding {
+    normalizedForm: string;
+    foodId: string;
+    foodName: string;
+    usedCount: number;
+    validatedBy: string;
+    reason: string;
+}
+
+function tokens(key: string): string[] {
+    return key.split(/\s+/).filter(t => t.length > 0);
+}
+
+/** Tokens that appear back-to-back identically in the given key. */
+function adjacentDuplicates(key: string): string[] {
+    const ts = tokens(key);
+    const dups: string[] = [];
+    for (let i = 1; i < ts.length; i++) {
+        if (ts[i] === ts[i - 1] && !dups.includes(ts[i])) dups.push(ts[i]);
+    }
+    return dups;
+}
+
+/** True when the duplicated stem looks like a brand (so the row is the
+ *  doubled-brand-prefix class). Tries the stem and its plural form since
+ *  the brand list stores plural spellings ("oikos") while stored keys carry
+ *  the singularized stem ("oiko"). */
+function stemLooksLikeBrand(stem: string): boolean {
+    return isBrandedIngredient(stem) || isBrandedIngredient(`${stem}s`);
+}
+
+function classify(row: { normalizedForm: string }): string | null {
+    const raw = row.normalizedForm;
+    const reasons: string[] = [];
+
+    const rawDups = adjacentDuplicates(raw);
+    for (const d of rawDups) {
+        reasons.push(
+            stemLooksLikeBrand(d)
+                ? `doubled-brand-prefix "${d}" (adjacent)`
+                : `adjacent duplicate token "${d}"`
+        );
+    }
+
+    // Stem-space check: re-canonicalize (sort + singularize) and look for
+    // adjacent duplicates there — catches plural/singular double-brands and
+    // legacy unsorted keys whose duplicates aren't literally adjacent.
+    const canonical = canonicalizeCacheKey(raw);
+    const stemDups = adjacentDuplicates(canonical).filter(d => !rawDups.includes(d));
+    for (const d of stemDups) {
+        reasons.push(
+            stemLooksLikeBrand(d)
+                ? `doubled-brand-prefix "${d}" (stem-space)`
+                : `duplicate token stem "${d}" (stem-space)`
+        );
+    }
+
+    // Defensive: canonical collapse changing the key without a dup being
+    // named above cannot happen (collapse only removes adjacent dups), but
+    // keep the invariant explicit.
+    if (reasons.length === 0 && collapseAdjacentDuplicateTokens(canonical) !== canonical) {
+        reasons.push('canonical collapse changed key');
+    }
+
+    return reasons.length > 0 ? reasons.join('; ') : null;
+}
+
+async function main() {
+    console.log(`fix-malformed-cache-keys — mode: ${APPLY ? 'APPLY (deleting)' : 'dry-run (report only)'}`);
+
+    const rows = await prisma.foodMapping.findMany({
+        select: {
+            normalizedForm: true,
+            foodName: true,
+            offBarcode: true,
+            fdcId: true,
+            source: true,
+            usedCount: true,
+            validatedBy: true,
+        },
+    });
+    console.log(`scanned ${rows.length} FoodMapping rows`);
+
+    const findings: Finding[] = [];
+    for (const row of rows) {
+        const reason = classify(row);
+        if (!reason) continue;
+        const foodId = row.offBarcode
+            ? `off_${row.offBarcode}`
+            : row.fdcId != null
+                ? `fdc_${row.fdcId}`
+                : `${row.source}:${row.foodName}`;
+        findings.push({
+            normalizedForm: row.normalizedForm,
+            foodId,
+            foodName: row.foodName,
+            usedCount: row.usedCount,
+            validatedBy: row.validatedBy,
+            reason,
+        });
+    }
+
+    findings.sort((a, b) => b.usedCount - a.usedCount);
+
+    console.log(`\nmalformed rows: ${findings.length}`);
+    for (const f of findings) {
+        console.log(
+            `  key="${f.normalizedForm}"  foodId=${f.foodId}  usedCount=${f.usedCount}  ` +
+            `validatedBy=${f.validatedBy}  food="${f.foodName}"  wrong: ${f.reason}`
+        );
+    }
+
+    const brandDoubled = findings.filter(f => f.reason.includes('doubled-brand-prefix')).length;
+    console.log(`\nsummary: ${findings.length} malformed (${brandDoubled} doubled-brand-prefix, ` +
+        `${findings.length - brandDoubled} duplicate-token), ` +
+        `${findings.filter(f => f.validatedBy === 'human-triage').length} human-triage`);
+
+    if (!APPLY) {
+        console.log('\ndry-run: nothing deleted. Re-run with --apply to delete these rows.');
+        return;
+    }
+
+    if (findings.length === 0) {
+        console.log('nothing to delete.');
+        return;
+    }
+
+    const { count } = await prisma.foodMapping.deleteMany({
+        where: { normalizedForm: { in: findings.map(f => f.normalizedForm) } },
+    });
+    console.log(`\ndeleted ${count} rows. Next queries re-resolve and re-cache under symmetric keys.`);
+}
+
+main()
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/scripts/fix-malformed-cache-keys.ts
+++ b/scripts/fix-malformed-cache-keys.ts
@@ -33,7 +33,7 @@
 import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { canonicalizeCacheKey } from '../src/lib/mapping/normalization-rules';
-import { collapseAdjacentDuplicateTokens } from '../src/lib/mapping/cache-key';
+import { collapseAdjacentDuplicateTokens, isMalformedCacheKey } from '../src/lib/mapping/cache-key';
 import { isBrandedIngredient } from '../src/lib/mapping/brand-detector';
 
 const prisma = new PrismaClient();
@@ -73,6 +73,10 @@ function stemLooksLikeBrand(stem: string): boolean {
 
 function classify(row: { normalizedForm: string }): string | null {
     const raw = row.normalizedForm;
+    // Gate on the SHARED predicate — the same isMalformedCacheKey that the
+    // read path's legacy-key fallback uses to keep zombie rows dead. The
+    // reason strings below are reporting detail on top of it.
+    if (!isMalformedCacheKey(raw)) return null;
     const reasons: string[] = [];
 
     const rawDups = adjacentDuplicates(raw);

--- a/src/lib/mapping/__tests__/cache-key-symmetry.test.ts
+++ b/src/lib/mapping/__tests__/cache-key-symmetry.test.ts
@@ -1,0 +1,274 @@
+import { deriveMappingCacheKey, collapseAdjacentDuplicateTokens, BrandKeyInput } from '../cache-key';
+import { canonicalizeCacheKey } from '../normalization-rules';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+/**
+ * Round-trip property tests for cache-key read/write symmetry (Track 1c).
+ *
+ * The defect: the brand-prefix step used to live ONLY at the save site in
+ * map-ingredient-with-fallback.ts, guarded by a substring includes() that
+ * singularization defeats — querying "oikos" wrote key "oiko oiko" while
+ * reads derived "oiko" (dead row, permanent cache miss). Live FoodMapping
+ * also carries dup-token keys of the "canned canned kidney beans" /
+ * "dry rolled rolled oats" class from key composition over already-doubled
+ * normalized names.
+ *
+ * deriveMappingCacheKey is now THE single key function for both lookups and
+ * the save. These tests pin the properties that make that safe:
+ *   1. write key === read key for the same (normalizedName, parsed, brand)
+ *   2. the key survives saveValidatedMapping's re-canonicalization unchanged
+ *   3. no key ever contains the same token twice in a row
+ *   4. idempotence: deriving from a line equal to a saved key yields that key
+ */
+
+function parsed(overrides: Partial<ParsedIngredient>): ParsedIngredient {
+    return {
+        qty: 1,
+        multiplier: 1,
+        name: '',
+        ...overrides,
+    };
+}
+
+const NO_BRAND: BrandKeyInput = { isBranded: false, matchedBrand: null };
+
+interface MatrixCase {
+    label: string;
+    normalizedName: string;
+    parsed: ParsedIngredient | null;
+    brand: BrandKeyInput;
+    expectedKey: string;
+}
+
+// The write/read matrix: plain, modifier-carrying, branded (brand in name and
+// brand injected generically), brand-only, plural brands, doubled-token input.
+const MATRIX: MatrixCase[] = [
+    {
+        label: 'plain: "kidney beans"',
+        normalizedName: 'kidney beans',
+        parsed: parsed({ name: 'kidney beans' }),
+        brand: NO_BRAND,
+        expectedKey: 'bean kidney',
+    },
+    {
+        label: 'modifier-carrying: "canned kidney beans"',
+        normalizedName: 'canned kidney beans',
+        parsed: parsed({ name: 'canned kidney beans' }),
+        brand: NO_BRAND,
+        expectedKey: 'bean canned kidney',
+    },
+    {
+        label: 'modifier-carrying: "dry rolled oats"',
+        normalizedName: 'dry rolled oats',
+        parsed: parsed({ name: 'dry rolled oats' }),
+        brand: NO_BRAND,
+        expectedKey: 'dry oat rolled',
+    },
+    {
+        label: 'doubled-modifier input: "canned canned kidney beans" (AI-normalize class)',
+        normalizedName: 'canned canned kidney beans',
+        parsed: parsed({ name: 'canned canned kidney beans' }),
+        brand: NO_BRAND,
+        expectedKey: 'bean canned kidney',
+    },
+    {
+        label: 'doubled-modifier input: "dry rolled rolled oats"',
+        normalizedName: 'dry rolled rolled oats',
+        parsed: parsed({ name: 'dry rolled rolled oats' }),
+        brand: NO_BRAND,
+        expectedKey: 'dry oat rolled',
+    },
+    {
+        label: 'branded, brand in name: "oikos greek yogurt"',
+        normalizedName: 'oikos greek yogurt',
+        parsed: parsed({ name: 'oikos greek yogurt' }),
+        brand: { isBranded: true, matchedBrand: 'Oikos' },
+        expectedKey: 'greek oiko yogurt',
+    },
+    {
+        label: 'brand-only: "oikos" (the historical "oiko oiko" trigger)',
+        normalizedName: 'oikos',
+        parsed: parsed({ name: 'oikos' }),
+        brand: { isBranded: true, matchedBrand: 'Oikos' },
+        expectedKey: 'oiko',
+    },
+    {
+        label: 'branded, brand in name: "heinz tomato ketchup"',
+        normalizedName: 'heinz tomato ketchup',
+        parsed: parsed({ name: 'heinz tomato ketchup' }),
+        brand: { isBranded: true, matchedBrand: 'Heinz' },
+        expectedKey: 'heinz ketchup tomato',
+    },
+    {
+        label: 'branded, generic name (AI stripped brand): "greek yogurt" + brand oikos → prefix fires',
+        normalizedName: 'greek yogurt',
+        parsed: parsed({ name: 'greek yogurt' }),
+        brand: { isBranded: true, matchedBrand: 'Oikos' },
+        expectedKey: 'greek oiko yogurt',
+    },
+    {
+        label: 'plural brand token in name: "siggis yogurt"',
+        normalizedName: 'siggis yogurt',
+        parsed: parsed({ name: 'siggis yogurt' }),
+        brand: { isBranded: true, matchedBrand: 'Siggis' },
+        expectedKey: 'siggi yogurt',
+    },
+    {
+        label: 'brand-only, plural brand: "siggis"',
+        normalizedName: 'siggis',
+        parsed: parsed({ name: 'siggis' }),
+        brand: { isBranded: true, matchedBrand: 'Siggis' },
+        expectedKey: 'siggi',
+    },
+    {
+        label: 'multi-word brand, generic name: "protein bar" + brand "met rx"',
+        normalizedName: 'protein bar',
+        parsed: parsed({ name: 'protein bar' }),
+        brand: { isBranded: true, matchedBrand: 'Met Rx' },
+        expectedKey: 'bar met protein rx',
+    },
+];
+
+function hasAdjacentDuplicateTokens(key: string): boolean {
+    const tokens = key.split(/\s+/).filter(t => t.length > 0);
+    return tokens.some((t, i) => i > 0 && tokens[i - 1] === t);
+}
+
+describe('deriveMappingCacheKey — read/write symmetry', () => {
+    describe.each(MATRIX)('$label', (c) => {
+        it('write key === read key', () => {
+            // The save site and both lookup sites call the identical function
+            // with the identical request-stable inputs.
+            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            expect(writeKey).toBe(c.expectedKey);
+            expect(readKey).toBe(writeKey);
+        });
+
+        it('survives the save-side re-canonicalization unchanged', () => {
+            // saveValidatedMapping does normalizedForm = canonicalizeCacheKey(canonicalBase);
+            // the stored key must equal the derived key or writes drift again.
+            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            expect(canonicalizeCacheKey(writeKey)).toBe(writeKey);
+        });
+
+        it('survives the read-side re-canonicalization unchanged', () => {
+            // getValidatedMappingByNormalizedName does canonicalizeCacheKey(normalizedName)
+            // on the key it is handed before the exact-match lookup.
+            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            expect(canonicalizeCacheKey(readKey)).toBe(readKey);
+        });
+
+        it('never contains the same token twice in a row', () => {
+            const key = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            expect(hasAdjacentDuplicateTokens(key)).toBe(false);
+        });
+
+        it('is idempotent: deriving from the saved key yields the same key', () => {
+            // A later query whose normalized name equals the stored key (e.g.
+            // the row's own normalizedForm fed back through the pipeline) must
+            // derive the identical key — this is what makes saved rows
+            // permanently reachable.
+            const savedKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            expect(deriveMappingCacheKey(savedKey, null, c.brand)).toBe(savedKey);
+            // And stability under repeated derivation with the original parse:
+            expect(deriveMappingCacheKey(savedKey, c.parsed, c.brand)).toBe(savedKey);
+        });
+    });
+
+    describe('the historical includes() defeat (oikos → "oiko oiko")', () => {
+        it('brand-only query no longer doubles the brand token', () => {
+            // Old write path: cacheKey = "oiko"; "oiko".includes("oikos") === false
+            // → prepend → canonicalize("oikos oiko") = "oiko oiko". Read path
+            // derived "oiko" → row dead forever.
+            const key = deriveMappingCacheKey('oikos', parsed({ name: 'oikos' }), {
+                isBranded: true,
+                matchedBrand: 'oikos',
+            });
+            expect(key).toBe('oiko');
+            expect(key).not.toBe('oiko oiko');
+        });
+
+        it('brand stem-present-in-key skips the prefix (token stems, not substrings)', () => {
+            const key = deriveMappingCacheKey(
+                'oikos greek yogurt',
+                parsed({ name: 'oikos greek yogurt' }),
+                { isBranded: true, matchedBrand: 'oikos' },
+            );
+            expect(key).toBe('greek oiko yogurt');
+            expect(key.split(' ').filter(t => t === 'oiko')).toHaveLength(1);
+        });
+
+        it('substring-only overlap does NOT count as brand presence', () => {
+            // Brand "eat" is a substring of the token "meat" — the old
+            // includes() guard would wrongly treat the brand as present and
+            // skip the prefix. Stem-token comparison prefixes it.
+            const key = deriveMappingCacheKey('meat snack', parsed({ name: 'meat snack' }), {
+                isBranded: true,
+                matchedBrand: 'eat',
+            });
+            expect(key).toBe('eat meat snack');
+        });
+    });
+
+    describe('brand input edge cases', () => {
+        it('isBranded=false ignores matchedBrand entirely', () => {
+            const key = deriveMappingCacheKey('greek yogurt', parsed({ name: 'greek yogurt' }), {
+                isBranded: false,
+                matchedBrand: 'oikos',
+            });
+            expect(key).toBe('greek yogurt');
+        });
+
+        it('isBranded=true with no matchedBrand adds nothing', () => {
+            const key = deriveMappingCacheKey('greek yogurt', parsed({ name: 'greek yogurt' }), {
+                isBranded: true,
+                matchedBrand: null,
+            });
+            expect(key).toBe('greek yogurt');
+        });
+
+        it('null/undefined brandDetection behaves like unbranded (legacy callers)', () => {
+            expect(deriveMappingCacheKey('kidney beans', null, null)).toBe('bean kidney');
+            expect(deriveMappingCacheKey('kidney beans', null, undefined)).toBe('bean kidney');
+        });
+
+        it('partial multi-word-brand presence skips the prefix (no half-doubled brands)', () => {
+            // Key already carries "rx"; prepending "met rx" would double it.
+            const key = deriveMappingCacheKey('met rx protein bar', parsed({ name: 'met rx protein bar' }), {
+                isBranded: true,
+                matchedBrand: 'met rx',
+            });
+            expect(key).toBe('bar met protein rx');
+            expect(hasAdjacentDuplicateTokens(key)).toBe(false);
+        });
+    });
+
+    describe('identity discriminators still compose symmetrically (PR D pt3 C1)', () => {
+        it('"egg" + unitHint "white" round-trips with a brand', () => {
+            const p = parsed({ name: 'egg', unitHint: 'white' });
+            const brand = { isBranded: true, matchedBrand: 'vital farms' };
+            const writeKey = deriveMappingCacheKey('egg', p, brand);
+            expect(writeKey).toBe(canonicalizeCacheKey('vital farms egg white'));
+            expect(deriveMappingCacheKey(writeKey, null, brand)).toBe(writeKey);
+            expect(hasAdjacentDuplicateTokens(writeKey)).toBe(false);
+        });
+    });
+});
+
+describe('collapseAdjacentDuplicateTokens', () => {
+    it('collapses runs of identical adjacent tokens', () => {
+        expect(collapseAdjacentDuplicateTokens('oiko oiko')).toBe('oiko');
+        expect(collapseAdjacentDuplicateTokens('bean canned canned kidney')).toBe('bean canned kidney');
+        expect(collapseAdjacentDuplicateTokens('a a a b b c')).toBe('a b c');
+    });
+
+    it('leaves clean keys untouched', () => {
+        expect(collapseAdjacentDuplicateTokens('bean canned kidney')).toBe('bean canned kidney');
+        expect(collapseAdjacentDuplicateTokens('')).toBe('');
+    });
+
+    it('does not collapse non-adjacent duplicates (canonical keys are sorted, so this cannot occur post-canonicalize)', () => {
+        expect(collapseAdjacentDuplicateTokens('oiko greek oiko')).toBe('oiko greek oiko');
+    });
+});

--- a/src/lib/mapping/__tests__/cache-key-symmetry.test.ts
+++ b/src/lib/mapping/__tests__/cache-key-symmetry.test.ts
@@ -1,5 +1,11 @@
-import { deriveMappingCacheKey, collapseAdjacentDuplicateTokens, BrandKeyInput } from '../cache-key';
+import {
+    deriveMappingCacheKey,
+    collapseAdjacentDuplicateTokens,
+    isMalformedCacheKey,
+    BrandKeyInput,
+} from '../cache-key';
 import { canonicalizeCacheKey } from '../normalization-rules';
+import { detectBrandInQuery } from '../brand-detector';
 import type { ParsedIngredient } from '../../parse/ingredient-line';
 
 /**
@@ -13,12 +19,23 @@ import type { ParsedIngredient } from '../../parse/ingredient-line';
  * "dry rolled rolled oats" class from key composition over already-doubled
  * normalized names.
  *
- * deriveMappingCacheKey is now THE single key function for both lookups and
- * the save. These tests pin the properties that make that safe:
- *   1. write key === read key for the same (normalizedName, parsed, brand)
+ * Regression (golden n-mq-30 "bell pepper"): the brand lexicon carries a bare
+ * "bell" entry (Bell & Evans), so detectBrandInQuery("bell pepper") returns
+ * matchedBrand "bell". Once AI normalize rewrote the name to "capsicum", an
+ * UNCONDITIONAL brand prefix produced read/write key "bell capsicum" and
+ * orphaned the live human-triage "capsicum" row. The prefix is therefore
+ * gated on hasDecisiveBrandContext — the same "did the query really name a
+ * brand" definition the brand-mismatch save gate and rerank already use:
+ * multi-word brands count only as their full detected phrase; single-word
+ * brands only next to a product-form token ("ghost whey", "ryse shake").
+ *
+ * deriveMappingCacheKey is THE single key function for both lookups and the
+ * save. These tests pin the properties that make that safe:
+ *   1. write key === read key for the same (normalizedName, parsed, brand, rawLine)
  *   2. the key survives saveValidatedMapping's re-canonicalization unchanged
  *   3. no key ever contains the same token twice in a row
  *   4. idempotence: deriving from a line equal to a saved key yields that key
+ *   5. non-decisive brand hits NEVER alter the key
  */
 
 function parsed(overrides: Partial<ParsedIngredient>): ParsedIngredient {
@@ -37,17 +54,20 @@ interface MatrixCase {
     normalizedName: string;
     parsed: ParsedIngredient | null;
     brand: BrandKeyInput;
+    rawLine: string;
     expectedKey: string;
 }
 
-// The write/read matrix: plain, modifier-carrying, branded (brand in name and
-// brand injected generically), brand-only, plural brands, doubled-token input.
+// The write/read matrix: plain, modifier-carrying, branded (decisive and
+// non-decisive), brand-only, plural brands, doubled-token input, and the
+// n-mq-30 false-positive class.
 const MATRIX: MatrixCase[] = [
     {
         label: 'plain: "kidney beans"',
         normalizedName: 'kidney beans',
         parsed: parsed({ name: 'kidney beans' }),
         brand: NO_BRAND,
+        rawLine: 'kidney beans',
         expectedKey: 'bean kidney',
     },
     {
@@ -55,6 +75,7 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'canned kidney beans',
         parsed: parsed({ name: 'canned kidney beans' }),
         brand: NO_BRAND,
+        rawLine: 'canned kidney beans',
         expectedKey: 'bean canned kidney',
     },
     {
@@ -62,6 +83,7 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'dry rolled oats',
         parsed: parsed({ name: 'dry rolled oats' }),
         brand: NO_BRAND,
+        rawLine: 'dry rolled oats',
         expectedKey: 'dry oat rolled',
     },
     {
@@ -69,6 +91,7 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'canned canned kidney beans',
         parsed: parsed({ name: 'canned canned kidney beans' }),
         brand: NO_BRAND,
+        rawLine: 'canned kidney beans',
         expectedKey: 'bean canned kidney',
     },
     {
@@ -76,13 +99,63 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'dry rolled rolled oats',
         parsed: parsed({ name: 'dry rolled rolled oats' }),
         brand: NO_BRAND,
+        rawLine: 'dry rolled oats',
         expectedKey: 'dry oat rolled',
     },
     {
-        label: 'branded, brand in name: "oikos greek yogurt"',
+        label: 'n-mq-30: "bell pepper" with false-positive lexicon brand "bell" — key untouched',
+        normalizedName: 'bell pepper',
+        parsed: parsed({ name: 'bell pepper' }),
+        brand: { isBranded: true, matchedBrand: 'bell' },
+        rawLine: 'bell pepper',
+        expectedKey: 'bell pepper',
+    },
+    {
+        label: 'n-mq-30 regression: AI-rewritten "capsicum" + false-positive brand "bell" — NO prefix',
+        normalizedName: 'capsicum',
+        parsed: parsed({ name: 'bell pepper' }),
+        brand: { isBranded: true, matchedBrand: 'bell' },
+        rawLine: 'bell pepper',
+        expectedKey: 'capsicum',
+    },
+    {
+        label: '"dr pepper" — genuine multi-word brand, tokens already in name',
+        normalizedName: 'dr pepper',
+        parsed: parsed({ name: 'dr pepper' }),
+        brand: { isBranded: true, matchedBrand: 'dr pepper' },
+        rawLine: 'dr pepper',
+        expectedKey: 'dr pepper',
+    },
+    {
+        label: '"dr pepper" AI-stripped to "soda" — multi-word brand decisive, prefix fires',
+        normalizedName: 'soda',
+        parsed: parsed({ name: 'dr pepper' }),
+        brand: { isBranded: true, matchedBrand: 'dr pepper' },
+        rawLine: 'dr pepper',
+        expectedKey: 'dr pepper soda',
+    },
+    {
+        label: '"taco bell burrito" with detector 1-gram hit "bell" (non-decisive) — key untouched',
+        normalizedName: 'taco bell burrito',
+        parsed: parsed({ name: 'taco bell burrito' }),
+        brand: { isBranded: true, matchedBrand: 'bell' },
+        rawLine: 'taco bell burrito',
+        expectedKey: 'bell burrito taco',
+    },
+    {
+        label: '"taco bell burrito" with full brand "taco bell" — tokens present, prefix skipped',
+        normalizedName: 'taco bell burrito',
+        parsed: parsed({ name: 'taco bell burrito' }),
+        brand: { isBranded: true, matchedBrand: 'taco bell' },
+        rawLine: 'taco bell burrito',
+        expectedKey: 'bell burrito taco',
+    },
+    {
+        label: 'branded, brand in name: "oikos greek yogurt" (single-word, non-decisive)',
         normalizedName: 'oikos greek yogurt',
         parsed: parsed({ name: 'oikos greek yogurt' }),
         brand: { isBranded: true, matchedBrand: 'Oikos' },
+        rawLine: 'oikos greek yogurt',
         expectedKey: 'greek oiko yogurt',
     },
     {
@@ -90,6 +163,7 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'oikos',
         parsed: parsed({ name: 'oikos' }),
         brand: { isBranded: true, matchedBrand: 'Oikos' },
+        rawLine: 'oikos',
         expectedKey: 'oiko',
     },
     {
@@ -97,20 +171,31 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'heinz tomato ketchup',
         parsed: parsed({ name: 'heinz tomato ketchup' }),
         brand: { isBranded: true, matchedBrand: 'Heinz' },
+        rawLine: 'heinz tomato ketchup',
         expectedKey: 'heinz ketchup tomato',
     },
     {
-        label: 'branded, generic name (AI stripped brand): "greek yogurt" + brand oikos → prefix fires',
+        label: 'single-word brand + product-form context: "ghost whey" AI-normalized to "whey protein" — decisive, prefix fires',
+        normalizedName: 'whey protein',
+        parsed: parsed({ name: 'ghost whey' }),
+        brand: { isBranded: true, matchedBrand: 'ghost' },
+        rawLine: 'ghost whey',
+        expectedKey: 'ghost protein whey',
+    },
+    {
+        label: 'non-decisive stripped brand: "oikos greek yogurt" AI-normalized to "greek yogurt" — no prefix (matches legacy read reality)',
         normalizedName: 'greek yogurt',
         parsed: parsed({ name: 'greek yogurt' }),
         brand: { isBranded: true, matchedBrand: 'Oikos' },
-        expectedKey: 'greek oiko yogurt',
+        rawLine: 'oikos greek yogurt',
+        expectedKey: 'greek yogurt',
     },
     {
         label: 'plural brand token in name: "siggis yogurt"',
         normalizedName: 'siggis yogurt',
         parsed: parsed({ name: 'siggis yogurt' }),
         brand: { isBranded: true, matchedBrand: 'Siggis' },
+        rawLine: 'siggis yogurt',
         expectedKey: 'siggi yogurt',
     },
     {
@@ -118,13 +203,15 @@ const MATRIX: MatrixCase[] = [
         normalizedName: 'siggis',
         parsed: parsed({ name: 'siggis' }),
         brand: { isBranded: true, matchedBrand: 'Siggis' },
+        rawLine: 'siggis',
         expectedKey: 'siggi',
     },
     {
-        label: 'multi-word brand, generic name: "protein bar" + brand "met rx"',
+        label: 'multi-word brand, generic name: "protein bar" + brand "met rx" — decisive, prefix fires',
         normalizedName: 'protein bar',
         parsed: parsed({ name: 'protein bar' }),
         brand: { isBranded: true, matchedBrand: 'Met Rx' },
+        rawLine: 'met rx protein bar',
         expectedKey: 'bar met protein rx',
     },
 ];
@@ -139,8 +226,8 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
         it('write key === read key', () => {
             // The save site and both lookup sites call the identical function
             // with the identical request-stable inputs.
-            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
-            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
+            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
             expect(writeKey).toBe(c.expectedKey);
             expect(readKey).toBe(writeKey);
         });
@@ -148,20 +235,21 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
         it('survives the save-side re-canonicalization unchanged', () => {
             // saveValidatedMapping does normalizedForm = canonicalizeCacheKey(canonicalBase);
             // the stored key must equal the derived key or writes drift again.
-            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            const writeKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
             expect(canonicalizeCacheKey(writeKey)).toBe(writeKey);
         });
 
         it('survives the read-side re-canonicalization unchanged', () => {
             // getValidatedMappingByNormalizedName does canonicalizeCacheKey(normalizedName)
             // on the key it is handed before the exact-match lookup.
-            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            const readKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
             expect(canonicalizeCacheKey(readKey)).toBe(readKey);
         });
 
         it('never contains the same token twice in a row', () => {
-            const key = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
+            const key = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
             expect(hasAdjacentDuplicateTokens(key)).toBe(false);
+            expect(isMalformedCacheKey(key)).toBe(false);
         });
 
         it('is idempotent: deriving from the saved key yields the same key', () => {
@@ -169,10 +257,37 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
             // the row's own normalizedForm fed back through the pipeline) must
             // derive the identical key — this is what makes saved rows
             // permanently reachable.
-            const savedKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand);
-            expect(deriveMappingCacheKey(savedKey, null, c.brand)).toBe(savedKey);
+            const savedKey = deriveMappingCacheKey(c.normalizedName, c.parsed, c.brand, c.rawLine);
+            expect(deriveMappingCacheKey(savedKey, null, c.brand, c.rawLine)).toBe(savedKey);
             // And stability under repeated derivation with the original parse:
-            expect(deriveMappingCacheKey(savedKey, c.parsed, c.brand)).toBe(savedKey);
+            expect(deriveMappingCacheKey(savedKey, c.parsed, c.brand, c.rawLine)).toBe(savedKey);
+        });
+    });
+
+    describe('n-mq-30 "bell pepper" false-positive brand (lexicon "bell" 1-gram)', () => {
+        it('the real detector flags "bell pepper" as branded via the bare lexicon entry', () => {
+            // Documents the trigger: brand-lexicon.json carries "bell"
+            // (Bell & Evans), and the 1-gram scan returns it for produce.
+            const det = detectBrandInQuery('bell pepper');
+            expect(det.isBranded).toBe(true);
+            expect(det.matchedBrand?.toLowerCase()).toBe('bell');
+        });
+
+        it('non-decisive detector hit does not alter the AI-rewritten key (the orphaned-"capsicum" regression)', () => {
+            const det = detectBrandInQuery('bell pepper');
+            const brand = { isBranded: det.isBranded, matchedBrand: det.matchedBrand };
+            // AI normalize rewrote "bell pepper" → "capsicum"; the stored
+            // human-triage row lives at key "capsicum" and MUST stay reachable.
+            const key = deriveMappingCacheKey('capsicum', parsed({ name: 'bell pepper' }), brand, 'bell pepper');
+            expect(key).toBe('capsicum');
+            expect(key).not.toBe('bell capsicum');
+        });
+
+        it('"dr pepper" keeps its brand handling (multi-word = decisive full phrase)', () => {
+            const det = detectBrandInQuery('dr pepper');
+            expect(det.matchedBrand?.toLowerCase()).toBe('dr pepper');
+            const brand = { isBranded: det.isBranded, matchedBrand: det.matchedBrand };
+            expect(deriveMappingCacheKey('dr pepper', parsed({ name: 'dr pepper' }), brand, 'dr pepper')).toBe('dr pepper');
         });
     });
 
@@ -184,30 +299,34 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
             const key = deriveMappingCacheKey('oikos', parsed({ name: 'oikos' }), {
                 isBranded: true,
                 matchedBrand: 'oikos',
-            });
+            }, 'oikos');
             expect(key).toBe('oiko');
             expect(key).not.toBe('oiko oiko');
         });
 
-        it('brand stem-present-in-key skips the prefix (token stems, not substrings)', () => {
+        it('decisive brand already present as stem in key skips the prefix (token stems, not substrings)', () => {
+            // "ghost whey": decisive (product-form adjacency); name kept the
+            // brand token, so the prefix must skip on stem presence.
             const key = deriveMappingCacheKey(
-                'oikos greek yogurt',
-                parsed({ name: 'oikos greek yogurt' }),
-                { isBranded: true, matchedBrand: 'oikos' },
+                'ghost whey',
+                parsed({ name: 'ghost whey' }),
+                { isBranded: true, matchedBrand: 'ghost' },
+                'ghost whey',
             );
-            expect(key).toBe('greek oiko yogurt');
-            expect(key.split(' ').filter(t => t === 'oiko')).toHaveLength(1);
+            expect(key).toBe('ghost whey');
+            expect(key.split(' ').filter(t => t === 'ghost')).toHaveLength(1);
         });
 
-        it('substring-only overlap does NOT count as brand presence', () => {
-            // Brand "eat" is a substring of the token "meat" — the old
-            // includes() guard would wrongly treat the brand as present and
-            // skip the prefix. Stem-token comparison prefixes it.
+        it('substring-only overlap does NOT count as brand presence (decisive multi-word brand)', () => {
+            // Brand token "eat" is a substring of the key token "meat" — the
+            // old includes() guard would wrongly treat the brand as present
+            // and skip the prefix. Stem-token comparison prefixes it.
             const key = deriveMappingCacheKey('meat snack', parsed({ name: 'meat snack' }), {
                 isBranded: true,
-                matchedBrand: 'eat',
-            });
-            expect(key).toBe('eat meat snack');
+                matchedBrand: 'eat protein',
+            }, 'eat protein meat snack');
+            expect(key).toBe(canonicalizeCacheKey('eat protein meat snack'));
+            expect(key.split(' ')).toContain('eat');
         });
     });
 
@@ -216,7 +335,7 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
             const key = deriveMappingCacheKey('greek yogurt', parsed({ name: 'greek yogurt' }), {
                 isBranded: false,
                 matchedBrand: 'oikos',
-            });
+            }, 'oikos greek yogurt');
             expect(key).toBe('greek yogurt');
         });
 
@@ -224,7 +343,7 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
             const key = deriveMappingCacheKey('greek yogurt', parsed({ name: 'greek yogurt' }), {
                 isBranded: true,
                 matchedBrand: null,
-            });
+            }, 'greek yogurt');
             expect(key).toBe('greek yogurt');
         });
 
@@ -234,23 +353,24 @@ describe('deriveMappingCacheKey — read/write symmetry', () => {
         });
 
         it('partial multi-word-brand presence skips the prefix (no half-doubled brands)', () => {
-            // Key already carries "rx"; prepending "met rx" would double it.
+            // Key already carries "rx" and "met"; prepending "met rx" would
+            // double them.
             const key = deriveMappingCacheKey('met rx protein bar', parsed({ name: 'met rx protein bar' }), {
                 isBranded: true,
                 matchedBrand: 'met rx',
-            });
+            }, 'met rx protein bar');
             expect(key).toBe('bar met protein rx');
             expect(hasAdjacentDuplicateTokens(key)).toBe(false);
         });
     });
 
     describe('identity discriminators still compose symmetrically (PR D pt3 C1)', () => {
-        it('"egg" + unitHint "white" round-trips with a brand', () => {
+        it('"egg" + unitHint "white" round-trips with a decisive multi-word brand', () => {
             const p = parsed({ name: 'egg', unitHint: 'white' });
             const brand = { isBranded: true, matchedBrand: 'vital farms' };
-            const writeKey = deriveMappingCacheKey('egg', p, brand);
+            const writeKey = deriveMappingCacheKey('egg', p, brand, 'vital farms egg whites');
             expect(writeKey).toBe(canonicalizeCacheKey('vital farms egg white'));
-            expect(deriveMappingCacheKey(writeKey, null, brand)).toBe(writeKey);
+            expect(deriveMappingCacheKey(writeKey, null, brand, 'vital farms egg whites')).toBe(writeKey);
             expect(hasAdjacentDuplicateTokens(writeKey)).toBe(false);
         });
     });
@@ -270,5 +390,26 @@ describe('collapseAdjacentDuplicateTokens', () => {
 
     it('does not collapse non-adjacent duplicates (canonical keys are sorted, so this cannot occur post-canonicalize)', () => {
         expect(collapseAdjacentDuplicateTokens('oiko greek oiko')).toBe('oiko greek oiko');
+    });
+});
+
+describe('isMalformedCacheKey (shared by legacy-read fallback + cleanup script)', () => {
+    it('flags adjacent duplicate tokens', () => {
+        expect(isMalformedCacheKey('oiko oiko')).toBe(true);
+        expect(isMalformedCacheKey('bean canned canned kidney')).toBe(true);
+        expect(isMalformedCacheKey('oat rolled rolled')).toBe(true);
+    });
+
+    it('flags stem-space duplicates (plural/singular doubled brand, legacy unsorted keys)', () => {
+        expect(isMalformedCacheKey('ree rees')).toBe(true);
+        expect(isMalformedCacheKey('oikos greek oiko yogurt')).toBe(true);
+    });
+
+    it('passes clean keys', () => {
+        expect(isMalformedCacheKey('bell pepper')).toBe(false);
+        expect(isMalformedCacheKey('capsicum')).toBe(false);
+        expect(isMalformedCacheKey('dr pepper')).toBe(false);
+        expect(isMalformedCacheKey('bean canned kidney')).toBe(false);
+        expect(isMalformedCacheKey('')).toBe(false);
     });
 });

--- a/src/lib/mapping/__tests__/legacy-key-fallback.test.ts
+++ b/src/lib/mapping/__tests__/legacy-key-fallback.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Legacy cache-key fallback (Track 1c backward compatibility) — pipeline tests.
+ *
+ * Every FoodMapping row written before Track 1c was keyed by the OLD read
+ * scheme: deriveCacheKeyName output, no brand prefix, no dup-token collapse.
+ * The symmetric key can differ (brand-prefixed, or collapsed), which would
+ * silently orphan previously-working rows. Both lookup call-sites therefore
+ * fall back to ONE extra point-read on the legacy key when the symmetric-key
+ * lookup misses — EXCEPT when the legacy key is malformed (adjacent duplicate
+ * tokens): those are the dead "oiko oiko"/"oat rolled rolled" zombie rows the
+ * cleanup script deletes, and the fallback must never resurrect them.
+ *
+ * Covered here, one case per read site:
+ *   1. EARLY lookup site: branded query (options.brand, decisive multi-word)
+ *      whose legacy-keyed row (no brand prefix) is still found and served.
+ *   2. STEP-1C lookup site: AI normalize strips a decisive single-word brand
+ *      from the name; the legacy (unprefixed) row is found and served.
+ *   3. Zombie guard: a dup-token legacy key is NEVER looked up.
+ */
+
+import { mapIngredientWithFallback, type MappingTelemetry } from '../map-ingredient-with-fallback';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import {
+    getValidatedMapping,
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates } from '../gather-candidates';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        ingredient: { findMany: jest.fn().mockResolvedValue([]) },
+    },
+}));
+
+jest.mock('../ai-normalize');
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return {
+        ...actual,
+        getCachedFoodWithRelations: jest.fn(),
+    };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return {
+        ...actual,
+        gatherCandidates: jest.fn(),
+    };
+});
+// The zombie-guard test runs the pipeline to a full miss; the AI nutrition
+// backfill tail must not fire a real LLM call from inside jest.
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: jest.fn().mockResolvedValue({ status: 'error', reason: 'skip' }),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: jest.fn().mockResolvedValue(null),
+}));
+
+function lookupKeys(): string[] {
+    return (getValidatedMappingByNormalizedName as jest.Mock).mock.calls.map(c => c[0]);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMapping as jest.Mock).mockResolvedValue(null);
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (gatherCandidates as jest.Mock).mockResolvedValue([]);
+});
+
+describe('legacy-key fallback at the EARLY lookup site', () => {
+    it('finds a legacy-keyed (unprefixed) row for a branded query and serves it', async () => {
+        // options.brand "optimum nutrition" is decisive (multi-word), so the
+        // symmetric key is brand-prefixed: "nutrition optimum protein shake".
+        // The pre-Track-1c row lives under the legacy read key "protein shake".
+        const legacyRow = {
+            foodId: 'ps-1',
+            foodName: 'Optimum Nutrition Protein Shake',
+            brandName: 'Optimum Nutrition',
+            source: 'ai_generated',
+            confidence: 0.9,
+            validatedBy: 'ai',
+        };
+        (getValidatedMappingByNormalizedName as jest.Mock).mockImplementation(
+            async (key: string) => (key === 'protein shake' ? legacyRow : null),
+        );
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'ps-1',
+            displayName: 'Optimum Nutrition Protein Shake',
+            ingredientName: 'protein shake',
+            caloriesPer100g: 44,
+            proteinPer100g: 10,
+            carbsPer100g: 1.5,
+            fatPer100g: 0.4,
+            servings: [{ id: 'srv-ps', label: '1 cup', grams: 240, volumeMl: 240 }],
+        });
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback('1 cup protein shake', {
+            minConfidence: 0,
+            skipFdc: true,
+            brand: 'optimum nutrition',
+            telemetry,
+        });
+
+        // Symmetric (brand-prefixed) key first, legacy key on miss — in order.
+        expect(lookupKeys().slice(0, 2)).toEqual([
+            'nutrition optimum protein shake',
+            'protein shake',
+        ]);
+        // The legacy row is served as an early cache hit.
+        expect(result).not.toBeNull();
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('ps-1');
+        expect(telemetry.cacheHit).toBe('early');
+        // Cache hits must not re-save (B6) and must not need the LLM.
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        expect(aiNormalizeIngredient).not.toHaveBeenCalled();
+    });
+});
+
+describe('legacy-key fallback at the STEP-1C lookup site', () => {
+    it('finds a legacy-keyed row after AI normalize strips a decisive brand from the name', async () => {
+        // "ghost whey": decisive single-word brand (product-form adjacency).
+        // AI normalize rewrites the name to "whey protein" (brand stripped),
+        // so the symmetric step-1c key is "ghost protein whey" while the
+        // pre-Track-1c row lives under the legacy key "protein whey".
+        const legacyRow = {
+            foodId: 'gw-1',
+            foodName: 'Ghost Whey Protein',
+            brandName: 'Ghost',
+            source: 'ai_generated',
+            confidence: 0.9,
+            validatedBy: 'ai',
+        };
+        (getValidatedMappingByNormalizedName as jest.Mock).mockImplementation(
+            async (key: string) => (key === 'protein whey' ? legacyRow : null),
+        );
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'whey protein',
+            synonyms: [],
+            isBranded: true,
+        });
+        (getCachedFoodWithRelations as jest.Mock).mockResolvedValue({
+            id: 'gw-1',
+            displayName: 'Ghost Whey Protein',
+            ingredientName: 'whey protein',
+            caloriesPer100g: 370,
+            proteinPer100g: 74,
+            carbsPer100g: 11,
+            fatPer100g: 5,
+            servings: [{ id: 'srv-gw', label: '1 cup', grams: 30, volumeMl: 240 }],
+        });
+
+        const result = await mapIngredientWithFallback('1 cup ghost whey', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        const keys = lookupKeys();
+        // Early site: symmetric === legacy ("ghost whey", brand token already
+        // in the name) → exactly one call, no fallback duplicate.
+        expect(keys[0]).toBe('ghost whey');
+        // Step-1c site: symmetric (prefixed) key first, then the legacy key.
+        expect(keys).toContain('ghost protein whey');
+        expect(keys).toContain('protein whey');
+        expect(keys.indexOf('ghost protein whey')).toBeLessThan(keys.indexOf('protein whey'));
+
+        // The legacy row is served as the step-1c hit and not re-saved (B6).
+        expect(result).not.toBeNull();
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('gw-1');
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});
+
+describe('zombie-row guard: malformed legacy keys are never looked up', () => {
+    it('skips the fallback when the legacy key has adjacent duplicate tokens', async () => {
+        // AI normalize flaps to a doubled-modifier name. The symmetric key
+        // collapses the dup ("oat rolled"); the legacy key would be the dup
+        // form "oat rolled rolled" — exactly the malformed class the cleanup
+        // script deletes. The fallback must NOT resurrect such rows.
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'rolled rolled oats',
+            synonyms: [],
+            isBranded: false,
+        });
+
+        await mapIngredientWithFallback('1 cup oatmeal', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        const keys = lookupKeys();
+        // The collapsed symmetric key IS looked up...
+        expect(keys).toContain('oat rolled');
+        // ...but the malformed legacy key never is.
+        expect(keys).not.toContain('oat rolled rolled');
+        expect(keys.every(k => k !== 'oat rolled rolled')).toBe(true);
+    });
+});

--- a/src/lib/mapping/cache-key.ts
+++ b/src/lib/mapping/cache-key.ts
@@ -9,16 +9,26 @@
  * identity discriminators the parser already retains (ingredient-line.ts
  * qualifier/unit-hint extraction) before canonicalizing.
  *
- * Used at EXACTLY three sites in map-ingredient-with-fallback.ts, computed at
- * each site (so the AI-normalize replacement path is reflected):
- *   - :570  early cache lookup
- *   - :953  step-1c normalized-cache lookup
- *   - :2206 save key
- * The wire-in (3-site key swap) is a separately sequenced step — this module
- * ships first with no callers. Retrieval queries, baseName, and rerank input
- * are deliberately NOT touched: this is a cache-key-only concern.
+ * Key-symmetry fix (Track 1c, Jul 2026): read and write paths previously
+ * diverged because the brand-prefix step lived OUTSIDE this module, at the
+ * save site only, guarded by a substring includes() that singularization
+ * defeats ("oikos" not a substring of the canonical token "oiko" → write key
+ * "oiko oiko" while reads derived "oiko" — a permanently dead row). The full
+ * key derivation, INCLUDING the brand-prefix decision, now lives in
+ * deriveMappingCacheKey below, used verbatim at EXACTLY three sites in
+ * map-ingredient-with-fallback.ts, computed at each site (so the AI-normalize
+ * replacement path is reflected):
+ *   - early cache lookup
+ *   - step-1c normalized-cache lookup
+ *   - Step-6 save key
+ * All three pass the request-stable brandDetection (static detector +
+ * options.brand, computed once before the early lookup) — NOT the AI-mutable
+ * isBrandedQuery flag, which doesn't exist yet at early-lookup time.
+ * Retrieval queries, baseName, and rerank input are deliberately NOT touched:
+ * this is a cache-key-only concern.
  *
- * Kill-switch: CACHE_KEY_DISCRIMINATORS === '0' → plain canonicalizeCacheKey.
+ * Kill-switch: CACHE_KEY_DISCRIMINATORS === '0' → plain canonicalizeCacheKey
+ * (discriminators only; the brand step and dup-token guard always apply).
  */
 
 import { canonicalizeCacheKey } from './normalization-rules';
@@ -94,4 +104,82 @@ export function deriveCacheKeyName(
   }
 
   return canonicalizeCacheKey(`${normalizedName} ${appended.join(' ')}`);
+}
+
+/**
+ * Brand-detection shape consumed by deriveMappingCacheKey. Matches the
+ * request-stable brandDetection object built in map-ingredient-with-fallback
+ * (static detector result merged with options.brand).
+ */
+export interface BrandKeyInput {
+  isBranded: boolean;
+  matchedBrand?: string | null;
+}
+
+/**
+ * Collapse adjacent duplicate tokens in a key ("oiko oiko" → "oiko").
+ *
+ * canonicalizeCacheKey sorts tokens, so in canonical space ALL duplicate
+ * tokens are adjacent — collapsing adjacent runs is a full dedupe. Exported
+ * for the malformed-key cleanup script (scripts/fix-malformed-cache-keys.ts),
+ * which uses collapsed !== original as its malformation predicate.
+ */
+export function collapseAdjacentDuplicateTokens(key: string): string {
+  const out: string[] = [];
+  for (const token of key.split(/\s+/)) {
+    if (token.length === 0) continue;
+    if (out.length > 0 && out[out.length - 1] === token) continue;
+    out.push(token);
+  }
+  return out.join(' ');
+}
+
+/**
+ * THE cache key for FoodMapping reads AND writes — the single shared
+ * derivation (Track 1c). Pure function of (normalizedName, parsed,
+ * brandDetection); no I/O, no side effects.
+ *
+ * Steps:
+ *   1. deriveCacheKeyName — canonicalize + identity discriminators (above).
+ *   2. Brand prefix — when the query is branded, prepend the brand so branded
+ *      picks don't overwrite generic cache rows ("heinz ketchup tomato" vs
+ *      "ketchup tomato"). The skip-guard compares CANONICALIZED TOKEN STEMS,
+ *      not substring includes(): the brand is considered already present when
+ *      any token of the key stem-matches any token of the brand, so
+ *      "oikos" (stem "oiko") against key "greek oiko yogurt" correctly skips
+ *      — the old `key.includes('oikos')` check was defeated by
+ *      singularization and doubled the brand instead.
+ *   3. Final canonicalize (sorts the prefix into place, singularizes it) +
+ *      adjacent-dup-token collapse, so no composed key can ever carry the
+ *      same token twice — regardless of what AI normalize handed us as
+ *      normalizedName ("canned canned kidney beans" class).
+ *
+ * Idempotent: feeding a derived key back in as normalizedName (with the same
+ * brandDetection) returns the identical key — required so a row saved under
+ * key K is found by any later query that derives K.
+ */
+export function deriveMappingCacheKey(
+  normalizedName: string,
+  parsed: ParsedIngredient | null | undefined,
+  brandDetection?: BrandKeyInput | null
+): string {
+  const base = deriveCacheKeyName(normalizedName, parsed);
+
+  let composed = base;
+  const brand = brandDetection?.isBranded
+    ? brandDetection.matchedBrand?.trim().toLowerCase()
+    : undefined;
+  if (brand) {
+    const keyTokens = new Set(base.split(/\s+/).filter(t => t.length > 0));
+    const brandTokens = canonicalizeCacheKey(brand)
+      .split(/\s+/)
+      .filter(t => t.length > 0);
+    const brandAlreadyPresent =
+      brandTokens.length > 0 && brandTokens.some(bt => keyTokens.has(bt));
+    if (brandTokens.length > 0 && !brandAlreadyPresent) {
+      composed = `${brand} ${base}`;
+    }
+  }
+
+  return collapseAdjacentDuplicateTokens(canonicalizeCacheKey(composed));
 }

--- a/src/lib/mapping/cache-key.ts
+++ b/src/lib/mapping/cache-key.ts
@@ -32,6 +32,7 @@
  */
 
 import { canonicalizeCacheKey } from './normalization-rules';
+import { hasDecisiveBrandContext } from './simple-rerank';
 import { IDENTITY_QUALIFIERS } from '../parse/qualifiers';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 
@@ -135,33 +136,66 @@ export function collapseAdjacentDuplicateTokens(key: string): string {
 }
 
 /**
+ * True when a stored/derived cache key is malformed: it carries the same
+ * token (or token stem) twice. Canonical keys are token-sorted, so after
+ * re-canonicalizing, ALL duplicate stems sit adjacent — one adjacency scan is
+ * a full dup check, and it also catches legacy unsorted keys and
+ * plural/singular doubled brands ("oiko oikos").
+ *
+ * Shared by the legacy-key read fallback in map-ingredient-with-fallback.ts
+ * (a malformed legacy key must never be looked up — zombie rows stay dead)
+ * and scripts/fix-malformed-cache-keys.ts (the deletion predicate).
+ */
+export function isMalformedCacheKey(key: string): boolean {
+  const normalizedWhitespace = key.split(/\s+/).filter(t => t.length > 0).join(' ');
+  if (collapseAdjacentDuplicateTokens(key) !== normalizedWhitespace) return true;
+  const canonical = canonicalizeCacheKey(key);
+  return collapseAdjacentDuplicateTokens(canonical) !== canonical;
+}
+
+/**
  * THE cache key for FoodMapping reads AND writes — the single shared
  * derivation (Track 1c). Pure function of (normalizedName, parsed,
- * brandDetection); no I/O, no side effects.
+ * brandDetection, rawLine); no I/O, no side effects.
  *
  * Steps:
  *   1. deriveCacheKeyName — canonicalize + identity discriminators (above).
- *   2. Brand prefix — when the query is branded, prepend the brand so branded
- *      picks don't overwrite generic cache rows ("heinz ketchup tomato" vs
- *      "ketchup tomato"). The skip-guard compares CANONICALIZED TOKEN STEMS,
- *      not substring includes(): the brand is considered already present when
- *      any token of the key stem-matches any token of the brand, so
- *      "oikos" (stem "oiko") against key "greek oiko yogurt" correctly skips
- *      — the old `key.includes('oikos')` check was defeated by
- *      singularization and doubled the brand instead.
+ *   2. Brand prefix — when the query DECISIVELY names a brand, prepend it so
+ *      branded picks don't collide with generic cache rows ("met rx protein
+ *      bar" vs "protein bar"). Two guards, both required:
+ *
+ *      a. DECISIVENESS (hasDecisiveBrandContext — the same definition the
+ *         brand-mismatch save gate and rerank use): a multi-word brand counts
+ *         only as its full detected phrase; a single-word brand counts only
+ *         when it sits next to a product-form token in the raw line. This is
+ *         what keeps false-positive lexicon hits from mutating keys: the
+ *         lexicon's bare "bell" entry (Bell & Evans) matches the 1-gram scan
+ *         for "bell pepper", and once AI normalize rewrote the name to
+ *         "capsicum" an unconditional prefix produced read/write key
+ *         "bell capsicum" — orphaning the live human-triage "capsicum" row
+ *         (golden n-mq-30). Non-decisive brand hits must never alter the key.
+ *
+ *      b. PRESENCE, by CANONICALIZED TOKEN STEMS, not substring includes():
+ *         the brand is already represented when any token of the key
+ *         stem-matches any token of the brand, so "oikos" (stem "oiko")
+ *         against key "greek oiko yogurt" correctly skips — the old
+ *         `key.includes('oikos')` check was defeated by singularization and
+ *         doubled the brand instead ("oiko oiko").
+ *
  *   3. Final canonicalize (sorts the prefix into place, singularizes it) +
  *      adjacent-dup-token collapse, so no composed key can ever carry the
  *      same token twice — regardless of what AI normalize handed us as
  *      normalizedName ("canned canned kidney beans" class).
  *
  * Idempotent: feeding a derived key back in as normalizedName (with the same
- * brandDetection) returns the identical key — required so a row saved under
- * key K is found by any later query that derives K.
+ * brandDetection/rawLine) returns the identical key — required so a row
+ * saved under key K is found by any later query that derives K.
  */
 export function deriveMappingCacheKey(
   normalizedName: string,
   parsed: ParsedIngredient | null | undefined,
-  brandDetection?: BrandKeyInput | null
+  brandDetection?: BrandKeyInput | null,
+  rawLine?: string
 ): string {
   const base = deriveCacheKeyName(normalizedName, parsed);
 
@@ -169,7 +203,7 @@ export function deriveMappingCacheKey(
   const brand = brandDetection?.isBranded
     ? brandDetection.matchedBrand?.trim().toLowerCase()
     : undefined;
-  if (brand) {
+  if (brand && hasDecisiveBrandContext(rawLine ?? normalizedName, brand)) {
     const keyTokens = new Set(base.split(/\s+/).filter(t => t.length > 0));
     const brandTokens = canonicalizeCacheKey(brand)
       .split(/\s+/)

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -54,7 +54,7 @@ import { detectBrandInQuery } from './brand-detector';
 import { assessMacroPlausibility, assessRankTimePlausibility } from './macro-plausibility';
 import { isDenylistedOffRecord } from './corrupt-denylist';
 import { isCorruptExclusionEnabled } from './corrupt-mark';
-import { deriveCacheKeyName } from './cache-key';
+import { deriveMappingCacheKey } from './cache-key';
 import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
 
 // ============================================================
@@ -749,12 +749,13 @@ export async function mapIngredientWithFallback(
         // Check ValidatedMapping for normalized name BEFORE calling AI
         // This is the key optimization: "1 cup chopped onion" → normalized "onion" → cache hit!
         if (telemetry) telemetry.normalizedForm = normalizedName;
-        // PR D pt3 (C1): lookup key carries identity discriminators (egg
-        // white/yolk, cooked, whole) so identity-distinct senses stop fighting
-        // over one row. Computed identically at the step-1c lookup and the
-        // Step-6 save key — lookup and save must stay the same function of
-        // (normalizedName, parsed).
-        const earlyCacheHit = skipCache ? null : await getValidatedMappingByNormalizedName(deriveCacheKeyName(normalizedName, parsed), 'fatsecret', trimmed);
+        // PR D pt3 (C1) + key symmetry (Track 1c): lookup key carries identity
+        // discriminators (egg white/yolk, cooked, whole) AND the brand-prefix
+        // decision — deriveMappingCacheKey is THE key function, used verbatim
+        // at the step-1c lookup and the Step-6 save key. brandDetection (not
+        // the AI-mutable isBrandedQuery) is the brand input at all three
+        // sites: it's the only brand signal that exists this early.
+        const earlyCacheHit = skipCache ? null : await getValidatedMappingByNormalizedName(deriveMappingCacheKey(normalizedName, parsed, brandDetection), 'fatsecret', trimmed);
         if (earlyCacheHit) {
             logger.info('mapping.early_cache_hit', { rawLine: trimmed, normalizedName, foodName: earlyCacheHit.foodName });
 
@@ -1159,9 +1160,12 @@ export async function mapIngredientWithFallback(
             // skipCache must gate this layer too — without it a "cold" (nocache)
             // run would still serve cached rows via step 1c and parity runs
             // against the cache would be meaningless.
-            // PR D pt3 (C1): same derived key as the early lookup — recomputed
-            // here because AI normalize may have replaced normalizedName.
-            const normalizedCache = skipCache ? null : await getValidatedMappingByNormalizedName(deriveCacheKeyName(normalizedName, parsed), 'fatsecret', trimmed);
+            // PR D pt3 (C1) + key symmetry (Track 1c): same derived key
+            // (deriveMappingCacheKey incl. brand-prefix decision) as the early
+            // lookup and the Step-6 save — recomputed here because AI
+            // normalize may have replaced normalizedName. brandDetection is
+            // request-stable, so this key matches the save key exactly.
+            const normalizedCache = skipCache ? null : await getValidatedMappingByNormalizedName(deriveMappingCacheKey(normalizedName, parsed, brandDetection), 'fatsecret', trimmed);
             if (normalizedCache) {
                 logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
                 const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);
@@ -2469,20 +2473,17 @@ export async function mapIngredientWithFallback(
             // instead of canonicalBase (which collapses variants to a shared base).
             // This prevents cache poisoning where "powdered peanut butter" → "peanut butter" key
             // caused 73+ subsequent "peanut butter" queries to return powdered PB.
-            // PR D pt3 (C1): the key adds the parser's identity discriminators —
-            // the SAME function of (normalizedName, parsed) as both cache lookups.
-            let cacheKey = deriveCacheKeyName(normalizedName, parsed);
-
-            // Brand-Prefixed normalizedForm (Option A)
-            // If the query is branded and we have a targetBrand, prefix the cache key
-            // with the brand name so that it doesn't overwrite generic cache entries.
-            // e.g., "heinz tomato ketchup" instead of "tomato ketchup"
-            if (isBrandedQuery && brandDetection.matchedBrand) {
-                const brandPrefix = brandDetection.matchedBrand.toLowerCase();
-                if (!cacheKey.toLowerCase().includes(brandPrefix)) {
-                    cacheKey = `${brandPrefix} ${cacheKey}`;
-                }
-            }
+            // Key symmetry (Track 1c): the SAME function of (normalizedName,
+            // parsed, brandDetection) as both cache lookups — identity
+            // discriminators AND the brand-prefix decision now live inside
+            // deriveMappingCacheKey. The old site-local brand prepend used a
+            // substring includes() that singularization defeated ("oikos" vs
+            // canonical token "oiko" → dead "oiko oiko" rows); the shared
+            // function stem-matches tokens and collapses duplicate tokens.
+            // Note: brandDetection (request-stable), NOT isBrandedQuery — the
+            // AI-upgraded flag doesn't exist at early-lookup time, so a key
+            // built from it could never be symmetric.
+            const cacheKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection);
 
             // Per-100g macros of the pick + the AI estimate feed the save-time
             // plausibility gate inside saveValidatedMapping (PR D): corrupt

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -54,8 +54,47 @@ import { detectBrandInQuery } from './brand-detector';
 import { assessMacroPlausibility, assessRankTimePlausibility } from './macro-plausibility';
 import { isDenylistedOffRecord } from './corrupt-denylist';
 import { isCorruptExclusionEnabled } from './corrupt-mark';
-import { deriveMappingCacheKey } from './cache-key';
+import { deriveMappingCacheKey, deriveCacheKeyName, isMalformedCacheKey, type BrandKeyInput } from './cache-key';
 import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
+import type { CachedMappedIngredient } from './validated-mapping-helpers';
+
+// ============================================================
+// Symmetric cache lookup with legacy-key fallback (Track 1c)
+// ============================================================
+// Primary lookup uses deriveMappingCacheKey — THE shared read/write key.
+// But every FoodMapping row written before Track 1c was keyed by the OLD
+// read scheme (deriveCacheKeyName, no brand prefix), so whenever the new
+// key differs from the legacy key a miss falls back to ONE extra indexed
+// point-read on the legacy key. The write path stays new-scheme-only, so
+// legacy rows migrate forward naturally on their next save.
+//
+// Guard: the fallback must never look up a MALFORMED legacy key (adjacent
+// duplicate tokens — the "oiko oiko"/"canned canned" rows the cleanup
+// script deletes). Resurrecting those zombie rows would undo the fix, so
+// isMalformedCacheKey (the script's own predicate) gates the fallback.
+async function lookupValidatedMappingWithLegacyFallback(
+    normalizedName: string,
+    parsed: import('../parse/ingredient-line').ParsedIngredient | null | undefined,
+    brandDetection: BrandKeyInput,
+    rawLine: string,
+): Promise<CachedMappedIngredient | null> {
+    const symmetricKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection, rawLine);
+    const hit = await getValidatedMappingByNormalizedName(symmetricKey, 'fatsecret', rawLine);
+    if (hit) return hit;
+
+    const legacyKey = deriveCacheKeyName(normalizedName, parsed);
+    if (legacyKey === symmetricKey || isMalformedCacheKey(legacyKey)) return null;
+
+    const legacyHit = await getValidatedMappingByNormalizedName(legacyKey, 'fatsecret', rawLine);
+    if (legacyHit) {
+        logger.debug('mapping.legacy_cache_key_fallback_hit', {
+            rawLine,
+            symmetricKey,
+            legacyKey,
+        });
+    }
+    return legacyHit;
+}
 
 // ============================================================
 // In-Flight Lock (Prevents race conditions in parallel processing)
@@ -754,8 +793,10 @@ export async function mapIngredientWithFallback(
         // decision — deriveMappingCacheKey is THE key function, used verbatim
         // at the step-1c lookup and the Step-6 save key. brandDetection (not
         // the AI-mutable isBrandedQuery) is the brand input at all three
-        // sites: it's the only brand signal that exists this early.
-        const earlyCacheHit = skipCache ? null : await getValidatedMappingByNormalizedName(deriveMappingCacheKey(normalizedName, parsed, brandDetection), 'fatsecret', trimmed);
+        // sites: it's the only brand signal that exists this early. A miss
+        // additionally falls back to the legacy (pre-Track-1c) key so rows
+        // written under the old scheme stay reachable.
+        const earlyCacheHit = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed);
         if (earlyCacheHit) {
             logger.info('mapping.early_cache_hit', { rawLine: trimmed, normalizedName, foodName: earlyCacheHit.foodName });
 
@@ -1164,8 +1205,9 @@ export async function mapIngredientWithFallback(
             // (deriveMappingCacheKey incl. brand-prefix decision) as the early
             // lookup and the Step-6 save — recomputed here because AI
             // normalize may have replaced normalizedName. brandDetection is
-            // request-stable, so this key matches the save key exactly.
-            const normalizedCache = skipCache ? null : await getValidatedMappingByNormalizedName(deriveMappingCacheKey(normalizedName, parsed, brandDetection), 'fatsecret', trimmed);
+            // request-stable, so this key matches the save key exactly. A
+            // miss falls back to the legacy (pre-Track-1c) key.
+            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed);
             if (normalizedCache) {
                 logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
                 const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);
@@ -2474,16 +2516,19 @@ export async function mapIngredientWithFallback(
             // This prevents cache poisoning where "powdered peanut butter" → "peanut butter" key
             // caused 73+ subsequent "peanut butter" queries to return powdered PB.
             // Key symmetry (Track 1c): the SAME function of (normalizedName,
-            // parsed, brandDetection) as both cache lookups — identity
-            // discriminators AND the brand-prefix decision now live inside
-            // deriveMappingCacheKey. The old site-local brand prepend used a
-            // substring includes() that singularization defeated ("oikos" vs
-            // canonical token "oiko" → dead "oiko oiko" rows); the shared
-            // function stem-matches tokens and collapses duplicate tokens.
+            // parsed, brandDetection, rawLine) as both cache lookups —
+            // identity discriminators AND the brand-prefix decision now live
+            // inside deriveMappingCacheKey. The old site-local brand prepend
+            // used a substring includes() that singularization defeated
+            // ("oikos" vs canonical token "oiko" → dead "oiko oiko" rows);
+            // the shared function gates the prefix on decisive brand context
+            // (so false-positive lexicon hits like "bell" on "bell pepper"
+            // never mutate the key), stem-matches tokens, and collapses
+            // duplicate tokens.
             // Note: brandDetection (request-stable), NOT isBrandedQuery — the
             // AI-upgraded flag doesn't exist at early-lookup time, so a key
             // built from it could never be symmetric.
-            const cacheKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection);
+            const cacheKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection, trimmed);
 
             // Per-100g macros of the pick + the AI estimate feed the save-time
             // plausibility gate inside saveValidatedMapping (PR D): corrupt


### PR DESCRIPTION
## The defect

FoodMapping cache keys were derived differently at write time than at read time, so rows were written under keys no read can ever produce (dead rows) and every such query permanently re-runs the full pipeline. A live dry-run of the new cleanup script confirms the blast radius: **131 of 1,411 FoodMapping rows (9.3%) are malformed** — including `oiko oiko` (the historical mark-corrupt-session finding, usedCount 6) and `oat rolled rolled` (usedCount **119**).

## Asymmetries found (pre-fix line numbers on master cf6b1db)

1. **Brand prefix existed only at the save site** — `map-ingredient-with-fallback.ts:2477-2484`: `if (!cacheKey.toLowerCase().includes(brandPrefix)) cacheKey = brandPrefix + ' ' + cacheKey`. Both lookups (`:757` early, `:1164` step-1c) derived `deriveCacheKeyName(normalizedName, parsed)` with **no brand step at all**, so any branded save key was unreachable by the exact-match read phases (only the fuzzy token-set fallback in `validated-mapping-helpers.ts` could occasionally rescue it).
2. **Singularization defeats the `includes()` guard** — `map-ingredient-with-fallback.ts:2482`: `cacheKey` is already canonicalized (`canonicalizeCacheKey` singularizes via the general `-s` rule, `normalization-rules.ts:688`), so for query "oikos" the key is `oiko` and `'oiko'.includes('oikos')` is false → brand prepended anyway → `saveValidatedMapping` re-canonicalizes (`validated-mapping-helpers.ts:359`, sort + singularize, **no dedupe**) → stored key `oiko oiko`. Read key: `oiko`. Dead row, verified live.
3. **Substring semantics were wrong in the other direction too** — `includes()` matches brand-as-substring-of-token (brand "eat" inside key token "meat"), wrongly suppressing a legitimate prefix. Token-stem comparison fixes both directions.
4. **The write-time brand gate used mutable state that doesn't exist at read time** — `:2480` gated on `isBrandedQuery`, which AI normalize reassigns at `:1077`/`:1106` *after* the early lookup at `:757`. Even a shared function keyed on that flag could never be symmetric. The stable input is `brandDetection` (static detector + `options.brand`), computed once at `:733-738` before all three sites.
5. **No dedupe anywhere in key composition** — `canonicalizeCacheKey` (`normalization-rules.ts:712`) lowercases, singularizes, and sorts but never dedupes, so any doubled-token `normalizedName` arriving from AI normalize was stored verbatim (`canned canned kidney beans` / `dry rolled rolled oats` class — 81 of the 131 live rows).
6. **The PR-D-pt3 symmetry comment was false** — the claim that lookup and save are "the SAME function of (normalizedName, parsed)" (`:753-757`, `:2472-2473`) held only when brand detection didn't fire; the brand-prefix step happened outside `deriveCacheKeyName` at write time only.

## The fix

**One shared derivation:** `deriveMappingCacheKey(normalizedName, parsed, brandDetection)` in `src/lib/mapping/cache-key.ts`, used verbatim at all three sites (early lookup, step-1c lookup, Step-6 save key — including alias saves, which reuse the same `cacheKey`):

1. `deriveCacheKeyName` (unchanged) — canonicalize + identity discriminators.
2. Brand prefix decision **inside** the shared function: skip when **any token of the key stem-matches any token of the brand** (both sides passed through `canonicalizeCacheKey` token-wise) — no more substring `includes()`.
3. Final canonicalize + **adjacent-dup-token collapse** (`collapseAdjacentDuplicateTokens`): since canonical keys are sorted, adjacent-collapse is a full dedupe; no composed key can ever carry the same token twice, regardless of what AI normalize hands us.

Idempotent by construction: a key fed back through derivation (same brand input) returns itself, so saved rows stay reachable forever.

**Behavior notes**
- Branded reads now derive the same brand-prefixed key the save produces (previously reads never prefixed).
- The AI `isBranded` upgrade no longer influences the cache key (it still drives scoring/rerank) — a deliberate consequence of symmetry, since it isn't available at early-lookup time.

## Cleanup script

`scripts/fix-malformed-cache-keys.ts` — default **--dry-run** reports rows whose `normalizedForm` has adjacent duplicate tokens or a doubled brand prefix (raw and stem-space checks; brand-classification via the brand list); `--apply` DELETES them. Deletion is safe: the next query re-resolves through the fixed pipeline and re-caches under the correct symmetric key. **--apply has NOT been run** — gated for merge time.

### Live dry-run output (read-only, 2026-07-21)

```
scanned 1411 FoodMapping rows
malformed rows: 131
summary: 131 malformed (50 doubled-brand-prefix, 81 duplicate-token), 0 human-triage
```

Top rows by usedCount:

```
key="oat rolled rolled"                    foodId=off_65336533       usedCount=119  wrong: adjacent duplicate token "rolled"
key="c4 c4 cellucor cellucor pre workout"  foodId=off_0810390028405  usedCount=21   wrong: adjacent dup "c4"; doubled-brand-prefix "cellucor"
key="oiko oiko"                            foodId=off_0053700561128  usedCount=6    wrong: doubled-brand-prefix "oiko"
key="pop pop tart tart"                    foodId=off_0064100148062  usedCount=5    wrong: adjacent dups "pop","tart"
key="brussel sprout sprout"                foodId=off_4061463941527  usedCount=5    wrong: doubled-brand-prefix "sprout"
key="instant oat rolled rolled"            foodId=off_0039978031600  usedCount=2    wrong: adjacent duplicate token "rolled"
...plus 125 more at usedCount=1 (skittle skittle, snicker snicker, taki taki,
   ree rees (stem-space plural double), krispy krispy rice rice, wendy wendy ×3, ...)
```

## Tests

New `src/lib/mapping/__tests__/cache-key-symmetry.test.ts` — round-trip property matrix (plain / modifier-carrying / doubled-modifier input / branded with brand in name / branded with AI-stripped generic name / brand-only / plural brands / multi-word brands), asserting per case: write key === read key, stability under both helpers' re-canonicalization, no adjacent duplicate tokens, and idempotence (deriving from a saved key yields the same key). Plus regression tests for the exact `oikos → oiko oiko` includes() defeat and the substring-overlap false positive.

## Verification

- `npm run typecheck` — clean
- `npm run lint:ci` — 0 errors, 434 warnings (cap 700; pre-existing)
- `npm run build` — clean
- `npx jest` (full suite) — **68/68 suites, 1010 passed, 1 skipped, 0 failures** (no pre-existing failures)
- No new dependencies; no new env vars.

**Scope guard:** no changes to serving-resolution code, `ambiguous-unit-backfill.ts`, or count-label logic (owned by a parallel branch). Edits are confined to key derivation (`cache-key.ts`), the two lookup sites + save site (`map-ingredient-with-fallback.ts`), the new script, and tests.

---

## Round 2 — n-mq-30 "bell pepper" regression fix (commit 53d2d59)

The merge gate caught a deterministic regression: "bell pepper" failed 3/3 on this branch (~200ms, retrieval junk "CAPSICUM & ROASTED GARLIC") while passing 3/3 on master (~26ms cache hit). Two root causes, both fixed:

### 1. False-positive brand detection was mutating READ keys

The mechanism (verified): `brand-lexicon.json` carries a **bare `"bell"` entry** (the Bell & Evans family — `'bell'`, `'bell & evans'`, `'bell-view'`, `'taco bell'`), and `detectBrandInQuery`'s 1-gram scan returns `matchedBrand: "bell"` for any line containing the token — including "bell pepper". The key derivation itself left "bell pepper" alone (token "bell" already in the key), but once **AI normalize rewrote the name to "capsicum"** the brand token was absent from the replaced name, the prefix fired, and read/write key became `bell capsicum` — orphaning the live human-triage `capsicum` row (usedCount 44 → "Bell Pepper", off_0699058010682). The `validated_mapping.save_rejected_implausible_macros` log with `normalizedForm "bell capsicum"` is this composed key. On master the read never prefixed and the write prefix was vetoed by the AI's `isBranded=false`, so the row stayed reachable.

**Fix:** the prefix step inside `deriveMappingCacheKey` is now gated on `hasDecisiveBrandContext` (`simple-rerank.ts:1358`) — the exact definition the brand-mismatch save gate and rerank already use for "did the query really name a brand": a multi-word brand counts only as its full detected phrase (the detector's n-gram match guarantees the phrase is in the line); a single-word brand counts only when adjacent to a product-form token (`ghost whey`, `ryse shake`). Non-decisive hits — like lexicon "bell" on produce — can never alter the key. Required behaviors pinned by tests: "bell pepper" → key untouched (and `capsicum` stays `capsicum`); "dr pepper" → brand handling as before; "taco bell burrito" → covered with both the detector's actual 1-gram result ("bell", non-decisive) and the full "taco bell" phrase (tokens already present → no prefix).

### 2. Backward compatibility for legacy-keyed rows

Every existing FoodMapping row was written under the old scheme. Both lookup sites now go through `lookupValidatedMappingWithLegacyFallback` (`map-ingredient-with-fallback.ts`): symmetric-key lookup first; on miss, when the legacy read key (`deriveCacheKeyName` output, unprefixed) differs, **one extra indexed point-read** on the legacy key. Writes stay new-scheme-only, so rows migrate forward naturally on their next save. The fallback refuses malformed legacy keys via `isMalformedCacheKey` — the same predicate the cleanup script now gates deletion on — so the dead `oiko oiko`/`oat rolled rolled` zombie rows can never be resurrected through the fallback.

### Round-2 tests

- Matrix extended: bell pepper (false-positive brand), the AI-rewritten `capsicum` regression case, dr pepper (+ AI-stripped "soda" variant showing multi-word brands still prefix), taco bell burrito ×2, decisive vs non-decisive stripped-brand cases, `isMalformedCacheKey` units.
- New pipeline suite `legacy-key-fallback.test.ts` (mocked helpers, real key derivation): a legacy-keyed row is found and served through the EARLY site (branded via `options.brand`) and through the STEP-1C site (AI normalize strips a decisive brand), with key-order assertions; and the zombie guard — the malformed legacy key `oat rolled rolled` is never looked up while its collapsed form `oat rolled` is.
- Full verification re-run: typecheck clean, lint:ci 0 errors, `next build` clean, jest **69/69 suites, 1054 passed, 1 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu
