### PR TITLE
fix(mapping): supplement-brand lexicon + rocket-synonym & bare-category save gates

### DIFF
--- a/src/lib/mapping/__tests__/brand-detector-longest-match.test.ts
+++ b/src/lib/mapping/__tests__/brand-detector-longest-match.test.ts
@@ -1,0 +1,47 @@
+/**
+ * FIX 1: the brand detector must prefer the LONGEST matching brand phrase so
+ * multi-word supplement/energy brands are read as whole phrases. Before this,
+ * "alani nu ..." matched the bare 1-gram "alani" (already in the lexicon) and
+ * lost the decisive multi-word context; the whole-phrase match restores it.
+ */
+import { detectBrandInQuery } from '../brand-detector';
+import { hasDecisiveBrandContext } from '../simple-rerank';
+
+describe('brand detector longest-first matching (FIX 1)', () => {
+    it('matches the whole "alani nu" phrase, not the bare "alani" sub-token', () => {
+        const det = detectBrandInQuery('alani nu pre workout arctic white');
+        expect(det.isBranded).toBe(true);
+        expect(det.matchedBrand?.toLowerCase()).toBe('alani nu');
+    });
+
+    it('a whole-phrase multi-word brand is decisive on its own', () => {
+        const det = detectBrandInQuery('alani nu pre workout arctic white');
+        expect(hasDecisiveBrandContext('alani nu pre workout arctic white', det.matchedBrand!)).toBe(true);
+    });
+
+    it('newly-added supplement/energy/DTC brands are detected', () => {
+        for (const q of [
+            'bucked up rocket pop pre workout',
+            'gorilla mode pre workout',
+            'ghost energy sour patch',
+            'celsius sparkling orange',
+            'total war pre workout',
+            'core power protein shake',
+            'gomacro protein bar',
+            'slim jim original',
+            'redcon1 total war pre workout',
+            'kaged muscle creatine',
+        ]) {
+            expect(detectBrandInQuery(q).isBranded).toBe(true);
+        }
+    });
+
+    it('preserves existing single-token produce behavior ("bell pepper" -> "bell")', () => {
+        const det = detectBrandInQuery('bell pepper');
+        expect(det.matchedBrand?.toLowerCase()).toBe('bell');
+    });
+
+    it('preserves multi-word "dr pepper" detection', () => {
+        expect(detectBrandInQuery('dr pepper').matchedBrand?.toLowerCase()).toBe('dr pepper');
+    });
+});

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -100,6 +100,27 @@ describe('brand-mismatch save gate', () => {
         );
         expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
     });
+
+    it('FIX 1: rejects "alani nu pre workout" mapped to a generic "Pre-Workout" (supplement brand now in lexicon)', async () => {
+        // "alani nu" is a multi-word supplement brand; the longest-first n-gram
+        // scan matches the whole phrase so the context is decisive, and the
+        // generic "Pre-Workout" pick carries the brand in neither field.
+        await saveValidatedMapping(
+            'alani nu pre workout arctic white',
+            makeMapping({ foodName: 'Pre-Workout' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('FIX 1: saves when the alani nu pick carries the brand', async () => {
+        await saveValidatedMapping(
+            'alani nu pre workout arctic white',
+            makeMapping({ foodName: 'Pre-Workout Arctic White', brandName: 'Alani Nu' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe('serving-downgrade save guard', () => {
@@ -503,5 +524,57 @@ describe('save-time macro-plausibility gate interplay', () => {
         );
         expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
         expect(mockFoodMappingFindUnique).not.toHaveBeenCalled();
+    });
+});
+
+describe('FIX 3: bare-category takeover save gate', () => {
+    it('rejects "special k red berries" collapsing into a bare "Cereal"', async () => {
+        await saveValidatedMapping(
+            'special k red berries',
+            makeMapping({ foodName: 'Cereal' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects "wendys jr bacon cheeseburger" collapsing into a bare "Bacon Cheeseburger"', async () => {
+        // "wendys" is detected but NOT decisive (no adjacent product-form word),
+        // so the older brand-mismatch gate misses this — the bare-category gate
+        // catches it because a brand is named and the pick is all category words.
+        await saveValidatedMapping(
+            'wendys jr bacon cheeseburger',
+            makeMapping({ foodName: 'Bacon Cheeseburger' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('KEEPS "mcdonalds big mac" -> "Big Mac" (distinctive product token survives)', async () => {
+        await saveValidatedMapping(
+            'mcdonalds big mac',
+            makeMapping({ foodName: 'Big Mac' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('KEEPS a bare-category pick when the pick carries the brand', async () => {
+        await saveValidatedMapping(
+            'special k red berries',
+            makeMapping({ foodName: 'Red Berries Cereal', brandName: 'Special K' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire for a generic query resolving to its own generic category', async () => {
+        // No brand named, and the food name keeps distinctive ingredient tokens
+        // ("chicken", "noodle") that are not bare-category words -> saved.
+        await saveValidatedMapping(
+            'chicken noodle soup',
+            makeMapping({ foodName: 'Chicken Noodle Soup' }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/lib/mapping/brand-detector.ts
+++ b/src/lib/mapping/brand-detector.ts
@@ -250,6 +250,36 @@ const KNOWN_BRANDS: string[] = [
     'ritual', 'ritual vitamins', 'scivation', 'six star', 'skratch labs',
     'sunwarrior', 'thorne', 'vega', 'vega sport', 'vital proteins', 'xtend',
 
+    // ── Supplement / Energy / Pre-workout / DTC brands (2026 cache-warming) ──
+    // Modern sports-nutrition, energy-drink and DTC-protein brands surfaced by
+    // the branded-query cache-warming session. Multi-word entries ("alani nu",
+    // "gorilla mode", "total war", "ghost energy", "core power") are matched as
+    // whole phrases by the longest-first n-gram scan below, so hasDecisiveBrand
+    // context fires on them without an adjacent product-form word.
+    // NOTE: bare "on" (Optimum Nutrition) is deliberately OMITTED — as a 2-char
+    // English preposition it would flag countless non-branded lines; the
+    // multi-word "optimum nutrition" above covers the brand safely.
+    'alani nu', 'c4', 'celsius', 'gorilla mode', 'bang', 'reign', 'total war',
+    'redcon1', 'jocko', 'jocko fuel', 'kaged', 'kaged muscle', 'ghost energy',
+    'bloom', 'bloom nutrition', 'ryse', 'bucked up', 'transparent labs',
+    'legion', 'muscletech', 'ghost',
+
+    // ── RTD Protein / Functional Beverages ────────────────────
+    'premier protein', 'core power', 'fairlife', 'owyn', 'koia', 'iconic',
+    'muscle milk', 'isopure',
+
+    // ── Protein Bars / Better-for-you Snacks ──────────────────
+    'no cow', 'gomacro', 'aloha', 'rxbar', 'quest', 'barebells', 'built',
+    'built bar', 'met-rx', 'power crunch', 'one bar',
+
+    // ── Meat Snacks / Jerky ───────────────────────────────────
+    'jack links', 'jack link\'s', 'chomps', 'country archer', 'old trapper',
+    'slim jim', 'wilde',
+
+    // ── Frozen Dessert / QSR (branded-query coverage) ─────────
+    'halo top', 'talenti', 'jeni\'s', 'jenis', 'raising cane\'s', 'raising canes',
+    'canes', 'culver\'s', 'culvers', 'whataburger', 'jack in the box',
+
     // ── Specialty / Natural / Organic ─────────────────────────
     '365 everyday value', '365 whole foods', 'ancient harvest', 'annie\'s',
     'applegate', 'arrowhead mills', 'bob\'s red mill', 'bobs red mill',
@@ -428,8 +458,11 @@ export function detectBrandInQuery(rawLine: string): BrandDetectionResult {
         return { isBranded: false, matchedBrand: null };
     }
 
-    // Check 1-grams, 2-grams, 3-grams
-    for (let size = 1; size <= 3; size++) {
+    // Check 3-grams, 2-grams, 1-grams — LONGEST phrase first so a multi-word
+    // brand wins over a bare sub-token that is itself a lexicon entry
+    // ("alani nu" over "alani", "kettle brand" over "kettle"). A whole-phrase
+    // match is what lets hasDecisiveBrandContext treat the hit as decisive.
+    for (let size = 3; size >= 1; size--) {
         for (let i = 0; i <= tokens.length - size; i++) {
             const ngram = tokens.slice(i, i + size).join(' ');
             if (BRAND_SET.has(ngram)) {

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -28,6 +28,63 @@ import { normalizeIngredientName, canonicalizeCacheKey } from './normalization-r
 // over an existing cache row. Same-family swaps are exempt.
 const CROSS_SOURCE_DISPLACEMENT_MARGIN = 0.05;
 
+// Bare-category takeover gate (Jul 2026). See saveValidatedMapping.
+// Trivial words dropped before counting query specificity / testing whether a
+// food name is a bare category.
+const SAVE_GATE_STOPWORDS = new Set([
+    'the', 'a', 'an', 'of', 'with', 'and', 'or', 'in', 'on', 'for', 'to',
+    'plus', 'jr', 'sr', 'style', 'flavor', 'flavored', 'flavour', 'flavoured',
+    'original', 'classic', 'regular',
+]);
+
+// Generic food-category nouns. A food name built ENTIRELY of these adds no
+// identity beyond the category, so a specific branded query that resolves to
+// such a name is a poisoning collapse. Deliberately excludes distinctive
+// product names ("mac", "whopper", "baconator") and core single-ingredient
+// nouns ("chicken", "beef", "rice") so real SKUs and legitimate generic picks
+// from generic queries are never rejected.
+const BARE_CATEGORY_WORDS = new Set([
+    'cereal', 'burger', 'cheeseburger', 'hamburger', 'sandwich', 'sub', 'wrap',
+    'burrito', 'taco', 'pizza', 'nugget', 'nuggets', 'fries', 'soda', 'pop',
+    'drink', 'beverage', 'snack', 'candy', 'cookie', 'cookies', 'cracker',
+    'crackers', 'chips', 'shake', 'smoothie', 'sauce', 'dressing', 'soup',
+    'bacon', 'sausage', 'hotdog', 'breakfast', 'lunch', 'dinner', 'meal',
+    'platter', 'combo', 'pie', 'cake', 'muffin', 'donut', 'doughnut', 'roll',
+    'bun', 'oatmeal', 'pudding', 'popsicle', 'pretzel', 'dessert',
+]);
+
+/**
+ * Count the distinctive (specific) tokens in a raw query for the bare-category
+ * gate: tokens longer than 2 chars that are not digits, not part of the
+ * detected brand, and not trivial stopwords. De-duplicated.
+ */
+function countSpecificSaveTokens(rawLine: string, detectedBrand: string | null): number {
+    const brandTokens = new Set(
+        (detectedBrand ?? '').toLowerCase().split(/\s+/).filter(Boolean),
+    );
+    const tokens = rawLine.toLowerCase().split(/[\s,()[\]{}]+/).filter(Boolean);
+    const specific = tokens.filter(t =>
+        t.length > 2
+        && !/^\d/.test(t)
+        && !brandTokens.has(t)
+        && !SAVE_GATE_STOPWORDS.has(t),
+    );
+    return new Set(specific).size;
+}
+
+/**
+ * True when every significant token of a food name is a generic food-category
+ * word — i.e. the name is a bare category ("Cereal", "Bacon Cheeseburger") with
+ * no distinctive product/ingredient token.
+ */
+function isBareCategoryFoodName(foodName: string): boolean {
+    const tokens = foodName.toLowerCase()
+        .split(/[\s,()[\]{}/-]+/)
+        .filter(t => t.length > 0 && !SAVE_GATE_STOPWORDS.has(t));
+    if (tokens.length === 0) return false;
+    return tokens.every(t => BARE_CATEGORY_WORDS.has(t));
+}
+
 /**
  * Cache read result: the mapped ingredient plus row provenance. `validatedBy`
  * (FoodMapping.validatedBy: 'ai' | 'human-triage') is threaded through reads
@@ -391,6 +448,38 @@ export async function saveValidatedMapping(
             foodName: mapping.foodName,
             brandName: mapping.brandName,
             namedBrand: detectedBrand,
+        });
+        return;
+    }
+
+    // Bare-category takeover save gate (Jul 2026 cache-warming session): a
+    // specific branded/multi-token query must not collapse into a bare generic
+    // category that carries no brand — "special k red berries" -> "Cereal",
+    // "wendys jr bacon cheeseburger" -> "Bacon cheeseburger" poison the generic
+    // key so every later request for the plain category answers from a branded
+    // save (and vice-versa). Fires only when the query is specific (a brand is
+    // named, or it carries >= 3 distinctive tokens) AND the pick carries neither
+    // a brand field nor the detected brand in its name AND every significant
+    // token of the food name is a generic food-category word. Proper product
+    // names survive because they keep a distinctive non-category token
+    // ("mcdonalds big mac" -> "Big Mac"; "mac" is not a category word). The pick
+    // still serves THIS request, it just isn't cached under the collapsed key.
+    const bareBrandCarried = detectedBrand
+        ? candidateMatchesTargetBrand(mapping.brandName ?? undefined, mapping.foodName, detectedBrand)
+        : false;
+    const pickHasBrandField = !!(mapping.brandName && mapping.brandName.trim());
+    const specificTokenCount = countSpecificSaveTokens(rawIngredient, detectedBrand);
+    if ((!!detectedBrand || specificTokenCount >= 3)
+        && !bareBrandCarried
+        && !pickHasBrandField
+        && isBareCategoryFoodName(mapping.foodName)) {
+        logger.warn('validated_mapping.save_rejected_bare_category_takeover', {
+            rawIngredient,
+            normalizedForm,
+            foodName: mapping.foodName,
+            brandName: mapping.brandName,
+            namedBrand: detectedBrand,
+            specificTokenCount,
         });
         return;
     }

--- a/src/lib/parse/__tests__/rocket-arugula-guard.test.ts
+++ b/src/lib/parse/__tests__/rocket-arugula-guard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * FIX 2: the British "rocket" -> "arugula" produce synonym must stay out of
+ * branded/flavor product names. "bucked up rocket pop pre workout" was being
+ * normalized to "...arugula pop..." and then matched an "Arugula Lettuce"
+ * record. The guard keeps genuine produce phrasing working.
+ */
+import { guardedRocketToArugula } from '../ingredient-line';
+import { parseIngredientLine } from '../ingredient-line';
+
+describe('guardedRocketToArugula', () => {
+    it('rewrites genuine produce "rocket salad" -> "arugula salad"', () => {
+        expect(guardedRocketToArugula('rocket salad')).toBe('arugula salad');
+    });
+
+    it('rewrites "wild rocket" -> "wild arugula"', () => {
+        expect(guardedRocketToArugula('wild rocket')).toBe('wild arugula');
+    });
+
+    it('rewrites "rocket leaves" -> "arugula leaves"', () => {
+        expect(guardedRocketToArugula('rocket leaves')).toBe('arugula leaves');
+    });
+
+    it('leaves a bare "rocket" -> "arugula" (produce)', () => {
+        expect(guardedRocketToArugula('rocket')).toBe('arugula');
+    });
+
+    it('does NOT rewrite inside a branded line ("bucked up rocket pop pre workout")', () => {
+        const out = guardedRocketToArugula('bucked up rocket pop pre workout');
+        expect(out).toBe('bucked up rocket pop pre workout');
+        expect(out).not.toContain('arugula');
+    });
+
+    it('does NOT rewrite "rocket pop" flavor even without a detected brand', () => {
+        const out = guardedRocketToArugula('rocket pop');
+        expect(out).toBe('rocket pop');
+        expect(out).not.toContain('arugula');
+    });
+
+    it('is a no-op when the line has no "rocket" token', () => {
+        expect(guardedRocketToArugula('spinach salad')).toBe('spinach salad');
+    });
+});
+
+describe('parseIngredientLine end-to-end rocket handling', () => {
+    it('keeps "rocket" in a branded flavor name (no arugula leak)', () => {
+        const parsed = parseIngredientLine('1 scoop bucked up rocket pop pre workout');
+        expect(parsed).not.toBeNull();
+        expect(parsed!.name.toLowerCase()).toContain('rocket');
+        expect(parsed!.name.toLowerCase()).not.toContain('arugula');
+    });
+
+    it('still converts produce "rocket" to arugula in the parsed name', () => {
+        const parsed = parseIngredientLine('2 cups rocket');
+        expect(parsed).not.toBeNull();
+        expect(parsed!.name.toLowerCase()).toContain('arugula');
+    });
+});

--- a/src/lib/parse/ingredient-line.ts
+++ b/src/lib/parse/ingredient-line.ts
@@ -3,6 +3,37 @@ import { normalizeUnitToken, convertUnit } from './unit';
 import { extractQualifiers, extractQualifiersFromParentheses } from './qualifiers';
 import { extractUnitHint } from './unit-hint';
 import { isDigitBrandToken, matchDigitBrandTokens } from '../mapping/digit-brands';
+import { detectBrandInQuery } from '../mapping/brand-detector';
+
+/**
+ * Flavor/product words that mark "rocket" as part of a branded product name
+ * (e.g. "rocket pop", a red-white-and-blue popsicle flavor) rather than the
+ * British produce term for arugula.
+ */
+const ROCKET_FLAVOR_ADJACENT = new Set([
+  'pop', 'pops', 'popsicle', 'popsicles', 'freeze', 'fuel', 'blast', 'candy',
+]);
+
+/**
+ * Apply the British "rocket" -> "arugula" produce synonym, guarded against
+ * branded/flavor contexts. Returns the line unchanged when the query names a
+ * known brand (the whole line is a product name, not produce), and keeps
+ * "rocket <flavor-word>" intact ("rocket pop"). Genuine produce phrasing
+ * ("rocket salad", "wild rocket", "rocket leaves") is rewritten as before.
+ */
+export function guardedRocketToArugula(text: string): string {
+  if (!/\brocket\b/i.test(text)) return text;
+  // A brand anywhere in the line means "rocket" is almost certainly a product
+  // or flavor name, not the salad green — leave it untouched.
+  if (detectBrandInQuery(text).isBranded) return text;
+  return text.replace(/\brocket\b(\s+([a-z]+))?/gi, (match, _spaceWord, nextWord) => {
+    if (nextWord && ROCKET_FLAVOR_ADJACENT.has(nextWord.toLowerCase())) {
+      return match; // "rocket pop"/"rocket popsicle" flavor — keep as-is
+    }
+    // Preserve whatever trailing word/space the regex captured after "rocket".
+    return 'arugula' + match.slice('rocket'.length);
+  });
+}
 
 export type ParsedIngredient = {
   qty: number;
@@ -148,11 +179,20 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
     .replace(/\btinned\b/gi, 'canned')     // British "tinned" -> American "canned"
     .replace(/\bcourgettes?\b/gi, 'zucchini')  // British "courgette(s)" -> American "zucchini"
     .replace(/\baubergines?\b/gi, 'eggplant')  // British "aubergine(s)" -> American "eggplant"
-    .replace(/\brocket\b/gi, 'arugula')
+    // NOTE: rocket -> arugula is handled by guardedRocketToArugula() below so it
+    // never fires inside a branded/flavor name ("bucked up rocket pop ...").
     .replace(/\bcoriander\b/gi, 'cilantro')
     .replace(/\bspring onions?\b/gi, 'green onion')  // British "spring onion(s)" -> American
     // Synonym: "calorie free" → "sugar free" (many products labeled as sugar free, not calorie free)
     .replace(/\bcalorie[- ]free\b/gi, 'sugar free');
+
+  // rocket -> arugula (British produce term), context-guarded. The bare synonym
+  // mis-fired inside branded flavor names: "bucked up rocket pop pre workout"
+  // became "...arugula pop..." and then matched an "Arugula Lettuce" record.
+  // Skip the rewrite when the line names a known brand, or when "rocket" is
+  // immediately followed by a flavor/product word ("rocket pop"/"popsicle").
+  // Genuine produce ("rocket salad", "wild rocket", "rocket leaves") is kept.
+  unitNormalized = guardedRocketToArugula(unitNormalized);
 
   // === NEW: Spelling corrections for common misspellings ===
   // These would otherwise return 0 API results and fail with 0.00 confidence


### PR DESCRIPTION
## Summary

Three quality fixes surfaced by a branded-query **cache-warming session**, where wrong-brand / wrong-identity picks slipped past the `saveValidatedMapping` gates because the brand lexicon didn't know modern supplement/energy brands.

### FIX 1 — Supplement/energy/DTC brand lexicon + longest-first matching
`src/lib/mapping/brand-detector.ts`
- Added modern sports-nutrition, energy, RTD-protein, bar, jerky and QSR brands to `KNOWN_BRANDS`: `alani nu`, `c4`, `celsius`, `gorilla mode`, `bang`, `reign`, `total war`, `jocko`, `kaged`, `ghost energy`, `bloom`, `core power`, `koia`, `iconic`, `gomacro`, `country archer`, `old trapper`, `slim jim`, `jeni's`, `raising canes`, `no cow`, `barebells`, `built`, `power crunch`, `chomps`, `wilde`, `halo top`, `talenti`, `culvers`, `whataburger`, and more.
- **Reversed the n-gram scan to longest-first (3→1)** so a multi-word brand (`alani nu`) wins over a bare sub-token (`alani`) that is itself a lexicon entry. That whole-phrase match is what lets `hasDecisiveBrandContext` fire, so the existing brand-mismatch save gate now rejects `alani nu pre workout arctic white` → generic `Pre-Workout`.
- Deliberately **omitted bare `on`** (Optimum Nutrition) — a 2-char English preposition would over-flag countless non-branded lines; the multi-word `optimum nutrition` covers the brand safely.

**Failing case fixed:** `alani nu pre workout arctic white` whose top pick was a generic `Pre-Workout` was being cached; now rejected by the brand-mismatch gate.

### FIX 2 — Guard the British `rocket → arugula` synonym
`src/lib/parse/ingredient-line.ts`
- The bare `rocket`→`arugula` rewrite fired inside branded flavor names: `bucked up rocket pop pre workout` became `...arugula pop...` and matched an `Arugula Lettuce` record.
- New `guardedRocketToArugula()` skips the rewrite when the line names a known brand, or when `rocket` is adjacent to a flavor/product word (`rocket pop`/`popsicle`). Genuine produce (`rocket salad`, `wild rocket`, `rocket leaves`) still normalizes to arugula.

### FIX 3 — Bare-category takeover save gate
`src/lib/mapping/validated-mapping-helpers.ts`
- A specific branded/multi-token query must not collapse into a bare generic category carrying no brand — `special k red berries` → `Cereal`, `wendys jr bacon cheeseburger` → `Bacon Cheeseburger` — which poisons the generic key for every later request.
- Rejects the save when the query is specific (a brand is named, **or** it carries ≥ 3 distinctive tokens) **and** the pick carries neither a brand field nor the detected brand in its name **and** every significant token of the food name is a generic food-category word.
- Distinctive product names survive: `mcdonalds big mac` → `Big Mac` still saves (`mac` is not a category word). This catches cases the older brand-mismatch gate misses (e.g. `wendys` is detected but non-decisive).

## Tests
- `validated-mapping-save-gates.test.ts`: alani nu → generic Pre-Workout **rejected** (+ carries-brand saves); bare-category **rejects** `special k red berries`→Cereal and `wendys jr bacon cheeseburger`→Bacon Cheeseburger, **keeps** `mcdonalds big mac`→Big Mac and brand-carrying / distinctive-ingredient picks.
- `brand-detector-longest-match.test.ts` (new): whole-phrase `alani nu` match + decisiveness; new-brand detection; preserves `bell pepper`→`bell` and `dr pepper`.
- `rocket-arugula-guard.test.ts` (new): keeps produce rewrites, blocks branded/flavor lines.

## CI status
- `typecheck` (tsc --noEmit): **pass**
- `lint:ci` (eslint, max-warnings 700): **pass** (0 errors; no new warnings in changed files)
- `next build`: **pass** (compiles/lints; local page-data collection needs Supabase secrets, green with them supplied — CI provides them)
- Targeted jest suites: **all green**. One unrelated suite failure (`map-ingredient-with-fallback` → "canned tuna in water" water fast-path) is **pre-existing on master**, not touched here.
- No new `process.env.*` references → no `.env.example` change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)