### PR TITLE
feat(flywheel): seg replay-diff drift check in nightly sweep (report-only)

### DIFF
--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -19,6 +19,14 @@
  *      flips, per-100g kcal drift >5%, grams flap >25%, error deltas.
  *   4. EVAL GATE  — spawn run-eval.ts; real failures must be a subset of
  *      --allow-fail (default n-mq-10). Gate failure → exit 1.
+ *      4b. SEG REPLAY-DIFF (REPORT-ONLY) — top-N SegmentationCache lines by
+ *      hitCount re-run through fresh AI segmentation with the cache bypassed
+ *      (no cache read, NO cache write) and diffed against the cached splits;
+ *      writes results/seg-replay-<ts>.json + a trend line vs the previous
+ *      seg-replay artifact. Fail-soft: any error (LLM down, DB down) becomes
+ *      a warning in the report and NEVER changes the sweep's exit code or
+ *      gating. Logic: src/lib/ops/seg-replay.ts. Cost ~N LLM calls (default
+ *      20, --seg-replay-top).
  *   5. REPORT     — results/flywheel-<ts>.{json,md}; --publish-dir copies the
  *      markdown (dated + flywheel-latest.md) somewhere Syncthing carries it
  *      (e.g. sync-docs/) so every machine sees the nightly report.
@@ -31,12 +39,18 @@
  *   npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register \
  *     scripts/eval/flywheel-sweep.ts --base http://localhost:3000 \
  *     [--days 7] [--top 100] [--concurrency 4] [--allow-fail n-mq-10] \
- *     [--skip-warm] [--skip-eval] [--publish-dir sync-docs]
+ *     [--skip-warm] [--skip-eval] [--seg-replay-top 20] [--publish-dir sync-docs]
  *
  * --stuck-keys-only runs JUST the stuck-key report (read-only against the DB,
  * writes only results/stuck-keys-<ts>.json) — no warm, no eval, no publish.
+ * --seg-replay-only likewise runs JUST the seg replay-diff step (reads the DB,
+ * ~N LLM calls, writes only results/seg-replay-<ts>.json).
  */
 
+// Load .env before any src/lib import: the seg replay-diff step calls the LLM
+// in-process and structured-client captures OPENROUTER_API_KEY & co. from
+// process.env at import time. dotenv never overrides vars already set.
+import 'dotenv/config';
 import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
@@ -46,6 +60,11 @@ import {
     collectStuckKeys, computeStuckTrend, findPreviousStuckReport, formatStuckKeysSection,
     StuckKeysReport, StuckTrend,
 } from '../../src/lib/ops/stuck-keys';
+import {
+    collectSegReplay, computeSegReplayTrend, failedSegReplayReport, findPreviousSegReplayReport,
+    formatSegReplaySection, SegReplayReport, SegReplayTrend, SEG_REPLAY_DEFAULT_TOP_N,
+} from '../../src/lib/ops/seg-replay';
+import { segmentTextWithAi } from '../../src/lib/nlp/ai-segmenter';
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
@@ -61,6 +80,8 @@ const ALLOW_FAIL = (argValue('--allow-fail') ?? 'n-mq-10').split(',').map(s => s
 const SKIP_WARM = args.includes('--skip-warm');
 const SKIP_EVAL = args.includes('--skip-eval');
 const STUCK_ONLY = args.includes('--stuck-keys-only');
+const SEG_REPLAY_TOP = Number(argValue('--seg-replay-top') ?? SEG_REPLAY_DEFAULT_TOP_N);
+const SEG_REPLAY_ONLY = args.includes('--seg-replay-only');
 const PUBLISH_DIR = argValue('--publish-dir');
 
 const RESULTS_DIR = path.join(__dirname, 'results');
@@ -184,6 +205,64 @@ async function runStuckKeysReport(ranAt: string, stamp: string): Promise<StuckKe
         }, null, 1));
     }
     return { report, trend, outPath };
+}
+
+// ---------------------------------------------------------------------------
+// 4b. Seg replay-diff (REPORT-ONLY) — logic in src/lib/ops/seg-replay.ts
+// ---------------------------------------------------------------------------
+
+interface SegReplayRun {
+    report: SegReplayReport;
+    trend: SegReplayTrend;
+    /** results/seg-replay-<ts>.json; null when the step failed (nothing to trend against). */
+    outPath: string | null;
+}
+
+/**
+ * Fail-soft wrapper: this step is strictly report-only. ANY failure (prisma
+ * init, DB, LLM, fs) is folded into an ok:false report section — it must
+ * never throw into main() and never influence the eval gate's exit code.
+ */
+async function runSegReplayStep(ranAt: string, stamp: string): Promise<SegReplayRun> {
+    try {
+        const prisma = new PrismaClient();
+        let report: SegReplayReport;
+        try {
+            report = await collectSegReplay(prisma, segmentTextWithAi, { topN: SEG_REPLAY_TOP });
+        } finally {
+            await prisma.$disconnect().catch(() => {});
+        }
+
+        // Locate the previous artifact BEFORE writing this run's file (trend input).
+        const prev = findPreviousSegReplayReport(RESULTS_DIR);
+        const trend = computeSegReplayTrend(report.drifts, prev);
+
+        let outPath: string | null = null;
+        if (report.ok) {
+            // Zero cached lines is a valid (clean) result and still a trend
+            // datapoint; a failed run writes nothing so it can't fake a clean zero.
+            fs.mkdirSync(RESULTS_DIR, { recursive: true });
+            outPath = path.join(RESULTS_DIR, `seg-replay-${stamp}.json`);
+            fs.writeFileSync(outPath, JSON.stringify({ ranAt, ...report, trend }, null, 1));
+        }
+        return { report, trend, outPath };
+    } catch (err) {
+        return {
+            report: failedSegReplayReport(SEG_REPLAY_TOP, (err as Error).message),
+            trend: { previous: null, previousDrifts: null, delta: null },
+            outPath: null,
+        };
+    }
+}
+
+function segReplaySummaryLine(seg: SegReplayRun): string {
+    const r = seg.report;
+    if (!r.ok) return `  unavailable (report-only, not gating): ${r.error}`;
+    if (r.cachedLines === 0) return '  0 cached lines to replay — clean zero';
+    const trendBit = seg.trend.previous === null
+        ? 'first run'
+        : `prev drifts ${seg.trend.previousDrifts}, Δ ${seg.trend.delta}`;
+    return `  replayed ${r.replayed}: ${r.matches} match / ${r.drifts} drift / ${r.aiErrors} ai_error (${trendBit})`;
 }
 
 // ---------------------------------------------------------------------------
@@ -312,7 +391,7 @@ function fmtTable(rows: string[][], header: string[]): string {
 
 function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport | null,
     seedCount: number, telemetrySeedCount: number, diff: WarmDiff | null, gate: EvalGate | null,
-    stuck: StuckKeysRun | null): string {
+    stuck: StuckKeysRun | null, segReplay: SegReplayRun | null): string {
     const lines: string[] = [];
     lines.push(`# Flywheel sweep — ${ranAt}`);
     lines.push('');
@@ -403,6 +482,12 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
         if (stuck.outPath) lines.push('', `Triage input: \`${path.basename(stuck.outPath)}\``);
         lines.push('');
     }
