### PR TITLE
fix(fatsecret): select exact FS records instead of falling back to AI estimate

### DIFF
--- a/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
@@ -256,6 +256,77 @@ describe('buildFatSecretResult — gram resolution cascade', () => {
         expect(result!.kcal).toBe(150);
     });
 
+    it('bills a macro-only "1 serving" record with no grams / no per-100g (Impossible Whopper repro)', async () => {
+        // FatSecret generic restaurant record: the ONLY serving is "1 serving"
+        // with full per-serving macros but grams null and nutrientsPer100g {}.
+        // Pre-fix this returned null (fs.build_result.no_nutrition) and the
+        // exact-match FS winner was discarded for a fabricated AI estimate.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            fsId: '29778811',
+            name: 'Impossible Whopper',
+            brandName: 'Burger King',
+            nutrientsPer100g: {}, // derivePer100gFromServings returned null → {}
+            defaultServingId: '27148372',
+            servings: [{
+                servingId: '27148372',
+                description: '1 serving',
+                measurementDescription: 'serving',
+                grams: null,
+                volumeMl: null,
+                numberOfUnits: 1,
+                nutrients: { calories: 630, protein: 28, carbohydrate: 62, fat: 32 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_29778811', name: 'Impossible Whopper', brandName: 'Burger King' }),
+            parsedLine({ qty: 1, name: 'impossible whopper' }),
+            0.98, 'burger king impossible whopper'
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.servingTier).toBe('fs_serving_macros_only');
+        // Macros are billed DIRECTLY from the serving panel — authoritative.
+        expect(result!.kcal).toBe(630);
+        expect(result!.protein).toBe(28);
+        expect(result!.carbs).toBe(62);
+        expect(result!.fat).toBe(32);
+        // Grams is a secondary energy-density estimate: 630 / 2.0 = 315
+        // (macro mass 122g floor does not bind), density stays a plausible 2.0.
+        expect(result!.grams).toBeCloseTo(315, 3);
+        expect(result!.servingDescription).toBe('1 serving');
+    });
+
+    it('macro-only path scales macros by qty (2 servings = 2x panel)', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            fsId: '103243799',
+            name: 'McFlurry with OREO Cookies - Regular',
+            brandName: "McDonald's",
+            nutrientsPer100g: {},
+            defaultServingId: '82091818',
+            servings: [{
+                servingId: '82091818',
+                description: '1 serving',
+                measurementDescription: 'serving',
+                grams: null,
+                volumeMl: null,
+                numberOfUnits: 1,
+                nutrients: { calories: 410, protein: 10, carbohydrate: 64, fat: 13 },
+            }],
+        }));
+
+        const result = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_103243799', name: 'McFlurry with OREO Cookies - Regular', brandName: "McDonald's" }),
+            parsedLine({ qty: 2, name: 'mcflurry oreo' }),
+            0.9, '2 mcdonalds mcflurry oreo'
+        );
+
+        expect(result!.servingTier).toBe('fs_serving_macros_only');
+        expect(result!.kcal).toBe(820);
+        expect(result!.carbs).toBe(128);
+        expect(result!.servingDescription).toBe('2 x 1 serving');
+    });
+
     it('bare-query guard CAPs a package-scale default serving (olive oil 250g -> 14g)', async () => {
         mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
             name: 'Extra Virgin Olive Oil',

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -106,6 +106,23 @@ function servingMacros(nutrients: Record<string, unknown> | null): Macros | null
     };
 }
 
