### PR TITLE
fix(mapping): brand-aware filter relaxation for restaurant/branded items

### DIFF
--- a/src/lib/mapping/__tests__/restaurant-brand-filter-relax.test.ts
+++ b/src/lib/mapping/__tests__/restaurant-brand-filter-relax.test.ts
@@ -1,0 +1,97 @@
+import {
+    queryTargetsCandidateBrand,
+    hasSuspiciousMacros,
+    filterCandidatesByTokens,
+    isMealProductMismatch,
+} from '../filter-candidates';
+import type { UnifiedCandidate } from '../gather-candidates';
+
+let _id = 0;
+function cand(partial: Partial<UnifiedCandidate>): UnifiedCandidate {
+    return {
+        id: `c${_id++}`,
+        source: 'fatsecret',
+        name: 'x',
+        brandName: null,
+        score: 1,
+        rawData: null,
+        ...(partial as any),
+    } as UnifiedCandidate;
+}
+
+describe('queryTargetsCandidateBrand — possessive/punctuation insensitive', () => {
+    it('matches "arbys" query to "Arby\'s" brand (the apostrophe bug)', () => {
+        expect(queryTargetsCandidateBrand('arbys curly fries', "Arby's")).toBe(true);
+    });
+    it('matches "mcdonalds" query to "McDonald\'s" brand', () => {
+        expect(queryTargetsCandidateBrand('mcdonalds chicken nuggets', "McDonald's")).toBe(true);
+    });
+    it('matches multi-word brand "olive garden"', () => {
+        expect(queryTargetsCandidateBrand('olive garden breadsticks', 'Olive Garden')).toBe(true);
+    });
+    it('matches "starbucks" one-token brand', () => {
+        expect(queryTargetsCandidateBrand('starbucks spinach feta wrap', 'Starbucks')).toBe(true);
+    });
+    it('does NOT match when query omits the brand', () => {
+        expect(queryTargetsCandidateBrand('chicken nuggets', "Tyson")).toBe(false);
+        expect(queryTargetsCandidateBrand('curly fries', "Arby's")).toBe(false);
+    });
+    it('does NOT treat a bare generic word as a brand match', () => {
+        expect(queryTargetsCandidateBrand('original potato chips', 'Original')).toBe(false);
+        expect(queryTargetsCandidateBrand('classic marinara', 'Classic')).toBe(false);
+    });
+    it('null / empty brand is never a match', () => {
+        expect(queryTargetsCandidateBrand('anything', null)).toBe(false);
+        expect(queryTargetsCandidateBrand('anything', '')).toBe(false);
+    });
+});
+
+describe('hasSuspiciousMacros ignoreCeilings — ceilings drop, floors stay', () => {
+    it('ignoreCeilings lets a calorie-dense branded product past a produce ceiling', () => {
+        // "strawberry" produce profile caps ~60 kcal/100g; a Frosted Strawberry
+        // Pop-Tart is ~390. Default = suspicious; ignoreCeilings = allowed.
+        const poptart = { calories: 390, protein: 4, carbs: 70, fat: 9 };
+        expect(hasSuspiciousMacros('pop-tarts frosted strawberry', poptart)).toBe(true);
+        expect(hasSuspiciousMacros('pop-tarts frosted strawberry', poptart, { ignoreCeilings: true })).toBe(false);
+    });
+    it('ignoreCeilings STILL enforces the protein floor (supplement safety)', () => {
+        // "protein" whey profile requires a high min protein; a 12g/100g record
+        // must stay suspicious even with ceilings ignored (n-seg-25 protection).
+        const lowProtein = { calories: 350, protein: 12, carbs: 55, fat: 8 };
+        expect(hasSuspiciousMacros('whey protein', lowProtein, { ignoreCeilings: true })).toBe(true);
+    });
+});
+
+describe('filterCandidatesByTokens — branded restaurant items survive', () => {
+    it('keeps "Arby\'s Curly Fries" for "arbys curly fries"', () => {
+        const cands = [
+            cand({ source: 'fatsecret', name: 'Curly Fries - Large', brandName: "Arby's" }),
+            cand({ source: 'fdc', name: 'new zealand imported striploin cooked fast fried beef', brandName: null }),
+        ];
+        const { filtered } = filterCandidatesByTokens(cands, 'arbys curly fries', {
+            rawLine: 'arbys curly fries',
+        });
+        expect(filtered.some(c => c.brandName === "Arby's")).toBe(true);
+    });
+
+    it('keeps the Starbucks wrap despite normal-but-"suspicious" macros', () => {
+        const cands = [
+            cand({
+                source: 'fatsecret',
+                name: 'Spinach, Feta & Egg White Wrap',
+                brandName: 'Starbucks',
+                nutrition: { per100g: true, kcal: 182, protein: 12.58, fat: 5.03, carbs: 21.38 } as any,
+            }),
+        ];
+        const { filtered } = filterCandidatesByTokens(cands, 'starbucks spinach feta wrap', {
+            rawLine: 'starbucks spinach feta wrap',
+        });
+        expect(filtered.length).toBe(1);
+    });
+
+    it('still rejects a restaurant product for a bare raw-ingredient query', () => {
+        // "cinnamon sticks" must NOT grab "Cinnamon Sticks (DiGiorno)" — the query
+        // does not name DiGiorno, so the meal/product guard still applies.
+        expect(isMealProductMismatch('cinnamon sticks', 'Cinnamon Sticks', 'DiGiorno')).toBe(true);
+    });
+});

