### PR TITLE
feat(serving): bare-serving defaults, count-noun sibling routing, cooked-grain volume preference

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -3841,7 +3841,7 @@
         230,
         320
       ],
-      "notes": "DEMOTED back to knownIssue 2026-07-19 (over-promoted same day after 3 passing runs; flapped on run 4: grams=360 vs [230,320], and record flips between 'cooked quinoa' and 'uncooked quinoa' 150-360g across identical requests). Same root as n-cook-05: NO stable cooked-quinoa record in corpus, serving is AI-estimated and nondeterministic. Do NOT promote until the quinoa ingest gap is fixed. | PROMOTED 2026-07-19 after 3 consecutive passing runs. | Previously: KNOWN ISSUE (flaky serving resolution — demoted from hard 2026-07-18 after it flipped between two consecutive eval runs). '1 1/2 cups cooked quinoa' resolves NONDETERMINISTICALLY: some runs pick an FDC 'cooked quinoa' record (~185g/ PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals."
+      "notes": "DEMOTED back to knownIssue 2026-07-19 (over-promoted same day after 3 passing runs; flapped on run 4: grams=360 vs [230,320], and record flips between 'cooked quinoa' and 'uncooked quinoa' 150-360g across identical requests). Same root as n-cook-05: NO stable cooked-quinoa record in corpus, serving is AI-estimated and nondeterministic. Do NOT promote until the quinoa ingest gap is fixed. | PROMOTED 2026-07-19 after 3 consecutive passing runs. | Previously: KNOWN ISSUE (flaky serving resolution — demoted from hard 2026-07-18 after it flipped between two consecutive eval runs). '1 1/2 cups cooked quinoa' resolves NONDETERMINISTICALLY: some runs pick an FDC 'cooked quinoa' record (~185g/ PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals. | FIX SHIPPED (Track 3, feat/bare-serving-defaults): buildFdcResult volume branch now resolves the record's OWN FdcServing volume row first (fdc 168917 usda_fdc cup=185g -> 277.5g deterministic, tier fdc_label_volume; cached AI rows reused as fdc_volume_cached) and the cooked-grain rerank path passes servingLabelMatch for candidates OWNING a matching volume serving, so re-retrieval prefers cup-serving records over generic-density fallbacks."
     },
     {
       "id": "n-serv-07",
@@ -4847,6 +4847,127 @@
       ],
       "knownIssue": true,
       "notes": "PR D pt3 class (a) KNOWN ISSUE — bare whole-meat-cut raise DEFERRED (warm-2026-07-20: billed 100g floor; a real ribeye portion is ~225g). Whole-meat cuts are deliberately ABSENT from the bare-query lexicon this PR (raise direction needs its own design). Promote when a steak-portion default ships."
+    },
+    {
+      "id": "n-serv-52",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "combos cheddar pretzel",
+        "quantity": 1,
+        "name": "combos cheddar pretzel"
+      },
+      "expectName": [
+        [
+          "combos"
+        ]
+      ],
+      "grams": [
+        25,
+        34
+      ],
+      "notes": "Track 3 bare-serving defaults (triage-2026-07-21, 82-row serving class). Bare qty-1 on a count-labeled SKU ('9 piece (28 g)') must bill the WHOLE 28g label serving via bare_label_serving, not the 28/9=3.11g per-piece divide. Deterministic: own-label step pre-empts every per-piece branch. Hard."
+    },
+    {
+      "id": "n-serv-53",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "sun chips harvest cheddar",
+        "quantity": 1,
+        "name": "sun chips harvest cheddar"
+      },
+      "expectName": [
+        [
+          "sun",
+          "chip"
+        ]
+      ],
+      "grams": [
+        25,
+        34
+      ],
+      "notes": "Track 3 bare-serving defaults. Same class as n-serv-52 via the '14 chips (28 g)' label: bare qty-1 was billed 2g (one chip). Own-label step bills 28g; the salty-snack lexicon CAP is inert (28 <= 2x28). Hard."
+    },
+    {
+      "id": "n-serv-54",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "yoplait original strawberry",
+        "quantity": 1,
+        "name": "yoplait original strawberry"
+      },
+      "expectName": [
+        [
+          "yoplait"
+        ]
+      ],
+      "grams": [
+        140,
+        190
+      ],
+      "notes": "Track 3 bare-serving defaults. 'strawberry' was resolved as a countable produce piece (12g) despite the record's own 170g cup label. Own-label step (bare_label_serving) bills the 170g label; brand sibling median (~150g, 198 SKUs) backstops label-less Yoplait records. Hard."
+    },
+    {
+      "id": "n-serv-55",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "pepper jack",
+        "quantity": 1,
+        "name": "pepper jack"
+      },
+      "expectName": [
+        [
+          "pepper",
+          "jack"
+        ]
+      ],
+      "grams": [
+        18,
+        40
+      ],
+      "notes": "Track 3 bare-serving defaults — head-gated CAP. The contained 'pepper' token matched the spice lexicon and capped the record's genuine 28g slice label to 2.5g. The CAP now fires only when the lexicon category is the query HEAD token ('jack' is not lexicon-covered), so the label stands. Hard."
+    },
+    {
+      "id": "n-serv-56",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "snickers",
+        "quantity": 1,
+        "name": "snickers"
+      },
+      "expectName": [
+        [
+          "snickers"
+        ]
+      ],
+      "grams": [
+        34,
+        60
+      ],
+      "notes": "Track 3 bare-serving defaults — sibling median. OFF's '1 portion (100 g)' placeholder is no longer accepted as a serving (usableBareLabelServing rejects exact-100g with a g/portion unit word); the same-brand sibling median answers instead (live: 148 Snickers SKUs, median 39.8g; real bars 41.7-48g). Deterministic given DB state. Hard."
+    },
+    {
+      "id": "n-serv-57",
+      "category": "serving_unit",
+      "item": {
+        "rawText": "kirkland protein bar chocolate chip",
+        "quantity": 1,
+        "name": "kirkland protein bar chocolate chip"
+      },
+      "expectName": [
+        [
+          "kirkland"
+        ],
+        [
+          "protein",
+          "bar"
+        ]
+      ],
+      "grams": [
+        40,
+        80
+      ],
+      "knownIssue": true,
+      "notes": "Track 3 bare-serving defaults KNOWN ISSUE (soft until 2 stable runs — n-serv-06 flap precedent). NULL-servingGrams SKU billed 1g (poisoned 'bar' cache row). New per-noun bounds reject cached bars <15g; routing: discrete 'bar' backfill -> brand sibling borrow -> AI (floor-clamped >=15g) -> 50g bare_discrete_floor. First resolution may be AI-estimated (~60g real bar), hence soft."
     },
     {
       "id": "n-mq-01",

--- a/src/lib/ai/ambiguous-serving-estimator.ts
+++ b/src/lib/ai/ambiguous-serving-estimator.ts
@@ -69,6 +69,16 @@ export const UNIT_MIN_GRAMS: Record<string, number> = {
     handful: 10, handfuls: 10,
     bowl: 25, bowls: 25,
     plate: 50, plates: 50,
+    // Discrete-piece nouns (count-noun sibling routing, Track 3 Jul 2026):
+    // a cached "bar" of 1.5g is a poisoned per-nut weight in disguise
+    // (barebells 1.5g class) — reject it so sibling-borrow/AI re-resolve.
+    // "slice" is deliberately ABSENT: genuine slices span 2g (pepperoni) to
+    // 30g+ (bread), so no single floor is safe.
+    bar: 15, bars: 15,
+    patty: 15, patties: 15,
+    link: 10, links: 10,
+    tortilla: 15, tortillas: 15,
+    cookie: 4, cookies: 4,
 };
 
 /** Sanity bounds for an ambiguous unit's per-unit grams; either side may be undefined. */
@@ -96,6 +106,13 @@ const UNIT_MAX_GRAMS: Record<string, number> = {
     // Pieces/strips/chunks/breasts: reasonable max for cut produce/meat
     piece: 200, pieces: 200, strip: 50, strips: 50, chunk: 50, chunks: 50,
     breast: 300, breasts: 300, thigh: 200, thighs: 200,
+    // Discrete-piece nouns (count-noun sibling routing, Track 3 Jul 2026):
+    // caps reject package-scale cached rows (a 340g "bar" is a multipack).
+    bar: 150, bars: 150,
+    patty: 250, patties: 250,
+    link: 100, links: 100,
+    tortilla: 120, tortillas: 120,
+    cookie: 100, cookies: 100,
 };
 
 export interface AmbiguousServingRequest {

--- a/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
+++ b/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Bare-serving defaults (Track 3, Jul 2026) — buildOffResult resolution order
+ * for digitless unitless qty-1 requests ("the unitless qty-1 class", 82
+ * confirmed triage rows 2026-07-21):
+ *   (1) the record's OWN in-band label serving  → 'bare_label_serving'
+ *   (2) count-noun piece when the NAME implies one (seed / discrete backfill)
+ *   (3) same-brand sibling median label serving → 'bare_sibling_serving'
+ *   (4) bounded floor — never flat-100g for a discrete-piece name
+ *
+ * Representative triage rows exercised here: combos cheddar pretzel (label
+ * over per-piece divide), yoplait original strawberry (label over seed piece),
+ * pepper jack (head-gated CAP), snickers/barebells (placeholder-100 → sibling
+ * median), kirkland protein bar (discrete backfill), sun chips (label over
+ * count-label divide).
+ */
+
+import { buildOffResult } from '../map-ingredient-with-fallback';
+import { hydrateOffCandidate } from '../../openfoodfacts/hydrate';
+import { getOrCreateAmbiguousServing } from '../ambiguous-unit-backfill';
+import { prisma } from '../../db';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+    },
+}));
+
+jest.mock('../../openfoodfacts/hydrate', () => ({
+    hydrateOffCandidate: jest.fn(),
+}));
+
+jest.mock('../ambiguous-unit-backfill', () => {
+    const actual = jest.requireActual('../ambiguous-unit-backfill');
+    return {
+        ...actual,
+        getOrCreateAmbiguousServing: jest.fn(),
+    };
+});
+
+function makeCandidate(name: string) {
+    return {
+        id: 'off_100',
+        source: 'openfoodfacts' as const,
+        name,
+        score: 1,
+        foodType: 'generic',
+        rawData: {},
+    } as any;
+}
+
+function makeHydrated(overrides: Record<string, unknown>) {
+    return {
+        foodId: 'off_100',
+        foodName: 'Food',
+        brandName: null,
+        nutrientsPer100g: { calories: 400, protein: 10, carbs: 50, fat: 15 },
+        servingGrams: null,
+        servingDescription: null,
+        servingUnitCount: 1,
+        packageQuantity: null,
+        packageQuantityUnit: null,
+        ...overrides,
+    };
+}
+
+function bareParsed(name: string, qty = 1): ParsedIngredient {
+    return { qty, multiplier: 1, unit: null, name };
+}
+
+const mockedQueryRaw = prisma.$queryRaw as jest.Mock;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedQueryRaw.mockResolvedValue([]);
+    (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'error', error: 'not mocked' });
+});
+
+describe('step (1) — own in-band label serving wins for bare requests', () => {
+    it("bills the full label serving, not the per-piece divide ('combos cheddar pretzel' 28g label ÷ 9 pieces)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Combos Cheddar Pretzel',
+            brandName: 'Combos',
+            servingGrams: 28,
+            servingDescription: '9 piece (28 g)',
+            servingUnitCount: 9,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Combos Cheddar Pretzel'),
+            bareParsed('combos cheddar pretzel'), 0.9, 'combos cheddar pretzel'
+        );
+
+        expect(result?.servingTier).toBe('bare_label_serving');
+        expect(result?.grams).toBe(28);   // NOT 28/9 = 3.11
+    });
+
+    it("bills the label cup, not the strawberry seed piece ('yoplait original strawberry' 170g vs 12g)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Yoplait Original Strawberry',
+            brandName: 'Yoplait',
+            servingGrams: 170,
+            servingDescription: '170 g',
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Yoplait Original Strawberry'),
+            bareParsed('yoplait original strawberry'), 0.9, 'yoplait original strawberry'
+        );
+
+        expect(result?.servingTier).toBe('bare_label_serving');
+        expect(result?.grams).toBe(170);
+    });
+
+    it("survives the contained-token spice cap ('pepper jack' 28g label, was capped to 2.5g)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Pepper Jack Cheese',
+            servingGrams: 28,
+            servingDescription: '3 SLICES (28 g)',
+            servingUnitCount: 3,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Pepper Jack Cheese'), bareParsed('pepper jack'), 0.9, 'pepper jack'
+        );
+
+        expect(result?.servingTier).toBe('bare_label_serving');
+        expect(result?.grams).toBe(28);
+    });
+
+    it("bills the count-labeled serving whole, not one chip ('sun chips harvest cheddar' 28g vs 2g)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Sun Chips Harvest Cheddar',
+            brandName: 'Sun Chips',
+            servingGrams: 28,
+            servingDescription: '14 chips (28 g)',
+            servingUnitCount: 14,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Sun Chips Harvest Cheddar'),
+            bareParsed('sun chips harvest cheddar'), 0.9, 'sun chips harvest cheddar'
+        );
+
+        expect(result?.servingTier).toBe('bare_label_serving');
+        expect(result?.grams).toBe(28);
+    });
+
+    it('explicit counts still use the per-piece divide ("3 sun chips" keeps label_count_derived)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Sun Chips Harvest Cheddar',
+            servingGrams: 28,
+            servingDescription: '14 chips (28 g)',
+            servingUnitCount: 14,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Sun Chips Harvest Cheddar'),
+            bareParsed('sun chips', 3), 0.9, '3 sun chips'
+        );
+
+        expect(result?.servingTier).toBe('label_count_derived');
+        expect(result?.grams).toBe(6);   // 3 × 2g per chip
+    });
+});
+
+describe('step (3) — same-brand sibling median for placeholder/garbage labels', () => {
+    it("resolves the placeholder-100 snickers SKU from 148 sibling bars (~39.8g)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Snickers',
+            brandName: 'Snickers',
+            servingGrams: 100,
+            servingDescription: '1 portion (100 g)',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 39.8, n: 148 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Snickers'), bareParsed('snickers'), 0.9, 'snickers'
+        );
+
+        expect(result?.servingTier).toBe('bare_sibling_serving');
+        expect(result?.grams).toBe(39.8);
+    });
+
+    it("resolves 'barebells caramel cashew' to the 55g brand median, not the 1.5g cashew seed", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Caramel Cashew',
+            brandName: 'Barebells',
+            servingGrams: 100,
+            servingDescription: '100 g',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 55, n: 200 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Caramel Cashew'),
+            bareParsed('barebells caramel cashew'), 0.9, 'barebells caramel cashew'
+        );
+
+        expect(result?.servingTier).toBe('bare_sibling_serving');
+        expect(result?.grams).toBe(55);
+    });
+
+    it('rejects garbage sub-3g label metadata and borrows the sibling median (hot-pocket "1.0g" class)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Ham & Cheese Hot Pocket',
+            brandName: 'Hot Pockets',
+            servingGrams: 1,
+            servingDescription: '1.0g',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 127, n: 12 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Ham & Cheese Hot Pocket'),
+            bareParsed('hot pocket ham and cheese'), 0.9, 'hot pocket ham and cheese'
+        );
+
+        expect(result?.servingTier).toBe('bare_sibling_serving');
+        expect(result?.grams).toBe(127);
+    });
+
+    it('fewer than 3 siblings → falls through to the label default + legacy CAP (butter chicken)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Butter Chicken',
+            brandName: 'Golden Chicken',
+            servingGrams: 100,
+            servingDescription: '1 portion (100 g)',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 55, n: 2 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Butter Chicken'), bareParsed('butter chicken'), 0.9, 'butter chicken'
+        );
+
+        // Sibling borrow refused (n < 3) → label_serving_default 100g → the
+        // legacy containment CAP ('butter' token) shrinks it to 14g. This
+        // documents the PRE-EXISTING tail defect (triage row: butter chicken
+        // 14g): fixing it requires >=3 brand siblings, which routes through
+        // the untouched bare_sibling_serving tier instead.
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(14);
+    });
+
+    it('digit lines never take the bare path ("1 gatorade" keeps the package bill)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Gatorade Thirst Quencher',
+            brandName: 'Gatorade',
+            servingGrams: null,
+            packageQuantity: 591,
+            packageQuantityUnit: 'ml',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 355, n: 190 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Gatorade Thirst Quencher'), bareParsed('gatorade'), 0.9, '1 gatorade'
+        );
+
+        expect(result?.servingTier).toBe('package_count_own');
+        expect(result?.grams).toBe(591);
+    });
+
+    it('bare beverage with an own ml package keeps drink-the-unit semantics (digitless "gatorade")', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Gatorade Thirst Quencher',
+            brandName: 'Gatorade',
+            servingGrams: null,
+            packageQuantity: 591,
+            packageQuantityUnit: 'ml',
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 355, n: 190 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Gatorade Thirst Quencher'), bareParsed('gatorade'), 0.9, 'gatorade'
+        );
+
+        expect(result?.servingTier).toBe('package_count_own');
+        expect(result?.grams).toBe(591);
+    });
+});
+
+describe('step (2) — count-noun piece resolution for bare requests', () => {
+    it("routes 'kirkland protein bar chocolate chip' through the discrete 'bar' backfill with brandForBorrow", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Protein Bar Chocolate Chip Cookie Dough',
+            brandName: 'Kirkland Signature',
+            servingGrams: null,
+        }));
+        (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'success', grams: 60 });
+
+        const result = await buildOffResult(
+            makeCandidate('Protein Bar Chocolate Chip Cookie Dough'),
+            bareParsed('kirkland protein bar chocolate chip'), 0.9, 'kirkland protein bar chocolate chip'
+        );
+
+        expect(result?.servingTier).toBe('discrete_unit_backfill');
+        expect(result?.grams).toBe(60);
+        expect(getOrCreateAmbiguousServing).toHaveBeenCalledWith(
+            'off_100', 'Protein Bar Chocolate Chip Cookie Dough', 'bar', 'Kirkland Signature'
+        );
+    });
+
+    it('runs the discrete backfill even when the label is a placeholder (bare request, 100g flat)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Barebells Protein Bar Caramel Cashew',
+            brandName: 'Barebells',
+            servingGrams: 100,
+            servingDescription: '100 g',
+        }));
+        (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'success', grams: 55 });
+
+        const result = await buildOffResult(
+            makeCandidate('Barebells Protein Bar Caramel Cashew'),
+            bareParsed('barebells protein bar'), 0.9, 'barebells protein bar'
+        );
+
+        expect(result?.servingTier).toBe('discrete_unit_backfill');
+        expect(result?.grams).toBe(55);
+    });
+
+    it("skips a tiny per-piece seed on a bare singular (bare 'almond' → lexicon 28g, not the 1.2g nut)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Almond',
+            servingGrams: null,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Almond'), bareParsed('almond'), 0.9, 'almond'
+        );
+
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(28);
+    });
+
+    it("keeps a piece-sized seed on a bare singular ('banana' 118g — the piece IS the serving)", async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Banana',
+            servingGrams: null,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Banana'), bareParsed('banana'), 0.9, 'banana'
+        );
+
+        expect(result?.servingTier).toBe('seed_count_default');
+        expect(result?.grams).toBe(118);
+    });
+
+    it('explicit counts keep tiny per-piece seeds ("3 almonds" → 3.6g)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Almonds',
+            servingGrams: null,
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Almonds'), bareParsed('almonds', 3), 0.9, '3 almonds'
+        );
+
+        expect(result?.servingTier).toBe('seed_count_default');
+        expect(result?.grams).toBeCloseTo(3.6, 1);
+    });
+});
+
+describe('step (4) — bounded discrete floor, never flat-100g for piece names', () => {
+    it('bills one ~50g bar when nothing else resolves (no brand, no label, backfill error)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            // Two-char first token keeps brandForBorrow null → no sibling borrow.
+            foodName: 'IQ Protein Bar Birthday Cake',
+            brandName: null,
+            servingGrams: null,
+        }));
+        (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'error', error: 'ai down' });
+
+        const result = await buildOffResult(
+            makeCandidate('IQ Protein Bar Birthday Cake'),
+            bareParsed('protein bar birthday cake'), 0.9, 'protein bar birthday cake'
+        );
+
+        expect(result?.servingTier).toBe('bare_discrete_floor');
+        expect(result?.grams).toBe(50);
+    });
+});

