### PR TITLE
fix(site): footer text attribution → "Powered by fatsecret Platform API"

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -10,7 +10,7 @@ export function SiteFooter() {
       <div className="container mx-auto flex flex-col items-center justify-between gap-4 px-4 py-8 sm:flex-row">
         <div className="text-center text-sm font-semibold text-muted sm:text-left">
           <p>&copy; {new Date().getFullYear()} Mealspire</p>
-          <p className="mt-1">Nutrition data provided in part by fatsecret.</p>
+          <p className="mt-1">Powered by fatsecret Platform API</p>
         </div>
         <FatsecretBadge height={22} />
       </div>


### PR DESCRIPTION
## What

Changes the site footer's textual fatsecret attribution:

```diff
- Nutrition data provided in part by fatsecret.
+ Powered by fatsecret Platform API
```

## Why

fatsecret support ("James"), during the Premier Free tier reinstatement audit, approved the official badge images everywhere but asked that **text** mentions of fatsecret read exactly **"Powered by fatsecret Platform API"** (lowercase). The footer was the one textual attribution snippet that didn't match. The official Web Badge (`FatsecretBadge`) and the all-lowercase rule are unchanged.

The App Store listing commitment wording has separately been corrected to the same phrase in the reply to fatsecret support.

## Scope

- Single-line copy change in `src/components/SiteFooter.tsx`. No logic, no badge markup, no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)