--- a/src/lib/mapping/filter-candidates.ts
+++ b/src/lib/mapping/filter-candidates.ts
@@ -1478,9 +1478,17 @@ const INGREDIENT_MACRO_PROFILES: Array<{
  */
 export function hasSuspiciousMacros(
     query: string,
-    candidateNutrients?: { calories?: number | null; protein?: number | null; carbs?: number | null; fat?: number | null } | null
+    candidateNutrients?: { calories?: number | null; protein?: number | null; carbs?: number | null; fat?: number | null } | null,
+    options?: { ignoreCeilings?: boolean }
 ): boolean {
     if (!candidateNutrients) return false;  // No data = can't check
+    // ignoreCeilings: when the query explicitly names a brand, the candidate is a
+    // specific branded PRODUCT, so raw-produce upper bounds (a "strawberry" or
+    // "spinach" flavor word capping calories at ~30–60/100g) don't apply — a
+    // Frosted Strawberry Pop-Tart or a Starbucks Spinach Feta Wrap really is that
+    // calorie-dense. The FLOOR checks (e.g. whey "protein" min-protein) are kept:
+    // they catch a low-protein same-brand record winning a supplement query.
+    const ignoreCeilings = options?.ignoreCeilings === true;
 
     const queryLower = query.toLowerCase();
     // Normalize common variations for matching
@@ -1509,18 +1517,18 @@ export function hasSuspiciousMacros(
         // skip produce-based macro profiles. "Strawberry banana greek yogurt" should NOT
         // be checked against the fresh strawberry profile (maxCalPer100g: 60).
         // The berry/produce is a FLAVOR component, not the main food.
-        const COMPOUND_PRODUCT_TERMS = /\b(yogurt|yoghurt|ice cream|gelato|sorbet|smoothie|jam|jelly|preserve|marmalade|pie|cake|muffin|bread|cereal|granola|oatmeal|pancake|waffle|syrup|sauce|salsa|dressing|bar|cookie|pudding|mousse|parfait|protein bar|shake)\b/i;
+        const COMPOUND_PRODUCT_TERMS = /\b(yogurt|yoghurt|ice cream|gelato|sorbet|smoothie|jam|jelly|preserve|marmalade|pie|cake|muffin|bread|cereal|granola|oatmeal|pancake|waffle|syrup|sauce|salsa|dressing|bar|cookie|pudding|mousse|parfait|protein bar|shake|wrap|sandwich|burrito|quesadilla|panini|flatbread|calzone|empanada|melt)\b/i;
         if (COMPOUND_PRODUCT_TERMS.test(queryLower)) continue;
 
         // Check calorie bounds (e.g., ice/water should have ~0 calories)
-        if (profile.maxCalPer100g != null && candidateNutrients.calories != null) {
+        if (!ignoreCeilings && profile.maxCalPer100g != null && candidateNutrients.calories != null) {
             if (candidateNutrients.calories > profile.maxCalPer100g) {
                 return true; // Calories too high for this ingredient type
             }
         }
 
         // Check fat bounds
-        if (profile.maxFatPer100g != null && candidateNutrients.fat != null) {
+        if (!ignoreCeilings && profile.maxFatPer100g != null && candidateNutrients.fat != null) {
             if (candidateNutrients.fat > profile.maxFatPer100g) {
                 return true; // Fat too high for this ingredient type
             }
@@ -1532,7 +1540,7 @@ export function hasSuspiciousMacros(
         }
 
         // Check carb bounds
-        if (profile.maxCarbPer100g != null && candidateNutrients.carbs != null) {
+        if (!ignoreCeilings && profile.maxCarbPer100g != null && candidateNutrients.carbs != null) {
             if (candidateNutrients.carbs > profile.maxCarbPer100g) {
                 return true; // Carbs too high
             }
@@ -2121,6 +2129,86 @@ const RESTAURANT_BRANDS = [
     'el monterey', 'banquet', 'hungry-man',
 ];
 
+// Supplement/sports-nutrition query markers. When present, produce macro
+// CEILINGS are kept even for brand-named lookups (see filterCandidatesByTokens)
+// so the same-brand flavor-variant sibling set stays constrained for rerank.
+const SUPPLEMENT_QUERY_RE = /\b(protein|whey|isolate|casein|pre[\s-]?workout|bcaa|eaa|creatine|mass gainer|gainer|collagen|amino)\b/i;
+
+// Single-word "brands" that are really generic descriptors — matching one of
+// these in a query is NOT evidence the user named a specific brand, so they
+// must not trigger the branded-query relaxation below.
+const GENERIC_BRAND_WORDS = new Set([
+    'original', 'light', 'natural', 'classic', 'organic', 'value', 'great',
+    'simply', 'fresh', 'real', 'pure', 'gold', 'signature', 'select',
+    'premium', 'store', 'brand', 'plain', 'regular', 'family', 'home',
+]);
+
+/**
+ * Possessive/punctuation-insensitive brand normalization:
+ * "Arby's" -> "arbys", "McDonald's" -> "mcdonalds", "Chick-fil-A" -> "chick fil a".
+ */
+function normalizeBrandForMatch(s: string): string {
+    return s
+        .toLowerCase()
+        .replace(/['’`]/g, '')        // drop apostrophes so "arbys" == "arby's"
+        .replace(/[^a-z0-9]+/g, ' ')  // other punctuation -> space
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/**
+ * True when the QUERY explicitly names the candidate's brand/restaurant.
+ *
+ * When a user types "arbys curly fries" or "mcdonalds chicken nuggets", the
+ * brand is part of the intent — the exact restaurant menu item is the CORRECT
+ * match, not a mistake. The raw-ingredient guards (meal/product mismatch,
+ * produce macro profiles) exist to stop generic queries like "cinnamon sticks"
+ * from grabbing a branded product; they must NOT fire when the query itself
+ * asked for that brand. This is possessive-insensitive so "arbys" matches the
+ * candidate brand "Arby's" (the punctuation mismatch that was silently dropping
+ * every restaurant menu item).
+ *
+ * Scoped to be conservative: a bare generic word ("original", "classic") that
+ * happens to be an OFF brand does NOT count.
+ */
+export function queryTargetsCandidateBrand(
+    query: string,
+    candidateBrand?: string | null
+): boolean {
+    if (!candidateBrand) return false;
+    const q = normalizeBrandForMatch(query);
+    const brand = normalizeBrandForMatch(candidateBrand);
+    if (!q || !brand) return false;
+    const qPadded = ` ${q} `;
+    const qTokens = new Set(q.split(' '));
+
+    // 1) Full brand phrase appears in the query ("olive garden" ⊂ "olive garden breadsticks")
+    if (brand.length >= 3 && qPadded.includes(` ${brand} `)) {
+        if (!(brand.split(' ').length === 1 && GENERIC_BRAND_WORDS.has(brand))) return true;
+    }
+
+    // 2) Every significant brand token is present in the query (handles reorder / extra words).
+    //    Ignore 1–2 char tokens ("a", "of") and require at least one non-generic token.
+    const brandTokens = brand.split(' ').filter(t => t.length >= 3);
+    if (
+        brandTokens.length > 0 &&
+        brandTokens.every(t => qTokens.has(t)) &&
+        brandTokens.some(t => !GENERIC_BRAND_WORDS.has(t))
+    ) {
+        return true;
+    }
+
+    // 3) A known restaurant/prepared-food brand is named in BOTH the query and
+    //    this candidate's brand ("chili's" query ↔ candidate brand "Chili's").
+    for (const b of RESTAURANT_BRANDS) {
+        const nb = normalizeBrandForMatch(b);
+        if (nb.length < 3) continue;
+        if (qPadded.includes(` ${nb} `) && ` ${brand} `.includes(` ${nb} `)) return true;
+    }
+
+    return false;
+}
+
 export function isMealProductMismatch(
     normalizedName: string,
     candidateName: string,
@@ -2478,6 +2566,14 @@ export function filterCandidatesByTokens(
         return { filtered: [], removedCount: 0 };
     }
 
+    // Supplement queries ("... protein/whey/pre-workout ...") must KEEP the
+    // macro ceilings even for branded lookups: the ceilings constrain the
+    // same-brand flavor-variant sibling set that rerank consensus relies on.
+    // Relaxing them there admits extra flavor SKUs ("Blueberry Muffin Ryse
+    // Protein") that shift the winner. Produce-flavor false positives
+    // (strawberry Pop-Tart, spinach wrap) only occur on non-supplement foods.
+    const isSupplementQuery = SUPPLEMENT_QUERY_RE.test(modifierCheckSource);
+
     // Extract must-have tokens
     let mustHaveTokens = deriveMustHaveTokens(normalizedName);
     
@@ -2686,8 +2782,18 @@ export function filterCandidatesByTokens(
             return false;
         }
 
+        // Did the query explicitly name THIS candidate's brand/restaurant?
+        // If so, the meal/product guard must not fire — the user asked for the
+        // branded item, so retrieving that exact product is correct (this also
+        // fixes the possessive mismatch: "arbys" vs brand "Arby's"). Checked
+        // against both the normalized name and the raw line (either may carry
+        // the brand token). See queryTargetsCandidateBrand.
+        const brandTargeted =
+            queryTargetsCandidateBrand(normalizedName, candidate.brandName) ||
+            (!!rawLine && queryTargetsCandidateBrand(rawLine, candidate.brandName));
+
         // Meal/product mismatch (e.g., "orange zest" vs "ORANGE ZEST CHICKEN")
-        if (isMealProductMismatch(normalizedName, candidate.name, candidate.brandName)) {
+        if (!brandTargeted && isMealProductMismatch(normalizedName, candidate.name, candidate.brandName)) {
             if (debug) {
                 logger.info('filter.candidates.meal_product_mismatch', {
                     query: normalizedName,
@@ -2750,7 +2856,13 @@ export function filterCandidatesByTokens(
         // e.g. "strawberry" → FRUTSTIX (85 kcal/100g vs expected 32), "whey protein" with more carbs than protein
         // Use rawLine for this check as AI normalization may strip important modifiers like "unsweetened"
         const queryForMacroCheck = rawLine || normalizedName;
-        if (hasSuspiciousMacros(queryForMacroCheck, nutrientsToCheck)) {
+        // For deliberate branded FOOD lookups, ignore raw-produce macro CEILINGS
+        // (a "Frosted Strawberry Pop-Tart" or "Starbucks Spinach Feta Wrap" is
+        // legitimately calorie-dense). Supplement queries keep the ceilings
+        // (they constrain the flavor-variant sibling set rerank consensus uses).
+        if (hasSuspiciousMacros(queryForMacroCheck, nutrientsToCheck, {
+            ignoreCeilings: brandTargeted && !isSupplementQuery,
+        })) {
             if (debug) logger.info('filter.candidates.suspicious_macros', { query: queryForMacroCheck, candidate: candidate.name, nutrients: nutrientsToCheck });
             return false;
         }


### PR DESCRIPTION
## Problem

The early FatSecret grow batches recorded many restaurant/branded items as `no_match`. Investigation (box probes: retrieval dump → full-pipeline → per-candidate filter trace) showed this is **NOT a dataset gap** — retrieval returns near-perfect matches for every failed query:

| Query | Top retrieved candidate | Score |
|---|---|---|
| olive garden breadsticks | FS *Breadstick w/ Garlic Topping* (Olive Garden) | 1.425 |
| mcdonalds chicken nuggets | OFF *McDonald's, 6 Chicken McNuggets* | 5.7 |
| arbys curly fries | FS *Curly Fries - Large* (Arby's) | 1.425 |
| starbucks spinach feta wrap | FS/OFF *Spinach, Feta & Egg White Wrap* | 1.425 |
| pop-tarts frosted strawberry | FS *Pop-Tarts Frosted - Strawberry* | 1.425 |

The candidates were being **filtered out before selection** (`mapping.all_filtered`), so the pipeline fell through to a sub-0.85 AI estimate that never caches. Three raw-ingredient guards fired on the correct branded records:

1. **`isMealProductMismatch` Path B** rejected branded items on a possessive/punctuation mismatch — query `"arbys"` ≠ brand string `"Arby's"`.
2. **Path A** rejected on an extraneous meal word (`"...Breakfast Wrap"` — `breakfast` not in query).
3. **`hasSuspiciousMacros`** applied a raw-produce calorie **ceiling** (a `strawberry`/`spinach` flavor word capping ~30–80 kcal/100g) to a calorie-dense branded product.

## Fix

`queryTargetsCandidateBrand()` detects when the query explicitly **names** the candidate's brand (possessive/punctuation-insensitive, with a generic-word guard so bare "original"/"classic" don't count). For those candidates only:

- **skip `isMealProductMismatch`** — the user asked for the branded item;
- **ignore raw-produce macro *ceilings*** (keep *floors*) — **unless** it's a supplement query (`protein`/`whey`/`pre-workout`/…), where the ceilings must stay to constrain the same-brand flavor-variant sibling set that rerank consensus relies on.

A `Tyson nuggets` candidate under a `mcdonalds nuggets` query is untouched — only brand-named candidates get the pass. Also extends the compound-product exclusion (`wrap|sandwich|burrito|…`) so non-branded composite dishes skip produce profiles too.

## Validation

Direct-pipeline **diff eval over all 233 golden nlp cases** (patched vs. original filter, isolating my change from AI/retrieval non-determinism):
- The only brand-caused change is an **improvement** — `n-mq-09` (Built Puff) now selects a more specific same-brand record and still passes `["built"]`.
- `n-seg-25` (ryse protein) **stays on the Ryse record** via the supplement-query gate (an earlier broad version flipped it — root-caused to ceiling-relaxation admitting extra Ryse flavor SKUs and shifting rerank consensus; the supplement gate closes it).
- All other diffs are non-branded queries where `brandTargeted=false` → byte-identical code path → serving-estimation noise.

After fix (live pipeline probe): arbys/starbucks/pop-tarts/mcdonalds/olive-garden all resolve to real branded records (was 1/6 → 5/6; "doritos locos tacos" remains a product-line follow-up — it doesn't name "Taco Bell").

12 new unit tests. `filter-candidates.ts` is identical between the deployed commit and master, so this change is independent of the concurrent canonicalBase / quality-fix PRs.

## Follow-ups (not in this PR)
- **Rerank precision within a brand**: "olive garden breadsticks" selects the *Alfredo Dipping Sauce* record over the plain breadstick; same class as the ryse flavor case. Needs a same-brand variant-precision tiebreak in `simple-rerank`.
- **Product-line queries that don't name the restaurant** ("nacho doritos locos tacos" → Taco Bell): needs a product-line lexicon or high-retrieval-score trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)