--- a/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
+++ b/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
@@ -367,6 +367,81 @@ describe('step (2) — count-noun piece resolution for bare requests', () => {
     });
 });
 
+describe('dose-anchored categories — own-label/sibling steps must NOT outrank the tsp/scoop default', () => {
+    it('n-serv-37: bare "sugar" ignores a cup-measure label and lands on the 4g tsp default', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Granulated White Sugar',
+            brandName: 'Domino',
+            servingGrams: 104,
+            servingDescription: '0.5 cup (104 g)',
+        }));
+        // Even a plausible sibling median must not answer either.
+        mockedQueryRaw.mockResolvedValue([{ med: 104, n: 12 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Granulated White Sugar'), bareParsed('sugar'), 0.9, 'sugar'
+        );
+
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(4);
+    });
+
+    it('n-serv-37 variant: label-less sugar record skips the sibling median too', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Granulated White Sugar',
+            brandName: 'Domino',
+            servingGrams: null,
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 104, n: 12 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Granulated White Sugar'), bareParsed('sugar'), 0.9, 'sugar'
+        );
+
+        // count_unresolved_floor → REPLACE via the sugars lexicon entry.
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(4);
+    });
+
+    it('n-serv-43: bare "ghost pre workout" skips the 32.5g two-scoop sibling median → 12g scoop default', async () => {
+        // Live shape: off_0810028296060 has NULL servingGrams/servingSize;
+        // 147 Ghost siblings (protein tubs) median exactly 32.5g — which the
+        // eval caught billing as bare_sibling_serving.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Ghost Legend Pre Workout Cherry Limeade',
+            brandName: 'Ghost',
+            servingGrams: null,
+        }));
+        mockedQueryRaw.mockResolvedValue([{ med: 32.5, n: 147 }]);
+
+        const result = await buildOffResult(
+            makeCandidate('Ghost Legend Pre Workout Cherry Limeade'),
+            bareParsed('ghost pre workout'), 0.9, 'ghost pre workout'
+        );
+
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(12);
+    });
+
+    it('dose category with an in-band package tier still resolves through the CAP (ghost 473g tub → 12g)', async () => {
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Ghost Legend Pre Workout',
+            brandName: 'Ghost',
+            servingGrams: null,
+            packageQuantity: 473,
+            packageQuantityUnit: 'ml',
+        }));
+
+        const result = await buildOffResult(
+            makeCandidate('Ghost Legend Pre Workout'),
+            bareParsed('ghost pre workout'), 0.9, 'ghost pre workout'
+        );
+
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(12);
+    });
+});
+
 describe('step (4) — bounded discrete floor, never flat-100g for piece names', () => {
     it('bills one ~50g bar when nothing else resolves (no brand, no label, backfill error)', async () => {
         (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({

--- a/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
+++ b/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
@@ -120,7 +120,10 @@ describe('buildOffResult — bare-query guard wire-in (A1)', () => {
             makeCandidate('Tomato Ketchup'), bareParsed('ketchup'), 0.9, 'ketchup'
         );
 
-        expect(result?.servingTier).toBe('label_serving_default');
+        // Since the bare-serving defaults (Track 3, Jul 2026), an in-band own
+        // label serving on a bare singular bills as 'bare_label_serving' —
+        // same grams, more precise telemetry.
+        expect(result?.servingTier).toBe('bare_label_serving');
         expect(result?.grams).toBe(15);
     });
 

--- a/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
+++ b/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
@@ -120,10 +120,10 @@ describe('buildOffResult — bare-query guard wire-in (A1)', () => {
             makeCandidate('Tomato Ketchup'), bareParsed('ketchup'), 0.9, 'ketchup'
         );
 
-        // Since the bare-serving defaults (Track 3, Jul 2026), an in-band own
-        // label serving on a bare singular bills as 'bare_label_serving' —
-        // same grams, more precise telemetry.
-        expect(result?.servingTier).toBe('bare_label_serving');
+        // Ketchup is a dose-anchored condiment (tbsp default), so the Track 3
+        // own-label step defers to the original label/CAP flow — byte-
+        // identical to master.
+        expect(result?.servingTier).toBe('label_serving_default');
         expect(result?.grams).toBe(15);
     });
 

--- a/src/lib/mapping/__tests__/count-noun-sibling-routing.test.ts
+++ b/src/lib/mapping/__tests__/count-noun-sibling-routing.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Count-noun sibling routing (Track 3, Jul 2026) — probes that the unit nouns
+ * bar / patty / link / slice / tortilla, requested against a SKU LACKING that
+ * serving, actually reach borrowSiblingServing inside
+ * getOrCreateAmbiguousServing instead of dead-ending in AI/flat-100g:
+ *
+ *   - routing: bar/link are estimable-unknown units; patty/slice/tortilla sit
+ *     in AMBIGUOUS_UNITS — all five route into getOrCreateAmbiguousServing;
+ *   - poisoned cached rows below the new per-noun UNIT_MIN_GRAMS bounds are
+ *     rejected (the barebells "bar"=1.5g class) so the sibling borrow runs;
+ *   - food-name seed fallbacks outside the unit bounds are rejected (a "bar"
+ *     request on "… Caramel Cashew" must not surface the 1.5g cashew seed);
+ *   - the golden probe: a branded bar whose exact SKU lacks a "bar" serving
+ *     resolves from sibling label servings (Quest/Chomps style).
+ */
+
+import { getOrCreateAmbiguousServing } from '../ambiguous-unit-backfill';
+import {
+    isAmbiguousUnit,
+    isEstimableUnknownUnit,
+    AMBIGUOUS_UNITS,
+    getAmbiguousUnitBounds,
+} from '../../ai/ambiguous-serving-estimator';
+import { estimateAmbiguousServing } from '../../ai/ambiguous-serving-estimator';
+import { prisma } from '../../db';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        offServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue({}),
+        },
+        fdcServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue({}),
+        },
+        aiGeneratedServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue({}),
+        },
+    },
+}));
+
+// AI estimation must never be reached in the sibling-borrow paths under test.
+jest.mock('../../ai/ambiguous-serving-estimator', () => {
+    const actual = jest.requireActual('../../ai/ambiguous-serving-estimator');
+    return {
+        ...actual,
+        estimateAmbiguousServing: jest.fn().mockResolvedValue({ status: 'error', error: 'ai must not run' }),
+    };
+});
+
+const mockedQueryRaw = prisma.$queryRaw as jest.Mock;
+const mockedOffServingFindUnique = prisma.offServing.findUnique as jest.Mock;
+const mockedOffServingUpsert = prisma.offServing.upsert as jest.Mock;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedQueryRaw.mockResolvedValue([]);
+    mockedOffServingFindUnique.mockResolvedValue(null);
+});
+
+describe('routing: all five nouns are estimable units', () => {
+    it.each(['bar', 'link'])('"%s" routes via isEstimableUnknownUnit (not in AMBIGUOUS_UNITS)', (noun) => {
+        expect(AMBIGUOUS_UNITS.has(noun)).toBe(false);
+        expect(isEstimableUnknownUnit(noun)).toBe(true);
+        expect(isAmbiguousUnit(noun)).toBe(true);
+    });
+
+    it.each(['patty', 'slice', 'tortilla'])('"%s" routes via the curated AMBIGUOUS_UNITS set', (noun) => {
+        expect(AMBIGUOUS_UNITS.has(noun)).toBe(true);
+        expect(isAmbiguousUnit(noun)).toBe(true);
+    });
+
+    it('per-noun bounds exist for bar/patty/link/tortilla (not slice — too food-varied)', () => {
+        expect(getAmbiguousUnitBounds('bar')).toEqual({ min: 15, max: 150 });
+        expect(getAmbiguousUnitBounds('patty')).toEqual({ min: 15, max: 250 });
+        expect(getAmbiguousUnitBounds('link')).toEqual({ min: 10, max: 100 });
+        expect(getAmbiguousUnitBounds('tortilla')).toEqual({ min: 15, max: 120 });
+        expect(getAmbiguousUnitBounds('slice')).toEqual({ min: undefined, max: undefined });
+    });
+});
+
+describe('golden probe: branded bar whose SKU lacks a "bar" serving', () => {
+    it('borrows the sibling median from same-brand label servings (Quest style)', async () => {
+        // No cached serving for this SKU; three sibling SKUs carry genuine
+        // "bar" label servings.
+        mockedQueryRaw.mockResolvedValue([
+            { grams: 60, description: '1 bar (60 g)' },
+            { grams: 54, description: 'bar' },
+            { grams: 100, description: '2 bars (100 g)' },  // → 50 per bar
+        ]);
+
+        const r = await getOrCreateAmbiguousServing(
+            'off_888', 'Chocolate Chip Cookie Dough Protein Bar', 'bar', 'Quest'
+        );
+
+        expect(r.status).toBe('success');
+        expect(r.grams).toBe(54);   // median of [60, 54, 50]
+        expect(estimateAmbiguousServing).not.toHaveBeenCalled();
+        // Borrowed value is persisted as a non-AI 'sibling_borrow' serving.
+        expect(mockedOffServingUpsert).toHaveBeenCalledWith(expect.objectContaining({
+            create: expect.objectContaining({ source: 'sibling_borrow', isAiEstimated: false, grams: 54 }),
+        }));
+    });
+
+    it('a poisoned cached "bar" row below the 15g floor is rejected and the sibling borrow runs (barebells 1.5g class)', async () => {
+        mockedOffServingFindUnique.mockResolvedValue({ grams: 1.5 });
+        mockedQueryRaw.mockResolvedValue([
+            { grams: 55, description: '1 bar (55 g)' },
+            { grams: 55, description: 'bar' },
+        ]);
+
+        const r = await getOrCreateAmbiguousServing(
+            'off_777', 'Caramel Cashew Protein Bar', 'bar', 'Barebells'
+        );
+
+        expect(r.status).toBe('success');
+        expect(r.grams).toBe(55);
+        expect(estimateAmbiguousServing).not.toHaveBeenCalled();
+    });
+
+    it('a sane cached "bar" row is served from cache (no borrow, no AI)', async () => {
+        mockedOffServingFindUnique.mockResolvedValue({ grams: 60 });
+
+        const r = await getOrCreateAmbiguousServing(
+            'off_777', 'Protein Bar', 'bar', 'Quest'
+        );
+
+        expect(r).toEqual({ status: 'cached', grams: 60 });
+        expect(mockedQueryRaw).not.toHaveBeenCalled();
+    });
+
+    it('a food-name seed outside the unit bounds is rejected ("bar" on "… Caramel Cashew" ≠ 1.5g cashew)', async () => {
+        // getDefaultCountServing falls back to the food-name last word:
+        // 'cashew' seeds 1.5g — out of the bar [15,150] bounds, so the
+        // routing must continue to the sibling borrow.
+        mockedQueryRaw.mockResolvedValue([
+            { grams: 55, description: '1 bar (55 g)' },
+            { grams: 55, description: 'bar' },
+        ]);
+
+        const r = await getOrCreateAmbiguousServing(
+            'off_777', 'Caramel Cashew', 'bar', 'Barebells'
+        );
+
+        expect(r.status).toBe('success');
+        expect(r.grams).toBe(55);
+        expect(estimateAmbiguousServing).not.toHaveBeenCalled();
+    });
+});
+
+describe.each([
+    ['patty', 'Beyond Burger Patty Pack', 'Beyond Meat', 113, 5],
+    ['link', 'Original Breakfast Sausage', 'Johnsonville', 45, 2],
+    ['slice', 'Sourdough Bread Loaf', 'Daves Killer Bread', 32, 4],
+    // 'tortilla' resolves one tier EARLIER — the curated 45g seed answers
+    // before the borrow (also a non-dead-end); grams below mirror the seed
+    // so the assertion holds for whichever deterministic tier answered.
+    ['tortilla', 'Flour Tortillas Family Pack', 'Mission', 45, 7],
+])('sibling routing for "%s"', (noun, foodName, brand, gramsPerPiece, poisoned) => {
+    it(`reaches borrowSiblingServing when the SKU lacks a "${noun}" serving`, async () => {
+        mockedQueryRaw.mockResolvedValue([
+            { grams: gramsPerPiece, description: `1 ${noun} (${gramsPerPiece} g)` },
+            { grams: gramsPerPiece * 2, description: `2 ${noun}s (${gramsPerPiece * 2} g)` },
+            { grams: gramsPerPiece, description: noun },
+        ]);
+
+        const r = await getOrCreateAmbiguousServing(`off_${noun}1`, foodName, noun, brand);
+
+        expect(r.status).toBe('success');
+        expect(r.grams).toBe(gramsPerPiece);
+        expect(estimateAmbiguousServing).not.toHaveBeenCalled();
+    });
+
+    it(`rejects a poisoned sub-floor cached "${noun}" row where a floor exists`, async () => {
+        mockedOffServingFindUnique.mockResolvedValue({ grams: poisoned });
+        mockedQueryRaw.mockResolvedValue([
+            { grams: gramsPerPiece, description: `1 ${noun} (${gramsPerPiece} g)` },
+            { grams: gramsPerPiece, description: noun },
+        ]);
+
+        const r = await getOrCreateAmbiguousServing(`off_${noun}2`, foodName, noun, brand);
+
+        const { min } = getAmbiguousUnitBounds(noun);
+        if (min != null && poisoned < min) {
+            // Poisoned row rejected → sibling borrow answers.
+            expect(r.grams).toBe(gramsPerPiece);
+            expect(r.status).toBe('success');
+        } else {
+            // 'slice' has no floor: cached row is (deliberately) trusted.
+            expect(r).toEqual({ status: 'cached', grams: poisoned });
+        }
+    });
+});
+
+describe('dead-end guard: no brand → no borrow → AI (bounded), never flat-100g here', () => {
+    it('null brand skips the sibling borrow and reaches the (mocked, failing) AI estimator', async () => {
+        const r = await getOrCreateAmbiguousServing('off_999', 'Generic Protein Bar', 'bar', null);
+
+        expect(mockedQueryRaw).not.toHaveBeenCalled();
+        expect(estimateAmbiguousServing).toHaveBeenCalled();
+        expect(r.status).toBe('error');   // caller falls to its own floor logic
+    });
+});