+
+    if (segReplay) {
+        lines.push(...formatSegReplaySection(segReplay.report, segReplay.trend));
+        if (segReplay.outPath) lines.push('', `Artifact: \`${path.basename(segReplay.outPath)}\``);
+        lines.push('');
+    }
     return lines.join('\n');
 }
 
@@ -418,6 +503,15 @@ async function main() {
         console.log('');
         console.log(formatStuckKeysSection(stuck.report, stuck.trend).join('\n'));
         if (stuck.outPath) console.log(`\nJSON: ${stuck.outPath}`);
+        return;
+    }
+
+    if (SEG_REPLAY_ONLY) {
+        console.log(`Seg-replay-only report @ ${ranAt} (top ${SEG_REPLAY_TOP} cached lines)`);
+        const seg = await runSegReplayStep(ranAt, stamp);
+        console.log('');
+        console.log(formatSegReplaySection(seg.report, seg.trend).join('\n'));
+        if (seg.outPath) console.log(`\nJSON: ${seg.outPath}`);
         return;
     }
 
@@ -465,6 +559,11 @@ async function main() {
             : `  ${gate.pass ? 'PASS' : 'FAIL'} (real fails: ${gate.realFails.map(f => f.id).join(', ') || 'none'})`);
     }
 
+    // Report-only drift check — runs after the gate, never changes its verdict.
+    console.log('\n[4b] Seg replay-diff (report-only)…');
+    const segReplay = await runSegReplayStep(ranAt, stamp);
+    console.log(segReplaySummaryLine(segReplay));
+
     fs.mkdirSync(RESULTS_DIR, { recursive: true });
     const jsonPath = path.join(RESULTS_DIR, `flywheel-${stamp}.json`);
     fs.writeFileSync(jsonPath, JSON.stringify({
@@ -477,9 +576,18 @@ async function main() {
             ok: stuck.report.ok, error: stuck.report.error,
             count: stuck.report.count, trend: stuck.trend, report: stuck.outPath,
         },
+        // Entries live in the dedicated seg-replay-<ts>.json; summary + pointer here.
+        segReplay: {
+            ok: segReplay.report.ok, error: segReplay.report.error,
+            topN: segReplay.report.topN, cachedLines: segReplay.report.cachedLines,
+            replayed: segReplay.report.replayed, matches: segReplay.report.matches,
+            drifts: segReplay.report.drifts, aiErrors: segReplay.report.aiErrors,
+            driftRate: segReplay.report.driftRate,
+            trend: segReplay.trend, report: segReplay.outPath,
+        },
     }, null, 1));
 
-    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate, stuck);
+    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate, stuck, segReplay);
     const mdPath = path.join(RESULTS_DIR, `flywheel-${stamp}.md`);
     fs.writeFileSync(mdPath, md);
     console.log(`\nReport: ${mdPath}`);

--- a/scripts/seg-replay-diff.ts
+++ b/scripts/seg-replay-diff.ts
@@ -1,149 +1,42 @@
 /**
- * seg-replay-diff.ts — drift defense for the SegmentationCache.
+ * seg-replay-diff.ts — standalone CLI for the SegmentationCache drift defense.
  *
- * A cached segmentation is served verbatim forever (within SEG_PARSER_VERSION
- * and the 30d TTL), so silent drift between cached splits and what the LLM
- * would say TODAY is invisible in production. This script takes the top-N
- * cached lines by hitCount (the rows doing the most serving), re-runs AI
- * segmentation for each while BYPASSING the cache (direct segmentTextWithAi
- * call — no route, no lookup, no write-back), and diffs the outputs on item
- * count + normalized item names (src/lib/nlp/segmentation-diff.ts; multiset
- * compare, order-insensitive).
+ * Thin wrapper over src/lib/ops/seg-replay.ts (collectSegReplay + trend +
+ * markdown section) — the SAME logic the nightly flywheel sweep runs as its
+ * report-only "seg replay-diff" step (scripts/eval/flywheel-sweep.ts, step 4b;
+ * `npm run flywheel:sweep -- --seg-replay-only` is the sweep-flavored twin of
+ * this script). See the lib header for semantics: top-N cached lines by
+ * hitCount, fresh AI segmentation with the cache BYPASSED (no read, no write —
+ * the replay never overwrites the cached split), diff on item count +
+ * normalized names (match / drift / ai_error).
  *
- * Statuses per line:
- *   - match:    fresh split agrees with the cached one
- *   - drift:    count or name multiset changed — model/prompt behavior moved;
- *               investigate, and if real, bump SEG_PARSER_VERSION
- *   - ai_error: the fresh LLM call failed/timed out — NOT drift, retry later
+ * Read-only on the DB, paid on the LLM (~$0.0003/line) — keep --top modest.
+ * On drift: investigate; if the fresh splits are correct/intended, bump
+ * SEG_PARSER_VERSION (src/lib/nlp/ai-segmenter.ts).
  *
- * The script never mutates SegmentationCache. It is read-only on the DB and
- * paid on the LLM (~$0.0003/line) — keep --top modest.
- *
- * Wiring into the nightly flywheel sweep (scripts/eval/flywheel-sweep.ts) is a
- * follow-up PR; runReplayDiff() is importable and pure of CLI state for that.
- *
- * Run (from repo root; needs DATABASE_URL + OPENROUTER_API_KEY):
+ * Run (from repo root; .env supplies DATABASE_URL + OPENROUTER_API_KEY):
  *   npm run seg:replay-diff -- [--top 50] [--out <file>]
  * or:
  *   npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register \
  *     scripts/seg-replay-diff.ts --top 50
  *
- * Writes scripts/eval/results/seg-replay-diff-<timestamp>.json:
- *   { generatedAt, parserVersion, topN, replayed, matches, drifts, aiErrors,
- *     driftRate, entries: [{ lineKey, hitCount, status, cachedCount,
- *     freshCount, onlyCached, onlyFresh, cachedNames, freshNames }] }
+ * Writes scripts/eval/results/seg-replay-<timestamp>.json (same artifact
+ * family the sweep writes and trends against):
+ *   { ranAt, parserVersion, topN, cachedLines, replayed, skippedMalformed,
+ *     matches, drifts, aiErrors, driftRate, entries, trend }
  */
 
