### PR TITLE
feat(mapping): fatsecret scoring parity — name-quality multiplier + branded prior

### DIFF
--- a/src/app/api/foods/search/route.ts
+++ b/src/app/api/foods/search/route.ts
@@ -293,16 +293,18 @@ export async function GET(req: NextRequest) {
       const category = mapUsdaToCategory(q);
       const isProduceQuery = category === 'fruit' || category === 'veg';
 
-      // FDC and OFF scores live on different scales (computePositionScore
-      // ~0–1.5 vs computeOffScore ~0–10), so they can't be compared or fed
-      // into the confidence formula raw. Normalize each per source, and
-      // weight FDC by how much of the query its name actually covers —
+      // FDC/fatsecret and OFF scores live on different scales
+      // (computePositionScore and the fs lane's positionScore ~0–1.5 vs
+      // computeOffScore ~0–10), so they can't be compared or fed into the
+      // confidence formula raw. Normalize each per source, and weight
+      // FDC/fatsecret by how much of the query its name actually covers —
       // engine typo-expansion can surface FDC rows that share no real
-      // token with the query (e.g. "ryse" pulling in "rye flour").
+      // token with the query (e.g. "ryse" pulling in "rye flour"), and
+      // fatsecret's API returns loosely related items deep in its list.
       const relevanceById = new Map<string, { coverage: number; relevance: number }>();
       for (const c of fallbackCandidates) {
         const coverage = queryTokenCoverage(q, c.name, c.brandName);
-        let relevance = c.source === 'fdc'
+        let relevance = c.source === 'fdc' || c.source === 'fatsecret'
           ? Math.min(1, (c.score || 0) / 1.5) * coverage
           : Math.min(1, Math.max(0, (c.score || 0) / 10));
         if (isJunkNamed(c)) relevance *= 0.5;

--- a/src/lib/mapping/__tests__/fatsecret-lane.test.ts
+++ b/src/lib/mapping/__tests__/fatsecret-lane.test.ts
@@ -308,22 +308,39 @@ describe('per-100g derivation', () => {
 // ============================================================
 
 describe('score scale', () => {
-    it('scores by rank position on the 0-1 scale with a 0.5 floor', async () => {
+    it('decays the positional base by rank with a 0.5 floor', async () => {
+        // Names share no token with the query → no name-quality multiplier,
+        // the raw positional base is exposed.
         const hits = Array.from({ length: 10 }, (_, i) =>
-            summary({ id: String(1000 + i), name: `Food ${i}` })
+            summary({ id: String(1000 + i), name: `Unrelated Item${i}x` })
         );
         const client = makeClient(hits);
 
-        const candidates = await lane.searchFatSecretLane('food', 10, client);
+        const candidates = await lane.searchFatSecretLane('quinoa', 10, client);
 
-        const expected = [1, 0.94, 0.88, 0.82, 0.76, 0.7, 0.64, 0.58, 0.52, 0.5];
+        const expected = [0.95, 0.93, 0.91, 0.89, 0.87, 0.85, 0.83, 0.81, 0.79, 0.77];
         expect(candidates).toHaveLength(10);
         candidates.forEach((c, i) => expect(c.score).toBeCloseTo(expected[i], 10));
-        // Every score stays on the 0-1 rerank ORIGINAL_SCORE scale
-        candidates.forEach(c => {
-            expect(c.score).toBeGreaterThanOrEqual(0.5);
-            expect(c.score).toBeLessThanOrEqual(1);
-        });
+    });
+
+    it('multiplies by name quality so full-coverage hits saturate ORIGINAL_SCORE', async () => {
+        const hits = [
+            // Full coverage (both query tokens in name+brand) → ×1.5
+            summary({ id: '1', name: 'Protein Bar', brandName: 'Quest' }),
+            // Partial coverage (1 of 2 tokens) → ×1.2
+            summary({ id: '2', name: 'Granola Bar' }),
+            // No coverage → base only
+            summary({ id: '3', name: 'Orange Juice' }),
+        ];
+        const client = makeClient(hits);
+
+        const candidates = await lane.searchFatSecretLane('protein bar', 8, client);
+
+        expect(candidates[0].score).toBeCloseTo(0.95 * 1.5, 10); // clamps to 1 in rerank
+        expect(candidates[1].score).toBeCloseTo(0.93 * 1.2, 10);
+        expect(candidates[2].score).toBeCloseTo(0.91, 10);
+        // A full-coverage hit deep in the list still beats a no-coverage top hit
+        expect(candidates[0].score).toBeGreaterThan(1);
     });
 });
 

--- a/src/lib/mapping/fatsecret-lane.ts
+++ b/src/lib/mapping/fatsecret-lane.ts
@@ -27,6 +27,7 @@ import {
 } from './client';
 import type { UnifiedCandidate } from './gather-candidates';
 import { registerBackgroundTask } from './deferred-hydration';
+import { queryTokenCoverage } from '../search/query-token-coverage';
 
 // ============================================================
 // Client Singleton (lazy; unit tests inject their own)
@@ -179,12 +180,28 @@ export function derivePer100gFromServings(
 // Candidate Mapping
 // ============================================================
 
-/** Position-rank score on the FDC-style 0-1 scale (rerank clamps at 1). */
-function positionScore(index: number): number {
-    return Math.max(0.5, 1 - index * 0.06);
+/**
+ * Position-rank score on the FDC-style scale (rerank clamps at 1).
+ * The positional base decays with rank; the name-quality multiplier
+ * mirrors FDC's computePositionScore so a fatsecret record whose
+ * name/brand fully covers the query saturates the rerank's
+ * ORIGINAL_SCORE term the way name-boosted OFF/FDC scores do. A purely
+ * positional score can never saturate, which structurally under-ranked
+ * genuinely-good fatsecret records against mediocre OFF matches.
+ */
+function positionScore(index: number, query: string, hit: FatSecretFoodSummary): number {
+    const base = Math.max(0.5, 0.95 - index * 0.02);
+    const coverage = queryTokenCoverage(query, hit.name, hit.brandName);
+    if (coverage >= 1) return base * 1.5;
+    if (coverage >= 0.5) return base * 1.2;
+    return base;
 }
 
-function toUnifiedCandidate(hit: FatSecretFoodSummary, index: number): UnifiedCandidate {
+function toUnifiedCandidate(
+    hit: FatSecretFoodSummary,
+    index: number,
+    query: string
+): UnifiedCandidate {
     const per100 = derivePer100gFromServings(hit.servings);
 
     const servings = (hit.servings ?? [])
@@ -201,7 +218,7 @@ function toUnifiedCandidate(hit: FatSecretFoodSummary, index: number): UnifiedCa
         source: 'fatsecret',
         name: hit.name,
         brandName: hit.brandName ?? null,
-        score: positionScore(index),
+        score: positionScore(index, query, hit),
         foodType: hit.foodType ?? undefined,
         nutrition: per100
             ? {
@@ -359,7 +376,7 @@ export async function searchFatSecretLane(
         });
         registerBackgroundTask(task);
 
-        return hits.map(toUnifiedCandidate);
+        return hits.map((hit, index) => toUnifiedCandidate(hit, index, trimmed));
     } catch (err) {
         // FAIL-OPEN: rate limits, timeouts (AbortError), auth failures — the
         // lane never breaks a mapping request.

--- a/src/lib/mapping/simple-rerank.ts
+++ b/src/lib/mapping/simple-rerank.ts
@@ -1148,6 +1148,15 @@ function computeSimpleScore(candidate: RerankCandidate, query: string, isBranded
         score += 0.03;  // Small enough not to override a genuine name-quality difference
     }
 
+    // Source tiebreaker — fatsecret wins for branded/SKU queries. fatsecret
+    // Premier records carry label-derived serving panels and brand data that
+    // crowdsourced OFF rows often lack. Same magnitude as the FDC prior
+    // above: a tiebreaker between equal name matches, not a blanket
+    // preference.
+    if (candidate.source === 'fatsecret' && (isBranded || targetBrand)) {
+        score += 0.03;
+    }
+
 
     // 4. Prefer generic over branded (but smarter about it)
     if (!candidate.brandName) {
@@ -1723,6 +1732,7 @@ export function simpleRerank(
             const coverage = getWordCoverageBonus(query, s.candidate.name);
             const apiScore = Math.min(s.candidate.score, 1) * WEIGHTS.ORIGINAL_SCORE;
             const fdcBoost = (s.candidate.source === 'fdc' && isProduceOrMeat(query)) ? 0.03 : 0;
+            const fsBoost = (s.candidate.source === 'fatsecret' && (isBranded || targetBrand)) ? 0.03 : 0;
             const brand = !s.candidate.brandName ? WEIGHTS.NO_BRAND : 0;
             const nutrDev = (aiNutritionEstimate && s.candidate.nutrition?.per100g && s.candidate.nutrition.kcal != null)
                 ? Math.abs(s.candidate.nutrition.kcal - aiNutritionEstimate.caloriesPer100g).toFixed(0)
@@ -1734,7 +1744,7 @@ export function simpleRerank(
                 `[exact=${exact.toFixed(2)} overlap=${overlap.toFixed(2)} api=${apiScore.toFixed(2)} ` +
                 `catΔ=-${catChange.toFixed(2)} contra=-${contradiction.toFixed(2)} bloat=-${bloat.toFixed(2)} ` +
                 `phrase=${phrase.toFixed(2)} mod=${modifier.toFixed(2)} cover=${coverage.toFixed(2)} ` +
-                `fdc=${fdcBoost.toFixed(2)} brand=${brand.toFixed(2)}] ` +
+                `fdc=${fdcBoost.toFixed(2)} fs=${fsBoost.toFixed(2)} brand=${brand.toFixed(2)}] ` +
                 `nutr=${s.nutritionScore.toFixed(3)} nutrDev=${nutrDev} constr=-${s.constraintPenalty.toFixed(3)} ` +
                 `cnt=${((s as any).countLabelBoost ?? 0).toFixed(2)} dbrand=${((s as any).decisiveBrandBoost ?? 0).toFixed(2)} ` +
                 `floor=${s.plausibilityFloorHit ? 1 : 0} src=${s.candidate.source}`


### PR DESCRIPTION
## What

Part 1 of the fatsecret displacement-policy hardening (pre-req for flipping `FATSECRET_RETRIEVAL_ENABLED` on). Levels the scoring field the lane competes on:

1. **Lane name-quality multiplier** (`fatsecret-lane.ts`): the lane score was purely positional, so fs records could never saturate the rerank's `ORIGINAL_SCORE` (0.45) term the way name-boosted OFF (~0–10 scale) and FDC (×1.5 name multiplier) scores do. Now mirrors FDC's `computePositionScore` shape: positional base × `queryTokenCoverage` multiplier (×1.5 full, ×1.2 ≥50%).
2. **Branded-query source prior** (`simple-rerank.ts`): +0.03 for `source === 'fatsecret'` when the query is branded/SKU-shaped — same magnitude and intent as the existing FDC produce/meat prior. Echoed in `DEBUG_RERANK_SCORES`.
3. **Manual search-bar normalization** (`foods/search/route.ts`): fs candidates were falling into the OFF `score/10` branch (top hit → ~0.10 relevance, buried). They now normalize on the FDC `/1.5 × coverage` branch.

## Testing

- `fatsecret-lane.test.ts`: score-scale tests rewritten to pin the new base decay and all three multiplier tiers (17/17 pass).
- Full jest: identical to master baseline (the 11 env-dependent suite failures pre-exist in a clean clone with no live DB).
- `lint:ci` 0 errors, `typecheck` clean, `next build` green.
- Box eval gate (flag-off parity + flag-on) to run on the branch before merge; results will be posted here.

## Follow-up (part 2, separate PR)

Cross-source macro-consensus outlier penalty (targets n-mq-08 quest-bar plausible-wrong-data regression) + displacement-margin clause in the save-time guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y