--- a/src/lib/mapping/__tests__/fdc-volume-serving.test.ts
+++ b/src/lib/mapping/__tests__/fdc-volume-serving.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Cooked-grain volume-serving preference (Track 3, Jul 2026) — n-serv-06.
+ *
+ * Root cause of the quinoa flap: buildFdcResult's volume branch NEVER
+ * consulted existing FdcServing rows — every "1.5 cups cooked quinoa" went
+ * straight to AI estimation (nondeterministic) and, on failure, to the
+ * generic 240ml×density fallback (360g for 1.5 cups), even though fdc 168917
+ * carries a genuine usda_fdc "cup"=185g row.
+ *
+ * Fix under test:
+ *   (0) findOwnFdcVolumeServing resolves the record's own matching volume
+ *       serving first — genuine rows beat cached AI rows, both beat a fresh
+ *       AI call ('fdc_label_volume' / 'fdc_volume_cached');
+ *   - candidateHasVolumeServing feeds the rerank serving-shape flag so the
+ *     cooked-grain re-retrieval prefers candidates owning a cup serving.
+ */
+
+import {
+    hydrateAndSelectServing,
+    findOwnFdcVolumeServing,
+    candidateHasVolumeServing,
+} from '../map-ingredient-with-fallback';
+import { insertFdcAiServing } from '../../usda/fdc-ai-backfill';
+import { prisma } from '../../db';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcServing: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findUnique: jest.fn().mockResolvedValue(null),
+            findFirst: jest.fn().mockResolvedValue(null),
+            upsert: jest.fn().mockResolvedValue({}),
+        },
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+    },
+}));
+
+jest.mock('../../usda/fdc-ai-backfill', () => {
+    const actual = jest.requireActual('../../usda/fdc-ai-backfill');
+    return {
+        ...actual,
+        insertFdcAiServing: jest.fn().mockResolvedValue({ success: false, reason: 'mocked-off' }),
+    };
+});
+
+const mockedFindMany = prisma.fdcServing.findMany as jest.Mock;
+
+function quinoaCandidate() {
+    return {
+        id: 'fdc_168917',
+        source: 'fdc' as const,
+        name: 'Quinoa, cooked',
+        score: 1,
+        foodType: 'foundation',
+        nutrition: { kcal: 120, protein: 4.4, carbs: 21.3, fat: 1.92, per100g: true },
+        rawData: {},
+    } as any;
+}
+
+function cupsParsed(qty = 1.5): ParsedIngredient {
+    return { qty, multiplier: 1, unit: 'cup', name: 'cooked quinoa' };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFindMany.mockResolvedValue([]);
+    (insertFdcAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'mocked-off' });
+});
+
+describe('findOwnFdcVolumeServing', () => {
+    it('prefers the genuine usda_fdc cup row over a cached AI row', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: '1 cup', grams: 240, isAiEstimated: true },
+            { description: 'cup', grams: 185, isAiEstimated: false },
+        ]);
+
+        const r = await findOwnFdcVolumeServing(168917, 'cup');
+        expect(r).toEqual({ perUnitGrams: 185, genuine: true });
+    });
+
+    it('falls back to a cached AI row when no genuine row matches', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: '1 cup', grams: 210, isAiEstimated: true },
+        ]);
+
+        const r = await findOwnFdcVolumeServing(168917, 'cup');
+        expect(r).toEqual({ perUnitGrams: 210, genuine: false });
+    });
+
+    it('divides multi-unit descriptions ("0.25 cup" 61.25g → 245 g/cup)', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: '0.25 cup', grams: 61.25, isAiEstimated: false },
+        ]);
+
+        const r = await findOwnFdcVolumeServing(1, 'cup');
+        expect(r).toEqual({ perUnitGrams: 245, genuine: true });
+    });
+
+    it('rejects corrupt rows outside the density band (a 976g "cup" is a package weight)', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: 'cup', grams: 976, isAiEstimated: false },
+        ]);
+
+        expect(await findOwnFdcVolumeServing(1, 'cup')).toBeNull();
+    });
+
+    it('matches tablespoon spellings for a tbsp request, but never a non-volume row', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: '1 tablespoon', grams: 21, isAiEstimated: false },
+            { description: '1 cupcake', grams: 66, isAiEstimated: false },
+        ]);
+
+        expect(await findOwnFdcVolumeServing(1, 'tbsp')).toEqual({ perUnitGrams: 21, genuine: true });
+        expect(await findOwnFdcVolumeServing(1, 'cup')).toBeNull();  // "cupcake" must not match "cup"
+    });
+
+    it('returns null for unsupported units', async () => {
+        expect(await findOwnFdcVolumeServing(1, 'bar')).toBeNull();
+        expect(mockedFindMany).not.toHaveBeenCalled();
+    });
+});
+
+describe('buildFdcResult volume branch (via hydrateAndSelectServing)', () => {
+    it('n-serv-06: "1.5 cups cooked quinoa" bills 1.5 × the genuine 185g cup row — no AI call', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: 'cup', grams: 185, isAiEstimated: false },
+            { description: '1 cup', grams: 185, isAiEstimated: true },
+        ]);
+
+        const result = await hydrateAndSelectServing(
+            quinoaCandidate(), cupsParsed(1.5), 0.9, '1 1/2 cups cooked quinoa'
+        );
+
+        expect(result?.grams).toBeCloseTo(277.5, 1);           // inside the [230,320] golden band
+        expect(result?.servingTier).toBe('fdc_label_volume');
+        expect(result?.kcal).toBeCloseTo(120 * 2.775, 1);
+        expect(insertFdcAiServing).not.toHaveBeenCalled();     // determinism: no fresh estimate
+    });
+
+    it('reuses a cached AI cup row deterministically when no genuine row exists', async () => {
+        mockedFindMany.mockResolvedValue([
+            { description: '1 cup', grams: 190, isAiEstimated: true },
+        ]);
+
+        const result = await hydrateAndSelectServing(
+            quinoaCandidate(), cupsParsed(1.5), 0.9, '1 1/2 cups cooked quinoa'
+        );
+
+        expect(result?.grams).toBeCloseTo(285, 1);
+        expect(result?.servingTier).toBe('fdc_volume_cached');
+        expect(insertFdcAiServing).not.toHaveBeenCalled();
+    });
+
+    it('no matching serving → AI estimation still runs (existing behavior)', async () => {
+        (insertFdcAiServing as jest.Mock).mockResolvedValue({ success: true, grams: 185, servingLabel: '1 cup' });
+
+        const result = await hydrateAndSelectServing(
+            quinoaCandidate(), cupsParsed(1.5), 0.9, '1 1/2 cups cooked quinoa'
+        );
+
+        expect(result?.servingTier).toBe('fdc_volume_ai');
+        expect(result?.grams).toBeCloseTo(277.5, 1);
+    });
+
+    it('AI failure falls to the generic density fallback (the old 360g path, now last resort)', async () => {
+        const result = await hydrateAndSelectServing(
+            quinoaCandidate(), cupsParsed(1.5), 0.9, '1 1/2 cups cooked quinoa'
+        );
+
+        expect(result?.servingTier).toBe('volume_unit');
+        expect(result?.grams).toBeCloseTo(1.5 * 240 * 0.5, 1);  // solid density fallback
+    });
+});
+
+describe('candidateHasVolumeServing — rerank serving-shape flag for grain volume requests', () => {
+    it('true for an FDC candidate owning a cup serving', () => {
+        const c = { ...quinoaCandidate(), servings: [{ description: 'cup', grams: 185 }] };
+        expect(candidateHasVolumeServing(c, 'cup')).toBe(true);
+    });
+
+    it('false for an FDC candidate with only non-matching servings', () => {
+        const c = { ...quinoaCandidate(), servings: [{ description: '1 tbsp', grams: 12 }] };
+        expect(candidateHasVolumeServing(c, 'cup')).toBe(false);
+    });
+
+    it('false when servings have no grams', () => {
+        const c = { ...quinoaCandidate(), servings: [{ description: 'cup', grams: null }] };
+        expect(candidateHasVolumeServing(c, 'cup')).toBe(false);
+    });
+
+    it('OFF candidates match through their raw label servingSize', () => {
+        const off = {
+            id: 'off_1', source: 'openfoodfacts', name: 'Cooked Quinoa Pouch', score: 1,
+            rawData: { servingSize: '1 cup (185 g)', servingGrams: 185 },
+        } as any;
+        expect(candidateHasVolumeServing(off, 'cup')).toBe(true);
+
+        const offNo = { ...off, rawData: { servingSize: '1 pouch (250 g)', servingGrams: 250 } };
+        expect(candidateHasVolumeServing(offNo, 'cup')).toBe(false);
+    });
+});

--- a/src/lib/mapping/ambiguous-unit-backfill.ts
+++ b/src/lib/mapping/ambiguous-unit-backfill.ts
@@ -14,6 +14,7 @@ import {
     isAmbiguousUnit,
     isEstimableUnknownUnit,
     estimateAmbiguousServing,
+    getAmbiguousUnitBounds,
     AMBIGUOUS_UNITS,
 } from '../ai/ambiguous-serving-estimator';
 
@@ -278,17 +279,34 @@ export async function getOrCreateAmbiguousServing(
             normalizedUnit,
             isSize ? sizeFromUnit : undefined
         );
+        // Unit-bounds sanity (count-noun sibling routing, Track 3 Jul 2026):
+        // the seed lookup falls back to FOOD-NAME word matching, so a "bar"
+        // request on "… Caramel Cashew" can surface the 1.5g cashew seed —
+        // a per-piece weight in disguise for the requested unit. Out-of-bounds
+        // seeds fall through to sibling-borrow / AI instead.
         if (countDefault) {
-            logger.debug('ambiguous_backfill.count_deterministic', {
-                foodId,
-                unit: normalizedUnit,
-                grams: countDefault.grams,
-            });
-            return {
-                status: 'success',
-                grams: countDefault.grams,
-                confidence: countDefault.confidence,
-            };
+            const seedBounds = getAmbiguousUnitBounds(normalizedUnit);
+            const seedOutOfBounds = (seedBounds.min != null && countDefault.grams < seedBounds.min)
+                || (seedBounds.max != null && countDefault.grams > seedBounds.max);
+            if (seedOutOfBounds) {
+                logger.warn('ambiguous_backfill.count_default_out_of_bounds', {
+                    foodId,
+                    unit: normalizedUnit,
+                    grams: countDefault.grams,
+                    bounds: seedBounds,
+                });
+            } else {
+                logger.debug('ambiguous_backfill.count_deterministic', {
+                    foodId,
+                    unit: normalizedUnit,
+                    grams: countDefault.grams,
+                });
+                return {
+                    status: 'success',
+                    grams: countDefault.grams,
+                    confidence: countDefault.confidence,
+                };
+            }
         }
     } catch (e) {
         // Ignore
@@ -307,7 +325,6 @@ export async function getOrCreateAmbiguousServing(
     // disguise; fall through so the estimator overwrites it).
     const existing = await findExistingServing(foodId, normalizedUnit);
     if (existing?.grams) {
-        const { getAmbiguousUnitBounds } = await import('../ai/ambiguous-serving-estimator');
         const bounds = getAmbiguousUnitBounds(normalizedUnit);
         const outOfBounds = (bounds.min != null && existing.grams < bounds.min)
             || (bounds.max != null && existing.grams > bounds.max);

--- a/src/lib/mapping/count-label.ts
+++ b/src/lib/mapping/count-label.ts
@@ -105,6 +105,58 @@ export function servingLabelCountsPiece(
     return perPiece >= 0.2 && perPiece <= 500;
 }
 
+// ============================================================
+// Discrete-item unit nouns (moved here from map-ingredient-with-fallback so
+// the bare-serving guard can share the SAME lexicon — no parallel copies).
+// ============================================================
+
+/**
+ * Discrete packaged-item nouns: when an item NAME names one of these and has
+ * no genuine serving, the noun itself is an estimable unit ("quest protein
+ * bar" → 1 bar) — sibling-borrow / AI resolve its weight rather than
+ * defaulting to a flat 100g. Deliberately excludes ambiguous words like
+ * "cup"/"pack"/"stick" that collide with volume/package/butter handling.
+ * links/slices/tortillas added for the bare-serving defaults (Track 3, Jul
+ * 2026) — same routing, they were already estimable units downstream.
+ */
+export const DISCRETE_ITEM_UNIT_RE = /\b(bars?|cookies?|brownies?|patties|patty|nuggets?|puffs?|wafers?|biscuits?|muffins?|links?|slices?|tortillas?)\b/i;
+
+/** First discrete-item unit noun in a food name, singularized ("Quest Protein Bars" → "bar"). */
+export function inferDiscreteUnit(name: string): string | null {
+    const m = name.match(DISCRETE_ITEM_UNIT_RE);
+    return m ? singularizeUnit(m[1]) : null;
+}
+
+/**
+ * Bounded single-piece floors for discrete-item nouns (bare-serving defaults,
+ * Jul 2026). Last-resort grams for a bare query whose NAME implies a discrete
+ * piece but for which no label / seed / sibling / AI weight resolved — such a
+ * food must NEVER bill the flat 100g default ("protein bar" is ~50g, not
+ * 100g). Values are conservative mid-range piece weights, not label data.
+ */
+export const DISCRETE_PIECE_FLOOR_GRAMS: Record<string, number> = {
+    bar: 50,
+    cookie: 30,
+    brownie: 40,
+    patty: 45,
+    nugget: 20,
+    puff: 20,
+    wafer: 15,
+    biscuit: 30,
+    muffin: 55,
+    link: 45,
+    slice: 30,
+    tortilla: 45,
+};
+
+/** The bounded piece floor implied by a food name, else null. */
+export function discretePieceFloor(name: string): { unit: string; grams: number } | null {
+    const unit = inferDiscreteUnit(name || '');
+    if (!unit) return null;
+    const grams = DISCRETE_PIECE_FLOOR_GRAMS[unit];
+    return grams ? { unit, grams } : null;
+}
+
 /**
  * Noun-agnostic form of servingLabelCountsPiece — does this label enumerate
  * ≥2 of ANY recognized piece word with a sane per-piece weight? Used to compute

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -58,6 +58,7 @@ import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { deriveCacheKeyName } from './cache-key';
 import {
     applyOffBareQueryGuard, isBareUnitlessQty1, usableBareLabelServing,
+    isDoseAnchoredBareQuery,
     BARE_LABEL_MIN_GRAMS, BARE_LABEL_MAX_GRAMS, BARE_MIN_PIECE_SERVING_GRAMS,
 } from '../servings/bare-query-guard';
 
@@ -4571,6 +4572,14 @@ export async function buildOffResult(
     const bareLabelGrams = bareRequest
         ? usableBareLabelServing(hydrated.servingGrams, labelUnitWord)
         : null;
+    // Dose-measured categories (n-serv-37 sugar / n-serv-43 ghost pre workout
+    // eval regressions): when the bare query IS a scoop/spoon-dosed category
+    // (tail-anchored — "sugar", "ghost pre workout", "peanut butter"), the
+    // own-label and sibling-median steps are SKIPPED so resolution flows to
+    // the label/package tiers where the category CAP restores the tsp/scoop
+    // dose default. Piece/tub foods (yoplait, snickers, pepper jack) are
+    // unaffected: their categories are absent or oz/cup/can-based.
+    const doseAnchored = bareRequest && isDoseAnchoredBareQuery(parsed?.name || '');
 
     // Units where the product's own label serving IS the thing the user asked
     // for ("1 container of yogurt" → the container size on the label). For these,
@@ -4711,7 +4720,10 @@ export async function buildOffResult(
         // not 28/9 per piece (A); "yoplait original strawberry" the 170g cup,
         // not the 12g strawberry seed (B). usableBareLabelServing already
         // rejected the flat-100g placeholder and garbage sub-3g metadata.
-        if (grams == null && !barePluralRequest && bareRequest && bareLabelGrams != null) {
+        // Dose-anchored categories skip this step: a sugar record's cup-
+        // measure label must not outrank the 1-tsp default (n-serv-37).
+        if (grams == null && !barePluralRequest && bareRequest && !doseAnchored
+            && bareLabelGrams != null) {
             grams = bareLabelGrams;
             servingDescription = `1 serving (${bareLabelGrams}g)`;
             servingTier = 'bare_label_serving';
@@ -4832,8 +4844,11 @@ export async function buildOffResult(
         // Plural bare requests may borrow ONLY on a real brand (snickers,
         // airheads): the name-token pseudo-brand ("Almonds" → brand 'almonds')
         // could match junk OFF brands for generic produce plurals.
+        // Dose-anchored categories skip the borrow too: Ghost's 32.5g
+        // two-scoop sibling median must not outrank the 1-scoop pre-workout
+        // default (n-serv-43) — the package tiers + category CAP handle it.
         if (
-            grams == null && bareRequest
+            grams == null && bareRequest && !doseAnchored
             && (!barePluralRequest || hydrated.brandName != null)
             && bareLabelGrams == null && brandForBorrow
             && !(hydrated.packageQuantityUnit === 'ml' && packageGrams != null)

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -27,6 +27,7 @@ import {
     singularizeUnit, extractLabelServingUnit,
     LABEL_COUNT_PIECE_NOUNS, GENERIC_PIECE_WORDS,
     pieceNounInName, labelPieceMatchesItem, countedPieceNoun, servingLabelCountsPiece,
+    inferDiscreteUnit,
 } from './count-label';
 import { getValidatedMappingByNormalizedName, saveValidatedMapping, getAiNormalizeCache, isTrustedHumanRow, isHumanTrustSkippableEscape } from './validated-mapping-helpers';
 import { logMappingAnalysis } from './mapping-logger';
@@ -55,7 +56,10 @@ import { assessMacroPlausibility, assessRankTimePlausibility } from './macro-pla
 import { isDenylistedOffRecord } from './corrupt-denylist';
 import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { deriveCacheKeyName } from './cache-key';
-import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
+import {
+    applyOffBareQueryGuard, isBareUnitlessQty1, usableBareLabelServing,
+    BARE_LABEL_MIN_GRAMS, BARE_LABEL_MAX_GRAMS, BARE_MIN_PIECE_SERVING_GRAMS,
+} from '../servings/bare-query-guard';
 
 // ============================================================
 // In-Flight Lock (Prevents race conditions in parallel processing)
@@ -1601,6 +1605,15 @@ export async function mapIngredientWithFallback(
                         }
 
                         const billsByServing = requestBillsByServing(parsed);
+                        // Cooked-grain volume requests (n-serv-06): the re-retrieval must
+                        // prefer candidates that OWN a matching volume serving over ones
+                        // that would fall back to generic density. requestBillsByServing
+                        // excludes explicit volume units by design (PR D pt2), so the
+                        // serving-shape flag is wired through this grain-scoped path.
+                        const grainVolumeUnit = !billsByServing && parsed?.unit
+                            && isMatchableVolumeUnit(parsed.unit)
+                            && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+                            ? parsed.unit : null;
                         const rerankCandidates = candidatesForRerank.map(c => toRerankCandidate({
                             id: c.id,
                             name: c.name,
@@ -1610,7 +1623,8 @@ export async function mapIngredientWithFallback(
                             source: c.source,
                             nutrition: c.nutrition,  // Include for Route C macro sanity check + nutrition tiebreaker
                             countLabelMatch: countedNoun ? candidateHasCountLabel(c, countedNoun) : undefined,
-                            servingLabelMatch: billsByServing ? candidateHasServingData(c) : undefined,
+                            servingLabelMatch: billsByServing ? candidateHasServingData(c)
+                                : grainVolumeUnit ? candidateHasVolumeServing(c, grainVolumeUnit) : undefined,
                         }));
 
                         // Hybrid prep stripping: prefer AI canonicalBase (strips prep but preserves
@@ -2262,6 +2276,12 @@ export async function mapIngredientWithFallback(
                 // Run reranker to ensure anomaly penalties (e.g. canned beans) are applied
                 const countedNounFB = countedPieceNoun(parsed);
                 const billsByServingFB = requestBillsByServing(parsed);
+                // Same grain-scoped volume serving-shape wiring as the primary
+                // rerank site (n-serv-06).
+                const grainVolumeUnitFB = !billsByServingFB && parsed?.unit
+                    && isMatchableVolumeUnit(parsed.unit)
+                    && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+                    ? parsed.unit : null;
                 const rerankCandidates = searchFilterResult.filtered.map(c => toRerankCandidate({
                     id: c.id,
                     name: c.name,
@@ -2271,7 +2291,8 @@ export async function mapIngredientWithFallback(
                     source: c.source,
                     nutrition: c.nutrition,
                     countLabelMatch: countedNounFB ? candidateHasCountLabel(c, countedNounFB) : undefined,
-                    servingLabelMatch: billsByServingFB ? candidateHasServingData(c) : undefined,
+                    servingLabelMatch: billsByServingFB ? candidateHasServingData(c)
+                        : grainVolumeUnitFB ? candidateHasVolumeServing(c, grainVolumeUnitFB) : undefined,
                 }));
                 const rerankQuery = aiCanonicalBase || stripPrepModifiers(normalizedName);
                 const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNounFB != null);
@@ -3859,11 +3880,34 @@ async function buildFdcResult(
         servingDescription = `${grams.toFixed(1)}g`;
         servingTier = 'weight_unit';
     } else if (unit && volumeToGrams[unit]) {
-        // Unit is a volume unit - try AI estimation first for food-specific density
+        // Unit is a volume unit. Resolution order (Track 3, Jul 2026):
+        //   (0) the record's OWN matching volume serving (USDA household
+        //       measure, or a previously cached AI row) — deterministic and
+        //       food-specific ("1.5 cups cooked quinoa" on fdc 168917 must
+        //       bill 1.5 × the 185g usda_fdc cup row, never a fresh AI guess
+        //       or the generic 240ml×density fallback; n-serv-06 flap);
+        //   (1) AI estimation for food-specific density;
+        //   (2) hardcoded density fallback.
         const fdcId = parseInt(candidate.id.replace('fdc_', ''), 10);
-        let aiEstimated = false;
+        let volumeResolved = false;
 
         if (!isNaN(fdcId)) {
+            const ownVolume = await findOwnFdcVolumeServing(fdcId, unit);
+            if (ownVolume) {
+                grams = qty * ownVolume.perUnitGrams;
+                servingDescription = `${qty} ${unit}`;
+                volumeResolved = true;
+                servingTier = ownVolume.genuine ? 'fdc_label_volume' : 'fdc_volume_cached';
+                logger.info('fdc.volume_own_serving', {
+                    foodName: candidate.name, unit,
+                    gramsPerUnit: ownVolume.perUnitGrams,
+                    totalGrams: grams,
+                    genuine: ownVolume.genuine,
+                });
+            }
+        }
+
+        if (!volumeResolved && !isNaN(fdcId)) {
             try {
                 const { insertFdcAiServing } = await import('../usda/fdc-ai-backfill');
                 const aiResult = await insertFdcAiServing(fdcId, 'volume', { targetUnit: unit });
@@ -3874,7 +3918,7 @@ async function buildFdcResult(
                 if (aiResult.success && aiResult.grams && aiResult.grams > 0) {
                     grams = qty * aiResult.grams;
                     servingDescription = `${qty} ${unit}`;
-                    aiEstimated = true;
+                    volumeResolved = true;
                     servingTier = 'fdc_volume_ai';
                     logger.info('fdc.volume_ai_estimated', {
                         foodName: candidate.name, unit, gramsPerUnit: aiResult.grams, totalGrams: grams,
@@ -3885,7 +3929,7 @@ async function buildFdcResult(
             }
         }
 
-        if (!aiEstimated) {
+        if (!volumeResolved) {
             // Fallback to hardcoded density estimate
             grams = qty * volumeToGrams[unit];
             servingDescription = `${qty} ${unit}`;
@@ -4190,15 +4234,8 @@ async function buildFdcResult(
  * Hydrates the candidate into the local DB, resolves grams from the parsed unit,
  * and falls back to AI nutrition backfill when the Atwater gate rejects label data.
  */
-// Discrete packaged-snack nouns: when a unitless branded item names one of these
-// and has no genuine serving, estimate that unit's weight (sibling-borrow / AI)
-// rather than defaulting to a flat 100g. Deliberately excludes ambiguous words
-// like "cup"/"pack"/"slice" that collide with volume/package handling.
-const DISCRETE_ITEM_UNIT_RE = /\b(bars?|cookies?|brownies?|patties|patty|nuggets?|puffs?|wafers?|biscuits?|muffins?)\b/i;
-function inferDiscreteUnit(name: string): string | null {
-    const m = name.match(DISCRETE_ITEM_UNIT_RE);
-    return m ? singularizeUnit(m[1]) : null;
-}
+// (inferDiscreteUnit moved to count-label.ts — shared with the bare-serving
+// guard's discrete floor so there is exactly ONE discrete-noun lexicon.)
 
 /**
  * True when an OFF search candidate's raw label serving enumerates >=2 of the
@@ -4239,6 +4276,117 @@ function candidateHasServingData(candidate: UnifiedCandidate): boolean {
     }
     if (candidate.source === 'fdc') {
         return !!candidate.servings?.some(s => typeof s.grams === 'number' && s.grams > 0);
+    }
+    return false;
+}
+
+// ============================================================
+// Volume-serving matching (cooked-grain volume preference, Track 3 Jul 2026)
+// ============================================================
+
+// Requested-volume-unit → serving-description stems. FDC household measures
+// store "cup" / "1 cup" / "0.25 cup, sliced"; tbsp rows may spell "tablespoon".
+const VOLUME_UNIT_STEMS: Record<string, string[]> = {
+    cup: ['cup'], cups: ['cup'],
+    tbsp: ['tbsp', 'tablespoon'], tablespoon: ['tbsp', 'tablespoon'], tablespoons: ['tbsp', 'tablespoon'],
+    tsp: ['tsp', 'teaspoon'], teaspoon: ['tsp', 'teaspoon'], teaspoons: ['tsp', 'teaspoon'],
+    floz: ['fl oz', 'fluid ounce'], 'fl oz': ['fl oz', 'fluid ounce'],
+};
+const VOLUME_UNIT_ML: Record<string, number> = {
+    cup: 240, cups: 240,
+    tbsp: 15, tablespoon: 15, tablespoons: 15,
+    tsp: 5, teaspoon: 5, teaspoons: 5,
+    floz: 30, 'fl oz': 30,
+};
+
+/** True when the requested unit is one the volume-serving matcher understands. */
+function isMatchableVolumeUnit(unit: string): boolean {
+    return VOLUME_UNIT_STEMS[unit.toLowerCase().trim()] != null;
+}
+
+/** True when a serving description names the requested volume unit ("0.5 cup (126 g)" for "cup"). */
+function servingDescriptionMatchesVolumeUnit(description: string | null | undefined, unit: string): boolean {
+    if (!description) return false;
+    const stems = VOLUME_UNIT_STEMS[unit.toLowerCase().trim()];
+    if (!stems) return false;
+    return stems.some(s => new RegExp(`\\b${s.replace(' ', '\\s+')}s?\\b`, 'i').test(description));
+}
+
+/** Leading count of a serving description ("0.25 cup" → 0.25, "1/2 cup" → 0.5, "cup" → 1). */
+function servingLeadingCount(description: string): number {
+    const frac = description.match(/^\s*(\d+)\s*\/\s*(\d+)/);
+    if (frac) {
+        const denom = parseFloat(frac[2]);
+        return denom > 0 ? parseFloat(frac[1]) / denom : 1;
+    }
+    const m = description.match(/^\s*(\d+(?:\.\d+)?)/);
+    if (!m) return 1;
+    const n = parseFloat(m[1]);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+// Density plausibility band for trusting a volume serving (g/ml). Foods span
+// ~0.1 (puffed cereal) to ~1.45 (honey); anything outside is a corrupt row
+// (e.g. a whole-package weight stored under a "cup" description).
+const VOLUME_SERVING_MIN_DENSITY = 0.1;
+const VOLUME_SERVING_MAX_DENSITY = 1.6;
+
+/**
+ * The record's OWN volume serving matching the requested unit, per-unit
+ * (n-serv-06): the USDA cooked-quinoa "cup"=185g row must beat both a fresh
+ * AI estimate and the generic 240ml×density fallback. Genuine (non-AI) rows
+ * win over previously cached AI rows; either makes resolution deterministic
+ * across runs. Density-banded so corrupt rows can't smuggle package weights.
+ */
+export async function findOwnFdcVolumeServing(
+    fdcId: number,
+    unit: string,
+): Promise<{ perUnitGrams: number; genuine: boolean } | null> {
+    const mlPerUnit = VOLUME_UNIT_ML[unit.toLowerCase().trim()];
+    if (!mlPerUnit || !isMatchableVolumeUnit(unit)) return null;
+    let rows: Array<{ description: string; grams: number | null; isAiEstimated: boolean | null }>;
+    try {
+        const { prisma } = await import('../db');
+        rows = await prisma.fdcServing.findMany({
+            where: { fdcId },
+            select: { description: true, grams: true, isAiEstimated: true },
+        });
+    } catch {
+        return null;
+    }
+    const matches = rows
+        .filter(r => r.grams != null && r.grams > 0 && servingDescriptionMatchesVolumeUnit(r.description, unit))
+        .map(r => {
+            const count = servingLeadingCount(r.description);
+            return {
+                perUnitGrams: (r.grams as number) / (count > 0 ? count : 1),
+                genuine: !r.isAiEstimated,
+            };
+        })
+        .filter(m => {
+            const density = m.perUnitGrams / mlPerUnit;
+            return density >= VOLUME_SERVING_MIN_DENSITY && density <= VOLUME_SERVING_MAX_DENSITY;
+        });
+    if (matches.length === 0) return null;
+    return matches.find(m => m.genuine) ?? matches[0];
+}
+
+/**
+ * True when a search candidate carries a serving matching the requested
+ * volume unit. Feeds the rerank serving-shape flag for cooked-grain volume
+ * requests (n-serv-06): among cooked candidates, one that OWNS a cup serving
+ * must beat one that would fall back to generic volume density.
+ */
+export function candidateHasVolumeServing(candidate: UnifiedCandidate, unit: string): boolean {
+    if (candidate.source === 'fdc') {
+        return !!candidate.servings?.some(s =>
+            typeof s.grams === 'number' && s.grams > 0
+            && servingDescriptionMatchesVolumeUnit(s.description, unit));
+    }
+    if (candidate.source === 'openfoodfacts') {
+        const raw = candidate.rawData as { servingSize?: string | null; servingGrams?: number | null } | undefined;
+        return typeof raw?.servingGrams === 'number' && raw.servingGrams > 0
+            && servingDescriptionMatchesVolumeUnit(raw?.servingSize, unit);
     }
     return false;
 }
@@ -4287,6 +4435,40 @@ async function borrowSiblingPackageGrams(
         const winner = rows[0];
         if (!winner?.med || winner.n < 2) return null;
         return winner.med;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Median same-brand LABEL serving (bare-serving defaults, Track 3 Jul 2026).
+ * Within a brand's line the single-serving size is near-constant (all 15
+ * IQ Bar SKUs label 45g; 148 Snickers SKUs median 39.8g), so when the matched
+ * SKU's own servingGrams is NULL, garbage, or the flat-100g placeholder, the
+ * sibling median answers a bare qty-1 request deterministically from real
+ * label data. Band-restricted to single-serving scale and excludes exact-100g
+ * rows (the per-100g placeholder would otherwise dominate many brands).
+ * Requires >=3 in-band siblings so a bogus pair can't set the median.
+ */
+async function borrowSiblingLabelServing(
+    brandName: string | null | undefined,
+    selfBarcode: string,
+): Promise<{ grams: number; samples: number } | null> {
+    const brand = brandName?.trim();
+    if (!brand || brand.length < 2) return null;
+    try {
+        const { prisma } = await import('../db');
+        const rows = await prisma.$queryRaw<Array<{ med: number | null; n: number }>>`
+            SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY "servingGrams") AS med,
+                   count(*)::int AS n
+            FROM "OffFood"
+            WHERE "brandName" ILIKE ${brand}
+              AND barcode <> ${selfBarcode}
+              AND "servingGrams" BETWEEN ${BARE_LABEL_MIN_GRAMS} AND ${BARE_LABEL_MAX_GRAMS}
+              AND "servingGrams" <> 100`;
+        const row = rows[0];
+        if (!row?.med || row.n < 3) return null;
+        return { grams: row.med, samples: row.n };
     } catch {
         return null;
     }
@@ -4375,6 +4557,21 @@ export async function buildOffResult(
     const perLabelUnitGrams = hydrated.servingGrams && hydrated.servingGrams > 0
         ? hydrated.servingGrams / labelUnitCount : null;
 
+    // Bare-serving defaults (Track 3, Jul 2026): a digitless unitless qty-1
+    // line asks for A SERVING. Deterministic resolution order:
+    //   (1) the record's own in-band label serving ('bare_label_serving');
+    //   (2) a count-noun piece when the NAME implies one (seed / discrete
+    //       backfill branches below);
+    //   (3) the same-brand sibling median label serving ('bare_sibling_serving');
+    //   (4) bounded floor — never flat-100g for a discrete-piece name
+    //       (wired in applyOffBareQueryGuard's REPLACE path).
+    // The digit gate inside isBareUnitlessQty1 keeps "1 gatorade" / "3 almonds"
+    // on the counted-resolution path — nothing below changes for them.
+    const bareRequest = isBareUnitlessQty1(parsed, rawLine);
+    const bareLabelGrams = bareRequest
+        ? usableBareLabelServing(hydrated.servingGrams, labelUnitWord)
+        : null;
+
     // Units where the product's own label serving IS the thing the user asked
     // for ("1 container of yogurt" → the container size on the label). For these,
     // trust servingGrams over estimation.
@@ -4452,8 +4649,11 @@ export async function buildOffResult(
     } else if (unit && (isAmbiguousUnit(unit) || classifyUnit(unit) === 'count')) {
         // Count/size/unknown units ("slice", "medium", "can", "knob", "rasher"):
         // deterministic count defaults + cached per-food servings + AI estimation.
+        // brandForBorrow (not the raw, often-null brandName) so a "1 bar" on a
+        // null-brand SKU can still reach the same-brand sibling-serving borrow
+        // (count-noun sibling routing, Track 3 Jul 2026).
         const ambiguous = await getOrCreateAmbiguousServing(
-            candidate.id, hydrated.foodName, unit, hydrated.brandName ?? null
+            candidate.id, hydrated.foodName, unit, brandForBorrow
         );
         if ((ambiguous.status === 'success' || ambiguous.status === 'cached')
             && ambiguous.grams && ambiguous.grams > 0) {
@@ -4487,8 +4687,13 @@ export async function buildOffResult(
         // fall through to the label/floor defaults, where the bare-query
         // guard applies the category default.
         const barePluralRequest = isBarePluralRequest(parsed, rawLine, itemNameForCount);
+        // Placeholder rejection (Track 3, Jul 2026): the flat-100g EU
+        // per-100g pseudo-serving must not satisfy the plural band either —
+        // "snickers" on a '1 portion (100 g)' SKU falls through to the
+        // sibling-median step below instead of billing the placeholder.
         if (barePluralRequest && hydrated.servingGrams
-            && hydrated.servingGrams >= 10 && hydrated.servingGrams <= 150) {
+            && hydrated.servingGrams >= 10 && hydrated.servingGrams <= 150
+            && usableBareLabelServing(hydrated.servingGrams, labelUnitWord) != null) {
             grams = hydrated.servingGrams;
             servingDescription = `1 serving (${hydrated.servingGrams}g)`;
             servingTier = 'bare_plural_serving';
@@ -4496,6 +4701,24 @@ export async function buildOffResult(
                 foodId: candidate.id,
                 name: itemNameForCount,
                 servingGrams: hydrated.servingGrams,
+            });
+        }
+
+        // (1) OWN LABEL SERVING for a bare request (bare-serving defaults,
+        // Track 3 Jul 2026): a digitless qty-1 line bills the record's own
+        // single-serving-scale label directly, pre-empting every per-piece
+        // divide below — "combos cheddar pretzel" must bill the 28g label,
+        // not 28/9 per piece (A); "yoplait original strawberry" the 170g cup,
+        // not the 12g strawberry seed (B). usableBareLabelServing already
+        // rejected the flat-100g placeholder and garbage sub-3g metadata.
+        if (grams == null && !barePluralRequest && bareRequest && bareLabelGrams != null) {
+            grams = bareLabelGrams;
+            servingDescription = `1 serving (${bareLabelGrams}g)`;
+            servingTier = 'bare_label_serving';
+            logger.info('off.build_result.bare_label_serving', {
+                foodId: candidate.id,
+                name: itemNameForCount,
+                servingGrams: bareLabelGrams,
             });
         }
 
@@ -4515,6 +4738,7 @@ export async function buildOffResult(
             genericPieceNoun != null
         );
         if (
+            grams == null &&
             !barePluralRequest &&
             perLabelUnitGrams != null && perLabelUnitGrams >= 0.2 && perLabelUnitGrams <= 500 &&
             labelCountsUserPiece
@@ -4538,7 +4762,14 @@ export async function buildOffResult(
             try {
                 const { getDefaultCountServing } = await import('../servings/default-count-grams');
                 const countDefault = getDefaultCountServing(itemNameForCount, 'each');
-                if (countDefault && countDefault.grams > 0) {
+                // Bare-request piece sanity (Track 3, Jul 2026): a digitless
+                // qty-1 singular asks for A SERVING — a tiny per-piece seed
+                // ("barebells caramel cashew" → the 1.5g cashew, bare
+                // "almond" → 1.2g) must not answer it. Pieces >=20g (banana,
+                // egg, bagel) ARE the serving and pass through.
+                const bareTinyPiece = bareRequest && countDefault != null
+                    && countDefault.grams < BARE_MIN_PIECE_SERVING_GRAMS;
+                if (countDefault && countDefault.grams > 0 && !bareTinyPiece) {
                     grams = qty * countDefault.grams;
                     servingDescription = `${qty} each (${countDefault.grams.toFixed(1)}g each)`;
                     servingTier = 'seed_count_default';
@@ -4546,6 +4777,12 @@ export async function buildOffResult(
                         foodId: candidate.id,
                         name: itemNameForCount,
                         perPieceGrams: countDefault.grams,
+                    });
+                } else if (bareTinyPiece) {
+                    logger.info('off.build_result.bare_tiny_piece_skipped', {
+                        foodId: candidate.id,
+                        name: itemNameForCount,
+                        perPieceGrams: countDefault!.grams,
                     });
                 }
             } catch {
@@ -4556,12 +4793,18 @@ export async function buildOffResult(
         // No deterministic per-piece weight and no genuine label serving: if the
         // product names a discrete packaged item (a protein "bar", "cookie"...),
         // estimate that unit's weight via sibling-borrow / AI instead of the flat
-        // 100g default (a 60g Quest bar must not log as 100g).
-        if (grams == null && !barePluralRequest && (!hydrated.servingGrams || hydrated.servingGrams <= 0)) {
+        // 100g default (a 60g Quest bar must not log as 100g). For a bare
+        // request this also runs when the record's serving is unusable (the
+        // flat-100g placeholder / garbage band) — order step (2). Passes
+        // brandForBorrow (not the raw, often-null brandName) so null-brand
+        // SKUs can still reach the same-brand sibling-serving borrow.
+        if (grams == null && !barePluralRequest
+            && (!hydrated.servingGrams || hydrated.servingGrams <= 0
+                || (bareRequest && bareLabelGrams == null))) {
             const discreteUnit = inferDiscreteUnit(parsed.name || hydrated.foodName);
             if (discreteUnit) {
                 const amb = await getOrCreateAmbiguousServing(
-                    candidate.id, hydrated.foodName, discreteUnit, hydrated.brandName ?? null
+                    candidate.id, hydrated.foodName, discreteUnit, brandForBorrow
                 );
                 if ((amb.status === 'success' || amb.status === 'cached') && amb.grams && amb.grams > 0) {
                     grams = qty * amb.grams;
@@ -4574,6 +4817,40 @@ export async function buildOffResult(
                         status: amb.status,
                     });
                 }
+            }
+        }
+
+        // (C2) SAME-BRAND SIBLING MEDIAN LABEL SERVING — bare request whose
+        // own label is unusable and whose name resolved no piece: borrow the
+        // brand's median single-serving label ("snickers" on a placeholder-100
+        // SKU → ~40g from 148 sibling bars; "barebells caramel cashew" → 55g).
+        // Runs BEFORE the package fallback: a bare query prefers a sibling's
+        // single-serving label over this SKU's multi-serve package weight
+        // (airheads 85.78g pack class). Exception: an own ml-band package is
+        // a discrete retail beverage ("gatorade" bottle) — drink-the-unit
+        // semantics keep the package answer.
+        // Plural bare requests may borrow ONLY on a real brand (snickers,
+        // airheads): the name-token pseudo-brand ("Almonds" → brand 'almonds')
+        // could match junk OFF brands for generic produce plurals.
+        if (
+            grams == null && bareRequest
+            && (!barePluralRequest || hydrated.brandName != null)
+            && bareLabelGrams == null && brandForBorrow
+            && !(hydrated.packageQuantityUnit === 'ml' && packageGrams != null)
+        ) {
+            const sibling = await borrowSiblingLabelServing(
+                brandForBorrow, candidate.id.replace(/^off_/, '')
+            );
+            if (sibling != null) {
+                grams = sibling.grams;
+                servingDescription = `1 serving (~${sibling.grams.toFixed(0)}g, brand median)`;
+                servingTier = 'bare_sibling_serving';
+                logger.info('off.build_result.bare_sibling_serving', {
+                    foodId: candidate.id,
+                    brand: brandForBorrow,
+                    grams: sibling.grams,
+                    samples: sibling.samples,
+                });
             }
         }
 

--- a/src/lib/servings/__tests__/bare-query-guard.test.ts
+++ b/src/lib/servings/__tests__/bare-query-guard.test.ts
@@ -8,7 +8,7 @@
 
 import {
     applyOffBareQueryGuard, BareQueryGuardInput,
-    isBareUnitlessQty1, usableBareLabelServing,
+    isBareUnitlessQty1, usableBareLabelServing, isDoseAnchoredBareQuery,
 } from '../bare-query-guard';
 import type { ParsedIngredient } from '../../parse/ingredient-line';
 
@@ -446,6 +446,36 @@ describe('applyOffBareQueryGuard — bounded discrete floor on REPLACE tiers (Tr
             foodName: 'Chobani Greek Yogurt',
         }));
         expect(r).toBeNull();
+    });
+});
+
+describe('isDoseAnchoredBareQuery — scoop/spoon-dosed tier-order gate (eval regressions n-serv-37/43)', () => {
+    it.each([
+        ['sugar', 'single-token tsp category'],
+        ['brown sugar', 'tail token anchors the tsp category'],
+        ['ghost pre workout', 'two-token scoop phrase at the tail ("pre workout")'],
+        ['pre workout', 'the scoop phrase itself'],
+        ['peanut butter', 'tbsp phrase whose head is itself lexicon-covered'],
+        ['olive oil', 'tbsp condiment anchored at the head'],
+        ['ketchup', 'single-token tbsp condiment'],
+        ['whey protein powder', 'scoop category with the phrase at the tail'],
+    ])('anchored: "%s" (%s)', (q) => {
+        expect(isDoseAnchoredBareQuery(q)).toBe(true);
+    });
+
+    it.each([
+        ['pepper jack', 'spice token survives without the tail ("pepper" alone matches)'],
+        ['butter chicken', 'condiment token is a leading modifier'],
+        ['pumpkin spice latte', 'spice token is a middle modifier'],
+        ['cinnamon raisin bagel', 'spice token is a leading modifier'],
+        ['creatine gummies', 'scoop token is a leading modifier — gummies keep piece resolution'],
+        ['yoplait original strawberry', 'no lexicon category at all'],
+        ['snickers', 'no lexicon category at all'],
+        ['combos cheddar pretzel', 'salty-snack category is oz-dosed, not tsp/tbsp/scoop'],
+        ['muscle milk', 'can-dosed category'],
+        ['milk', 'cup-dosed liquid category'],
+    ])('NOT anchored: "%s" (%s)', (q) => {
+        expect(isDoseAnchoredBareQuery(q)).toBe(false);
     });
 });
 

--- a/src/lib/servings/__tests__/bare-query-guard.test.ts
+++ b/src/lib/servings/__tests__/bare-query-guard.test.ts
@@ -6,7 +6,10 @@
  * n-serv-27/28 (red bull/clif untouchable tiers).
  */
 
-import { applyOffBareQueryGuard, BareQueryGuardInput } from '../bare-query-guard';
+import {
+    applyOffBareQueryGuard, BareQueryGuardInput,
+    isBareUnitlessQty1, usableBareLabelServing,
+} from '../bare-query-guard';
 import type { ParsedIngredient } from '../../parse/ingredient-line';
 
 function bare(name: string, over: Partial<ParsedIngredient> = {}): ParsedIngredient {
@@ -268,6 +271,200 @@ describe('applyOffBareQueryGuard — eligibility gates', () => {
 
     it('rejects an undefined serving tier', () => {
         expect(applyOffBareQueryGuard(input({ servingTier: undefined }))).toBeNull();
+    });
+});
+
+describe('usableBareLabelServing — own-label usability band (Track 3)', () => {
+    it('accepts a genuine in-band label serving (yoplait 170g)', () => {
+        expect(usableBareLabelServing(170, null)).toBe(170);
+    });
+
+    it('rejects the flat-100g placeholder in all its spellings', () => {
+        expect(usableBareLabelServing(100, null)).toBeNull();       // "100 g" / no description
+        expect(usableBareLabelServing(100, 'g')).toBeNull();        // "100.0g"
+        expect(usableBareLabelServing(100, 'portion')).toBeNull();  // "1 portion (100 g)"
+    });
+
+    it('accepts a genuine 100g serving carried by a household unit word ("1 cup (100 g)")', () => {
+        expect(usableBareLabelServing(100, 'cup')).toBe(100);
+    });
+
+    it('rejects garbage sub-3g metadata (trout/hot-pocket "1.0g" rows)', () => {
+        expect(usableBareLabelServing(1, 'g')).toBeNull();
+        expect(usableBareLabelServing(1, null)).toBeNull();
+    });
+
+    it('rejects package-scale servings above 400g (turkey-leg 976g pack, miso 623g tub)', () => {
+        expect(usableBareLabelServing(976, 'leg')).toBeNull();
+        expect(usableBareLabelServing(623.7, 'container')).toBeNull();
+    });
+
+    it('accepts a single-serve RTD at 355g (pumpkin spice latte)', () => {
+        expect(usableBareLabelServing(355, 'portion')).toBe(355);
+    });
+
+    it('rejects null/zero', () => {
+        expect(usableBareLabelServing(null, null)).toBeNull();
+        expect(usableBareLabelServing(0, null)).toBeNull();
+    });
+});
+
+describe('applyOffBareQueryGuard — head-gated CAP on bare_label/bare_sibling tiers (Track 3)', () => {
+    it("still caps a whole-bottle label when the category IS the query head ('olive oil' 250g → 14g)", () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 250,
+            servingTier: 'bare_label_serving',
+        }));
+        expect(r).toEqual({
+            grams: 14,
+            servingTier: 'bare_category_default',
+            servingDescription: '1 serving (~14g)',
+        });
+    });
+
+    it("does NOT cap a genuine label on a contained-token hijack ('pepper jack' 28g vs spice 2.5g)", () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 28,
+            servingTier: 'bare_label_serving',
+            parsed: bare('pepper jack'),
+            rawLine: 'pepper jack',
+            queryName: 'pepper jack',
+            foodName: 'Pepper Jack Cheese Slices',
+        }));
+        expect(r).toBeNull();
+    });
+
+    it("does NOT cap 'butter chicken' (condiment token, head 'chicken') — the 100g portion stands", () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 100,
+            servingTier: 'bare_label_serving',
+            parsed: bare('butter chicken'),
+            rawLine: 'butter chicken',
+            queryName: 'butter chicken',
+            foodName: 'Butter Chicken',
+        }));
+        expect(r).toBeNull();
+    });
+
+    it("does NOT cap 'pumpkin spice latte' (spice token, head 'latte') — the 355ml RTD stands", () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 355,
+            servingTier: 'bare_label_serving',
+            parsed: bare('pumpkin spice latte'),
+            rawLine: 'pumpkin spice latte',
+            queryName: 'pumpkin spice latte',
+            foodName: 'Pumpkin Spice Oat Latte',
+        }));
+        expect(r).toBeNull();
+    });
+
+    it('never touches the sibling-median tier (median of >=3 real labels beats a category default)', () => {
+        // Even a head-anchored lexicon hit ("olive oil") leaves the sibling
+        // median alone; and trailing-lexicon-noun dishes keep their median
+        // ("hot pocket ham and cheese" 127g must not become a 28g cheese cap).
+        expect(applyOffBareQueryGuard(input({
+            grams: 250,
+            servingTier: 'bare_sibling_serving',
+        }))).toBeNull();
+
+        expect(applyOffBareQueryGuard(input({
+            grams: 127,
+            servingTier: 'bare_sibling_serving',
+            parsed: bare('hot pocket ham and cheese'),
+            rawLine: 'hot pocket ham and cheese',
+            queryName: 'hot pocket ham and cheese',
+            foodName: 'Ham & Cheese Hot Pocket',
+        }))).toBeNull();
+    });
+
+    it('peanut butter keeps its multi-word category on the head gate (head "butter" is lexicon-covered)', () => {
+        // 300g package-scale "label" on a bare peanut butter query: head token
+        // "butter" is itself lexicon-covered, so the CAP fires with the
+        // full-query 32g default (300 > 64).
+        const r = applyOffBareQueryGuard(input({
+            grams: 300,
+            servingTier: 'bare_label_serving',
+            parsed: bare('peanut butter'),
+            rawLine: 'peanut butter',
+            queryName: 'peanut butter',
+            foodName: 'Creamy Peanut Butter',
+        }));
+        expect(r!.grams).toBe(32);
+    });
+});
+
+describe('applyOffBareQueryGuard — bounded discrete floor on REPLACE tiers (Track 3)', () => {
+    it("bills one ~50g bar instead of the flat 100g ('quest protein bar birthday cake')", () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 100,
+            servingTier: 'flat_100g_default',
+            parsed: bare('quest protein bar birthday cake'),
+            rawLine: 'quest protein bar birthday cake',
+            queryName: 'quest protein bar birthday cake',
+            foodName: 'Protein Bar Birthday Cake',
+        }));
+        expect(r).toEqual({
+            grams: 50,
+            servingTier: 'bare_discrete_floor',
+            servingDescription: '1 bar (~50g)',
+        });
+    });
+
+    it('lexicon categories still win over the floor (doritos stays 28g via salty snacks)', () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 100,
+            servingTier: 'flat_100g_default',
+            parsed: bare('doritos'),
+            rawLine: 'doritos',
+            queryName: 'doritos',
+            foodName: 'Doritos Nacho Cheese Tortilla Chips',
+        }));
+        expect(r!.grams).toBe(28);
+        expect(r!.servingTier).toBe('bare_category_default');
+    });
+
+    it('falls back to the foodName noun when the query names none', () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 100,
+            servingTier: 'count_unresolved_floor',
+            parsed: bare('barebells caramel'),
+            rawLine: 'barebells caramel',
+            queryName: 'barebells caramel',
+            foodName: 'Barebells Caramel Protein Bar',
+        }));
+        expect(r!.servingTier).toBe('bare_discrete_floor');
+        expect(r!.grams).toBe(50);
+    });
+
+    it('still a no-op when neither lexicon nor a discrete noun applies (greek yogurt)', () => {
+        const r = applyOffBareQueryGuard(input({
+            grams: 100,
+            servingTier: 'flat_100g_default',
+            parsed: bare('greek yogurt'),
+            rawLine: 'greek yogurt',
+            queryName: 'greek yogurt',
+            foodName: 'Chobani Greek Yogurt',
+        }));
+        expect(r).toBeNull();
+    });
+});
+
+describe('isBareUnitlessQty1', () => {
+    it('accepts a digitless unitless qty-1 line', () => {
+        expect(isBareUnitlessQty1(bare('protein bar'), 'protein bar')).toBe(true);
+    });
+
+    it.each([
+        ['digit in raw line', bare('gatorade'), '1 gatorade'],
+        ['explicit unit', bare('olive oil', { unit: 'cup' }), 'cup of olive oil'],
+        ['qty !== 1', bare('almonds', { qty: 2 }), 'two almonds'],
+        ['multiplier !== 1', bare('olive oil', { multiplier: 2 }), 'olive oil'],
+    ])('rejects %s', (_label, parsed, rawLine) => {
+        expect(isBareUnitlessQty1(parsed as ParsedIngredient, rawLine as string)).toBe(false);
+    });
+
+    it('rejects a null parse', () => {
+        expect(isBareUnitlessQty1(null, 'olive oil')).toBe(false);
     });
 });
 

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -1,20 +1,25 @@
 /**
- * Bare-query serving guard for the OFF result builder (PR D pt3, Lever A).
+ * Bare-query serving guard for the OFF result builder (PR D pt3, Lever A;
+ * extended for bare-serving defaults, Track 3, Jul 2026).
  *
  * A "bare" query is a unitless qty-1 request with no digits in the raw line
  * ("olive oil", "doritos", "bacon") — the user asked for *a serving*, not a
- * package. Two failure classes in buildOffResult's tier cascade betray that
- * intent:
- *   - package/label tiers billing the whole retail unit (olive oil → 250g
- *     bottle, ghost pre-workout → 473g tub);
- *   - fabricated tiers billing a flat floor (mayonnaise → 100g, bacon → 100g).
- * This module maps such results onto the shared bare-query category lexicon
- * (getBareQueryDefault). Pure function, no I/O; the caller wires it in after
- * the tier cascade and keeps its original result on a null return.
+ * package. Deterministic resolution order for such requests (triage batch
+ * 2026-07-21, 82 confirmed serving rows):
+ *   (1) the record's OWN in-band label serving (usableBareLabelServing,
+ *       billed by buildOffResult as tier 'bare_label_serving');
+ *   (2) a count-noun piece weight when the NAME implies a discrete piece
+ *       (buildOffResult's seed / discrete-unit-backfill branches);
+ *   (3) the same-brand sibling median label serving ('bare_sibling_serving');
+ *   (4) a bounded floor — NEVER flat-100g for a discrete-piece name
+ *       ('bare_discrete_floor', wired below in the REPLACE path).
+ * This module owns the eligibility predicate, the label-usability band, and
+ * the post-cascade override (CAP / REPLACE / floor). Pure functions, no I/O.
  */
 
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import { getBareQueryDefault } from '../ai/ambiguous-serving-estimator';
+import { discretePieceFloor } from '../mapping/count-label';
 
 /**
  * Tiers whose grams come from real package/label machinery and can only be
@@ -35,6 +40,25 @@ const CAP_TIERS = new Set([
 ]);
 
 /**
+ * Tier billed from the record's own in-band label serving — real
+ * single-serving-scale data (bare-serving defaults, Jul 2026). The category
+ * CAP may only override it when the lexicon category is the query's HEAD
+ * noun ("olive oil" → oil, whole-bottle labels still capped). A merely
+ * CONTAINED token must not cap it: "pepper jack" (spice hijack → 2.5g) and
+ * "pumpkin spice latte" (→ 2.5g) previously lost their genuine label
+ * servings to token-containment caps (triage 2026-07-21).
+ *
+ * 'bare_sibling_serving' is deliberately UNTOUCHED (not merely head-gated):
+ * the median of >=3 sibling label servings, band-limited to 3–400g and
+ * excluding the flat-100 placeholder, is stronger evidence than a category
+ * default — capping it re-breaks trailing-lexicon-noun dishes ("hot pocket
+ * ham and cheese" → 28g cheese cap over the 127g pocket median).
+ */
+const HEAD_GATED_CAP_TIERS = new Set([
+    'bare_label_serving',
+]);
+
+/**
  * Fabricated tiers — the grams are a made-up floor, not label data — so a
  * category default is strictly better in BOTH directions (mayonnaise 100→14,
  * coca cola 100→355).
@@ -43,6 +67,59 @@ const REPLACE_TIERS = new Set([
     'flat_100g_default',
     'count_unresolved_floor',
 ]);
+
+/** Band for trusting a record's own label serving on a bare request. */
+export const BARE_LABEL_MIN_GRAMS = 3;
+export const BARE_LABEL_MAX_GRAMS = 400;
+
+/**
+ * Seed per-piece weights below this never answer a bare qty-1 request on
+ * their own: "barebells caramel cashew" must not bill one 1.5g cashew, and
+ * bare "almond" means a serving of almonds, not a 1.2g nut. Pieces at or
+ * above it (banana 118g, egg 50g, bagel) ARE the serving and pass through.
+ */
+export const BARE_MIN_PIECE_SERVING_GRAMS = 20;
+
+/**
+ * Eligibility for every bare-serving lever: unitless qty-1, multiplier 1, no
+ * digit anywhere in the raw line. The digit gate keeps every explicit count
+ * ("1 gatorade", "3 almonds", "15 pretzels") on the counted-resolution path.
+ */
+export function isBareUnitlessQty1(parsed: ParsedIngredient | null, rawLine: string): boolean {
+    if (!parsed || parsed.unit || parsed.qty !== 1 || parsed.multiplier !== 1) return false;
+    if (/\d/.test(rawLine)) return false;
+    return true;
+}
+
+/**
+ * The record's own label serving, when it is usable as THE answer to a bare
+ * request: single-serving-scale (3–400g) and not a per-100g placeholder.
+ *
+ *   - EU per-100g panels are routinely registered as a "serving" ("100 g",
+ *     "100.0g", "1 portion (100 g)") — exactly 100g with no household unit
+ *     word is treated as a placeholder, NOT a label (snickers/mascarpone/
+ *     gorgonzola class). A genuine "1 cup (100 g)" passes via its unit word.
+ *   - Sub-3g servings with no unit word are garbage metadata ("1.0g" on a
+ *     whole trout / hot pocket) — the band rejects them so the sibling
+ *     median can answer instead.
+ */
+export function usableBareLabelServing(
+    servingGrams: number | null | undefined,
+    labelUnitWord: string | null,
+): number | null {
+    if (!servingGrams || servingGrams <= 0) return null;
+    if (servingGrams < BARE_LABEL_MIN_GRAMS || servingGrams > BARE_LABEL_MAX_GRAMS) return null;
+    if (servingGrams === 100 && (labelUnitWord == null || labelUnitWord === 'g' || labelUnitWord === 'portion')) {
+        return null;
+    }
+    return servingGrams;
+}
+
+/** Last alphabetic token of a query name ("pumpkin spice latte" → "latte"). */
+function queryHeadToken(queryName: string): string {
+    const toks = (queryName || '').toLowerCase().split(/[^a-z]+/).filter(t => t.length > 0);
+    return toks[toks.length - 1] ?? '';
+}
 
 export interface BareQueryGuardInput {
     /** Grams billed by the tier cascade. */
@@ -76,8 +153,7 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
     // Eligibility: bare unitless qty-1 request only. The digit gate keeps every
     // explicit count out ("15 pretzels" must retain its count_unresolved_floor
     // backstop, "3 almonds" its per-piece resolution).
-    if (!parsed || parsed.unit || parsed.qty !== 1 || parsed.multiplier !== 1) return null;
-    if (/\d/.test(rawLine)) return null;
+    if (!isBareUnitlessQty1(parsed, rawLine)) return null;
     if (!servingTier) return null;
 
     const queryDefault = getBareQueryDefault(queryName);
@@ -92,6 +168,20 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
         return null;
     }
 