+import 'dotenv/config';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PrismaClient } from '@prisma/client';
+import { segmentTextWithAi } from '../src/lib/nlp/ai-segmenter';
 import {
-    SEG_PARSER_VERSION,
-    SegmentedItem,
-    isSegmentedItemArray,
-    segmentTextWithAi,
-} from '../src/lib/nlp/ai-segmenter';
-import { diffSegments, segmentNames } from '../src/lib/nlp/segmentation-diff';
-
-export interface ReplayDiffEntry {
-    lineKey: string;
-    hitCount: number;
-    status: 'match' | 'drift' | 'ai_error';
-    cachedCount: number;
-    freshCount: number | null;
-    onlyCached: string[];
-    onlyFresh: string[];
-    cachedNames: string[];
-    freshNames: string[] | null;
-}
-
-export interface ReplayDiffReport {
-    generatedAt: string;
-    parserVersion: string;
-    topN: number;
-    replayed: number;
-    skippedMalformed: number;
-    matches: number;
-    drifts: number;
-    aiErrors: number;
-    /** drifts / (matches + drifts) — ai_error rows are excluded. */
-    driftRate: number;
-    entries: ReplayDiffEntry[];
-}
-
-/**
- * Replay the top-N cached lines through fresh AI segmentation and diff.
- * Sequential on purpose: N is small (nightly top-50) and the 'parse' purpose
- * shares a concurrency semaphore with live traffic.
- */
-export async function runReplayDiff(prisma: PrismaClient, topN: number): Promise<ReplayDiffReport> {
-    const rows = await prisma.segmentationCache.findMany({
-        where: { parserVersion: SEG_PARSER_VERSION },
-        orderBy: { hitCount: 'desc' },
-        take: topN,
-    });
-    console.log(`[seg-replay] ${rows.length} cached lines (parserVersion=${SEG_PARSER_VERSION}, top ${topN} by hitCount)`);
-
-    const entries: ReplayDiffEntry[] = [];
-    let skippedMalformed = 0;
-
-    for (const [i, row] of rows.entries()) {
-        const cached: unknown = row.segmentsJson;
-        if (!isSegmentedItemArray(cached)) {
-            // Route-side validation already treats these as misses; just report.
-            console.warn(`[seg-replay] malformed segmentsJson for "${row.lineKey}" — skipping`);
-            skippedMalformed += 1;
-            continue;
-        }
-
-        const fresh = await segmentTextWithAi(row.lineKey);
-        if (fresh === null) {
-            entries.push({
-                lineKey: row.lineKey,
-                hitCount: row.hitCount,
-                status: 'ai_error',
-                cachedCount: cached.length,
-                freshCount: null,
-                onlyCached: [],
-                onlyFresh: [],
-                cachedNames: segmentNames(cached),
-                freshNames: null,
-            });
-        } else {
-            const diff = diffSegments(cached, fresh as SegmentedItem[]);
-            entries.push({
-                lineKey: row.lineKey,
-                hitCount: row.hitCount,
-                status: diff.same ? 'match' : 'drift',
-                cachedCount: diff.cachedCount,
-                freshCount: diff.freshCount,
-                onlyCached: diff.onlyCached,
-                onlyFresh: diff.onlyFresh,
-                cachedNames: segmentNames(cached),
-                freshNames: segmentNames(fresh as SegmentedItem[]),
-            });
-        }
-        if ((i + 1) % 10 === 0) console.log(`[seg-replay]   ${i + 1}/${rows.length}`);
-    }
-
-    const matches = entries.filter((e) => e.status === 'match').length;
-    const drifts = entries.filter((e) => e.status === 'drift').length;
-    const aiErrors = entries.filter((e) => e.status === 'ai_error').length;
-    const compared = matches + drifts;
-
-    return {
-        generatedAt: new Date().toISOString(),
-        parserVersion: SEG_PARSER_VERSION,
-        topN,
-        replayed: entries.length,
-        skippedMalformed,
-        matches,
-        drifts,
-        aiErrors,
-        driftRate: compared > 0 ? Number((drifts / compared).toFixed(4)) : 0,
-        entries,
-    };
-}
+    collectSegReplay,
+    computeSegReplayTrend,
+    findPreviousSegReplayReport,
+    formatSegReplaySection,
+} from '../src/lib/ops/seg-replay';
 
 function argValue(args: string[], flag: string): string | undefined {
     const idx = args.indexOf(flag);
@@ -159,26 +52,29 @@ async function main(): Promise<void> {
     }
 
     const prisma = new PrismaClient();
+    let report;
     try {
-        const report = await runReplayDiff(prisma, topN);
-
-        const outDir = path.join(__dirname, 'eval', 'results');
-        fs.mkdirSync(outDir, { recursive: true });
-        const ts = new Date().toISOString().replace(/[:.]/g, '-');
-        const outPath = argValue(args, '--out') ?? path.join(outDir, `seg-replay-diff-${ts}.json`);
-        fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
-
-        console.log(`[seg-replay] replayed ${report.replayed}: ${report.matches} match / ${report.drifts} drift / ${report.aiErrors} ai_error (driftRate ${(report.driftRate * 100).toFixed(1)}%)`);
-        for (const e of report.entries.filter((x) => x.status === 'drift')) {
-            console.log(`[seg-replay]   DRIFT "${e.lineKey}" (hits ${e.hitCount}): ${e.cachedCount}→${e.freshCount} items; -[${e.onlyCached.join(', ')}] +[${e.onlyFresh.join(', ')}]`);
-        }
-        console.log(`[seg-replay] report: ${outPath}`);
-        if (report.drifts > 0) {
-            console.log('[seg-replay] drift detected — review; if the new splits are correct/intended, bump SEG_PARSER_VERSION');
-        }
+        report = await collectSegReplay(prisma, segmentTextWithAi, { topN });
     } finally {
         await prisma.$disconnect();
     }
+    if (!report.ok) {
+        console.error(`[seg-replay] failed: ${report.error}`);
+        process.exit(1);
+    }
+
+    const outDir = path.join(__dirname, 'eval', 'results');
+    // Locate the previous artifact BEFORE writing this run's file (trend input).
+    const prev = findPreviousSegReplayReport(outDir);
+    const trend = computeSegReplayTrend(report.drifts, prev);
+
+    fs.mkdirSync(outDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = argValue(args, '--out') ?? path.join(outDir, `seg-replay-${ts}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({ ranAt: new Date().toISOString(), ...report, trend }, null, 1));
+
+    console.log(formatSegReplaySection(report, trend).join('\n'));
+    console.log(`\n[seg-replay] report: ${outPath}`);
 }
 
 if (require.main === module) {

--- a/src/lib/ops/__tests__/seg-replay.test.ts
+++ b/src/lib/ops/__tests__/seg-replay.test.ts
@@ -1,0 +1,378 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SEG_PARSER_VERSION, SegmentedItem } from '../../nlp/ai-segmenter';
+import {
+    collectSegReplay,
+    computeSegReplayTrend,
+    failedSegReplayReport,
+    findPreviousSegReplayReport,
+    formatSegReplaySection,
+    SegCacheReadClient,
+    SegReplayReport,
+    SegReplayTrend,
+    SEG_REPLAY_DEFAULT_TOP_N,
+} from '../seg-replay';
+
+/**
+ * Tests for the nightly sweep's seg replay-diff step (report-only drift check
+ * over SegmentationCache). Prisma and the AI segmenter are both mocked — the
+ * step's contract is: top-N by hitCount, NEVER writes to the cache, aggregates
+ * diffs, trends vs the previous artifact, and fails soft on every error.
+ */
+
+function item(normalizedForm: string, rawText = normalizedForm): SegmentedItem {
+    return { rawText, mealType: 'snacks', brand: '', normalizedForm };
+}
+
+interface CacheRow { lineKey: string; hitCount: number; segmentsJson: unknown }
+
+/** Full prisma-delegate mock incl. write methods, to prove none is ever called. */
+function mockDb(result: CacheRow[] | Error) {
+    const findMany = result instanceof Error
+        ? jest.fn().mockRejectedValue(result)
+        : jest.fn().mockResolvedValue(result);
+    const writes = {
+        create: jest.fn(), createMany: jest.fn(), update: jest.fn(), updateMany: jest.fn(),
+        upsert: jest.fn(), delete: jest.fn(), deleteMany: jest.fn(),
+    };
+    const db = { segmentationCache: { findMany, ...writes } } as unknown as SegCacheReadClient;
+    return { db, findMany, writes };
+}
+
+const ROWS: CacheRow[] = [
+    {
+        lineKey: '2 eggs and toast for breakfast', hitCount: 41,
+        segmentsJson: [item('eggs', '2 eggs'), item('toast')],
+    },
+    {
+        lineKey: 'chicken and rice', hitCount: 17,
+        segmentsJson: [item('chicken'), item('rice')],
+    },
+    {
+        lineKey: 'protein shake', hitCount: 5,
+        segmentsJson: [item('protein shake')],
+    },
+];
+
+describe('collectSegReplay', () => {
+    it('selects top-N by hitCount for the current parser version, read-only', async () => {
+        const { db, findMany, writes } = mockDb(ROWS);
+        const segment = jest.fn(async (text: string) =>
+            (ROWS.find(r => r.lineKey === text)!.segmentsJson as SegmentedItem[]));
+
+        const report = await collectSegReplay(db, segment, { topN: 3 });
+
+        expect(findMany).toHaveBeenCalledTimes(1);
+        expect(findMany).toHaveBeenCalledWith({
+            where: { parserVersion: SEG_PARSER_VERSION },
+            orderBy: { hitCount: 'desc' },
+            take: 3,
+            select: { lineKey: true, hitCount: true, segmentsJson: true },
+        });
+        // No-write guarantee: the replay must never overwrite the cached split.
+        for (const spy of Object.values(writes)) expect(spy).not.toHaveBeenCalled();
+        // Segmenter got each cached line exactly once (cache bypassed, direct call).
+        expect(segment.mock.calls.map(c => c[0])).toEqual(ROWS.map(r => r.lineKey));
+
+        expect(report.ok).toBe(true);
+        expect(report.parserVersion).toBe(SEG_PARSER_VERSION);
+        expect(report.cachedLines).toBe(3);
+        expect(report.replayed).toBe(3);
+        expect(report.matches).toBe(3);
+        expect(report.drifts).toBe(0);
+        expect(report.aiErrors).toBe(0);
+        expect(report.driftRate).toBe(0);
+    });
+
+    it('defaults topN to SEG_REPLAY_DEFAULT_TOP_N', async () => {
+        const { db, findMany } = mockDb([]);
+        await collectSegReplay(db, jest.fn());
+        expect(findMany.mock.calls[0][0].take).toBe(SEG_REPLAY_DEFAULT_TOP_N);
+    });
+
+    it('aggregates match / drift / ai_error and computes driftRate excluding ai_error', async () => {
+        const rows: CacheRow[] = [
+            { lineKey: 'a', hitCount: 9, segmentsJson: [item('eggs'), item('toast')] },
+            { lineKey: 'b', hitCount: 8, segmentsJson: [item('chicken'), item('rice')] },
+            { lineKey: 'c', hitCount: 7, segmentsJson: [item('oatmeal')] },
+        ];
+        const { db } = mockDb(rows);
+        const segment = jest.fn()
+            // a: same names, different order → match (multiset compare)
+            .mockResolvedValueOnce([item('toast'), item('eggs')])
+            // b: "chicken and rice" now one item → drift
+            .mockResolvedValueOnce([item('chicken and rice')])
+            // c: LLM failure (ai-segmenter returns null)
+            .mockResolvedValueOnce(null);
+
+        const report = await collectSegReplay(db, segment, { topN: 3 });
+        expect(report.matches).toBe(1);
+        expect(report.drifts).toBe(1);
+        expect(report.aiErrors).toBe(1);
+        expect(report.driftRate).toBe(0.5); // 1 drift / (1 match + 1 drift)
+
+        const drift = report.entries.find(e => e.status === 'drift')!;
+        expect(drift.lineKey).toBe('b');
+        expect(drift.cachedCount).toBe(2);
+        expect(drift.freshCount).toBe(1);
+        expect(drift.onlyCached).toEqual(['chicken', 'rice']);
+        expect(drift.onlyFresh).toEqual(['chicken and rice']);
+        expect(drift.cachedNames).toEqual(['chicken', 'rice']);
+        expect(drift.freshNames).toEqual(['chicken and rice']);
+
+        const aiError = report.entries.find(e => e.status === 'ai_error')!;
+        expect(aiError.lineKey).toBe('c');
+        expect(aiError.freshCount).toBeNull();
+        expect(aiError.freshNames).toBeNull();
+        expect(aiError.error).toBeUndefined(); // returned null, did not throw
+    });
+
+    it('skips malformed cached segmentsJson without calling the segmenter for it', async () => {
+        const rows: CacheRow[] = [
+            { lineKey: 'good', hitCount: 3, segmentsJson: [item('eggs')] },
+            { lineKey: 'bad', hitCount: 2, segmentsJson: { not: 'an array' } },
+            { lineKey: 'empty', hitCount: 1, segmentsJson: [] },
+        ];
+        const { db } = mockDb(rows);
+        const segment = jest.fn().mockResolvedValue([item('eggs')]);
+
+        const report = await collectSegReplay(db, segment, { topN: 3 });
+        expect(segment).toHaveBeenCalledTimes(1);
+        expect(segment).toHaveBeenCalledWith('good');
+        expect(report.cachedLines).toBe(3);
+        expect(report.replayed).toBe(1);
+        expect(report.skippedMalformed).toBe(2);
+        expect(report.matches).toBe(1);
+    });
+
+    it('a DB failure is captured as ok:false, never thrown (sweep must not die)', async () => {
+        const { db } = mockDb(new Error('connection refused'));
+        const segment = jest.fn();
+        const report = await collectSegReplay(db, segment, { topN: 5 });
+        expect(report.ok).toBe(false);
+        expect(report.error).toBe('connection refused');
+        expect(report.topN).toBe(5);
+        expect(report.replayed).toBe(0);
+        expect(report.entries).toEqual([]);
+        expect(segment).not.toHaveBeenCalled();
+    });
+
+    it('a segmenter THROW becomes that line\'s ai_error and the remaining lines still run', async () => {
+        const rows: CacheRow[] = [
+            { lineKey: 'a', hitCount: 2, segmentsJson: [item('eggs')] },
+            { lineKey: 'b', hitCount: 1, segmentsJson: [item('rice')] },
+        ];
+        const { db } = mockDb(rows);
+        const segment = jest.fn()
+            .mockRejectedValueOnce(new Error('LLM down'))
+            .mockResolvedValueOnce([item('rice')]);
+
+        const report = await collectSegReplay(db, segment, { topN: 2 });
+        expect(report.ok).toBe(true);
+        expect(report.aiErrors).toBe(1);
+        expect(report.matches).toBe(1);
+        const errored = report.entries.find(e => e.lineKey === 'a')!;
+        expect(errored.status).toBe('ai_error');
+        expect(errored.error).toBe('LLM down');
+    });
+
+    it('zero cached lines is a valid ok report (clean zero), not an error', async () => {
+        const { db } = mockDb([]);
+        const segment = jest.fn();
+        const report = await collectSegReplay(db, segment, { topN: 20 });
+        expect(report.ok).toBe(true);
+        expect(report.cachedLines).toBe(0);
+        expect(report.replayed).toBe(0);
+        expect(report.driftRate).toBe(0);
+        expect(segment).not.toHaveBeenCalled();
+    });
+});
+
+describe('failedSegReplayReport', () => {
+    it('builds the ok:false shell used when the step itself blows up', () => {
+        const report = failedSegReplayReport(20, 'prisma init failed');
+        expect(report.ok).toBe(false);
+        expect(report.error).toBe('prisma init failed');
+        expect(report.topN).toBe(20);
+        expect(report.parserVersion).toBe(SEG_PARSER_VERSION);
+        expect(report.entries).toEqual([]);
+    });
+});
+
+describe('computeSegReplayTrend', () => {
+    it('first run: no previous report', () => {
+        expect(computeSegReplayTrend(2, null)).toEqual({ previous: null, previousDrifts: null, delta: null });
+    });
+
+    it('delta vs previous drift count (growth, shrink, flat)', () => {
+        const prev = { path: '/x/results/seg-replay-2026-07-20.json', drifts: 1 };
+        expect(computeSegReplayTrend(3, prev)).toEqual({
+            previous: 'seg-replay-2026-07-20.json', previousDrifts: 1, delta: 2,
+        });
+        expect(computeSegReplayTrend(0, prev).delta).toBe(-1);
+        expect(computeSegReplayTrend(1, prev).delta).toBe(0);
+    });
+});
+
+describe('findPreviousSegReplayReport', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seg-replay-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    function writeReport(name: string, content: unknown, mtimeSec: number): string {
+        const p = path.join(dir, name);
+        fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content));
+        fs.utimesSync(p, mtimeSec, mtimeSec);
+        return p;
+    }
+
+    it('returns null when the dir does not exist or holds no seg-replay files', () => {
+        expect(findPreviousSegReplayReport(path.join(dir, 'nope'))).toBeNull();
+        writeReport('flywheel-2026-07-20.json', { drifts: 9 }, 1000);
+        writeReport('stuck-keys-2026-07-20.json', { count: 3 }, 1000);
+        expect(findPreviousSegReplayReport(dir)).toBeNull();
+    });
+
+    it('picks the most recent seg-replay-*.json by mtime and reads its drift count', () => {
+        writeReport('seg-replay-2026-07-19.json', { drifts: 4, entries: [] }, 1000);
+        const newest = writeReport('seg-replay-2026-07-20.json', { drifts: 1, entries: [] }, 2000);
+        expect(findPreviousSegReplayReport(dir)).toEqual({ path: newest, drifts: 1 });
+    });
+
+    it('falls back to counting drift entries when drifts is missing, skips unparseable files and excludePath', () => {
+        writeReport('seg-replay-a.json', {
+            entries: [{ status: 'drift' }, { status: 'match' }, { status: 'drift' }],
+        }, 1000);
+        writeReport('seg-replay-b.json', '{not json', 2000);
+        const excluded = writeReport('seg-replay-c.json', { drifts: 7 }, 3000);
+        expect(findPreviousSegReplayReport(dir, excluded))
+            .toEqual({ path: path.join(dir, 'seg-replay-a.json'), drifts: 2 });
+    });
+
+    it('also accepts legacy seg-replay-diff-*.json artifacts (same prefix family)', () => {
+        const legacy = writeReport('seg-replay-diff-2026-07-20.json', {
+            entries: [{ status: 'drift' }],
+        }, 1000);
+        expect(findPreviousSegReplayReport(dir)).toEqual({ path: legacy, drifts: 1 });
+    });
+});
+
+describe('formatSegReplaySection', () => {
+    const firstRun: SegReplayTrend = { previous: null, previousDrifts: null, delta: null };
+
+    function okReport(partial: Partial<SegReplayReport>): SegReplayReport {
+        return {
+            ok: true, parserVersion: 'seg-v1', topN: 20,
+            cachedLines: 0, replayed: 0, skippedMalformed: 0,
+            matches: 0, drifts: 0, aiErrors: 0, driftRate: 0, entries: [],
+            ...partial,
+        };
+    }
+
+    it('renders header, summary, trend and drift table with pipe-escaped cells', () => {
+        const report = okReport({
+            cachedLines: 3, replayed: 3, matches: 1, drifts: 1, aiErrors: 1, driftRate: 0.5,
+            entries: [
+                {
+                    lineKey: 'a', hitCount: 9, status: 'match', cachedCount: 2, freshCount: 2,
+                    onlyCached: [], onlyFresh: [], cachedNames: ['eggs', 'toast'], freshNames: ['eggs', 'toast'],
+                },
+                {
+                    lineKey: 'rice | beans', hitCount: 8, status: 'drift', cachedCount: 2, freshCount: 1,
+                    onlyCached: ['beans', 'rice'], onlyFresh: ['rice and beans'],
+                    cachedNames: ['beans', 'rice'], freshNames: ['rice and beans'],
+                },
+                {
+                    lineKey: 'c', hitCount: 7, status: 'ai_error', cachedCount: 1, freshCount: null,
+                    onlyCached: [], onlyFresh: [], cachedNames: ['oatmeal'], freshNames: null,
+                },
+            ],
+        });
+        const md = formatSegReplaySection(report, firstRun).join('\n');
+        expect(md).toContain('## Seg replay-diff (report-only)');
+        expect(md).toContain('no cache read, no cache write');
+        expect(md).toContain('3 lines checked · 1 match · 1 drift · 1 ai_error · drift rate 50.0%');
+        expect(md).toContain('Trend: first run (no previous seg-replay report).');
+        expect(md).toContain('### Drifts (1 of 1 shown, by hitCount)');
+        expect(md).toContain('| rice \\| beans | 8 | 2 → 1 | beans, rice | rice and beans |');
+        expect(md).toContain('bump SEG_PARSER_VERSION');
+        expect(md).toContain('AI errors (fresh split failed — not drift, retry next sweep): "c"');
+        // match rows do not get table rows of their own
+        expect(md).not.toContain('| a | 9 |');
+    });
+
+    it('zero cached lines renders a clean zero-section, not an error', () => {
+        const md = formatSegReplaySection(okReport({}), firstRun).join('\n');
+        expect(md).toContain('## Seg replay-diff (report-only)');
+        expect(md).toContain('clean zero');
+        expect(md).toContain('Trend: first run');
+        expect(md).not.toContain('### Drifts');
+        expect(md).not.toContain('unavailable');
+    });
+
+    it('all-match run has no drift table and no drift note', () => {
+        const report = okReport({
+            cachedLines: 2, replayed: 2, matches: 2,
+            entries: [
+                {
+                    lineKey: 'a', hitCount: 2, status: 'match', cachedCount: 1, freshCount: 1,
+                    onlyCached: [], onlyFresh: [], cachedNames: ['eggs'], freshNames: ['eggs'],
+                },
+                {
+                    lineKey: 'b', hitCount: 1, status: 'match', cachedCount: 1, freshCount: 1,
+                    onlyCached: [], onlyFresh: [], cachedNames: ['rice'], freshNames: ['rice'],
+                },
+            ],
+        });
+        const md = formatSegReplaySection(report, firstRun).join('\n');
+        expect(md).toContain('2 lines checked · 2 match · 0 drift · 0 ai_error · drift rate 0.0%');
+        expect(md).not.toContain('### Drifts');
+        expect(md).not.toContain('bump SEG_PARSER_VERSION');
+    });
+
+    it('reports skipped malformed rows in the summary line', () => {
+        const md = formatSegReplaySection(
+            okReport({ cachedLines: 2, replayed: 1, matches: 1, skippedMalformed: 1 }),
+            firstRun,
+        ).join('\n');
+        expect(md).toContain('1 malformed cached row(s) skipped');
+    });
+
+    it('trend line reports the drift delta against the previous artifact', () => {
+        const base = okReport({ cachedLines: 1, replayed: 1, drifts: 3, driftRate: 1 });
+        const grow: SegReplayTrend = { previous: 'seg-replay-2026-07-20.json', previousDrifts: 1, delta: 2 };
+        expect(formatSegReplaySection(base, grow).join('\n'))
+            .toContain('Trend: drifts 1 → 3 (+2) vs `seg-replay-2026-07-20.json`.');
+        const shrink: SegReplayTrend = { previous: 'seg-replay-2026-07-20.json', previousDrifts: 5, delta: -2 };
+        expect(formatSegReplaySection(base, shrink).join('\n')).toContain('(-2)');
+        const flat: SegReplayTrend = { previous: 'seg-replay-2026-07-20.json', previousDrifts: 3, delta: 0 };
+        expect(formatSegReplaySection(base, flat).join('\n')).toContain('(±0)');
+    });
+
+    it('caps the drift table at maxRows but reports the full drift count', () => {
+        const entries = Array.from({ length: 8 }, (_, i) => ({
+            lineKey: `line ${i}`, hitCount: 8 - i, status: 'drift' as const,
+            cachedCount: 1, freshCount: 2, onlyCached: [], onlyFresh: [`extra ${i}`],
+            cachedNames: [`food ${i}`], freshNames: [`food ${i}`, `extra ${i}`],
+        }));
+        const report = okReport({ cachedLines: 8, replayed: 8, drifts: 8, driftRate: 1, entries });
+        const md = formatSegReplaySection(report, firstRun, 5).join('\n');
+        expect(md).toContain('### Drifts (5 of 8 shown, by hitCount)');
+        expect(md).toContain('| line 4 |');
+        expect(md).not.toContain('| line 5 |');
+    });
+
+    it('failed report renders as unavailable and states it never gates', () => {
+        const md = formatSegReplaySection(failedSegReplayReport(20, 'boom'), firstRun).join('\n');
+        expect(md).toContain('_unavailable: boom_');
+        expect(md).toContain('never affects');
+        expect(md).not.toContain('### Drifts');
+    });
+});

--- a/src/lib/ops/seg-replay.ts
+++ b/src/lib/ops/seg-replay.ts
@@ -1,0 +1,332 @@
+/**
+ * seg-replay.ts — segmentation replay-diff drift check for the nightly
+ * flywheel sweep (scripts/eval/flywheel-sweep.ts) and the standalone
+ * scripts/seg-replay-diff.ts wrapper.
+ *
+ * A cached segmentation (SegmentationCache) is served verbatim forever within
+ * SEG_PARSER_VERSION and the 30d TTL, so drift between cached splits and what
+ * the LLM would say TODAY is invisible in production. This module takes the
+ * top-N cached lines by hitCount (the rows doing the most serving), re-runs AI
+ * segmentation for each with the cache BYPASSED (direct segmenter call — no
+ * cache read, and never a cache write: the replay must not overwrite the
+ * cached split), and diffs the outputs on item count + normalized item names
+ * (src/lib/nlp/segmentation-diff.ts; multiset compare, order-insensitive).
+ *
+ * Statuses per line:
+ *   - match:    fresh split agrees with the cached one
+ *   - drift:    count or name multiset changed — model/prompt behavior moved;
+ *               investigate, and if the fresh splits are correct/intended,
+ *               bump SEG_PARSER_VERSION
+ *   - ai_error: the fresh LLM call failed/threw/timed out — NOT drift
+ *
+ * REPORT-ONLY + fail-soft by contract: collectSegReplay never throws (a DB
+ * failure comes back as an ok:false report the sweep can render), and nothing
+ * here may influence the sweep's gating or exit code. Read-only on the DB,
+ * paid on the LLM (~$0.0003/line) — keep topN modest (nightly default 20).
+ *
+ * Lives in src/lib (not scripts/) so the logic is jest-coverable — the jest
+ * projects only match tests under src/**. Structural model: stuck-keys.ts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { SEG_PARSER_VERSION, SegmentedItem, isSegmentedItemArray } from '../nlp/ai-segmenter';
+import { diffSegments, segmentNames } from '../nlp/segmentation-diff';
+
+/** Nightly default: ~20 LLM calls/night is the accepted budget. */
+export const SEG_REPLAY_DEFAULT_TOP_N = 20;
+
+/**
+ * Structural slice of PrismaClient we need — read-only by construction (the
+ * interface exposes no write method), which is the module-level enforcement of
+ * the "replay never overwrites the cached split" guarantee.
+ */
+export interface SegCacheReadClient {
+    segmentationCache: {
+        findMany(args: {
+            where: { parserVersion: string };
+            orderBy: { hitCount: 'desc' };
+            take: number;
+            select: { lineKey: true; hitCount: true; segmentsJson: true };
+        }): Promise<{ lineKey: string; hitCount: number; segmentsJson: unknown }[]>;
+    };
+}
+
+/** Fresh-segmentation function: SegmentedItem[] on success, null on LLM failure (ai-segmenter contract). */
+export type SegmentFn = (text: string) => Promise<SegmentedItem[] | null>;
+
+export type SegReplayStatus = 'match' | 'drift' | 'ai_error';
+
+export interface SegReplayEntry {
+    lineKey: string;
+    hitCount: number;
+    status: SegReplayStatus;
+    cachedCount: number;
+    freshCount: number | null;
+    /** Names in the cached split but missing from the fresh one (drift only). */
+    onlyCached: string[];
+    /** Names in the fresh split but missing from the cached one (drift only). */
+    onlyFresh: string[];
+    cachedNames: string[];
+    freshNames: string[] | null;
+    /** Set only when the segmenter THREW (vs returning null) — always status ai_error. */
+    error?: string;
+}
+
+export interface SegReplayReport {
+    ok: boolean;
+    error?: string;
+    parserVersion: string;
+    topN: number;
+    /** Rows fetched from SegmentationCache (0 is a valid, clean result). */
+    cachedLines: number;
+    replayed: number;
+    skippedMalformed: number;
+    matches: number;
+    drifts: number;
+    aiErrors: number;
+    /** drifts / (matches + drifts) — ai_error rows are excluded. */
+    driftRate: number;
+    entries: SegReplayEntry[];
+}
+
+export interface SegReplayTrend {
+    /** Basename of the previous seg-replay-*.json compared against; null = first run. */
+    previous: string | null;
+    previousDrifts: number | null;
+    /** current drifts − previous drifts; null on first run. */
+    delta: number | null;
+}
+
+/** ok:false report shell — used internally and by callers wrapping unexpected step failures. */
+export function failedSegReplayReport(topN: number, error: string): SegReplayReport {
+    return {
+        ok: false, error, parserVersion: SEG_PARSER_VERSION, topN,
+        cachedLines: 0, replayed: 0, skippedMalformed: 0,
+        matches: 0, drifts: 0, aiErrors: 0, driftRate: 0, entries: [],
+    };
+}
+
+/**
+ * Replay the top-N cached lines through fresh AI segmentation and diff.
+ * Sequential on purpose: N is small and the 'parse' purpose shares a
+ * concurrency semaphore with live traffic. Never throws: a DB failure returns
+ * ok:false; a per-line segmenter throw becomes that line's ai_error entry and
+ * the remaining lines still run.
+ */
+export async function collectSegReplay(
+    db: SegCacheReadClient,
+    segment: SegmentFn,
+    opts?: { topN?: number },
+): Promise<SegReplayReport> {
+    const topN = opts?.topN ?? SEG_REPLAY_DEFAULT_TOP_N;
+
+    let rows: { lineKey: string; hitCount: number; segmentsJson: unknown }[];
+    try {
+        rows = await db.segmentationCache.findMany({
+            where: { parserVersion: SEG_PARSER_VERSION },
+            orderBy: { hitCount: 'desc' },
+            take: topN,
+            select: { lineKey: true, hitCount: true, segmentsJson: true },
+        });
+    } catch (err) {
+        return failedSegReplayReport(topN, (err as Error).message);
+    }
+
+    const entries: SegReplayEntry[] = [];
+    let skippedMalformed = 0;
+
+    for (const row of rows) {
+        const cached: unknown = row.segmentsJson;
+        if (!isSegmentedItemArray(cached)) {
+            // Route-side validation already treats these as misses; just count them.
+            skippedMalformed += 1;
+            continue;
+        }
+
+        let fresh: SegmentedItem[] | null = null;
+        let thrown: string | undefined;
+        try {
+            fresh = await segment(row.lineKey);
+        } catch (err) {
+            thrown = (err as Error).message;
+        }
+
+        if (fresh === null) {
+            entries.push({
+                lineKey: row.lineKey,
+                hitCount: row.hitCount,
+                status: 'ai_error',
+                cachedCount: cached.length,
+                freshCount: null,
+                onlyCached: [],
+                onlyFresh: [],
+                cachedNames: segmentNames(cached),
+                freshNames: null,
+                ...(thrown !== undefined ? { error: thrown } : {}),
+            });
+        } else {
+            const diff = diffSegments(cached, fresh);
+            entries.push({
+                lineKey: row.lineKey,
+                hitCount: row.hitCount,
+                status: diff.same ? 'match' : 'drift',
+                cachedCount: diff.cachedCount,
+                freshCount: diff.freshCount,
+                onlyCached: diff.onlyCached,
+                onlyFresh: diff.onlyFresh,
+                cachedNames: segmentNames(cached),
+                freshNames: segmentNames(fresh),
+            });
+        }
+    }
+
+    const matches = entries.filter((e) => e.status === 'match').length;
+    const drifts = entries.filter((e) => e.status === 'drift').length;
+    const aiErrors = entries.filter((e) => e.status === 'ai_error').length;
+    const compared = matches + drifts;
+
+    return {
+        ok: true,
+        parserVersion: SEG_PARSER_VERSION,
+        topN,
+        cachedLines: rows.length,
+        replayed: entries.length,
+        skippedMalformed,
+        matches,
+        drifts,
+        aiErrors,
+        driftRate: compared > 0 ? Number((drifts / compared).toFixed(4)) : 0,
+        entries,
+    };
+}
+
+/**
+ * Most recent previous seg-replay-*.json in resultsDir (by mtime), skipping
+ * excludePath and unparseable files. Returns its drift count for the trend
+ * line, or null when this is the first run. Same pattern as
+ * findPreviousStuckReport (stuck-keys.ts).
+ */
+export function findPreviousSegReplayReport(
+    resultsDir: string,
+    excludePath?: string,
+): { path: string; drifts: number } | null {
+    if (!fs.existsSync(resultsDir)) return null;
+    const files = fs.readdirSync(resultsDir)
+        .filter(f => f.startsWith('seg-replay-') && f.endsWith('.json'))
+        .map(f => path.join(resultsDir, f))
+        .filter(f => f !== excludePath)
+        .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+    for (const file of files) {
+        try {
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const drifts = typeof data?.drifts === 'number' ? data.drifts
+                : Array.isArray(data?.entries)
+                    ? data.entries.filter((e: { status?: string }) => e?.status === 'drift').length
+                    : null;
+            if (drifts !== null) return { path: file, drifts };
+        } catch {
+            // unparseable previous report — skip it, keep looking
+        }
+    }
+    return null;
+}
+
+export function computeSegReplayTrend(
+    currentDrifts: number,
+    prev: { path: string; drifts: number } | null,
+): SegReplayTrend {
+    if (!prev) return { previous: null, previousDrifts: null, delta: null };
+    return {
+        previous: path.basename(prev.path),
+        previousDrifts: prev.drifts,
+        delta: currentDrifts - prev.drifts,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatting (mirrors stuck-keys.ts / flywheel-sweep conventions)
+// ---------------------------------------------------------------------------
+
+/** Markdown-table cell safety: collapse newlines, escape pipes. */
+function cell(s: string): string {
+    return s.replace(/\s*\n\s*/g, ' ').replace(/\|/g, '\\|');
+}
+
+function mdTable(rows: string[][], header: string[]): string {
+    if (rows.length === 0) return '_none_';
+    return [
+        `| ${header.join(' | ')} |`,
+        `| ${header.map(() => '---').join(' | ')} |`,
+        ...rows.map(r => `| ${r.join(' | ')} |`),
+    ].join('\n');
+}
+
+function fmtDelta(delta: number): string {
+    if (delta > 0) return `+${delta}`;
+    if (delta < 0) return `${delta}`;
+    return '±0';
+}
+
+/**
+ * The "## Seg replay-diff (report-only)" section, as markdown lines ready for
+ * flywheel-sweep's buildMarkdown (or console output).
+ */
+export function formatSegReplaySection(
+    report: SegReplayReport,
+    trend: SegReplayTrend,
+    maxRows = 20,
+): string[] {
+    const lines: string[] = [];
+    lines.push('## Seg replay-diff (report-only)');
+    if (!report.ok) {
+        lines.push(`⚠️ _unavailable: ${report.error ?? 'unknown'}_ — report-only, never affects the sweep's gating or exit code.`);
+        return lines;
+    }
+
+    lines.push(`Top ${report.topN} cached segmentations (parserVersion \`${report.parserVersion}\`, by hitCount) `
+        + 're-run through a fresh AI split with the cache bypassed — no cache read, no cache write. '
+        + 'Report-only: drift here never fails the sweep.');
+
+    const trendLine = trend.previous === null
+        ? 'Trend: first run (no previous seg-replay report).'
+        : `Trend: drifts ${trend.previousDrifts} → ${report.drifts} (${fmtDelta(trend.delta ?? 0)}) vs \`${trend.previous}\`.`;
+
+    if (report.cachedLines === 0) {
+        lines.push('No cached lines to replay yet (SegmentationCache is empty for this parser version) — clean zero.');
+        lines.push(trendLine);
+        return lines;
+    }
+
+    const malformedNote = report.skippedMalformed > 0
+        ? ` · ${report.skippedMalformed} malformed cached row(s) skipped`
+        : '';
+    lines.push(`${report.replayed} lines checked · ${report.matches} match · ${report.drifts} drift · `
+        + `${report.aiErrors} ai_error · drift rate ${(report.driftRate * 100).toFixed(1)}%${malformedNote}`);
+    lines.push(trendLine);
+
+    const driftEntries = report.entries.filter(e => e.status === 'drift');
+    if (driftEntries.length > 0) {
+        const shown = driftEntries.slice(0, maxRows);
+        lines.push('');
+        lines.push(`### Drifts (${shown.length} of ${driftEntries.length} shown, by hitCount)`);
+        lines.push(mdTable(shown.map(e => [
+            cell(e.lineKey),
+            String(e.hitCount),
+            `${e.cachedCount} → ${e.freshCount ?? '?'}`,
+            cell(e.cachedNames.join(', ')),
+            cell((e.freshNames ?? []).join(', ')),
+        ]), ['line', 'hits', 'items (cached → fresh)', 'cached names', 'fresh names']));
+        lines.push('');
+        lines.push('Drift = the model would split these lines differently today. Investigate; '
+            + 'if the fresh splits are correct/intended, bump SEG_PARSER_VERSION.');
+    }
+
+    const errorEntries = report.entries.filter(e => e.status === 'ai_error');
+    if (errorEntries.length > 0) {
+        lines.push('');
+        lines.push(`AI errors (fresh split failed — not drift, retry next sweep): `
+            + errorEntries.slice(0, maxRows).map(e => `"${e.lineKey}"`).join(', '));
+    }
+    return lines;
+}


### PR DESCRIPTION
## What

Wires the segmentation replay-diff drift check into the nightly flywheel sweep as a new **report-only** step **[4b], after the eval gate**: the top-N `SegmentationCache` lines by `hitCount` (default 20, `--seg-replay-top`) are re-run through fresh AI segmentation with the cache **bypassed** (no cache read, **no cache write** — the replay never overwrites the cached split) and diffed against the cached segments using the existing pure diff logic (`src/lib/nlp/segmentation-diff.ts`).

## Changes

- **`src/lib/ops/seg-replay.ts`** (new): replay logic factored out of the standalone script, structurally modeled on `stuck-keys.ts`:
  - `collectSegReplay(db, segment, {topN})` — read-only structural prisma slice (the interface exposes no write method) + injected segmenter; never throws (DB failure → `ok:false` report; a per-line segmenter throw → that line's `ai_error`, remaining lines still run).
  - `findPreviousSegReplayReport` / `computeSegReplayTrend` — drift-count trend vs the previous `seg-replay-*.json`, same pattern as the stuck-keys trend.
  - `formatSegReplaySection` — the markdown section (drift table: line, hits, cached→fresh item counts, cached/fresh names; ai_error list; zero cached lines renders a clean zero-section).
- **`scripts/eval/flywheel-sweep.ts`**: step `[4b] Seg replay-diff (report-only)` inserted after the eval gate, before report writing. Emits the markdown section in `flywheel-<ts>.md`, a `seg-replay-<ts>.json` artifact in `scripts/eval/results/`, a trend line vs the previous artifact, and a summary+pointer block in `flywheel-<ts>.json`. **Fail-soft**: the whole step is wrapped — any error (LLM down, DB down, prisma init, fs) becomes a warning section and never changes the sweep's exit code or gating; no existing step/gate/exit code was modified. New `--seg-replay-only` flag mirrors `--stuck-keys-only`. Added `import 'dotenv/config'` (established scripts pattern, never overrides set vars) so the in-process LLM call sees `OPENROUTER_API_KEY`.
- **`scripts/seg-replay-diff.ts`**: reduced to a thin wrapper over the shared lib (no duplicated logic); writes the same `seg-replay-<ts>.json` artifact family the sweep trends against.
- **`src/lib/ops/__tests__/seg-replay.test.ts`** (new, 21 tests): mocked prisma (incl. write-method spies) + mocked segmenter — top-N selection, **no-write guarantee**, diff aggregation/driftRate (ai_error excluded), malformed-row skip, trend + previous-artifact lookup (incl. legacy `seg-replay-diff-*` names), fail-soft on DB errors and segmenter throws, markdown rendering (pipe escaping, clean zero, maxRows cap, unavailable).

Cost: ~N LLM calls/night (default 20, gpt-4o-mini ≈ $0.0003/call) — accepted budget.

## Live `--seg-replay-only` run (prod DB, 2026-07-21)

```
## Seg replay-diff (report-only)
Top 20 cached segmentations (parserVersion `seg-v1`, by hitCount) re-run through a fresh AI split with the cache bypassed — no cache read, no cache write. Report-only: drift here never fails the sweep.
20 lines checked · 18 match · 2 drift · 0 ai_error · drift rate 10.0%
Trend: first run (no previous seg-replay report).

### Drifts (2 of 2 shown, by hitCount)
| line | hits | items (cached → fresh) | cached names | fresh names |
| --- | --- | --- | --- | --- |
| greek yogurt with granola, honey and strawberries | 2 | 3 → 4 | greek yogurt with granola, honey, strawberries | granola, greek yogurt, honey, strawberries |
| coffee with cream and sugar | 0 | 3 → 1 | coffee, cream, sugar | coffee with cream and sugar |

Drift = the model would split these lines differently today. Investigate; if the fresh splits are correct/intended, bump SEG_PARSER_VERSION.
```

(Both drifts are real "with"-attachment flapping — exactly the class this check exists to surface. Report-only; no action taken here.)

## Verification

- `npm ci` clean; `npm run lint:ci` 0 errors (my files warning-free); `npm run typecheck` clean; `npx tsc --noEmit -p tsconfig.scripts.json` — 34 pre-existing errors in unrelated debug scripts, identical count before/after this change; `npm run build` OK.
- Full jest: **68 suites / 960 passed, 1 skipped (pre-existing), 0 failures**.
- No new env vars, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu