### PR TITLE
feat(mapping): FatSecret retrieval lane (flag-off) + FatSecretFood store + .21→.133 eval defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,14 @@ FATSECRET_CACHE_SYNC_BATCH_SIZE=25
 # Optional internal endpoint to request AI density estimates (leave blank to disable)
 FATSECRET_CACHE_DENSITY_AI_ENDPOINT=
 # See docs/FATSECRET_MIGRATION.md for cache schema and rollout details.
+# FatSecret retrieval lane (Phase 1): fs candidates compete in rerank on cache miss (kill-switch, default false)
+FATSECRET_RETRIEVAL_ENABLED=false
+# Per-call timeout for the retrieval lane's search request (ms) — lane is fail-open on timeout
+FATSECRET_LANE_TIMEOUT_MS=800
+# Max fs candidates fetched per lane search
+FATSECRET_LANE_MAX_RESULTS=8
+# Persisted FatSecretFood rows older than this many days are refreshed in the background
+FATSECRET_REFRESH_DAYS=30
 
 # Eval harness mode: local (default), fatsecret, hybrid (fatsecret-first with fallback), or problem
 # Note: npm run eval -- --fatsecret ... still works and forces fatsecret mode for that invocation

--- a/prisma/migrations/20260723000000_fatsecret_food_store/migration.sql
+++ b/prisma/migrations/20260723000000_fatsecret_food_store/migration.sql
@@ -1,0 +1,60 @@
+-- FatSecret Premier retrieval-lane food store: lane hits persist locally
+-- (FatSecretFood + FatSecretServing) so cache hits never touch the external
+-- API; FoodMapping.fsId is the third source column alongside offBarcode/fdcId.
+
+-- CreateTable
+CREATE TABLE "FatSecretFood" (
+    "fsId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "brandName" TEXT,
+    "foodType" TEXT,
+    "nutrientsPer100g" JSONB NOT NULL,
+    "defaultServingId" TEXT,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FatSecretFood_pkey" PRIMARY KEY ("fsId")
+);
+
+-- CreateTable
+CREATE TABLE "FatSecretServing" (
+    "id" TEXT NOT NULL,
+    "fsId" TEXT NOT NULL,
+    "servingId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "measurementDescription" TEXT,
+    "grams" DOUBLE PRECISION,
+    "volumeMl" DOUBLE PRECISION,
+    "numberOfUnits" DOUBLE PRECISION,
+    "nutrients" JSONB,
+
+    CONSTRAINT "FatSecretServing_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FatSecretFood_name_idx" ON "FatSecretFood"("name");
+
+-- CreateIndex
+CREATE INDEX "FatSecretFood_brandName_idx" ON "FatSecretFood"("brandName");
+
+-- CreateIndex
+CREATE INDEX "FatSecretFood_fetchedAt_idx" ON "FatSecretFood"("fetchedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FatSecretServing_fsId_servingId_key" ON "FatSecretServing"("fsId", "servingId");
+
+-- CreateIndex
+CREATE INDEX "FatSecretServing_fsId_idx" ON "FatSecretServing"("fsId");
+
+-- AddForeignKey
+ALTER TABLE "FatSecretServing" ADD CONSTRAINT "FatSecretServing_fsId_fkey" FOREIGN KEY ("fsId") REFERENCES "FatSecretFood"("fsId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "FoodMapping" ADD COLUMN "fsId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "FoodMapping_fsId_idx" ON "FoodMapping"("fsId");
+
+-- AddForeignKey
+ALTER TABLE "FoodMapping" ADD CONSTRAINT "FoodMapping_fsId_fkey" FOREIGN KEY ("fsId") REFERENCES "FatSecretFood"("fsId") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -419,6 +419,45 @@ model OffServing {
 }
 
 // ============================================================================
+// FatSecret Premier — retrieval-lane food store (persisted lane hits;
+// cache hits never touch the external API)
+// ============================================================================
+
+model FatSecretFood {
+  fsId             String        @id           // FatSecret food_id (no "fs_" prefix)
+  name             String
+  brandName        String?
+  foodType         String?                     // e.g., "Brand", "Generic"
+  nutrientsPer100g Json                        // { kcal, protein, carbs, fat, fiber, sugar, sodium }
+  defaultServingId String?                     // FatSecret serving_id of the default serving
+  fetchedAt        DateTime      @default(now())  // staleness marker (FATSECRET_REFRESH_DAYS)
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+  servings         FatSecretServing[]
+  foodMappings     FoodMapping[]
+
+  @@index([name])
+  @@index([brandName])
+  @@index([fetchedAt])
+}
+
+model FatSecretServing {
+  id                     String        @id @default(cuid())
+  fsId                   String                     // FK → FatSecretFood.fsId
+  servingId              String                     // FatSecret serving_id
+  description            String                     // e.g., "1 bar", "1 cup"
+  measurementDescription String?
+  grams                  Float?                     // metric_serving_amount normalized to g
+  volumeMl               Float?
+  numberOfUnits          Float?
+  nutrients              Json?                      // per-serving macros
+  food                   FatSecretFood @relation(fields: [fsId], references: [fsId], onDelete: Cascade)
+
+  @@unique([fsId, servingId])
+  @@index([fsId])
+}
+
+// ============================================================================
 // Canonical Food Mapping Cache (replaces ValidatedMapping)
 // normalizedForm is the primary lookup key — one mapping per ingredient concept
 // ============================================================================
@@ -427,9 +466,10 @@ model FoodMapping {
   normalizedForm  String   @id              // Canonical lookup key (e.g., "strawberry")
   foodName        String
   brandName       String?
-  source          String   @default("fdc")  // "fdc" | "openfoodfacts" | "ai_generated"
+  source          String   @default("fdc")  // "fdc" | "openfoodfacts" | "ai_generated" | "fatsecret"
   offBarcode      String?                   // FK → OffFood.barcode
   fdcId           Int?                      // FK → FdcFood.fdcId
+  fsId            String?                   // FK → FatSecretFood.fsId
   aiConfidence    Float
   validatedAt     DateTime @default(now())
   validatedBy     String   @default("ai")
@@ -440,9 +480,11 @@ model FoodMapping {
 
   offFood         OffFood?  @relation(fields: [offBarcode], references: [barcode])
   fdcFood         FdcFood?  @relation(fields: [fdcId], references: [fdcId])
+  fatSecretFood   FatSecretFood? @relation(fields: [fsId], references: [fsId])
 
   @@index([fdcId])
   @@index([offBarcode])
+  @@index([fsId])
   @@index([lastUsedAt(sort: Desc)])
 }
 

--- a/scripts/dedupe-off-purge-typesense.ts
+++ b/scripts/dedupe-off-purge-typesense.ts
@@ -19,7 +19,7 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-const HOST = process.env.TYPESENSE_HOST ?? 'http://192.168.1.21:8108';
+const HOST = process.env.TYPESENSE_HOST ?? 'http://192.168.1.133:8108';
 const KEY = process.env.TYPESENSE_API_KEY ?? '';
 const COLLECTION = 'off_foods';
 const DRY_RUN = process.argv.includes('--dry-run');

--- a/scripts/eval/cache-parity-sweep.ts
+++ b/scripts/eval/cache-parity-sweep.ts
@@ -11,7 +11,7 @@
  * Run (from repo root):
  *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
  *     scripts/eval/cache-parity-sweep.ts --before scripts/eval/results/foodmapping-before-2026-07-20.json \
- *     [--base http://192.168.1.21:3000] [--concurrency 4]
+ *     [--base http://192.168.1.133:3000] [--concurrency 4]
  *
  * The --before file is a JSON array of FoodMapping rows:
  *   select json_agg(row_to_json(t)) from (select "normalizedForm","foodName",
@@ -31,7 +31,7 @@ function argValue(flag: string): string | undefined {
     return i >= 0 ? args[i + 1] : undefined;
 }
 
-const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.21:3000';
+const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.133:3000';
 const API_KEY = process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
 const CONCURRENCY = Number(argValue('--concurrency') ?? 4);
 const TIMEOUT_MS = Number(argValue('--timeout') ?? 30000);

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -8,7 +8,7 @@
  *
  * Run (from repo root):
  *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
- *     scripts/eval/run-eval.ts [--base http://192.168.1.21:3000] [--only search|nlp] [--grep s-brand]
+ *     scripts/eval/run-eval.ts [--base http://192.168.1.133:3000] [--only search|nlp] [--grep s-brand]
  *
  * Results are written to scripts/eval/results/eval-<timestamp>.json for
  * before/after diffing across ranking or ingest changes.
@@ -26,7 +26,7 @@ function argValue(flag: string): string | undefined {
     return i >= 0 ? args[i + 1] : undefined;
 }
 
-const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.21:3000';
+const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.133:3000';
 const API_KEY = process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
 const ONLY = argValue('--only');
 const GREP = argValue('--grep');

--- a/scripts/eval/stress-latency.ts
+++ b/scripts/eval/stress-latency.ts
@@ -9,7 +9,7 @@
  *
  * Run (from repo root):
  *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
- *     scripts/eval/stress-latency.ts [--base http://192.168.1.21:3000] [--n 1] [--concurrency 8] [--nlp] [--timeout 15000]
+ *     scripts/eval/stress-latency.ts [--base http://192.168.1.133:3000] [--n 1] [--concurrency 8] [--nlp] [--timeout 15000]
  *
  *   --n <k>            repeat the whole corpus k times (default 1)
  *   --concurrency <c>  parallel in-flight requests (default 1 = sequential latency; >1 = load test)
@@ -26,7 +26,7 @@ const argv = process.argv.slice(2);
 const flag = (f: string) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : undefined; };
 const has = (f: string) => argv.includes(f);
 
-const BASE = flag('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.21:3000';
+const BASE = flag('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.133:3000';
 const API_KEY = process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
 const REPEAT = parseInt(flag('--n') ?? '1', 10);
 const CONCURRENCY = parseInt(flag('--concurrency') ?? '1', 10);

--- a/scripts/eval/warm-cache.ts
+++ b/scripts/eval/warm-cache.ts
@@ -260,7 +260,7 @@ async function main() {
         return i >= 0 ? args[i + 1] : undefined;
     };
 
-    const base = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.21:3000';
+    const base = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.133:3000';
     const concurrency = Number(argValue('--concurrency') ?? 4);
     const timeoutMs = Number(argValue('--timeout') ?? 45000);
     const limit = argValue('--limit') ? Number(argValue('--limit')) : undefined;

--- a/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
@@ -1,0 +1,286 @@
+/**
+ * buildFatSecretResult — hydration + gram/macros resolution for fatsecret
+ * retrieval-lane candidates (fs_ prefix), Phase 1.
+ *
+ * Covers the resolution cascade:
+ *   (a) explicit weight unit → direct grams        ('fs_weight_direct')
+ *   (b) volume unit → serving volumeMl density     ('fs_label_volume')
+ *   (c) count noun → noun-matched serving          ('fs_label_count')
+ *       else default serving                       ('fs_default_serving')
+ *   (d) per-100g fallback                          ('fs_per100g_fallback')
+ * plus: per-serving macros preferred over per-100g rescale, the candidate
+ * fallback when the DB row is missing, the bare-query-guard CAP parity on the
+ * default-serving path, and the null-when-no-data contract.
+ *
+ * Mocks only the db (save-gates pattern).
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_12345',
+        source: 'fatsecret' as const,
+        name: 'Quest Protein Bar',
+        brandName: 'Quest',
+        score: 1,
+        foodType: 'Brand',
+        rawData: {},
+        ...overrides,
+    } as any;
+}
+
+function barServing(overrides: Record<string, unknown> = {}) {
+    return {
+        servingId: 'sv1',
+        description: '1 bar',
+        measurementDescription: 'bar',
+        grams: 60,
+        volumeMl: null,
+        numberOfUnits: 1,
+        nutrients: { calories: 240, protein: 20, carbohydrate: 24, fat: 8 },
+        ...overrides,
+    };
+}
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+    return {
+        fsId: '12345',
+        name: 'Quest Protein Bar, Chocolate Chip',
+        brandName: 'Quest Nutrition',
+        foodType: 'Brand',
+        nutrientsPer100g: { kcal: 400, protein: 33, carbs: 40, fat: 13 },
+        defaultServingId: 'sv1',
+        fetchedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        servings: [barServing()],
+        ...overrides,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '' , ...over } as ParsedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(null);
+});
+
+describe('buildFatSecretResult — gram resolution cascade', () => {
+    it('(a) explicit weight unit bills direct grams from per-100g', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+
+        const result = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 2, unit: 'oz', name: 'protein bar' }),
+            0.9, '2 oz protein bar'
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.servingTier).toBe('fs_weight_direct');
+        expect(result!.grams).toBeCloseTo(56.7, 3);
+        // Weight path has no picked serving — macros come from per-100g.
+        expect(result!.kcal).toBeCloseTo(400 * 0.567, 3);
+        expect(result!.foodId).toBe('fs_12345');
+        expect(result!.source).toBe('fatsecret');
+        expect(result!.foodName).toBe('Quest Protein Bar, Chocolate Chip');
+    });
+
+    it('(b) volume unit scales through a serving with volumeMl (own density)', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Plain Greek Yogurt',
+            defaultServingId: 'svCup',
+            servings: [{
+                servingId: 'svCup',
+                description: '1 cup',
+                measurementDescription: 'cup',
+                grams: 245,
+                volumeMl: 240,
+                numberOfUnits: 1,
+                nutrients: { calories: 150, protein: 25, carbohydrate: 9, fat: 1 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_777', name: 'Plain Greek Yogurt' }),
+            parsedLine({ qty: 0.5, unit: 'cup', name: 'greek yogurt' }),
+            0.9, '1/2 cup greek yogurt'
+        );
+
+        expect(result!.servingTier).toBe('fs_label_volume');
+        expect(result!.grams).toBeCloseTo(120 * (245 / 240), 3); // 122.5
+        // Per-serving macros scaled by grams ratio, not per-100g rescale.
+        expect(result!.kcal).toBeCloseTo(150 * (122.5 / 245), 3); // 75
+    });
+
+    it('(c) count noun "1 protein bar" picks the "1 bar" serving grams', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+
+        const result = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 1, name: 'protein bar' }),
+            0.9, '1 protein bar'
+        );
+
+        expect(result!.servingTier).toBe('fs_label_count');
+        expect(result!.grams).toBe(60);
+        expect(result!.servingId).toBe('sv1');
+        expect(result!.kcal).toBe(240);
+    });
+
+    it('(c) explicit count unit divides multi-unit servings by numberOfUnits', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Whey Protein Powder',
+            defaultServingId: 'svScoop',
+            servings: [{
+                servingId: 'svScoop',
+                description: '2 scoops',
+                measurementDescription: 'scoops',
+                grams: 46,
+                volumeMl: null,
+                numberOfUnits: 2,
+                nutrients: { calories: 180, protein: 36, carbohydrate: 4, fat: 2 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_888', name: 'Whey Protein Powder' }),
+            parsedLine({ qty: 1, unit: 'scoop', name: 'whey protein' }),
+            0.9, '1 scoop whey protein'
+        );
+
+        expect(result!.servingTier).toBe('fs_label_count');
+        expect(result!.grams).toBe(23);
+        expect(result!.kcal).toBeCloseTo(90, 3);
+    });
+
+    it('per-serving macros are preferred over the per-100g rescale', async () => {
+        // Deliberately inconsistent per-100g so the preference is observable:
+        // 60g at 1000 kcal/100g would be 600 kcal; the serving panel says 240.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            nutrientsPer100g: { kcal: 1000, protein: 1, carbs: 1, fat: 1 },
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 1, name: 'protein bar' }),
+            0.9, '1 protein bar'
+        );
+
+        expect(result!.kcal).toBe(240);
+        expect(result!.protein).toBe(20);
+    });
+
+    it('(d) falls back to per-100g x qty when the food has no servings', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Mystery Gruel',
+            defaultServingId: null,
+            servings: [],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_999', name: 'Mystery Gruel' }),
+            parsedLine({ qty: 2, name: 'mystery gruel' }),
+            0.9, '2 mystery gruel'
+        );
+
+        expect(result!.servingTier).toBe('fs_per100g_fallback');
+        expect(result!.grams).toBe(200);
+        expect(result!.kcal).toBeCloseTo(800, 3);
+    });
+
+    it('returns null when there is no row and the candidate carries no usable data', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(null);
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ rawData: {}, servings: undefined, nutrition: undefined }),
+            parsedLine({ qty: 1, name: 'protein bar' }),
+            0.9, '1 protein bar'
+        );
+
+        expect(result).toBeNull();
+    });
+
+    it('falls back to the candidate inline servings/nutrition when the DB row is missing', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(null);
+
+        const result = await buildFatSecretResult(
+            makeCandidate({
+                servings: [{ description: '1 bar', grams: 55 }],
+                nutrition: { kcal: 400, protein: 30, carbs: 40, fat: 10, per100g: true },
+            }),
+            parsedLine({ qty: 1, name: 'protein bar' }),
+            0.9, '1 protein bar'
+        );
+
+        expect(result!.servingTier).toBe('fs_label_count');
+        expect(result!.grams).toBe(55);
+        // Inline servings carry no per-serving macros — per-100g rescale.
+        expect(result!.kcal).toBeCloseTo(400 * 0.55, 3);
+        expect(result!.foodName).toBe('Quest Protein Bar');
+    });
+
+    it('bare unitless qty-1 uses the default serving (fs_default_serving)', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Vanilla Yogurt Cup',
+            defaultServingId: 'svCup',
+            servings: [{
+                servingId: 'svCup',
+                description: '1 container',
+                measurementDescription: 'container',
+                grams: 170,
+                volumeMl: null,
+                numberOfUnits: 1,
+                nutrients: { calories: 150, protein: 12, carbohydrate: 18, fat: 3 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_555', name: 'Vanilla Yogurt Cup' }),
+            parsedLine({ qty: 1, name: 'vanilla yogurt' }),
+            0.9, 'vanilla yogurt'
+        );
+
+        expect(result!.servingTier).toBe('fs_default_serving');
+        expect(result!.grams).toBe(170);
+        expect(result!.kcal).toBe(150);
+    });
+
+    it('bare-query guard CAPs a package-scale default serving (olive oil 250g -> 14g)', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Extra Virgin Olive Oil',
+            defaultServingId: 'svBottle',
+            nutrientsPer100g: { kcal: 884, protein: 0, carbs: 0, fat: 100 },
+            servings: [{
+                servingId: 'svBottle',
+                description: '1 bottle',
+                measurementDescription: 'bottle',
+                grams: 250,
+                volumeMl: null,
+                numberOfUnits: 1,
+                nutrients: { calories: 2210, protein: 0, carbohydrate: 0, fat: 250 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_333', name: 'Extra Virgin Olive Oil' }),
+            parsedLine({ qty: 1, name: 'olive oil' }),
+            0.9, 'olive oil'
+        );
+
+        expect(result!.servingTier).toBe('bare_category_default');
+        expect(result!.grams).toBe(14);
+        // Per-serving macros rescaled to the capped grams.
+        expect(result!.kcal).toBeCloseTo(2210 * (14 / 250), 3);
+    });
+});

--- a/src/lib/mapping/__tests__/fatsecret-lane.test.ts
+++ b/src/lib/mapping/__tests__/fatsecret-lane.test.ts
@@ -1,0 +1,454 @@
+/**
+ * FatSecret retrieval lane (Phase 1) — unit tests with a mocked client.
+ *
+ * Covers: kill-switch (flag off → []), missing-credentials no-op, per-100g
+ * derivation (100g metric panel preference, largest-serving scaling,
+ * zero-grams guard), fail-open on client throw + rate-limit, position-score
+ * scale, persist upsert shapes (OffFood-convention nutrient keys, sodium
+ * mg→g), and drain registration via drainPendingBackgroundTasks().
+ */
+
+import type {
+    FatSecretFoodSummary,
+    FatSecretServing as FatSecretApiServing,
+} from '../client';
+
+// Mutable flag object — read lazily via a getter so individual tests can
+// flip the kill-switch without jest.resetModules() gymnastics.
+const mockFlags = { retrievalEnabled: true };
+
+jest.mock('../config', () => {
+    const actual = jest.requireActual('../config');
+    return {
+        ...actual,
+        get FATSECRET_RETRIEVAL_ENABLED() {
+            return mockFlags.retrievalEnabled;
+        },
+        FATSECRET_LANE_TIMEOUT_MS: 800,
+        FATSECRET_LANE_MAX_RESULTS: 8,
+        // Force "no credentials" for the singleton path — tests inject clients.
+        FATSECRET_CLIENT_ID: '',
+        FATSECRET_CLIENT_SECRET: '',
+    };
+});
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: { upsert: jest.fn() },
+        fatSecretServing: { upsert: jest.fn() },
+    },
+}));
+
+jest.mock('../../logger', () => ({
+    logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    },
+}));
+
+// Loaded lazily in beforeAll so the jest.mock factories above (which close
+// over mockFlags) run after module-scope consts are initialized.
+let lane: typeof import('../fatsecret-lane');
+let deferred: typeof import('../deferred-hydration');
+let FatSecretRateLimitError: typeof import('../client').FatSecretRateLimitError;
+let mockPrisma: any;
+let mockLogger: any;
+
+beforeAll(async () => {
+    lane = await import('../fatsecret-lane');
+    deferred = await import('../deferred-hydration');
+    FatSecretRateLimitError = (await import('../client')).FatSecretRateLimitError;
+    mockPrisma = (await import('../../db')).prisma;
+    mockLogger = (await import('../../logger')).logger;
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlags.retrievalEnabled = true;
+    lane.__setFatSecretLaneClientForTests(undefined);
+    mockPrisma.fatSecretFood.upsert.mockResolvedValue({});
+    mockPrisma.fatSecretServing.upsert.mockResolvedValue({});
+});
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+function serving(over: Partial<FatSecretApiServing> = {}): FatSecretApiServing {
+    return {
+        id: 's1',
+        description: '1 serving',
+        metricServingAmount: null,
+        metricServingUnit: null,
+        numberOfUnits: 1,
+        measurementDescription: null,
+        servingWeightGrams: null,
+        calories: null,
+        carbohydrate: null,
+        protein: null,
+        fat: null,
+        saturatedFat: null,
+        polyunsaturatedFat: null,
+        monounsaturatedFat: null,
+        transFat: null,
+        cholesterol: null,
+        sodium: null,
+        potassium: null,
+        fiber: null,
+        sugar: null,
+        ...over,
+    };
+}
+
+/** Exact 100g metric panel: 250 kcal / 20 P / 30 C / 10 F, sodium 400mg. */
+function metric100Serving(over: Partial<FatSecretApiServing> = {}): FatSecretApiServing {
+    return serving({
+        id: 's1',
+        description: '100 g',
+        measurementDescription: 'g',
+        metricServingAmount: 100,
+        metricServingUnit: 'g',
+        servingWeightGrams: 100,
+        calories: 250,
+        protein: 20,
+        carbohydrate: 30,
+        fat: 10,
+        fiber: 5,
+        sugar: 8,
+        sodium: 400,
+        saturatedFat: 3,
+        ...over,
+    });
+}
+
+function summary(over: Partial<FatSecretFoodSummary> = {}): FatSecretFoodSummary {
+    return {
+        id: '12345',
+        name: 'Protein Bar',
+        brandName: 'Quest',
+        foodType: 'Brand',
+        description: null,
+        country: null,
+        servings: [metric100Serving()],
+        ...over,
+    };
+}
+
+function makeClient(result: FatSecretFoodSummary[] | Error) {
+    return {
+        searchFoodsV4:
+            result instanceof Error
+                ? jest.fn().mockRejectedValue(result)
+                : jest.fn().mockResolvedValue(result),
+    };
+}
+
+// ============================================================
+// Kill-switch & no-op paths
+// ============================================================
+
+describe('searchFatSecretLane — gating', () => {
+    it('returns [] immediately when FATSECRET_RETRIEVAL_ENABLED is off (client never called)', async () => {
+        mockFlags.retrievalEnabled = false;
+        const client = makeClient([summary()]);
+
+        const result = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(result).toEqual([]);
+        expect(client.searchFoodsV4).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when credentials are missing and no client is injected', async () => {
+        const result = await lane.searchFatSecretLane('protein bar');
+        expect(result).toEqual([]);
+    });
+
+    it('returns [] for a blank query without calling the client', async () => {
+        const client = makeClient([summary()]);
+        const result = await lane.searchFatSecretLane('   ', 8, client);
+        expect(result).toEqual([]);
+        expect(client.searchFoodsV4).not.toHaveBeenCalled();
+    });
+
+    it('passes lane timeout and caps maxResults at 10', async () => {
+        const client = makeClient([]);
+        await lane.searchFatSecretLane('protein bar', 20, client);
+        expect(client.searchFoodsV4).toHaveBeenCalledWith('protein bar', {
+            maxResults: 10,
+            timeoutMs: 800,
+        });
+
+        await lane.searchFatSecretLane('protein bar', undefined, client);
+        expect(client.searchFoodsV4).toHaveBeenLastCalledWith('protein bar', {
+            maxResults: 8, // FATSECRET_LANE_MAX_RESULTS
+            timeoutMs: 800,
+        });
+    });
+});
+
+// ============================================================
+// Per-100g derivation
+// ============================================================
+
+describe('per-100g derivation', () => {
+    it('uses an exact 100g metric serving directly', async () => {
+        const client = makeClient([summary()]);
+        const [candidate] = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(candidate.id).toBe('fs_12345');
+        expect(candidate.source).toBe('fatsecret');
+        expect(candidate.name).toBe('Protein Bar');
+        expect(candidate.brandName).toBe('Quest');
+        expect(candidate.nutrition).toEqual({
+            kcal: 250,
+            protein: 20,
+            carbs: 30,
+            fat: 10,
+            per100g: true,
+        });
+    });
+
+    it('prefers the 100g metric panel over a larger gram serving', () => {
+        const per100 = lane.derivePer100gFromServings([
+            serving({
+                id: 'big',
+                description: '1 package',
+                servingWeightGrams: 200,
+                calories: 900, // deliberately different — must NOT win
+                protein: 2,
+                carbohydrate: 2,
+                fat: 2,
+            }),
+            metric100Serving(),
+        ]);
+
+        expect(per100).toMatchObject({ calories: 250, protein: 20, carbs: 30, fat: 10 });
+    });
+
+    it('scales the largest gram-weighted serving to per-100g', () => {
+        const per100 = lane.derivePer100gFromServings([
+            serving({
+                id: 'small',
+                description: '1 mini bar',
+                metricServingAmount: 30,
+                metricServingUnit: 'g',
+                calories: 120,
+                protein: 6,
+                carbohydrate: 12,
+                fat: 4,
+            }),
+            serving({
+                id: 'bar',
+                description: '1 bar',
+                metricServingAmount: 50,
+                metricServingUnit: 'g',
+                calories: 200,
+                protein: 10,
+                carbohydrate: 20,
+                fat: 8,
+                sodium: 200, // mg per 50g serving → 400mg/100g → 0.4 g
+            }),
+        ]);
+
+        expect(per100).toEqual({
+            calories: 400,
+            protein: 20,
+            carbs: 40,
+            fat: 16,
+            sodium: 0.4,
+        });
+    });
+
+    it('zero-guard: no usable grams → candidate still emitted with nutrition undefined', async () => {
+        const hit = summary({
+            servings: [
+                serving({
+                    id: 'z',
+                    description: '1 unit',
+                    metricServingAmount: 0,
+                    metricServingUnit: 'g',
+                    servingWeightGrams: 0,
+                    calories: 100,
+                }),
+            ],
+        });
+        const client = makeClient([hit]);
+
+        const [candidate] = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(candidate).toBeDefined();
+        expect(candidate.id).toBe('fs_12345');
+        expect(candidate.nutrition).toBeUndefined();
+        expect(candidate.servings).toBeUndefined(); // no gram-bearing servings
+    });
+
+    it('exposes gram-bearing servings as {description, grams}', async () => {
+        const hit = summary({
+            servings: [
+                serving({ id: 'a', description: '1 bar', metricServingAmount: 50, metricServingUnit: 'g', calories: 200 }),
+                serving({ id: 'b', description: null, measurementDescription: 'cup', servingWeightGrams: 240, calories: 150 }),
+                serving({ id: 'c', description: '1 mystery' }), // no grams → dropped
+            ],
+        });
+        const client = makeClient([hit]);
+
+        const [candidate] = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(candidate.servings).toEqual([
+            { description: '1 bar', grams: 50 },
+            { description: 'cup', grams: 240 }, // measurementDescription fallback
+        ]);
+    });
+});
+
+// ============================================================
+// Score scale
+// ============================================================
+
+describe('score scale', () => {
+    it('scores by rank position on the 0-1 scale with a 0.5 floor', async () => {
+        const hits = Array.from({ length: 10 }, (_, i) =>
+            summary({ id: String(1000 + i), name: `Food ${i}` })
+        );
+        const client = makeClient(hits);
+
+        const candidates = await lane.searchFatSecretLane('food', 10, client);
+
+        const expected = [1, 0.94, 0.88, 0.82, 0.76, 0.7, 0.64, 0.58, 0.52, 0.5];
+        expect(candidates).toHaveLength(10);
+        candidates.forEach((c, i) => expect(c.score).toBeCloseTo(expected[i], 10));
+        // Every score stays on the 0-1 rerank ORIGINAL_SCORE scale
+        candidates.forEach(c => {
+            expect(c.score).toBeGreaterThanOrEqual(0.5);
+            expect(c.score).toBeLessThanOrEqual(1);
+        });
+    });
+});
+
+// ============================================================
+// Fail-open
+// ============================================================
+
+describe('fail-open', () => {
+    it('returns [] and warns once when the client throws', async () => {
+        const client = makeClient(new Error('boom'));
+
+        const result = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(result).toEqual([]);
+        expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns [] on FatSecretRateLimitError (429 does not propagate)', async () => {
+        const client = makeClient(new FatSecretRateLimitError('rate limit exceeded', 429));
+
+        await expect(lane.searchFatSecretLane('protein bar', 8, client)).resolves.toEqual([]);
+        expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ============================================================
+// Persistence
+// ============================================================
+
+describe('persistFatSecretHits', () => {
+    it('upserts FatSecretFood with OffFood-convention per-100g keys (sodium mg→g)', async () => {
+        await lane.persistFatSecretHits([summary()]);
+
+        expect(mockPrisma.fatSecretFood.upsert).toHaveBeenCalledTimes(1);
+        const call = mockPrisma.fatSecretFood.upsert.mock.calls[0][0];
+        expect(call.where).toEqual({ fsId: '12345' });
+        expect(call.create).toMatchObject({
+            fsId: '12345',
+            name: 'Protein Bar',
+            brandName: 'Quest',
+            foodType: 'Brand',
+            defaultServingId: 's1',
+            nutrientsPer100g: {
+                calories: 250,
+                protein: 20,
+                carbs: 30,
+                fat: 10,
+                fiber: 5,
+                sugars: 8,      // plural, matching OffFood ingest keys
+                sodium: 0.4,    // grams per 100g, not mg
+                saturatedFat: 3,
+            },
+        });
+        expect(call.create.fetchedAt).toBeInstanceOf(Date);
+        expect(call.update.fetchedAt).toBeInstanceOf(Date);
+        expect(call.update.nutrientsPer100g).toEqual(call.create.nutrientsPer100g);
+    });
+
+    it('upserts each serving on the fsId+servingId compound key with raw per-serving nutrients', async () => {
+        await lane.persistFatSecretHits([summary()]);
+
+        expect(mockPrisma.fatSecretServing.upsert).toHaveBeenCalledTimes(1);
+        const call = mockPrisma.fatSecretServing.upsert.mock.calls[0][0];
+        expect(call.where).toEqual({
+            fsId_servingId: { fsId: '12345', servingId: 's1' },
+        });
+        expect(call.create).toMatchObject({
+            fsId: '12345',
+            servingId: 's1',
+            description: '100 g',
+            measurementDescription: 'g',
+            grams: 100,
+            volumeMl: null,
+            numberOfUnits: 1,
+            nutrients: {
+                calories: 250,
+                protein: 20,
+                carbohydrate: 30, // raw fatsecret field names, unconverted
+                fat: 10,
+                fiber: 5,
+                sugar: 8,
+                sodium: 400, // raw mg
+                saturatedFat: 3,
+            },
+        });
+    });
+
+    it('skips servings without an id or description and survives per-hit upsert failures', async () => {
+        mockPrisma.fatSecretFood.upsert
+            .mockRejectedValueOnce(new Error('db down'))
+            .mockResolvedValue({});
+
+        const badHit = summary({ id: '111' });
+        const goodHit = summary({
+            id: '222',
+            servings: [
+                metric100Serving({ id: null }), // no serving_id → skipped
+                metric100Serving({ id: 's9', description: null, measurementDescription: null }), // no description → skipped
+            ],
+        });
+
+        await expect(lane.persistFatSecretHits([badHit, goodHit])).resolves.toBeUndefined();
+
+        // badHit failed (logged), goodHit's food row still written
+        expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+        expect(mockPrisma.fatSecretFood.upsert).toHaveBeenCalledTimes(2);
+        expect(mockPrisma.fatSecretServing.upsert).not.toHaveBeenCalled();
+    });
+
+    it('lane registers the persist with the background drain (drainPendingBackgroundTasks awaits it)', async () => {
+        // Make the upsert async-slow enough that it cannot have completed inline
+        let resolveUpsert!: (v: unknown) => void;
+        mockPrisma.fatSecretFood.upsert.mockImplementation(
+            () => new Promise(resolve => { resolveUpsert = resolve; })
+        );
+
+        const client = makeClient([summary({ servings: [] })]);
+        const candidates = await lane.searchFatSecretLane('protein bar', 8, client);
+        expect(candidates).toHaveLength(1);
+
+        // Persist is in flight in the background; drain must await it
+        const drain = deferred.drainPendingBackgroundTasks();
+        resolveUpsert({});
+        await drain;
+
+        expect(mockPrisma.fatSecretFood.upsert).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -15,6 +15,7 @@ const mockFoodMappingFindUnique = jest.fn();
 const mockFoodMappingUpsert = jest.fn();
 const mockFoodMappingUpdate = jest.fn();
 const mockOffFoodFindUnique = jest.fn();
+const mockFatSecretServingFindFirst = jest.fn();
 
 jest.mock('../../db', () => ({
     prisma: {
@@ -26,10 +27,13 @@ jest.mock('../../db', () => ({
         offFood: {
             findUnique: (...args: unknown[]) => mockOffFoodFindUnique(...args),
         },
+        fatSecretServing: {
+            findFirst: (...args: unknown[]) => mockFatSecretServingFindFirst(...args),
+        },
     },
 }));
 
-import { saveValidatedMapping } from '../validated-mapping-helpers';
+import { saveValidatedMapping, getValidatedMappingByNormalizedName } from '../validated-mapping-helpers';
 import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
 import type { AIValidationResult } from '../ai-validation';
 
@@ -55,6 +59,7 @@ beforeEach(() => {
     mockFoodMappingUpsert.mockResolvedValue({});
     mockFoodMappingUpdate.mockResolvedValue({});
     mockOffFoodFindUnique.mockResolvedValue(null);
+    mockFatSecretServingFindFirst.mockResolvedValue(null);
 });
 
 describe('brand-mismatch save gate', () => {
@@ -303,6 +308,100 @@ describe('human-row write-guard (PR D pt3)', () => {
         const upsertArgs = mockFoodMappingUpsert.mock.calls[0][0];
         expect(upsertArgs.update.validatedBy).toBe('ai');
         expect(upsertArgs.update.offBarcode).toBe(OTHER_BARCODE);
+    });
+});
+
+describe('fatsecret lane fs_ branch (Phase 1)', () => {
+    it('derives fsId + mappingSource fatsecret and nulls the other id columns', async () => {
+        await saveValidatedMapping(
+            'protein bar',
+            makeMapping({ foodId: 'fs_12345', foodName: 'Protein Bar' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+        const args = mockFoodMappingUpsert.mock.calls[0][0];
+        expect(args.create.fsId).toBe('12345');
+        expect(args.create.offBarcode).toBeNull();
+        expect(args.create.fdcId).toBeNull();
+        expect(args.create.source).toBe('fatsecret');
+        expect(args.update.fsId).toBe('12345');
+        expect(args.update.offBarcode).toBeNull();
+        expect(args.update.fdcId).toBeNull();
+        expect(args.update.source).toBe('fatsecret');
+    });
+
+    it('downgrade guard: an fs pick without gram servings must not evict a serving-labeled OFF row', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({ offBarcode: '9002490100070' });
+        mockOffFoodFindUnique.mockResolvedValue({ servingGrams: 250, packageQuantity: null, corruptReason: null });
+        mockFatSecretServingFindFirst.mockResolvedValue(null); // fs record has no gram serving
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: 'fs_444', foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('downgrade guard: an fs pick WITH a gram serving may replace the OFF row', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({ offBarcode: '9002490100070' });
+        mockOffFoodFindUnique.mockResolvedValue({ servingGrams: 250, packageQuantity: null, corruptReason: null });
+        mockFatSecretServingFindFirst.mockResolvedValue({ id: 'sv1' });
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: 'fs_444', foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+        expect(mockFoodMappingUpsert.mock.calls[0][0].create.fsId).toBe('444');
+    });
+
+    it('downgrade guard: an fs incumbent with serving shape is protected from a shapeless OFF pick', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({ offBarcode: null, fsId: '999' });
+        mockFatSecretServingFindFirst.mockResolvedValue({ id: 'sv1' }); // incumbent HAS shape
+        mockOffFoodFindUnique.mockResolvedValue({ servingGrams: null, packageQuantity: null }); // new pick has none
+        await saveValidatedMapping(
+            'red bull',
+            makeMapping({ foodId: 'off_5099839628986', foodName: 'Red Bull Energy Drink' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('human-row write-guard matches fs identity (same fs record bumps usage only)', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({
+            offBarcode: null,
+            fdcId: null,
+            fsId: '777',
+            foodName: 'Protein Bar',
+            validatedBy: 'human-triage',
+        });
+        await saveValidatedMapping(
+            'protein bar',
+            makeMapping({ foodId: 'fs_777', foodName: 'Protein Bar' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+        expect(mockFoodMappingUpdate).toHaveBeenCalledTimes(1);
+        expect(mockFoodMappingUpdate.mock.calls[0][0].data.usedCount).toEqual({ increment: 1 });
+    });
+
+    it('read path reconstructs fs_<fsId> and source fatsecret from a lane row', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue({
+            normalizedForm: 'protein bar',
+            foodName: 'Protein Bar',
+            brandName: null,
+            source: 'fatsecret',
+            offBarcode: null,
+            fdcId: null,
+            fsId: '12345',
+            aiConfidence: 0.92,
+            validatedBy: 'ai',
+        });
+        const result = await getValidatedMappingByNormalizedName('protein bar', 'fatsecret');
+        expect(result).not.toBeNull();
+        expect(result!.foodId).toBe('fs_12345');
+        expect(result!.source).toBe('fatsecret');
+        expect(result!.confidence).toBeCloseTo(0.92, 5);
     });
 });
 

--- a/src/lib/mapping/ai-backfill.ts
+++ b/src/lib/mapping/ai-backfill.ts
@@ -146,7 +146,7 @@ export interface InsertAiServingOptions {
         name: string;
         brandName?: string | null;
         foodType?: string;
-        source: 'fdc' | 'openfoodfacts' | 'ai_generated';
+        source: 'fdc' | 'openfoodfacts' | 'ai_generated' | 'fatsecret';
         nutrition?: {
             kcal: number;
             protein: number;

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -1,0 +1,411 @@
+/**
+ * FatSecret result builder (fatsecret retrieval lane, Phase 1 — Jul 2026).
+ *
+ * Hydrates a `fs_<food_id>` candidate from the local FatSecretFood /
+ * FatSecretServing store (persisted at retrieval time by the lane in
+ * gather-candidates) and resolves grams + macros for the parsed request.
+ * Same signature/return contract as buildOffResult / buildFdcResult in
+ * map-ingredient-with-fallback.ts, but deliberately FOCUSED: fs servings are
+ * clean household measures ("1 bar", "1 cup") with per-serving macros, so
+ * none of the OFF label-placeholder / sibling-median / package-quantity
+ * machinery is needed here.
+ *
+ * Gram-resolution priority:
+ *   (a) explicit weight unit  → direct conversion       ('fs_weight_direct')
+ *   (b) volume unit           → serving volumeMl match  ('fs_label_volume'),
+ *       else category-density fallback                  ('fs_volume_density')
+ *   (c) count/serving request → noun-matched serving    ('fs_label_count'),
+ *       else default serving                            ('fs_default_serving')
+ *   (d) nothing usable        → per-100g × qty          ('fs_per100g_fallback')
+ * Bare unitless qty-1 requests get the same bare-query-guard CAP/REPLACE
+ * parity as buildOffResult (see the guard wire-in below).
+ */
+
+import { prisma } from '../db';
+import { logger } from '../logger';
+import { FATSECRET_REFRESH_DAYS } from './config';
+import { singularizeUnit, inferDiscreteUnit } from './count-label';
+import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
+import type { ParsedIngredient } from '../parse/ingredient-line';
+import type { UnifiedCandidate } from './gather-candidates';
+import type { FatsecretMappedIngredient } from './map-ingredient-with-fallback';
+
+// ============================================================
+// Local copies of unexported map-ingredient-with-fallback helpers.
+// map-ingredient-with-fallback imports THIS module (hydrateAndSelectServing
+// branch), so a value import back into it would create an import cycle —
+// requestBillsByServing / EXPLICIT_MEASURE_UNIT_RE are unexported there
+// anyway. Keep the regex byte-identical to the mapper's copy.
+// ============================================================
+const EXPLICIT_MEASURE_UNIT_RE = /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|ml|milliliter|milliliters|l|liter|liters|floz|fl\s*oz|fluid\s*ounces?|pint|pints|quart|quarts|gallon|gallons)$/i;
+function requestBillsByServing(parsed: ParsedIngredient | null): boolean {
+    return !(parsed?.unit && EXPLICIT_MEASURE_UNIT_RE.test(parsed.unit.trim()));
+}
+
+const WEIGHT_TO_GRAMS: Record<string, number> = {
+    'g': 1, 'gram': 1, 'grams': 1,
+    'oz': 28.35, 'ounce': 28.35, 'ounces': 28.35,
+    'lb': 453.6, 'lbs': 453.6, 'pound': 453.6, 'pounds': 453.6,
+    'kg': 1000, 'kilogram': 1000,
+};
+
+const VOLUME_UNIT_ML: Record<string, number> = {
+    'cup': 240, 'cups': 240,
+    'tbsp': 15, 'tablespoon': 15, 'tablespoons': 15,
+    'tsp': 5, 'teaspoon': 5, 'teaspoons': 5,
+    'ml': 1, 'milliliter': 1, 'milliliters': 1,
+    'floz': 30, 'fl oz': 30,
+};
+
+/** Serving-description stems for matching a requested volume unit ("1 cup" for "cup"). */
+const VOLUME_UNIT_STEMS: Record<string, string[]> = {
+    'cup': ['cup'], 'cups': ['cup'],
+    'tbsp': ['tbsp', 'tablespoon'], 'tablespoon': ['tbsp', 'tablespoon'], 'tablespoons': ['tbsp', 'tablespoon'],
+    'tsp': ['tsp', 'teaspoon'], 'teaspoon': ['tsp', 'teaspoon'], 'teaspoons': ['tsp', 'teaspoon'],
+    'floz': ['fl oz', 'fluid ounce'], 'fl oz': ['fl oz', 'fluid ounce'],
+    'ml': ['ml', 'milliliter'], 'milliliter': ['ml', 'milliliter'], 'milliliters': ['ml', 'milliliter'],
+};
+
+// ============================================================
+// Normalized serving view (DB row or candidate fallback)
+// ============================================================
+
+interface FsServingView {
+    /** FatSecret serving_id when hydrated from DB; null on the candidate fallback. */
+    servingId: string | null;
+    description: string;
+    measurementDescription: string | null;
+    grams: number | null;
+    volumeMl: number | null;
+    numberOfUnits: number | null;
+    /** Per-serving macros Json when hydrated from DB. */
+    nutrients: Record<string, unknown> | null;
+}
+
+interface Macros { kcal: number; protein: number; carbs: number; fat: number }
+
+function num(v: unknown): number | null {
+    const n = typeof v === 'string' ? parseFloat(v) : typeof v === 'number' ? v : NaN;
+    return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Per-serving macros from a FatSecretServing.nutrients Json. The lane persists
+ * the client's normalized field names (calories/protein/carbohydrate/fat);
+ * accept kcal/carbs synonyms defensively — Json columns carry no schema.
+ */
+function servingMacros(nutrients: Record<string, unknown> | null): Macros | null {
+    if (!nutrients) return null;
+    const kcal = num(nutrients['calories'] ?? nutrients['kcal']);
+    if (kcal == null) return null;
+    return {
+        kcal,
+        protein: num(nutrients['protein']) ?? 0,
+        carbs: num(nutrients['carbohydrate'] ?? nutrients['carbs']) ?? 0,
+        fat: num(nutrients['fat']) ?? 0,
+    };
+}
+
+/** Per-100g macros from FatSecretFood.nutrientsPer100g (or candidate.nutrition). */
+function per100gMacros(source: Record<string, unknown> | null | undefined): Macros | null {
+    if (!source) return null;
+    const kcal = num(source['kcal'] ?? source['calories']);
+    if (kcal == null) return null;
+    return {
+        kcal,
+        protein: num(source['protein']) ?? 0,
+        carbs: num(source['carbs'] ?? source['carbohydrate']) ?? 0,
+        fat: num(source['fat']) ?? 0,
+    };
+}
+
+/** True when any token of the serving's description(s) singularizes to the noun. */
+function servingMatchesNoun(s: FsServingView, noun: string): boolean {
+    const text = `${s.description ?? ''} ${s.measurementDescription ?? ''}`.toLowerCase();
+    return text.split(/[^a-z]+/).some(tok => tok !== '' && singularizeUnit(tok) === noun);
+}
+
+/** True when the serving's description names the requested volume unit. */
+function servingMatchesVolumeUnit(s: FsServingView, unit: string): boolean {
+    const stems = VOLUME_UNIT_STEMS[unit];
+    if (!stems) return false;
+    const text = `${s.description ?? ''} ${s.measurementDescription ?? ''}`;
+    return stems.some(stem => new RegExp(`\\b${stem.replace(' ', '\\s+')}s?\\b`, 'i').test(text));
+}
+
+// ============================================================
+// Builder
+// ============================================================
+
+export async function buildFatSecretResult(
+    candidate: UnifiedCandidate,
+    parsed: ParsedIngredient | null,
+    confidence: number,
+    rawLine: string
+): Promise<FatsecretMappedIngredient | null> {
+    const fsId = candidate.id.replace(/^fs_/, '');
+
+    // 1. Hydrate from the local store (persisted at retrieval time by the lane).
+    const row = await prisma.fatSecretFood.findUnique({
+        where: { fsId },
+        include: { servings: true },
+    }).catch((err: Error) => {
+        logger.warn('fs.build_result.hydrate_failed', {
+            foodId: candidate.id,
+            error: err.message,
+        });
+        return null;
+    });
+
+    // TODO(fs-refresh): when row.fetchedAt is older than FATSECRET_REFRESH_DAYS,
+    // a background fail-open refresh from foods.get should re-persist the row
+    // (spec §4). Deliberately NOT implemented in this PR — we only log, and the
+    // stale row still serves (local data beats an extra external call).
+    if (row && Date.now() - row.fetchedAt.getTime() > FATSECRET_REFRESH_DAYS * 86_400_000) {
+        logger.debug('fs.build_result.stale_row', {
+            foodId: candidate.id,
+            fetchedAt: row.fetchedAt.toISOString(),
+            refreshDays: FATSECRET_REFRESH_DAYS,
+        });
+    }
+
+    // 2. Normalize servings: DB rows preferred; else candidate rawData/servings
+    // (the lane's inline search payload) so a not-yet-persisted hit still bills.
+    let servings: FsServingView[];
+    if (row?.servings?.length) {
+        servings = row.servings.map(s => ({
+            servingId: s.servingId,
+            description: s.description,
+            measurementDescription: s.measurementDescription,
+            grams: num(s.grams),
+            volumeMl: num(s.volumeMl),
+            numberOfUnits: num(s.numberOfUnits),
+            nutrients: (s.nutrients && typeof s.nutrients === 'object')
+                ? s.nutrients as Record<string, unknown> : null,
+        }));
+    } else {
+        // Prefer candidate.servings: the lane normalizes those to
+        // {description, grams}. rawData.servings are the RAW API servings
+        // (metricServingAmount, no grams field) — last-resort only.
+        const rawServings = (candidate.rawData as { servings?: unknown } | undefined)?.servings;
+        const fallback = candidate.servings?.length
+            ? candidate.servings
+            : Array.isArray(rawServings) ? rawServings : [];
+        servings = (fallback as unknown as Array<Record<string, unknown>>)
+            .filter(s => s && typeof s['description'] === 'string')
+            .map(s => ({
+                servingId: typeof s['servingId'] === 'string' ? s['servingId'] as string : null,
+                description: s['description'] as string,
+                measurementDescription: typeof s['measurementDescription'] === 'string'
+                    ? s['measurementDescription'] as string : null,
+                grams: num(s['grams']),
+                volumeMl: num(s['volumeMl']),
+                numberOfUnits: num(s['numberOfUnits']),
+                nutrients: (s['nutrients'] && typeof s['nutrients'] === 'object')
+                    ? s['nutrients'] as Record<string, unknown> : null,
+            }));
+    }
+
+    const per100 = per100gMacros(
+        (row?.nutrientsPer100g && typeof row.nutrientsPer100g === 'object'
+            ? row.nutrientsPer100g as Record<string, unknown> : null)
+        ?? (candidate.nutrition?.per100g
+            ? candidate.nutrition as unknown as Record<string, unknown> : null)
+    );
+
+    const usableServings = servings.filter(s => s.grams != null && s.grams > 0);
+    if (!per100 && usableServings.every(s => servingMacros(s.nutrients) == null)) {
+        // No per-100g nutrition and no per-serving macros anywhere — nothing
+        // this builder could bill. (Distinct from "no servings": per-100g alone
+        // still supports the fallback path below.)
+        logger.warn('fs.build_result.no_nutrition', { foodId: candidate.id });
+        return null;
+    }
+
+    const foodName = row?.name ?? candidate.name;
+    const brandName = row?.brandName ?? candidate.brandName ?? null;
+    const qty = parsed ? parsed.qty * parsed.multiplier : 1;
+    const unit = parsed?.unit?.toLowerCase().trim();
+
+    // 3. Gram resolution cascade.
+    let grams: number | null = null;
+    let servingDescription: string | null = null;
+    let servingTier: string | undefined;
+    /** The serving whose grams anchored the result, for per-serving macro scaling. */
+    let pickedServing: FsServingView | null = null;
+
+    if (unit && WEIGHT_TO_GRAMS[unit]) {
+        // (a) Explicit weight unit — direct conversion.
+        grams = qty * WEIGHT_TO_GRAMS[unit];
+        servingDescription = `${grams.toFixed(1)}g`;
+        servingTier = 'fs_weight_direct';
+    } else if (unit && VOLUME_UNIT_ML[unit]) {
+        // (b) Volume unit — a serving carrying volumeMl gives this food's own
+        // density (grams / volumeMl). Prefer a serving whose description names
+        // the requested unit; else any volume-quantified serving.
+        const totalMl = qty * VOLUME_UNIT_ML[unit];
+        const volServings = usableServings.filter(s => s.volumeMl != null && s.volumeMl > 0);
+        const volMatch = volServings.find(s => servingMatchesVolumeUnit(s, unit)) ?? volServings[0];
+        if (volMatch) {
+            grams = totalMl * (volMatch.grams! / volMatch.volumeMl!);
+            servingDescription = `${qty} ${unit}`;
+            servingTier = 'fs_label_volume';
+            pickedServing = volMatch;
+        } else {
+            // Category-density fallback, mirroring buildFdcResult: dry-granular
+            // categories get their tuned density, everything else the flat
+            // liquid=1.0 / solid=0.5 defaults.
+            const isLiquid = /broth|stock|water|juice|milk|sauce|vinegar|oil|syrup/i
+                .test(`${foodName} ${parsed?.name ?? ''}`);
+            let densityGml = isLiquid ? 1.0 : 0.5;
+            try {
+                const { inferCategoryFromName, categoryDensity, DRY_GRANULE_DENSITY_CATEGORIES } = require('../units/density');
+                const category = inferCategoryFromName(foodName) || inferCategoryFromName(parsed?.name || '');
+                if (category && DRY_GRANULE_DENSITY_CATEGORIES.has(category)) {
+                    const catDensity = categoryDensity(category);
+                    if (catDensity && catDensity > 0) densityGml = catDensity;
+                }
+            } catch {
+                // density.ts unavailable — keep the flat default
+            }
+            grams = totalMl * densityGml;
+            servingDescription = `${qty} ${unit}`;
+            servingTier = 'fs_volume_density';
+        }
+    } else if (requestBillsByServing(parsed)) {
+        // (c) Count/serving-style request: either an explicit count/container
+        // unit ("bar", "scoop", "bottle") or a unitless line whose NAME implies
+        // a discrete piece. Token-match the noun against serving descriptions —
+        // the fs "1 bar" serving is exactly the missing-serving-shape class
+        // this lane exists to fix.
+        const noun = unit
+            ? singularizeUnit(unit)
+            : inferDiscreteUnit(parsed?.name || foodName);
+        if (noun) {
+            const match = usableServings.find(s => servingMatchesNoun(s, noun));
+            if (match) {
+                const unitsPerServing = match.numberOfUnits && match.numberOfUnits > 0
+                    ? match.numberOfUnits : 1;
+                const perUnitGrams = match.grams! / unitsPerServing;
+                grams = qty * perUnitGrams;
+                servingDescription = `${qty} ${noun} (${perUnitGrams.toFixed(1)}g each)`;
+                servingTier = 'fs_label_count';
+                pickedServing = match;
+                logger.info('fs.build_result.label_count_matched', {
+                    foodId: candidate.id,
+                    noun,
+                    serving: match.description,
+                    perUnitGrams,
+                });
+            }
+        }
+        // Default-serving fallback for serving-billed requests the noun match
+        // couldn't resolve (bare qty-1, "1 serving", unmatched nouns).
+        if (grams == null) {
+            const defaultServing =
+                (row?.defaultServingId
+                    ? usableServings.find(s => s.servingId === row!.defaultServingId)
+                    : undefined)
+                ?? usableServings[0];
+            if (defaultServing) {
+                grams = qty * defaultServing.grams!;
+                servingDescription = qty === 1
+                    ? `${defaultServing.description} (${defaultServing.grams}g)`
+                    : `${qty} x ${defaultServing.description} (${defaultServing.grams}g each)`;
+                servingTier = 'fs_default_serving';
+                pickedServing = defaultServing;
+            }
+        }
+    }
+
+    // (d) Per-100g fallback — no serving data usable for this request.
+    if (grams == null || servingDescription == null) {
+        if (!per100) {
+            logger.warn('fs.build_result.no_usable_serving_or_per100g', { foodId: candidate.id });
+            return null;
+        }
+        grams = 100 * qty;
+        servingDescription = `${grams.toFixed(1)}g`;
+        servingTier = 'fs_per100g_fallback';
+        pickedServing = null;
+    }
+
+    // Bare-query guard parity (PR D pt3 Lever A, reused generically): the
+    // guard's entry point is tier-keyed on the OFF tier names, so map the two
+    // fs tiers it should police onto their OFF semantic twins —
+    //   fs_default_serving  → 'label_serving_default' (CAP-only: fires when the
+    //     default serving is package-scale, >2x the category default);
+    //   fs_per100g_fallback → 'flat_100g_default' (REPLACE: a fabricated 100g
+    //     yields to the category default / discrete-piece floor).
+    // Guard eligibility (bare unitless qty-1, digitless raw line) is checked
+    // inside applyOffBareQueryGuard itself; non-bare requests pass through.
+    const GUARD_TIER_ALIAS: Record<string, string> = {
+        'fs_default_serving': 'label_serving_default',
+        'fs_per100g_fallback': 'flat_100g_default',
+    };
+    if (servingTier && GUARD_TIER_ALIAS[servingTier]) {
+        const bareOverride = applyOffBareQueryGuard({
+            grams,
+            servingTier: GUARD_TIER_ALIAS[servingTier],
+            parsed,
+            rawLine,
+            queryName: parsed?.name || '',
+            foodName,
+        });
+        if (bareOverride) {
+            logger.info('fs.build_result.bare_category_default', {
+                foodId: candidate.id,
+                previousTier: servingTier,
+                previousGrams: grams,
+                grams: bareOverride.grams,
+            });
+            grams = bareOverride.grams;
+            servingDescription = bareOverride.servingDescription;
+            servingTier = bareOverride.servingTier;
+        }
+    }
+
+    // 4. Macros: per-serving macros scaled by grams are the most accurate
+    // (they ARE this serving's label panel); per-100g rescale is the fallback.
+    const pickedMacros = pickedServing?.grams && pickedServing.grams > 0
+        ? servingMacros(pickedServing.nutrients) : null;
+    let macros: Macros;
+    if (pickedMacros) {
+        const factor = grams / pickedServing!.grams!;
+        macros = {
+            kcal: pickedMacros.kcal * factor,
+            protein: pickedMacros.protein * factor,
+            carbs: pickedMacros.carbs * factor,
+            fat: pickedMacros.fat * factor,
+        };
+    } else if (per100) {
+        const factor = grams / 100;
+        macros = {
+            kcal: per100.kcal * factor,
+            protein: per100.protein * factor,
+            carbs: per100.carbs * factor,
+            fat: per100.fat * factor,
+        };
+    } else {
+        logger.warn('fs.build_result.no_macros_for_serving', { foodId: candidate.id });
+        return null;
+    }
+
+    return {
+        source: 'fatsecret',
+        foodId: `fs_${fsId}`,
+        foodName,
+        brandName,
+        servingId: pickedServing?.servingId ?? null,
+        servingDescription,
+        grams,
+        kcal: macros.kcal,
+        protein: macros.protein,
+        carbs: macros.carbs,
+        fat: macros.fat,
+        confidence,
+        quality: confidence >= 0.8 ? 'high' : confidence >= 0.6 ? 'medium' : 'low',
+        rawLine,
+        servingTier,
+    };
+}

--- a/src/lib/mapping/client.ts
+++ b/src/lib/mapping/client.ts
@@ -83,6 +83,8 @@ export interface FatSecretClientOptions {
 export interface FatSecretSearchOptions {
   maxResults?: number;
   pageNumber?: number;
+  /** Per-call timeout override (ms); falls back to the instance timeoutMs. */
+  timeoutMs?: number;
 }
 
 export interface FatSecretAutocompleteHit {
@@ -166,12 +168,15 @@ export class FatSecretClient {
   }
 
   async searchFoodsV4(query: string, opts: FatSecretSearchOptions = {}): Promise<FatSecretFoodSummary[]> {
-    const response = await this.request<any>({
-      method: 'foods.search.v4',
-      search_expression: query,
-      max_results: String(opts.maxResults ?? 8),
-      page_number: String(opts.pageNumber ?? 0),
-    });
+    const response = await this.request<any>(
+      {
+        method: 'foods.search.v4',
+        search_expression: query,
+        max_results: String(opts.maxResults ?? 8),
+        page_number: String(opts.pageNumber ?? 0),
+      },
+      { timeoutMs: opts.timeoutMs },
+    );
 
     const foodsNode =
       response?.foods_search?.results?.food ??
@@ -418,7 +423,7 @@ export class FatSecretClient {
     }
   }
 
-  private async request<T>(params: Record<string, string>): Promise<T> {
+  private async request<T>(params: Record<string, string>, opts: { timeoutMs?: number } = {}): Promise<T> {
     if (!this.clientId || !this.clientSecret) {
       throw new FatSecretAuthError('Missing FatSecret client credentials');
     }
@@ -439,7 +444,7 @@ export class FatSecretClient {
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    });
+    }, opts.timeoutMs);
 
     if (response.status === 401) {
       this.token = null;
@@ -449,7 +454,7 @@ export class FatSecretClient {
         headers: {
           Authorization: `Bearer ${retryToken}`,
         },
-      });
+      }, opts.timeoutMs);
     }
 
     if (response.status === 429) {
@@ -509,9 +514,9 @@ export class FatSecretClient {
     return data.access_token;
   }
 
-  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  private async fetchWithTimeout(url: string, init: RequestInit, timeoutMs?: number): Promise<Response> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs ?? this.timeoutMs);
     try {
       return await this.fetchImpl(url, { ...init, signal: controller.signal });
     } finally {

--- a/src/lib/mapping/config.ts
+++ b/src/lib/mapping/config.ts
@@ -40,6 +40,13 @@ export const FATSECRET_CACHE_AI_MAX_DENSITY = Number.parseFloat(
   process.env.FATSECRET_CACHE_AI_MAX_DENSITY ?? '5',
 );
 export const FATSECRET_CACHE_AI_ENABLED = getFlag('FATSECRET_CACHE_AI_ENABLED', true);
+
+// FatSecret retrieval lane (Phase 1): fs candidates compete in rerank on cache
+// miss; picked foods persist locally. Kill-switch default OFF.
+export const FATSECRET_RETRIEVAL_ENABLED = getFlag('FATSECRET_RETRIEVAL_ENABLED', false);
+export const FATSECRET_LANE_TIMEOUT_MS = Number.parseInt(process.env.FATSECRET_LANE_TIMEOUT_MS ?? '800', 10);
+export const FATSECRET_LANE_MAX_RESULTS = Number.parseInt(process.env.FATSECRET_LANE_MAX_RESULTS ?? '8', 10);
+export const FATSECRET_REFRESH_DAYS = Number.parseInt(process.env.FATSECRET_REFRESH_DAYS ?? '30', 10);
 export const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL ?? 'https://api.openai.com/v1';
 
 // OpenRouter configuration for cheap-first LLM fallback (Jan 2026)

--- a/src/lib/mapping/deferred-hydration.ts
+++ b/src/lib/mapping/deferred-hydration.ts
@@ -97,6 +97,17 @@ export async function drainPendingBackgroundTasks(): Promise<void> {
     pendingBackgroundTasks.clear();
 }
 
+/**
+ * Register an external fire-and-forget promise with the drain set, the same
+ * way this module's own tasks are tracked (e.g. the FatSecret lane's
+ * persist writes). The promise MUST already have a .catch() attached —
+ * registration does not add error handling.
+ */
+export function registerBackgroundTask(task: Promise<void>): void {
+    pendingBackgroundTasks.add(task);
+    task.finally(() => pendingBackgroundTasks.delete(task));
+}
+
 // ============================================================
 // Queue Management
 // ============================================================

--- a/src/lib/mapping/fatsecret-lane.ts
+++ b/src/lib/mapping/fatsecret-lane.ts
@@ -1,0 +1,373 @@
+/**
+ * FatSecret Retrieval Lane (Phase 1, Jul 2026)
+ *
+ * On cache miss, fatsecret Premier candidates compete in rerank alongside
+ * OFF/FDC. Every hit is persisted locally (FatSecretFood/FatSecretServing)
+ * fire-and-forget, so cache hits never touch the external API.
+ *
+ * Kill-switch: FATSECRET_RETRIEVAL_ENABLED (default OFF) — the lane is a
+ * silent no-op unless enabled. FAIL-OPEN: any client error (timeouts, 429
+ * FatSecretRateLimitError, auth) collapses to an empty lane; the gather
+ * boundary's Promise.allSettled stays isolated either way.
+ */
+
+import { prisma } from '../db';
+import { logger } from '../logger';
+import {
+    FATSECRET_RETRIEVAL_ENABLED,
+    FATSECRET_LANE_TIMEOUT_MS,
+    FATSECRET_LANE_MAX_RESULTS,
+    FATSECRET_CLIENT_ID,
+    FATSECRET_CLIENT_SECRET,
+} from './config';
+import {
+    FatSecretClient,
+    type FatSecretFoodSummary,
+    type FatSecretServing as FatSecretApiServing,
+} from './client';
+import type { UnifiedCandidate } from './gather-candidates';
+import { registerBackgroundTask } from './deferred-hydration';
+
+// ============================================================
+// Client Singleton (lazy; unit tests inject their own)
+// ============================================================
+
+/** Minimal surface the lane needs — lets tests inject a plain mock. */
+export type FatSecretLaneClient = Pick<FatSecretClient, 'searchFoodsV4'>;
+
+// undefined = not yet initialized; null = credentials missing (lane disabled)
+let clientSingleton: FatSecretLaneClient | null | undefined;
+
+function getClient(): FatSecretLaneClient | null {
+    if (clientSingleton !== undefined) return clientSingleton;
+    if (!FATSECRET_CLIENT_ID || !FATSECRET_CLIENT_SECRET) {
+        clientSingleton = null;
+        return null;
+    }
+    clientSingleton = new FatSecretClient();
+    return clientSingleton;
+}
+
+/** Test seam: override (or reset with undefined) the module-level singleton. */
+export function __setFatSecretLaneClientForTests(
+    client: FatSecretLaneClient | null | undefined
+): void {
+    clientSingleton = client;
+}
+
+// ============================================================
+// Per-100g Derivation
+// ============================================================
+
+/**
+ * Per-100g nutrient object persisted on FatSecretFood.nutrientsPer100g.
+ * Key names deliberately match the OffFood.nutrientsPer100g convention
+ * (ingest-off.ts / extractAndValidateNutrients): `calories` (not kcal),
+ * `sugars` (plural), `sodium` in GRAMS per 100g (fatsecret reports mg —
+ * converted here so corpus-wide sodium checks stay unit-consistent).
+ */
+export interface FsNutrientsPer100g {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    fiber?: number;
+    sugars?: number;
+    sodium?: number;
+    saturatedFat?: number;
+}
+
+/** Usable gram weight of a serving, or null. */
+function servingGramsOf(s: FatSecretApiServing): number | null {
+    if (
+        s.metricServingUnit?.toLowerCase() === 'g' &&
+        typeof s.metricServingAmount === 'number' &&
+        Number.isFinite(s.metricServingAmount) &&
+        s.metricServingAmount > 0
+    ) {
+        return s.metricServingAmount;
+    }
+    if (
+        typeof s.servingWeightGrams === 'number' &&
+        Number.isFinite(s.servingWeightGrams) &&
+        s.servingWeightGrams > 0
+    ) {
+        return s.servingWeightGrams;
+    }
+    return null;
+}
+
+function servingVolumeMlOf(s: FatSecretApiServing): number | null {
+    if (
+        s.metricServingUnit?.toLowerCase() === 'ml' &&
+        typeof s.metricServingAmount === 'number' &&
+        Number.isFinite(s.metricServingAmount) &&
+        s.metricServingAmount > 0
+    ) {
+        return s.metricServingAmount;
+    }
+    return null;
+}
+
+function round2(v: number): number {
+    return Math.round(v * 100) / 100;
+}
+
+/**
+ * Derive per-100g nutrition from a fatsecret inline servings array.
+ * Preference order:
+ *   1. A metric serving of exactly 100 g that carries calories.
+ *   2. The serving with the LARGEST usable gram weight that carries
+ *      calories, scaled to 100g (larger servings minimize rounding error).
+ * Returns null when no serving has usable grams + calories (the candidate
+ * is still emitted with nutrition undefined — rerank tolerates that, same
+ * as OFF rows without nutrientsPer100g).
+ */
+export function derivePer100gFromServings(
+    servings: FatSecretApiServing[] | undefined | null
+): FsNutrientsPer100g | null {
+    if (!servings || servings.length === 0) return null;
+
+    let chosen: FatSecretApiServing | null = null;
+    let chosenGrams = 0;
+
+    for (const s of servings) {
+        if (s.calories == null) continue;
+        if (
+            s.metricServingUnit?.toLowerCase() === 'g' &&
+            s.metricServingAmount === 100
+        ) {
+            chosen = s;
+            chosenGrams = 100;
+            break; // exact per-100g panel — done
+        }
+        const grams = servingGramsOf(s);
+        if (grams != null && grams > chosenGrams) {
+            chosen = s;
+            chosenGrams = grams;
+        }
+    }
+
+    if (!chosen || !(chosenGrams > 0)) return null; // zero/null-division guard
+
+    const factor = 100 / chosenGrams;
+    const scale = (v: number | null | undefined): number | undefined =>
+        typeof v === 'number' && Number.isFinite(v) ? round2(v * factor) : undefined;
+
+    const per100: FsNutrientsPer100g = {
+        calories: scale(chosen.calories) ?? 0,
+        protein: scale(chosen.protein) ?? 0,
+        carbs: scale(chosen.carbohydrate) ?? 0,
+        fat: scale(chosen.fat) ?? 0,
+    };
+
+    const fiber = scale(chosen.fiber);
+    if (fiber !== undefined) per100.fiber = fiber;
+    const sugars = scale(chosen.sugar);
+    if (sugars !== undefined) per100.sugars = sugars;
+    // fatsecret sodium is mg per serving; OffFood convention stores grams.
+    if (typeof chosen.sodium === 'number' && Number.isFinite(chosen.sodium)) {
+        per100.sodium = Math.round(chosen.sodium * factor) / 1000;
+    }
+    const saturatedFat = scale(chosen.saturatedFat);
+    if (saturatedFat !== undefined) per100.saturatedFat = saturatedFat;
+
+    return per100;
+}
+
+// ============================================================
+// Candidate Mapping
+// ============================================================
+
+/** Position-rank score on the FDC-style 0-1 scale (rerank clamps at 1). */
+function positionScore(index: number): number {
+    return Math.max(0.5, 1 - index * 0.06);
+}
+
+function toUnifiedCandidate(hit: FatSecretFoodSummary, index: number): UnifiedCandidate {
+    const per100 = derivePer100gFromServings(hit.servings);
+
+    const servings = (hit.servings ?? [])
+        .map(s => ({
+            description: (s.description ?? s.measurementDescription ?? '').trim(),
+            grams: servingGramsOf(s),
+        }))
+        .filter((s): s is { description: string; grams: number } =>
+            Boolean(s.description) && s.grams != null
+        );
+
+    return {
+        id: `fs_${hit.id}`,
+        source: 'fatsecret',
+        name: hit.name,
+        brandName: hit.brandName ?? null,
+        score: positionScore(index),
+        foodType: hit.foodType ?? undefined,
+        nutrition: per100
+            ? {
+                  kcal: per100.calories,
+                  protein: per100.protein,
+                  carbs: per100.carbs,
+                  fat: per100.fat,
+                  per100g: true,
+              }
+            : undefined,
+        servings: servings.length > 0 ? servings : undefined,
+        rawData: {
+            fsId: hit.id,
+            nutrientsPer100g: per100,
+            servings: hit.servings ?? [],
+            summary: hit,
+        },
+    };
+}
+
+// ============================================================
+// Persistence (fire-and-forget, drainable)
+// ============================================================
+
+const SERVING_NUTRIENT_FIELDS = [
+    'calories',
+    'carbohydrate',
+    'protein',
+    'fat',
+    'saturatedFat',
+    'polyunsaturatedFat',
+    'monounsaturatedFat',
+    'transFat',
+    'cholesterol',
+    'sodium',
+    'potassium',
+    'fiber',
+    'sugar',
+] as const;
+
+/** Raw per-serving macro fields (client-normalized names, unconverted units). */
+function rawServingNutrients(s: FatSecretApiServing): Record<string, number> | null {
+    const out: Record<string, number> = {};
+    for (const field of SERVING_NUTRIENT_FIELDS) {
+        const v = s[field];
+        if (typeof v === 'number' && Number.isFinite(v)) out[field] = v;
+    }
+    return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Upsert search hits into FatSecretFood/FatSecretServing. Called
+ * fire-and-forget from the lane (registered with the deferred-hydration
+ * drain so scripts can await it before prisma.$disconnect()), but exported
+ * + awaitable for tests and batch warmers. Never throws: per-hit failures
+ * are logged and skipped.
+ */
+export async function persistFatSecretHits(hits: FatSecretFoodSummary[]): Promise<void> {
+    const fetchedAt = new Date();
+
+    for (const hit of hits) {
+        try {
+            const per100 = derivePer100gFromServings(hit.servings);
+            const defaultServingId = hit.servings?.[0]?.id ?? null;
+
+            const foodData = {
+                name: hit.name,
+                brandName: hit.brandName ?? null,
+                foodType: hit.foodType ?? null,
+                nutrientsPer100g: (per100 ?? {}) as object,
+                defaultServingId,
+                fetchedAt,
+            };
+
+            await prisma.fatSecretFood.upsert({
+                where: { fsId: hit.id },
+                create: { fsId: hit.id, ...foodData },
+                update: foodData,
+            });
+
+            for (const s of hit.servings ?? []) {
+                if (!s.id) continue;
+                const description = (s.description ?? s.measurementDescription ?? '').trim();
+                if (!description) continue;
+
+                const nutrients = rawServingNutrients(s);
+                const servingData = {
+                    description,
+                    measurementDescription: s.measurementDescription ?? null,
+                    grams: servingGramsOf(s),
+                    volumeMl: servingVolumeMlOf(s),
+                    numberOfUnits: s.numberOfUnits ?? null,
+                    // omit when null: Json? columns reject plain JS null writes
+                    ...(nutrients ? { nutrients: nutrients as object } : {}),
+                };
+
+                await prisma.fatSecretServing.upsert({
+                    where: { fsId_servingId: { fsId: hit.id, servingId: s.id } },
+                    create: { fsId: hit.id, servingId: s.id, ...servingData },
+                    update: servingData,
+                });
+            }
+        } catch (err) {
+            logger.warn('fatsecret_lane.persist_failed', {
+                fsId: hit.id,
+                error: (err as Error).message,
+            });
+        }
+    }
+}
+
+// ============================================================
+// Lane Entry Point
+// ============================================================
+
+/**
+ * Search fatsecret and shape hits as UnifiedCandidates for the gather pool.
+ *
+ * - No-op ([]): flag off, blank query, or missing credentials.
+ * - FAIL-OPEN: any client error (incl. FatSecretRateLimitError) → one warn
+ *   log, empty lane.
+ * - Persists hits fire-and-forget (drainable via
+ *   drainPendingBackgroundTasks()).
+ *
+ * @param injectedClient - unit-test seam; production callers omit it.
+ */
+export async function searchFatSecretLane(
+    query: string,
+    limit?: number,
+    injectedClient?: FatSecretLaneClient
+): Promise<UnifiedCandidate[]> {
+    if (!FATSECRET_RETRIEVAL_ENABLED) return [];
+
+    const trimmed = query?.trim();
+    if (!trimmed) return [];
+
+    const client = injectedClient ?? getClient();
+    if (!client) return []; // credentials missing
+
+    try {
+        const maxResults = Math.min(limit ?? FATSECRET_LANE_MAX_RESULTS, 10);
+        const hits = await client.searchFoodsV4(trimmed, {
+            maxResults,
+            timeoutMs: FATSECRET_LANE_TIMEOUT_MS,
+        });
+        if (hits.length === 0) return [];
+
+        // Fire-and-forget persist — registered so scripts can drain before
+        // prisma.$disconnect(). persistFatSecretHits never throws, but keep
+        // the catch so the registered task can never reject.
+        const task = persistFatSecretHits(hits).catch(err => {
+            logger.debug('fatsecret_lane.persist_task_failed', {
+                error: (err as Error).message,
+            });
+        });
+        registerBackgroundTask(task);
+
+        return hits.map(toUnifiedCandidate);
+    } catch (err) {
+        // FAIL-OPEN: rate limits, timeouts (AbortError), auth failures — the
+        // lane never breaks a mapping request.
+        logger.warn('fatsecret_lane.search_failed_open', {
+            query: trimmed,
+            error: (err as Error).message,
+            errorName: (err as Error).name,
+        });
+        return [];
+    }
+}

--- a/src/lib/mapping/gather-candidates.ts
+++ b/src/lib/mapping/gather-candidates.ts
@@ -10,6 +10,7 @@ import { parseIngredientLine, type ParsedIngredient } from '../parse/ingredient-
 import { normalizeIngredientName } from './normalization-rules';
 import { logger } from '../logger';
 import { searchOffSimple, searchOffSemantic } from '../openfoodfacts/search';
+import { searchFatSecretLane } from './fatsecret-lane';
 import { countedPieceNoun } from './count-label';
 import { detectGrainCookingContext } from './filter-candidates';
 import { SEMANTIC_SEARCH_ENABLED, warmupEmbedder } from '../search/query-embedding';
@@ -24,7 +25,7 @@ warmupEmbedder();
 
 export interface UnifiedCandidate {
     id: string;
-    source: 'fdc' | 'openfoodfacts' | 'ai_generated';
+    source: 'fdc' | 'openfoodfacts' | 'ai_generated' | 'fatsecret';
     name: string;
     brandName?: string | null;
     score: number;
@@ -335,6 +336,18 @@ export async function gatherCandidates(
         );
     }
 
+    // FatSecret retrieval lane (Phase 1, Jul 2026): fatsecret Premier
+    // candidates compete in rerank alongside OFF/FDC on the same general
+    // queries the OFF simple lane fires for. The lane gates itself on
+    // FATSECRET_RETRIEVAL_ENABLED (default OFF) and is fully fail-open, so
+    // no extra gating here beyond skipOff (quick gather gate checks must
+    // stay local — never hit the external API for them). Deliberately NOT
+    // tied to offEnabled/isBrandedQuery: spec keeps the lane unconditional
+    // post-flag and lets rerank decide.
+    if (!skipOff) {
+        searchPromises.push(searchFatSecretLane(primaryQuery, maxPerSource));
+    }
+
     // Cooked-record retrieval (cooked-vs-dry fix, Jul 2026): a volume-unit
     // grain line ("1 cup white rice") prefers the cooked basis, but keyword
     // search on the bare name returns almost exclusively dry records — the
@@ -409,6 +422,8 @@ export async function gatherCandidates(
                 let id = c.id;
                 if (c.source === 'fdc' && !id.startsWith('fdc_')) {
                     id = `fdc_${id}`;
+                } else if (c.source === 'fatsecret' && !id.startsWith('fs_')) {
+                    id = `fs_${id}`;
                 }
 
                 const existing = byId.get(id);

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -62,6 +62,7 @@ import {
     BARE_LABEL_MIN_GRAMS, BARE_LABEL_MAX_GRAMS, BARE_MIN_PIECE_SERVING_GRAMS,
 } from '../servings/bare-query-guard';
 import type { CachedMappedIngredient } from './validated-mapping-helpers';
+import { buildFatSecretResult } from './build-fatsecret-result';
 
 // ============================================================
 // Symmetric cache lookup with legacy-key fallback (Track 1c)
@@ -2768,6 +2769,13 @@ export async function hydrateAndSelectServing(
         return await buildOffResult(candidate, parsed, confidence, rawLine);
     }
 
+    // Handle FatSecret retrieval-lane candidates (fs_ prefix). MUST run before
+    // the legacy branch below: that path is keyed to name-keyed AiGeneratedFood
+    // rows (getCachedFoodWithRelations) and would misroute fs_ ids.
+    if (candidate.source === 'fatsecret' || candidate.id.startsWith('fs_')) {
+        return await buildFatSecretResult(candidate, parsed, confidence, rawLine);
+    }
+
     // For cache/fatsecret candidates, get full details with servings
     let details: FatSecretFoodDetails | null = null;
     let targetFoodId = candidate.id;
@@ -4292,6 +4300,23 @@ async function buildFdcResult(
  * null-serving SKUs that would fall to the generic seed.
  */
 function candidateHasCountLabel(candidate: UnifiedCandidate, pieceNoun: string): boolean {
+    if (candidate.source === 'fatsecret') {
+        // fs servings are household measures — "1 cookie", "6 crackers" — so a
+        // serving whose unit word IS the counted noun (or the generic piece
+        // counter) carries an authoritative per-piece weight. Same noun list,
+        // unit-word extraction and per-piece sanity band as the OFF label
+        // check (servingLabelCountsPiece), except count >= 1 qualifies: an fs
+        // "1 cookie" serving is genuinely per-piece, unlike an OFF "1 portion"
+        // label.
+        return !!candidate.servings?.some(s => {
+            if (!(typeof s.grams === 'number' && s.grams > 0)) return false;
+            const labelWord = extractLabelServingUnit(s.description);
+            if (labelWord !== pieceNoun && !(labelWord && GENERIC_PIECE_WORDS.has(labelWord))) return false;
+            const count = servingLeadingCount(s.description);
+            const perPiece = s.grams / (count > 0 ? count : 1);
+            return perPiece >= 0.2 && perPiece <= 500;
+        });
+    }
     if (candidate.source !== 'openfoodfacts') return false;
     const raw = candidate.rawData as { servingSize?: string | null; servingGrams?: number | null } | undefined;
     return servingLabelCountsPiece(raw?.servingSize, raw?.servingGrams, pieceNoun);
@@ -4322,6 +4347,11 @@ function candidateHasServingData(candidate: UnifiedCandidate): boolean {
         return typeof raw?.servingGrams === 'number' && raw.servingGrams > 0;
     }
     if (candidate.source === 'fdc') {
+        return !!candidate.servings?.some(s => typeof s.grams === 'number' && s.grams > 0);
+    }
+    // fs lane candidates carry inline gram-quantified servings ("1 bar" 60g) —
+    // exactly the serving shape SERVING_LABEL_BOOST exists to reward.
+    if (candidate.source === 'fatsecret') {
         return !!candidate.servings?.some(s => typeof s.grams === 'number' && s.grams > 0);
     }
     return false;

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -212,12 +212,15 @@ export async function getValidatedMappingByNormalizedName(
 
         logger.debug('validated_mapping.normalized_cache_hit', { normalizedName, source });
 
-        // Build mapping food ID correctly from FDC ID, OFF barcode, or AI generated food
+        // Build mapping food ID correctly from FDC ID, OFF barcode, FatSecret
+        // food id, or AI generated food
         let foodId = '';
         if (cached.fdcId) {
             foodId = `fdc_${cached.fdcId}`;
         } else if (cached.offBarcode) {
             foodId = `off_${cached.offBarcode}`;
+        } else if (cached.fsId) {
+            foodId = `fs_${cached.fsId}`;
         } else {
             const aiFood = await prisma.aiGeneratedFood.findFirst({
                 where: {
@@ -248,7 +251,8 @@ export async function getValidatedMappingByNormalizedName(
             foodName: cached.foodName,
             brandName: cached.brandName,
             confidence: Math.max(0, Math.min(1, cached.aiConfidence)),
-            source: cached.source === 'openfoodfacts' ? 'openfoodfacts'
+            source: cached.fsId ? 'fatsecret'
+                    : cached.source === 'openfoodfacts' ? 'openfoodfacts'
                     : cached.source === 'fdc' ? 'fdc'
                     : 'ai_generated',
             validatedBy: cached.validatedBy,
@@ -282,11 +286,15 @@ async function findByTokenSet(
     const tokenArray = [...inputTokens];
     const firstToken = tokenArray[0];
 
-    const mappingSource = source === 'fatsecret' ? 'ai_generated' : source;
+    // Historical quirk: the mapper calls the read path with source='fatsecret'
+    // as its catch-all default, which this filter has always remapped to
+    // 'ai_generated' rows. Lane-written rows now genuinely carry
+    // source='fatsecret', so that call must match BOTH.
+    const mappingSources = source === 'fatsecret' ? ['ai_generated', 'fatsecret'] : [source];
 
     const candidates = await prisma.foodMapping.findMany({
         where: {
-            source: mappingSource,
+            source: { in: mappingSources },
             normalizedForm: { contains: firstToken }
         },
         take: 50,
@@ -438,22 +446,25 @@ export async function saveValidatedMapping(
     try {
         let fdcId: number | null = null;
         let offBarcode: string | null = null;
+        let fsId: string | null = null;
 
         if (mapping.foodId.startsWith('fdc_')) {
             fdcId = parseInt(mapping.foodId.replace('fdc_', ''), 10);
         } else if (mapping.foodId.startsWith('off_')) {
             offBarcode = mapping.foodId.replace('off_', '');
+        } else if (mapping.foodId.startsWith('fs_')) {
+            fsId = mapping.foodId.replace('fs_', '');
         }
 
-        const mappingSource = offBarcode ? 'openfoodfacts' : fdcId ? 'fdc' : 'ai_generated';
+        const mappingSource = offBarcode ? 'openfoodfacts' : fdcId ? 'fdc' : fsId ? 'fatsecret' : 'ai_generated';
         const clampedConfidence = Math.max(0, Math.min(1, validation.confidence));
 
         // Existing-row lookup, hoisted ahead of EVERY upsert (PR D pt3): the
-        // human-row write-guard below and the OFF serving-downgrade guard both
+        // human-row write-guard below and the serving-downgrade guard both
         // need the current row, so fetch it once.
         const existing = await prisma.foodMapping.findUnique({
             where: { normalizedForm },
-            select: { offBarcode: true, fdcId: true, foodName: true, validatedBy: true },
+            select: { offBarcode: true, fdcId: true, fsId: true, foodName: true, validatedBy: true },
         });
 
         // Human-row write-guard (PR D pt3): rows stamped validatedBy=
@@ -469,7 +480,9 @@ export async function saveValidatedMapping(
                 ? `off_${existing.offBarcode}`
                 : existing.fdcId != null
                     ? `fdc_${existing.fdcId}`
-                    : null;
+                    : existing.fsId
+                        ? `fs_${existing.fsId}`
+                        : null;
             const sameRecord = existingFoodId != null
                 ? existingFoodId === mapping.foodId
                 // ai_generated rows carry no id columns — match on food name.
@@ -498,46 +511,74 @@ export async function saveValidatedMapping(
             return;
         }
 
-        // Serving-shape downgrade guard (PR D pt2, Jul 2026): the parity sweep
-        // showed record swaps silently replacing a cache row whose OFF record
-        // carries real serving data ("red bull" with its 250ml can label) with
-        // a record that has none — every later serving-billed request then
-        // falls to flat_100g_default. When an overwrite would change the OFF
-        // barcode, keep the old row if the new record would lose all serving
-        // shape. The new pick still serves THIS request, it just isn't cached.
-        if (offBarcode) {
-            if (existing?.offBarcode && existing.offBarcode !== offBarcode) {
-                const [oldOff, newOff] = await Promise.all([
-                    prisma.offFood.findUnique({
-                        where: { barcode: existing.offBarcode },
-                        select: { servingGrams: true, packageQuantity: true, corruptReason: true },
-                    }),
-                    prisma.offFood.findUnique({
+        // Serving-shape downgrade guard (PR D pt2, Jul 2026; extended to the
+        // fatsecret lane, Phase 1): the parity sweep showed record swaps
+        // silently replacing a cache row whose OFF record carries real serving
+        // data ("red bull" with its 250ml can label) with a record that has
+        // none — every later serving-billed request then falls to
+        // flat_100g_default. When an overwrite would change the target record
+        // (OFF barcode or fs id, in either direction), keep the old row if the
+        // new record would lose all serving shape. fs picks do NOT bypass the
+        // guard: an fs record only counts as having serving shape when it
+        // carries a gram-quantified FatSecretServing. The new pick still
+        // serves THIS request, it just isn't cached.
+        const newTargetKey = offBarcode ? `off:${offBarcode}` : fsId ? `fs:${fsId}` : null;
+        const existingTargetKey = existing?.offBarcode
+            ? `off:${existing.offBarcode}`
+            : existing?.fsId ? `fs:${existing.fsId}` : null;
+        if (newTargetKey && existingTargetKey && newTargetKey !== existingTargetKey) {
+            const hasServingShape = (f: { servingGrams: number | null; packageQuantity: number | null } | null) =>
+                !!f && ((f.servingGrams ?? 0) > 0 || (f.packageQuantity ?? 0) > 0);
+            const fsHasServingShape = async (id: string) =>
+                !!(await prisma.fatSecretServing.findFirst({
+                    where: { fsId: id, grams: { gt: 0 } },
+                    select: { id: true },
+                }));
+
+            let incumbentShape: boolean;
+            let incumbentCorruptReason: string | null = null;
+            if (existing!.offBarcode) {
+                const oldOff = await prisma.offFood.findUnique({
+                    where: { barcode: existing!.offBarcode },
+                    select: { servingGrams: true, packageQuantity: true, corruptReason: true },
+                });
+                incumbentShape = hasServingShape(oldOff);
+                incumbentCorruptReason = oldOff?.corruptReason ?? null;
+            } else {
+                // fs incumbent — no fs corrupt-marking exists in Phase 1.
+                incumbentShape = await fsHasServingShape(existing!.fsId!);
+            }
+
+            // A corrupt-marked incumbent forfeits the guard: keeping it
+            // would zombie the row — every hit escapes ('corrupt_record'),
+            // re-resolves, and lands right back here. Serving shape on a
+            // corrupt panel is not worth preserving.
+            const incumbentCorrupt = incumbentCorruptReason != null && isCorruptExclusionEnabled();
+            if (incumbentCorrupt) {
+                logger.info('validated_mapping.downgrade_guard_bypassed_corrupt_incumbent', {
+                    normalizedForm,
+                    keptTarget: newTargetKey,
+                    evictedTarget: existingTargetKey,
+                    corruptReason: incumbentCorruptReason,
+                });
+            } else if (incumbentShape) {
+                let newShape: boolean;
+                if (offBarcode) {
+                    const newOff = await prisma.offFood.findUnique({
                         where: { barcode: offBarcode },
                         select: { servingGrams: true, packageQuantity: true },
-                    }),
-                ]);
-                const hasServingShape = (f: { servingGrams: number | null; packageQuantity: number | null } | null) =>
-                    !!f && ((f.servingGrams ?? 0) > 0 || (f.packageQuantity ?? 0) > 0);
-                // A corrupt-marked incumbent forfeits the guard: keeping it
-                // would zombie the row — every hit escapes ('corrupt_record'),
-                // re-resolves, and lands right back here. Serving shape on a
-                // corrupt panel is not worth preserving.
-                const incumbentCorrupt = oldOff?.corruptReason != null && isCorruptExclusionEnabled();
-                if (incumbentCorrupt) {
-                    logger.info('validated_mapping.downgrade_guard_bypassed_corrupt_incumbent', {
-                        normalizedForm,
-                        keptBarcode: offBarcode,
-                        evictedBarcode: existing.offBarcode,
-                        corruptReason: oldOff?.corruptReason,
                     });
-                } else if (hasServingShape(oldOff) && !hasServingShape(newOff)) {
+                    newShape = hasServingShape(newOff);
+                } else {
+                    newShape = await fsHasServingShape(fsId!);
+                }
+                if (!newShape) {
                     logger.warn('validated_mapping.save_rejected_serving_downgrade', {
                         rawIngredient,
                         normalizedForm,
                         foodName: mapping.foodName,
-                        keptBarcode: existing.offBarcode,
-                        rejectedBarcode: offBarcode,
+                        keptTarget: existingTargetKey,
+                        rejectedTarget: newTargetKey,
                     });
                     return;
                 }
@@ -555,6 +596,7 @@ export async function saveValidatedMapping(
                 source: mappingSource,
                 offBarcode,
                 fdcId,
+                fsId,
                 aiConfidence: clampedConfidence,
                 validatedBy: 'ai',
                 usedCount: 1,
@@ -565,11 +607,14 @@ export async function saveValidatedMapping(
                 // supersede a stale cached food with a re-resolution, and an
                 // increment-only update kept the stale row forever — every
                 // subsequent request paid the full re-resolution cost.
+                // offBarcode/fdcId/fsId are ALL written every save (non-matching
+                // ids are null), so the target columns stay mutually exclusive.
                 foodName: mapping.foodName,
                 brandName: mapping.brandName,
                 source: mappingSource,
                 offBarcode,
                 fdcId,
+                fsId,
                 aiConfidence: clampedConfidence,
                 validatedBy: 'ai',
                 usedCount: { increment: 1 },


### PR DESCRIPTION
## What

Premier tier is live and caching food data is permitted, so this adds fatsecret as a third candidate source in the mapping pipeline — dark by default behind `FATSECRET_RETRIEVAL_ENABLED=false`.

- **Retrieval lane** (`fatsecret-lane.ts`): on cache miss, `foods.search.v4` (bounded by `FATSECRET_LANE_TIMEOUT_MS`=800ms, fail-open on any error incl. 429) joins the OFF/FDC lanes at the existing `Promise.allSettled` gather boundary. Candidates: `fs_<food_id>`, source `fatsecret`, per-100g nutrition derived from inline serving panels (100g metric panel preferred), 0–1 rank-position score (FDC-scale).
- **Local store**: hits persist (fire-and-forget, drain-registered) to new `FatSecretFood` + `FatSecretServing` tables (migration `20260723000000`); hydration on cache hits is 100% local — no external call on the hot path.
- **`buildFatSecretResult`**: weight → volume (volumeMl, density fallback) → serving-label token match ("1 protein bar" → real "1 bar" serving grams, `numberOfUnits` division) → default serving → per-100g fallback; per-serving macros preferred over per-100g rescale; `fs_*` servingTier stamps; OFF-parity bare-query CAP/REPLACE.
- **Cache**: `FoodMapping.fsId` column; save/read symmetric with off/fdc (`saveValidatedMapping` prefix branch, read-path `fs_` reconstruction, human-triage guard, serving-downgrade guard generalized to fs targets both directions, `findByTokenSet` legacy `'fatsecret'→'ai_generated'` remap fixed to reach lane rows).
- **Rerank plumbing**: `candidateHasServingData`/`candidateHasCountLabel` fs branches so SERVING_LABEL_BOOST/COUNT_LABEL_BOOST apply.
- **Housekeeping**: eval/stress script `--base` defaults `.21`→`.133` (Mini-PC retired).

## Safety
- Flag OFF in code + `.env.example` → zero behavior change until enabled on the box; eval parity expected exactly n-mq-10.
- All existing save gates (plausibility, brand-mismatch, corrupt, 0.85 confidence) apply unchanged to fs picks.

## Verification
- `tsc --noEmit` clean, `lint:ci` 0 errors, `prisma validate` OK.
- 51 tests across 3 suites (lane derivation/fail-open/persist shapes; builder gram-cascade incl. protein-bar count case; save/read fs branches + downgrade guard both directions).
- Flag-on eval + warm-diff review happens on the box post-merge before enabling (spec: mobile `sync-docs/fatsecret_lane_spec_2026-07-23.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y