+    if (HEAD_GATED_CAP_TIERS.has(servingTier)) {
+        // Own-label / sibling-median grams are real single-serving-scale data.
+        // The CAP may fire only when the lexicon category is anchored at the
+        // query HEAD ("olive oil" → oil: a 250g whole-bottle "serving" still
+        // caps to 14g). Contained-token hijacks (pepper jack, butter chicken)
+        // keep the label.
+        if (queryDefault
+            && getBareQueryDefault(queryHeadToken(queryName)) != null
+            && grams > queryDefault.grams * 2) {
+            return buildOverride(queryDefault.grams);
+        }
+        return null;
+    }
+
     if (REPLACE_TIERS.has(servingTier)) {
         // Fabricated grams: the foodName fallback is safe here (nothing real is
         // being overridden) and lets branded queries hit via the product name
@@ -99,6 +189,17 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
         const def = queryDefault ?? getBareQueryDefault(foodName);
         if (def) {
             return buildOverride(def.grams);
+        }
+        // Bounded discrete floor (Track 3, Jul 2026): a name that implies a
+        // discrete piece must NEVER bill the flat 100g default — one sensible
+        // piece is strictly closer ("kirkland protein bar …" → ~50g bar).
+        const floor = discretePieceFloor(queryName) ?? discretePieceFloor(foodName);
+        if (floor) {
+            return {
+                grams: floor.grams,
+                servingTier: 'bare_discrete_floor',
+                servingDescription: `1 ${floor.unit} (~${floor.grams}g)`,
+            };
         }
     }
 

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -121,6 +121,54 @@ function queryHeadToken(queryName: string): string {
     return toks[toks.length - 1] ?? '';
 }
 
