### PR TITLE
feat(mapping): persist canonicalBase + cookingModifier on FoodMapping

### DIFF
--- a/prisma/migrations/20260724000000_add_foodmapping_canonical_base/migration.sql
+++ b/prisma/migrations/20260724000000_add_foodmapping_canonical_base/migration.sql
@@ -1,0 +1,9 @@
+-- Add canonicalBase + cookingModifier observability/grouping columns to FoodMapping.
+-- These are additive and nullable; the @id lookup key (normalizedForm) is unchanged.
+-- canonicalBase is the AI-derived base identity (prep/size stripped, brand + nutrition
+-- modifiers preserved) used for dedup/grouping/analytics, never as a lookup key.
+
+ALTER TABLE "FoodMapping" ADD COLUMN "canonicalBase" TEXT;
+ALTER TABLE "FoodMapping" ADD COLUMN "cookingModifier" TEXT;
+
+CREATE INDEX "FoodMapping_canonicalBase_idx" ON "FoodMapping"("canonicalBase");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -463,9 +463,16 @@ model FatSecretServing {
 // ============================================================================
 
 model FoodMapping {
-  normalizedForm  String   @id              // Canonical lookup key (e.g., "strawberry")
+  normalizedForm  String   @id              // Canonical lookup key (e.g., "strawberry"); token-sorted + singularized. UNCHANGED by canonicalBase — collapsing variants into the KEY poisoned the cache historically ("powdered peanut butter"→"peanut butter"), so canonicalBase is an OBSERVABILITY/grouping column only, never the lookup key.
   foodName        String
   brandName       String?
+  // AI-derived base identity (from ai-normalize `canonical_base`): prep/size stripped
+  // but nutrition-affecting AND brand modifiers PRESERVED — e.g. "strawberry halves"→
+  // "strawberries", "skim milk"→"skim milk", "tropicana orange juice"→"tropicana orange
+  // juice" (brand kept so two OJ brands stay distinct). Used for dedup/grouping/analytics;
+  // NOT a lookup key. Nullable: populated going forward + via backfill-canonical-base.ts.
+  canonicalBase   String?
+  cookingModifier String?                   // Cooking method extracted by ai-normalize (grilled/roasted/scrambled…), for diary/grouping use
   source          String   @default("fdc")  // "fdc" | "openfoodfacts" | "ai_generated" | "fatsecret"
   offBarcode      String?                   // FK → OffFood.barcode
   fdcId           Int?                      // FK → FdcFood.fdcId
@@ -486,6 +493,7 @@ model FoodMapping {
   @@index([offBarcode])
   @@index([fsId])
   @@index([lastUsedAt(sort: Desc)])
+  @@index([canonicalBase])
 }
 
 // ============================================================================

--- a/scripts/backfill-canonical-base.ts
+++ b/scripts/backfill-canonical-base.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env ts-node
+/**
+ * backfill-canonical-base.ts — populate FoodMapping.canonicalBase for existing rows.
+ *
+ * canonicalBase is an observability/grouping column (see the FoodMapping schema note);
+ * it never affects the normalizedForm lookup key. Historical rows predate the column and
+ * have no AI-derived base, so this backfill approximates it deterministically from the
+ * picked record's foodName + brandName via brandSafeCanonicalBase (brand kept so distinct
+ * branded products stay distinct). PRECISE AI bases populate automatically on the next
+ * save of each key; this just gives immediate dedup/grouping signal. LLM-free, idempotent.
+ *
+ * Only fills rows where canonicalBase IS NULL (won't clobber values written by the pipeline).
+ *
+ *   ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register \
+ *     scripts/backfill-canonical-base.ts [--dry-run] [--limit N] [--batch 500]
+ */
+import 'dotenv/config';
+import { prisma } from '../src/lib/db';
+import { brandSafeCanonicalBase } from '../src/lib/mapping/validated-mapping-helpers';
+
+function arg(flag: string): string | undefined {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function main() {
+    const dryRun = process.argv.includes('--dry-run');
+    const limit = arg('--limit') ? parseInt(arg('--limit')!, 10) : undefined;
+    const batchSize = arg('--batch') ? parseInt(arg('--batch')!, 10) : 500;
+
+    const rows = await prisma.foodMapping.findMany({
+        where: { canonicalBase: null },
+        select: { normalizedForm: true, foodName: true, brandName: true },
+        ...(limit ? { take: limit } : {}),
+    });
+
+    console.log(`${dryRun ? '[DRY RUN] ' : ''}rows to backfill: ${rows.length}`);
+    let updated = 0, skipped = 0;
+    const sample: string[] = [];
+
+    for (let i = 0; i < rows.length; i += batchSize) {
+        const chunk = rows.slice(i, i + batchSize);
+        await Promise.all(chunk.map(async (r) => {
+            const base = brandSafeCanonicalBase(r.foodName, r.brandName);
+            if (!base) { skipped++; return; }
+            if (sample.length < 15) sample.push(`${r.normalizedForm}  ->  ${base}`);
+            if (!dryRun) {
+                await prisma.foodMapping.update({
+                    where: { normalizedForm: r.normalizedForm },
+                    data: { canonicalBase: base },
+                });
+            }
+            updated++;
+        }));
+        if (!dryRun) console.log(`  ...${Math.min(i + batchSize, rows.length)}/${rows.length}`);
+    }
+
+    console.log('\nsample:');
+    sample.forEach((s) => console.log('  ' + s));
+    console.log(`\n${dryRun ? '[DRY RUN] would update' : 'updated'}: ${updated}, skipped(no base): ${skipped}`);
+    await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/mapping/__tests__/canonical-base-persist.test.ts
+++ b/src/lib/mapping/__tests__/canonical-base-persist.test.ts
@@ -1,0 +1,83 @@
+/**
+ * canonicalBase / cookingModifier persistence (observability columns).
+ *
+ * canonicalBase is a grouping/dedup column and NEVER the lookup key. Key rules under test:
+ *  - brand is preserved so two different branded products (Tropicana vs Simply orange
+ *    juice) get DISTINCT canonicalBase values and stay separate cache identities;
+ *  - saveValidatedMapping writes canonicalBase + cookingModifier without changing the
+ *    normalizedForm @id (the base "eggs" and the key "egg" coexist).
+ */
+
+const mockFoodMappingFindUnique = jest.fn();
+const mockFoodMappingUpsert = jest.fn();
+const mockFoodMappingUpdate = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        foodMapping: {
+            findUnique: (...args: unknown[]) => mockFoodMappingFindUnique(...args),
+            upsert: (...args: unknown[]) => mockFoodMappingUpsert(...args),
+            update: (...args: unknown[]) => mockFoodMappingUpdate(...args),
+        },
+    },
+}));
+
+import { brandSafeCanonicalBase, saveValidatedMapping } from '../validated-mapping-helpers';
+import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+
+describe('brandSafeCanonicalBase', () => {
+    it('keeps distinct brands distinct (Tropicana vs Simply orange juice)', () => {
+        const a = brandSafeCanonicalBase('orange juice', 'Tropicana');
+        const b = brandSafeCanonicalBase('orange juice', 'Simply');
+        expect(a).toBe('tropicana orange juice');
+        expect(b).toBe('simply orange juice');
+        expect(a).not.toBe(b);
+    });
+
+    it('does not double-prepend a brand already present in the base', () => {
+        expect(brandSafeCanonicalBase('tropicana orange juice', 'Tropicana')).toBe('tropicana orange juice');
+        expect(brandSafeCanonicalBase('Tropicana Orange Juice', 'tropicana')).toBe('tropicana orange juice');
+    });
+
+    it('leaves a generic base unchanged when there is no brand', () => {
+        expect(brandSafeCanonicalBase('strawberries', null)).toBe('strawberries');
+        expect(brandSafeCanonicalBase('eggs', undefined)).toBe('eggs');
+    });
+
+    it('returns null when there is no base to persist', () => {
+        expect(brandSafeCanonicalBase(null, 'Tropicana')).toBeNull();
+        expect(brandSafeCanonicalBase('', 'Tropicana')).toBeNull();
+        expect(brandSafeCanonicalBase(undefined, undefined)).toBeNull();
+    });
+});
+
+describe('saveValidatedMapping persists base/modifier without changing the key', () => {
+    beforeEach(() => {
+        mockFoodMappingFindUnique.mockReset();
+        mockFoodMappingUpsert.mockReset();
+        mockFoodMappingUpdate.mockReset();
+        mockFoodMappingFindUnique.mockResolvedValue(null); // new row
+        mockFoodMappingUpsert.mockResolvedValue(undefined);
+    });
+
+    it('writes canonicalBase="eggs" + cookingModifier="scrambled" while key stays "egg"', async () => {
+        const mapping = {
+            source: 'fdc', foodId: 'fdc_1', foodName: 'Scrambled Eggs', brandName: null,
+            grams: 100, kcal: 150, protein: 10, carbs: 1, fat: 11, confidence: 0.95,
+            quality: 'high', rawLine: '2 scrambled eggs',
+        } as unknown as FatsecretMappedIngredient;
+
+        await saveValidatedMapping('2 scrambled eggs', mapping,
+            { approved: true, confidence: 0.95, reason: 'test' },
+            { canonicalBase: 'eggs', persistCanonicalBase: 'eggs', persistCookingModifier: 'scrambled' });
+
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+        const call = mockFoodMappingUpsert.mock.calls[0][0];
+        // key is the canonicalized (singularized) "egg" — NOT the base "eggs"
+        expect(call.where.normalizedForm).toBe('egg');
+        expect(call.create.normalizedForm).toBe('egg');
+        // observability columns carry the un-singularized base + cooking method
+        expect(call.create.canonicalBase).toBe('eggs');
+        expect(call.create.cookingModifier).toBe('scrambled');
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -1077,6 +1077,7 @@ export async function mapIngredientWithFallback(
         let aiSynonyms: string[] = [];
         let aiNutritionEstimate: { caloriesPer100g: number; proteinPer100g: number; carbsPer100g: number; fatPer100g: number; confidence: number } | undefined;
         let aiCanonicalBase: string | undefined;  // For cache key consolidation
+        let aiCookingModifier: string | undefined;  // Persisted to FoodMapping.cookingModifier (grouping only)
         let skippedLlmNormalize = false;
         // ── Brand detection (already computed above, available here too) ────
         // isBrandedQuery and brandDetection are set before the early cache check.
@@ -1117,6 +1118,7 @@ export async function mapIngredientWithFallback(
                         normalizedName = aiHint.normalizedName;
                     }
                     aiCanonicalBase = aiHint.canonicalBase;
+                    aiCookingModifier = aiHint.cookingModifier;
                     aiSynonyms = aiHint.synonyms || [];
                     if (aiSynonyms.length > 0) {
                         logger.info('mapping.ai_synonyms', { rawLine: trimmed, synonyms: aiSynonyms });
@@ -2574,6 +2576,8 @@ export async function mapIngredientWithFallback(
                 reason: selectionReason,
             }, {
                 canonicalBase: cacheKey,  // Use normalizedName as cache key
+                persistCanonicalBase: aiCanonicalBase,   // AI base identity → canonicalBase column (grouping only)
+                persistCookingModifier: aiCookingModifier,
                 nutrientsPer100g: savedNutrientsPer100g,
                 expectedNutrition,
             });
@@ -2610,6 +2614,8 @@ export async function mapIngredientWithFallback(
                     isAlias: true,
                     canonicalRawIngredient: trimmed,
                     canonicalBase: cacheKey,  // Use same cache key for consolidation
+                    persistCanonicalBase: aiCanonicalBase,   // AI base identity → canonicalBase column (grouping only)
+                    persistCookingModifier: aiCookingModifier,
                     nutrientsPer100g: savedNutrientsPer100g,
                     expectedNutrition,
                 }).catch(() => { }); // Best effort, ignore duplicates

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -351,6 +351,28 @@ function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
 }
 
 /**
+ * Normalize the AI-derived base into a brand-safe value for the canonicalBase COLUMN.
+ * Returns null when there's no base to persist. When the pick carries a brand that the
+ * base doesn't already name, the brand is prepended so distinct branded products never
+ * collapse to the same canonicalBase (e.g. "tropicana orange juice" vs "simply orange
+ * juice"). This is grouping/observability only — it never touches the normalizedForm key.
+ */
+export function brandSafeCanonicalBase(
+    rawBase: string | undefined | null,
+    brandName: string | undefined | null,
+): string | null {
+    const base = rawBase?.toLowerCase().trim().replace(/\s+/g, ' ');
+    if (!base) return null;
+    const brand = brandName?.toLowerCase().trim().replace(/\s+/g, ' ');
+    if (!brand) return base;
+    // Already brand-qualified if every brand token is present in the base (whole-token).
+    const baseTokens = new Set(base.split(' '));
+    const brandTokens = brand.split(' ').filter(Boolean);
+    const hasBrand = brandTokens.length > 0 && brandTokens.every((t) => baseTokens.has(t));
+    return hasBrand ? base : `${brand} ${base}`;
+}
+
+/**
  * Save an AI-approved mapping to the validated cache
  * Saves by normalizedForm as the primary lookup key
  */
@@ -362,7 +384,11 @@ export async function saveValidatedMapping(
         isAlias?: boolean;
         canonicalRawIngredient?: string;
         normalizedForm?: string;  // If provided, uses this; otherwise normalizes rawIngredient
-        canonicalBase?: string;   // AI-derived base form for cache key consolidation (highest priority)
+        canonicalBase?: string;   // MISNOMER (historical): the pre-derived LOOKUP KEY basis, NOT the AI base. Canonicalized into normalizedForm below. Do NOT confuse with persistCanonicalBase.
+        // Observability/grouping columns (NEVER affect the lookup key). The AI base
+        // (ai-normalize `canonical_base`) + cooking method, persisted as-is for dedup/analytics.
+        persistCanonicalBase?: string;   // e.g. "tropicana orange juice" (brand kept), "strawberries"
+        persistCookingModifier?: string; // e.g. "grilled", "scrambled"
         nutrientsPer100g?: MacroPlausibilityInput | null;      // Pick's per-100g macros for the save-time gate
         expectedNutrition?: ExpectedNutritionPer100g | null;   // AI normalize estimate to cross-check against
     }
@@ -371,6 +397,15 @@ export async function saveValidatedMapping(
     const rawForm = options?.canonicalBase || options?.normalizedForm || normalizeQuery(rawIngredient);
     // Canonicalize: lowercase + singularize + sort tokens
     const normalizedForm = canonicalizeCacheKey(rawForm);
+
+    // Brand-safe base identity for the canonicalBase COLUMN (observability only —
+    // does not touch normalizedForm). ai-normalize is supposed to keep the brand in
+    // canonical_base when is_branded, but guard deterministically: if the pick carries
+    // a brand and the base doesn't already name it, prepend it — so two different
+    // branded products (e.g. Tropicana vs Simply orange juice) never share a
+    // canonicalBase and stay distinct for grouping/dedup.
+    const persistedCanonicalBase = brandSafeCanonicalBase(options?.persistCanonicalBase, mapping.brandName);
+    const persistedCookingModifier = options?.persistCookingModifier?.trim() || null;
 
     const detectedBrand = detectBrandInQuery(rawIngredient).matchedBrand;
 
@@ -626,6 +661,8 @@ export async function saveValidatedMapping(
                 normalizedForm,
                 foodName: mapping.foodName,
                 brandName: mapping.brandName,
+                canonicalBase: persistedCanonicalBase,
+                cookingModifier: persistedCookingModifier,
                 source: mappingSource,
                 offBarcode,
                 fdcId,
@@ -652,6 +689,11 @@ export async function saveValidatedMapping(
                 validatedBy: 'ai',
                 usedCount: { increment: 1 },
                 lastUsedAt: new Date(),
+                // Only overwrite the base/modifier when THIS save actually derived one
+                // (e.g. the LLM-skipped cached-normalize path may lack a brand-safe base) —
+                // otherwise leave a previously populated value intact.
+                ...(persistedCanonicalBase ? { canonicalBase: persistedCanonicalBase } : {}),
+                ...(persistedCookingModifier ? { cookingModifier: persistedCookingModifier } : {}),
             },
         });
 


### PR DESCRIPTION
## What
Adds two **additive, nullable** columns to `FoodMapping` — `canonicalBase` and `cookingModifier` (index on `canonicalBase`) — persisting the AI-derived base identity + cooking method that `ai-normalize` already computes but the pipeline previously discarded.

## Why
Near-identical foods currently fragment into different `normalizedForm` keys, and there's no stored "base" to group/dedup by. Measured on the live cache: ~86 redundant keys across 77 foods point to the same underlying record under different keys (~4%, growing). `canonicalBase` gives an observability/grouping handle for that.

## Critical constraint honored: the lookup key is UNCHANGED
`normalizedForm` (the `@id`) is **not** touched. Collapsing variants into the *key* poisoned the cache historically (`"powdered peanut butter"` → `"peanut butter"` key hit 73+ queries). So `canonicalBase` is a **grouping/analytics column only, never a lookup key**. Read-side fallback (answering misses via `canonicalBase`) is intentionally **out of scope** — it reintroduces that poisoning path and needs a separate design pass.

## Brand safety (distinct brands stay distinct)
`brandSafeCanonicalBase` prepends the pick's brand when the base doesn't already name it, so **Tropicana** vs **Simply** orange juice never collapse to one `canonicalBase` — they remain separate cache identities. (`ai-normalize` already keeps brand in `canonical_base`; this is a deterministic backstop.)

## Changes
- **schema + migration**: `canonicalBase TEXT`, `cookingModifier TEXT`, `@@index([canonicalBase])`
- **`saveValidatedMapping`**: new `persistCanonicalBase` / `persistCookingModifier` options; written on create; on update only overwrite when this save actually derived a value (won't null-out a populated base)
- **`map-ingredient-with-fallback`**: capture `aiCookingModifier`, pass both at the two save sites
- **`scripts/backfill-canonical-base.ts`**: LLM-free heuristic backfill for existing rows (`--dry-run`/`--limit`); precise bases fill in on next warm
- **tests**: brand distinction, no double-prepend, and key-unchanged (`eggs` base coexists with `egg` key)

## Verification
- `typecheck` ✅  `lint:ci` ✅ (0 errors)  `next build` compiled/typechecked/linted clean (local run only fails at page-data collection on a missing Supabase env var, unrelated)
- new test suite ✅ 5/5; existing save-gates + cache-key suites ✅ (132 tests) with a DB URL set
- migration is a plain `ADD COLUMN` + `CREATE INDEX` → `migrate-smoke` (pgvector pg16) safe

## Note for reviewer
The migration has **not** been applied to the box DB yet — holding for your go-ahead (one-way schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)