+/**
+ * Estimate a serving's gram weight from its per-serving macros, used ONLY for
+ * FatSecret records that carry per-serving macros but no metric weight and no
+ * per-100g panel (FatSecret's generic "1 serving" restaurant records — e.g.
+ * "Impossible Whopper", "Cheese Fries [Shake Shack]"). Grams is secondary
+ * metadata on this path: the per-serving macros are billed directly and stay
+ * authoritative, so a neutral energy-density estimate is sufficient. Floored at
+ * the physical macro mass (protein + carbs + fat), which a food can never weigh
+ * less than, so the reported density can never exceed a plausible value.
+ */
+const PREPARED_FOOD_KCAL_PER_GRAM = 2.0;
+function estimateServingGrams(m: Macros): number {
+    const macroMass = m.protein + m.carbs + m.fat;
+    const byEnergy = m.kcal > 0 ? m.kcal / PREPARED_FOOD_KCAL_PER_GRAM : 0;
+    return Math.max(macroMass, byEnergy, 1);
+}
+
 /** Per-100g macros from FatSecretFood.nutrientsPer100g (or candidate.nutrition). */
 function per100gMacros(source: Record<string, unknown> | null | undefined): Macros | null {
     if (!source) return null;
@@ -214,7 +231,16 @@ export async function buildFatSecretResult(
     );
 
     const usableServings = servings.filter(s => s.grams != null && s.grams > 0);
-    if (!per100 && usableServings.every(s => servingMacros(s.nutrients) == null)) {
+    // A serving may carry per-serving macros WITHOUT any gram weight —
+    // FatSecret's generic "1 serving" restaurant records are exactly this shape
+    // (e.g. Impossible Whopper: "1 serving" = 630 kcal / 28p / 62c / 32f, grams
+    // null, per100g {}). Those are still billable serving-by-serving via the
+    // macro-only branch in the count/serving cascade below, so keep the
+    // candidate alive whenever ANY serving has macros — not only the
+    // gram-anchored ones. Dropping here was discarding exact-match FS winners
+    // and fabricating an AI estimate in their place.
+    const anyServingHasMacros = servings.some(s => servingMacros(s.nutrients) != null);
+    if (!per100 && !anyServingHasMacros) {
         // No per-100g nutrition and no per-serving macros anywhere — nothing
         // this builder could bill. (Distinct from "no servings": per-100g alone
         // still supports the fallback path below.)
@@ -331,6 +357,39 @@ export async function buildFatSecretResult(
                     : `${qty} x ${defaultServing.description} (${defaultServing.grams}g each)`;
                 servingTier = 'fs_default_serving';
                 pickedServing = defaultServing;
+            }
+        }
+
+        // Macro-only-serving fallback: FatSecret's generic "1 serving"
+        // restaurant records carry per-serving macros but no gram weight and no
+        // per-100g panel, so every gram-anchored path above found nothing. The
+        // serving IS the unit the user is logging, so bill its macros directly.
+        // The reported grams is a secondary energy-density estimate anchored on
+        // the serving so the per-serving macro scaling below bills exactly
+        // `qty x` this serving's authoritative macros.
+        if (grams == null) {
+            const macroServing =
+                (row?.defaultServingId
+                    ? servings.find(s => s.servingId === row!.defaultServingId
+                        && servingMacros(s.nutrients) != null)
+                    : undefined)
+                ?? servings.find(s => servingMacros(s.nutrients) != null);
+            if (macroServing) {
+                const m = servingMacros(macroServing.nutrients)!;
+                const estPerServingGrams = estimateServingGrams(m);
+                macroServing.grams = estPerServingGrams;
+                grams = qty * estPerServingGrams;
+                servingDescription = qty === 1
+                    ? macroServing.description
+                    : `${qty} x ${macroServing.description}`;
+                servingTier = 'fs_serving_macros_only';
+                pickedServing = macroServing;
+                logger.info('fs.build_result.serving_macros_only', {
+                    foodId: candidate.id,
+                    serving: macroServing.description,
+                    kcalPerServing: m.kcal,
+                    estGrams: estPerServingGrams,
+                });
             }
         }
     }


### PR DESCRIPTION
## Class D defect
On a restaurant warm run, several queries retrieved the **exact** FatSecret record at top score (s≈1.425, rerank confidence 0.98 `decisive_brand_winner`) but the final mapping was a fabricated `ai_generated` estimate at low confidence:

| query | before | after |
|---|---|---|
| burger king impossible whopper | ai_generated 0.64 | **fatsecret 0.98** — Impossible Whopper [Burger King], 630 kcal |
| panera bacon turkey bravo sandwich | ai_generated 0.64 | **fatsecret** — Bacon Turkey Bravo on Tomato Basil - Whole [Panera], 870 kcal |
| shake shack cheese fries | ai_generated 0.64 | **fatsecret 0.95** — Cheese Fries [Shake Shack], 710 kcal |
| mcdonalds mcflurry oreo | ai_generated 0.72 | **fatsecret** — McFlurry with OREO Cookies [McDonald's], 240 kcal |

## Root cause (single, per case identical)
`buildFatSecretResult` cannot bill a FatSecret record whose **only serving is a generic "1 serving"** carrying full per-serving macros (calories/protein/carbs/fat) but **no gram weight**, with `nutrientsPer100g = {}`. This is the dominant shape for FatSecret restaurant items. Verified live in the box DB, e.g. `fs_29778811` (Impossible Whopper): one serving `"1 serving"`, `grams = NULL`, nutrients `{calories:630, protein:28, carbohydrate:62, fat:32}`, `nutrientsPer100g = {}`.

Because `derivePer100gFromServings` needs a serving with usable grams, it returns null → the food persists `nutrientsPer100g = {}` → on hydration `per100` is null and `usableServings` (grams>0) is empty. The builder hits the `fs.build_result.no_nutrition` guard and returns **null**. The pipeline then logs `mapping.hydration_failed_retrying`, exhausts fallbacks, and fabricates an AI estimate (`mapping.ai_nutrition_backfill_success_after_hydration_failure`, conf 0.64).

Debug evidence (whopper, pre-fix):
```
simple_rerank.decisive_brand_winner  winner="Impossible Whopper" winnerBrand="Burger King"
simple_rerank.result                 winner="Impossible Whopper" confidence="0.98" reason="exact_match"
fs.build_result.no_nutrition         foodId="fs_29778811"
mapping.hydration_failed_retrying    failedName="Impossible Whopper"
=> source: ai_generated, confidence 0.64
```

## Fix (narrow, `build-fatsecret-result.ts`)
1. **Early guard:** keep the candidate alive whenever *any* serving carries macros, not only gram-anchored ones (`anyServingHasMacros`).
2. **Macro-only serving branch** in the count/serving cascade: bill the serving's per-serving macros directly (authoritative), and report `grams` as a **secondary energy-density estimate** (`kcal / 2.0`, floored at physical macro mass) so the reported density is always plausible. New tier `fs_serving_macros_only`.

No gate was weakened. The change only affects FS candidates that **already win rerank** but were dropped at hydration. Weight/volume-unit requests on gram-less servings still return null (unchanged).

## Golden-gate reasoning
- The macro-only path is reached ONLY for FS candidates that survive filtering + win rerank AND have per-serving macros but no grams/no per-100g. Before this PR those produced an AI fallback; after, they produce the FS panel. So the only golden cases that can move are ones where such an FS record now wins in place of an AI estimate.
- Macros are billed 1:1 from FatSecret's serving panel (unchanged data), so any moved case gains authoritative macros. `grams` on this path is an estimate at a fixed 2.0 kcal/g density (plausible by construction — won't trip kcal/g gates).
- Existing builder tests unchanged (13/13, incl. the null-when-no-data contract); +2 new tests. Please run the authoritative 233-case golden diff before merge.

## Verification
- Live on the box (skip-cache, real FatSecret data): all 4 cases select the FS record via `fs_serving_macros_only` with correct macros.
- `npx jest build-fatsecret-result` 13/13, FS suite 30/30; `tsc --noEmit` clean; `npm run lint:ci` clean (exit 0, 0 findings on changed files).

## Notes / not fixed here
- **mcflurry oreo** now selects the **Mini** variant (s=1.425, top-ranked) over **Regular** (s=1.395) since the query gives no size — a size-default ranking nuance, not the Class D defect. Both are correct FS records; the defect (AI fabrication) is resolved.
- **panera** rerank confidence is 0.71 (sibling Half/Whole variants narrow the gap) — below the 0.85 cache threshold, so it returns the correct FS record live but won't persist to `FoodMapping`. Ranking-confidence issue, out of scope.
- **Pre-existing cache:** queries already cached (OFF/AI) under `FoodMapping` won't benefit until refreshed through the fixed pipeline — a cache-refresh data-op, separate from this code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y