+/**
+ * Dose-measured lexicon categories: the bare-query default is a tsp/tbsp/scoop
+ * DOSE, not a piece or package ("1 tsp" sugar/spices, "1 tbsp" condiments,
+ * "2 tbsp" nut butters, "1 scoop" pre-workout / protein powders).
+ */
+const DOSE_MEASURE_RE = /\b(tsp|tbsp|scoop)\b/i;
+
+/**
+ * True when a bare query belongs to a scoop/spoon-dosed lexicon category AND
+ * that category is anchored at the query's TAIL — i.e. the category noun IS
+ * what the user asked for, not a contained modifier.
+ *
+ * For these foods the product's own label serving / sibling median is the
+ * WRONG rank-1 answer to a bare request: a sugar record's 104g cup-measure
+ * label or Ghost's 32.5g two-scoop sibling median must not outrank the
+ * teaspoon/scoop dose default (eval regressions n-serv-37 / n-serv-43,
+ * 2026-07-21). buildOffResult skips the own-label and sibling-median steps
+ * when this holds, so resolution flows to the label/package tiers where the
+ * category CAP restores the dose default — exactly the pre-Track-3 path.
+ *
+ * Anchoring (reuses getBareQueryDefault — no parallel lexicon):
+ *   - the LAST token alone triggers the same category ("sugar", "oil",
+ *     "ketchup", peanut BUTTER); or
+ *   - the last TWO tokens trigger it while the second-to-last alone does NOT
+ *     ("pre workout", "greens powder" — the phrase needs its final token).
+ * Contained-token hijacks stay un-anchored: "pepper jack" (the spice match
+ * survives without "jack"), "butter chicken", "pumpkin spice latte" — their
+ * genuine label servings keep winning.
+ */
+export function isDoseAnchoredBareQuery(queryName: string): boolean {
+    const full = getBareQueryDefault(queryName);
+    if (!full || !DOSE_MEASURE_RE.test(full.description)) return false;
+    const toks = (queryName || '').toLowerCase().split(/[^a-z]+/).filter(t => t.length > 0);
+    if (toks.length === 0) return false;
+
+    const last1 = getBareQueryDefault(toks[toks.length - 1]);
+    if (last1 && last1.grams === full.grams) return true;
+
+    if (toks.length >= 2) {
+        const last2 = getBareQueryDefault(toks.slice(-2).join(' '));
+        const penult = getBareQueryDefault(toks[toks.length - 2]);
+        if (last2 && last2.grams === full.grams && !(penult && penult.grams === full.grams)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export interface BareQueryGuardInput {
     /** Grams billed by the tier cascade. */
     grams: number;


### PR DESCRIPTION
Track 3 of the cache-first sprint: three related fixes to how gram amounts resolve when the user gives no usable unit. Case list: the 82 confirmed `class=serving` rows in `triage-verdicts-2026-07-21.json`.

## 1. Bare-serving defaults (the "unitless qty-1" class)

Deterministic resolution order for digitless, unitless, qty-1 requests in `buildOffResult`:

| step | source | tier |
|---|---|---|
| 1 | record's OWN in-band label serving (3–400g; flat-100g placeholder & sub-3g garbage rejected) | `bare_label_serving` |
| 2 | count-noun piece when the NAME implies one (seed ≥20g on bare; discrete backfill now also runs on placeholder labels) | `seed_count_default` / `discrete_unit_backfill` |
| 3 | same-brand sibling median label serving (≥3 in-band siblings, exact-100g excluded) | `bare_sibling_serving` |
| 4 | bounded floor — **never flat-100g for a discrete-piece name** | `bare_discrete_floor` |

Fixes the triage headline classes: per-piece divides on bare queries (combos 3.11g, sun chips 2g, yoplait 12g "strawberry"), package-as-serving over-bills (snickers/airheads/barebells placeholder-100 SKUs now take the brand median — live: 148 Snickers SKUs median 39.8g), and wrong-category lexicon caps (the CAP is now head-token-gated on the own-label tier: "olive oil" bottle-labels still cap to 14g, but "pepper jack"/"pumpkin spice latte" keep their genuine labels). The digit gate keeps every counted line ("1 gatorade", "3 almonds") byte-identical.

## 2. Count-noun sibling routing (bar/patty/link/slice/tortilla)

All five nouns route into `getOrCreateAmbiguousServing` (bar/link via estimable-unknown, patty/slice/tortilla via `AMBIGUOUS_UNITS`); the dead-ends were:
- poisoned cached rows accepted for lack of bounds (the barebells `"bar"=1.5g` class) → new per-noun `UNIT_MIN/MAX_GRAMS` (bar 15–150, patty 15–250, link 10–100, tortilla 15–120, cookie 4–100; slice deliberately unbounded);
- food-name seed fallbacks outside the unit bounds (a "bar" request surfacing the 1.5g cashew seed) → bounds-checked before use;
- null-brand SKUs never borrowing → both call sites now pass `brandForBorrow`.

Golden probe: branded bar whose exact SKU lacks a "bar" serving resolves from sibling label servings (no AI call).

## 3. Cooked-grain volume-serving preference (n-serv-06)

Root cause of the quinoa flap: `buildFdcResult`'s volume branch **never consulted existing FdcServing rows** — every "1.5 cups cooked quinoa" went to AI (nondeterministic) or the generic 240ml×density fallback (=360g), despite fdc 168917's genuine `usda_fdc` cup=185g row. The branch now resolves the record's own matching volume serving first (`fdc_label_volume` / `fdc_volume_cached`, density-banded), and the cooked-grain rerank path feeds `servingLabelMatch` for candidates OWNING a matching volume serving (`requestBillsByServing` excludes volume units by design, which is why the PR #110 boost never fired here). 1.5 × 185 = 277.5g ∈ [230,320], zero AI calls.

## Golden & tests
- n-serv-52..56 promoted **hard** (combos, sun chips, yoplait, pepper jack, snickers); n-serv-57 (kirkland bar) as knownIssue until 2 stable runs; n-serv-06 notes updated.
- New suites: `bare-serving-defaults` (17), `count-noun-sibling-routing` (19), `fdc-volume-serving` (14); guard suite extended (+28).
- Full jest: **1012 passed / 0 failed**; `lint:ci` 0 errors; `tsc` clean; `next build` green.
- No new env vars, no new dependencies, no DB writes; cache-key/brand-prefix region untouched.

Known tail (documented, unfixed): trailing-lexicon-noun collisions where the head IS the token ("stouffers mac and cheese", "vodka sauce", "quaker … brown sugar" keep today's caps), "cinnamon life" REPLACE hijack, ml-package solids (talenti pint), miso-soup bowl basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8MqqQNCLS4fFPKyQwjcGu