### PR TITLE
fix(rerank): same-brand variant precision + branded-match confidence calibration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,6 +227,18 @@ RANK_PLAUSIBILITY_PARTITION=1
 # Kill-switch: "0" disables the pass.
 RANK_BRAND_CONSENSUS=1
 
+# Same-brand VARIANT precision (rerank): when the query names a brand, honor a
+# requested size/count and penalize un-requested distinguishing qualifiers
+# ("double", "ultimate"...) so "quarter pounder" doesn't map to "Double Quarter
+# Pounder" and "arbys curly fries medium" doesn't map to Small. Kill-switch: "0".
+RANK_BRAND_VARIANT=1
+
+# Branded-match confidence CALIBRATION (rerank): lift confidence to ~0.88 for a
+# tight same-brand exact match (brand matches, full non-brand token coverage, no
+# extra descriptor, not floor-hit/consensus-demoted) so correct branded records
+# clear the 0.85 cache gate. Strict by construction. Kill-switch: "0".
+RANK_BRANDED_CALIBRATION=1
+
 # Human-triage cache-row trust (PR D pt3, Lever B): FoodMapping rows with
 # validatedBy='human-triage' skip name-heuristic cache escapes at read time
 # (nutrition-invalid and serving-shape escapes stay active). Kill-switch: "0".

--- a/src/lib/mapping/__tests__/rerank-variant-precision.test.ts
+++ b/src/lib/mapping/__tests__/rerank-variant-precision.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Same-brand variant precision + branded-match confidence calibration.
+ *
+ * Covers the restaurant/QSR defects where the exact record is retrieved at top
+ * score but the reranker mis-selects a sibling variant, or the correct branded
+ * record lands just under the 0.85 cache gate:
+ *   - extra-qualifier penalty (QPC vs "Double" QPC)
+ *   - explicit size honoring (medium ≠ small)
+ *   - explicit count honoring (10 piece ≠ 6 piece)
+ *   - branded-exact-match confidence calibration (clears 0.85)
+ *   - calibration abstains on ambiguous / specialty picks (safety)
+ *
+ * These scenarios reproduce the real retrieval evidence: the rerank `query`
+ * argument has size/count/brand stripped by upstream normalization, while the
+ * raw line (4th arg) still carries them — which is exactly why the fix reads the
+ * raw line.
+ */
+
+import { simpleRerank, type RerankCandidate } from '../simple-rerank';
+
+function fs(id: string, name: string, brandName: string, score: number): RerankCandidate {
+    return { id, name, brandName, score, source: 'fatsecret' };
+}
+function off(id: string, name: string, brandName: string, score: number): RerankCandidate {
+    return { id, name, brandName, score, source: 'openfoodfacts' };
+}
+
+describe('same-brand variant precision', () => {
+    it('penalizes an un-requested "Double" qualifier: QPC beats Double QPC', () => {
+        const candidates: RerankCandidate[] = [
+            fs('qpc', 'Quarter Pounder with Cheese', "McDonald's", 1.425),
+            fs('dqpc', 'Double Quarter Pounder with Cheese', "McDonald's", 1.335),
+            fs('deluxe', 'Quarter Pounder with Cheese Deluxe', "McDonald's", 1.395),
+        ];
+        const r = simpleRerank(
+            'mcdonalds quarter pounder with cheese',
+            candidates,
+            undefined,
+            'mcdonalds quarter pounder with cheese',
+            true,
+            'mcdonalds',
+        );
+        expect(r.winner).not.toBeNull();
+        expect(r.winner!.name).toBe('Quarter Pounder with Cheese');
+    });
+
+    it('honors an explicit size from the raw line when the rerank query dropped it (medium ≠ small)', () => {
+        // rerank query has "medium" stripped; raw line retains it.
+        const candidates: RerankCandidate[] = [
+            off('sm', "Arby's, Curly Fries, Small", "Arby's", 2.8),
+            off('md', "Arby's, Curly Fries, Medium", "Arby's", 2.8),
+            off('lg', "Arby's, Curly Fries, Large", "Arby's", 2.8),
+        ];
+        const r = simpleRerank(
+            'arbys curly fries',
+            candidates,
+            undefined,
+            'arbys curly fries medium',
+            true,
+            'arbys',
+        );
+        expect(r.winner).not.toBeNull();
+        expect(r.winner!.name).toBe("Arby's, Curly Fries, Medium");
+    });
+
+    it('honors an explicit piece-count from the raw line (10 piece ≠ 6 piece)', () => {
+        const candidates: RerankCandidate[] = [
+            off('w6', "Wendy's, 6 Piece Chicken Nuggets", "Wendy's", 2.8),
+            off('w4', "Wendy's, 4 Piece Chicken Nuggets", "Wendy's", 2.75),
+            off('w10', "Wendy's, 10 Piece Chicken Nuggets", "Wendy's", 2.75),
+        ];
+        const r = simpleRerank(
+            'wendys chicken nuggets',
+            candidates,
+            undefined,
+            'wendys 10 piece nuggets',
+            true,
+            'wendys',
+        );
+        expect(r.winner).not.toBeNull();
+        expect(r.winner!.name).toBe("Wendy's, 10 Piece Chicken Nuggets");
+    });
+
+    it('does not fire for non-branded queries (no targetBrand, not branded)', () => {
+        // "double" qualifier must be ignored when there is no brand context.
+        const candidates: RerankCandidate[] = [
+            off('a', 'Cheeseburger', '', 2.0),
+            off('b', 'Double Cheeseburger', '', 2.0),
+        ];
+        const r = simpleRerank('double cheeseburger', candidates, undefined, 'double cheeseburger', false, undefined);
+        // With no brand gate, the variant penalty is inactive — "double" is in the
+        // query anyway, so the double record is a legitimate winner (not demoted).
+        expect(r.winner).not.toBeNull();
+        expect(r.winner!.name).toBe('Double Cheeseburger');
+    });
+});
+
+describe('branded-match confidence calibration', () => {
+    it('lifts a clean same-brand exact match over the 0.85 cache gate', () => {
+        const candidates: RerankCandidate[] = [
+            off('g', 'Chipotle, Guacamole', 'Chipotle', 7.9),
+            off('gk', 'Chipotle, Guacamole, Kids', 'Chipotle', 7.85),
+        ];
+        const r = simpleRerank(
+            'guacamole',           // brand stripped from rerank query
+            candidates,
+            undefined,
+            'chipotle guacamole',  // raw line retains the brand
+            true,
+            'chipotle',
+        );
+        expect(r.winner).not.toBeNull();
+        expect(r.winner!.name).toBe('Chipotle, Guacamole');
+        expect(r.confidence).toBeGreaterThanOrEqual(0.85);
+    });
+
+    it('abstains on a specialty pick that adds a descriptor beyond the query (no lift)', () => {
+        // "cheese pizza" but only specialty "Wisconsin 6 Cheese" variants exist —
+        // the winner adds "wisconsin", so calibration must NOT lift it.
+        const candidates: RerankCandidate[] = [
+            fs('sm', 'Wisconsin 6 Cheese Pizza - Hand Tossed - Small', "Domino's Pizza", 1.116),
+            fs('md', 'Wisconsin 6 Cheese Pizza - Hand Tossed - Medium', "Domino's Pizza", 1.14),
+            fs('lg', 'Wisconsin 6 Cheese Pizza - Hand Tossed - Large', "Domino's Pizza", 1.092),
+        ];
+        const r = simpleRerank(
+            'dominos cheese pizza',
+            candidates,
+            undefined,
+            'dominos cheese pizza medium slice',
+            true,
+            'dominos',
+        );
+        expect(r.winner).not.toBeNull();
+        // Size is still honored (medium wins its pool)...
+        expect(r.winner!.name).toBe('Wisconsin 6 Cheese Pizza - Hand Tossed - Medium');
+        // ...but confidence is NOT lifted to the branded-exact tier.
+        expect(r.confidence).toBeLessThan(0.85);
+    });
+
+    it('does not calibrate up when the winner carries an un-requested extra qualifier', () => {
+        // Only "Double …" SKUs exist for a plain query → the winner adds the
+        // un-requested "double" qualifier, so calibration must abstain (the
+        // branded-exact tier is reserved for tight matches only).
+        const candidates: RerankCandidate[] = [
+            fs('d', 'Double Quarter Pounder with Cheese', "McDonald's", 1.4),
+            fs('dm', 'Double Quarter Pounder with Cheese Meal', "McDonald's", 1.38),
+        ];
+        const r = simpleRerank(
+            'mcdonalds quarter pounder with cheese',
+            candidates,
+            undefined,
+            'mcdonalds quarter pounder with cheese',
+            true,
+            'mcdonalds',
+        );
+        // Either rejected outright (below the min-confidence gate) or kept below
+        // the cache gate — never calibrated into the branded-exact tier.
+        expect(r.reason).not.toBe('branded_exact_match');
+        expect(r.confidence).toBeLessThan(0.85);
+    });
+});

--- a/src/lib/mapping/simple-rerank.ts
+++ b/src/lib/mapping/simple-rerank.ts
@@ -1418,6 +1418,185 @@ function coversNonBrandQueryToken(candidateName: string, query: string, targetBr
 }
 
 // ============================================================
+// Same-brand variant precision (restaurant/QSR fix, Jul 2026)
+// ============================================================
+// When the user names a brand and the exact record is retrieved at top score,
+// the reranker still mis-selects a SIBLING variant, because the distinguishing
+// signal — an explicit size ("medium"), a count ("10 piece"), or an extra
+// qualifier ("Double", "Ultimate", "Deluxe") — is either stripped from the
+// rerank query by upstream normalization ("arbys curly fries medium" →
+// "arbys curly fries", so Small/Medium/Large tie) or too weakly penalized
+// (one extra "double" token diluted across a 4-token query ≈ 0.07).
+//
+// These adjustments read the RAW LINE (which retains size/count/qualifiers even
+// when the normalized rerank query dropped them) and are gated on a branded
+// context, so they never touch the generic-ingredient golden cases.
+
+const VARIANT_SIZE_TOKENS: Record<string, string> = {
+    small: 'small', sm: 'small', kids: 'small', kid: 'small', child: 'small',
+    childs: 'small', snack: 'small', mini: 'small', junior: 'small', jr: 'small',
+    medium: 'medium', med: 'medium', regular: 'medium', reg: 'medium',
+    large: 'large', lg: 'large', big: 'large',
+};
+const VARIANT_SIZE_ALL = new Set(Object.keys(VARIANT_SIZE_TOKENS));
+
+// Distinguishing qualifier tokens that describe a DIFFERENT SKU than the plain
+// product (a multiplier, a specialty build, or a bundled meal). Penalized only
+// when present in the candidate but ABSENT from the query — a curated list
+// (not "any extra token") so descriptive names like "Wisconsin Cheese Curds"
+// are never falsely demoted.
+const VARIANT_QUALIFIER_TOKENS = new Set([
+    'double', 'triple', 'quad', 'quadruple',
+    'ultimate', 'deluxe', 'supreme', 'premium', 'signature', 'gourmet',
+    'loaded', 'stuffed', 'bunless', 'animal',
+    'spicy', 'buffalo', 'bbq', 'barbecue', 'honey', 'sriracha', 'nashville',
+    'combo', 'bundle', 'platter', 'family', 'party',
+    'mega', 'monster', 'king', 'giant', 'colossal',
+]);
+
+// Neutral connectors / style words that carry no variant identity — excluded
+// from the "extra qualifier" scan so they can't masquerade as distinguishing.
+const VARIANT_STOPWORDS = new Set([
+    'on', 'in', 'of', 'the', 'and', 'with', 'for', 'to', 'or', 'an', 'at',
+    'style', 'hand', 'tossed', 'crust', 'oz', 'fl', 'inch', 'slice',
+    'slices', 'piece', 'pieces', 'pc', 'pcs', 'ct', 'count', 'meal',
+]);
+
+/** Resolve an explicit size class from free text, or null if none present. */
+function resolveVariantSize(text: string): string | null {
+    const lower = text.toLowerCase();
+    if (/\b(?:extra[\s-]?large|x[\s-]?large|xl)\b/.test(lower)) return 'xlarge';
+    for (const tok of tokenize(text)) {
+        const mapped = VARIANT_SIZE_TOKENS[tok];
+        if (mapped) return mapped;
+    }
+    return null;
+}
+
+/** Resolve an explicit piece-count from free text, or null if none present. */
+function resolveVariantCount(text: string): number | null {
+    const m = text.toLowerCase().match(/\b(\d{1,3})\s*(?:piece|pieces|pcs?|count|ct)\b/);
+    if (m) return parseInt(m[1], 10);
+    return null;
+}
+
+/** Brand + brand-field tokens to exclude when inspecting a candidate name. */
+function brandExclusionTokens(targetBrand: string | undefined, brandName: string | undefined): Set<string> {
+    const out = new Set<string>();
+    for (const t of tokenize(targetBrand ?? '')) out.add(t);
+    for (const t of tokenize(brandName ?? '')) out.add(t);
+    return out;
+}
+
+// Adjustment magnitudes. Sizing rationale: size/count classes routinely tie at
+// ~0.60 on name quality (same brand, same core tokens), so the mismatch penalty
+// must exceed that spread to reorder them; the match boost is smaller so it only
+// promotes within an already-strong pool.
+const VARIANT_SIZE_MATCH_BOOST = 0.12;
+const VARIANT_SIZE_MISMATCH_PENALTY = 0.25;
+const VARIANT_SIZE_UNREQUESTED_PENALTY = 0.06;  // query has NO size but candidate does → mild "prefer base"
+const VARIANT_COUNT_MATCH_BOOST = 0.15;
+const VARIANT_COUNT_MISMATCH_PENALTY = 0.30;    // "10 piece" vs "6 piece" is a large nutrition delta
+const VARIANT_QUALIFIER_PENALTY = 0.15;         // per un-requested qualifier
+const VARIANT_QUALIFIER_CAP = 0.30;
+
+interface BrandVariantBreakdown {
+    adjustment: number;
+    sizeMismatch: boolean;
+    countMismatch: boolean;
+    extraQualifiers: string[];
+}
+
+/**
+ * Score adjustment that enforces same-brand variant precision. Only meaningful
+ * under a branded context (caller gates on isBranded || targetBrand).
+ *   - Honors an explicitly requested size/count from the raw line.
+ *   - Penalizes candidates carrying an un-requested distinguishing qualifier.
+ * Returns the delta plus a breakdown used to gate the confidence calibration.
+ */
+function computeBrandVariantAdjustment(
+    rawText: string,
+    candidate: RerankCandidate,
+    targetBrand: string | undefined,
+): BrandVariantBreakdown {
+    let adjustment = 0;
+    let sizeMismatch = false;
+    let countMismatch = false;
+
+    const qSize = resolveVariantSize(rawText);
+    const cSize = resolveVariantSize(candidate.name);
+    if (qSize) {
+        if (cSize === qSize) adjustment += VARIANT_SIZE_MATCH_BOOST;
+        else if (cSize && cSize !== qSize) { adjustment -= VARIANT_SIZE_MISMATCH_PENALTY; sizeMismatch = true; }
+        // candidate with no size when a size was requested → neutral (acceptable base fallback)
+    } else if (cSize) {
+        adjustment -= VARIANT_SIZE_UNREQUESTED_PENALTY;
+    }
+
+    const qCount = resolveVariantCount(rawText);
+    const cCount = resolveVariantCount(candidate.name);
+    if (qCount != null && cCount != null) {
+        if (cCount === qCount) adjustment += VARIANT_COUNT_MATCH_BOOST;
+        else { adjustment -= VARIANT_COUNT_MISMATCH_PENALTY; countMismatch = true; }
+    }
+
+    // Un-requested distinguishing qualifiers.
+    const exclude = brandExclusionTokens(targetBrand, candidate.brandName);
+    const queryTokens = new Set(tokenize(rawText));
+    const extraQualifiers: string[] = [];
+    for (const t of tokenize(candidate.name)) {
+        if (exclude.has(t) || VARIANT_STOPWORDS.has(t) || VARIANT_SIZE_ALL.has(t)) continue;
+        if (!VARIANT_QUALIFIER_TOKENS.has(t)) continue;
+        if (queryTokens.has(t) || [...queryTokens].some(qt => tokensMatch(qt, t))) continue;
+        extraQualifiers.push(t);
+    }
+    if (extraQualifiers.length > 0) {
+        adjustment -= Math.min(VARIANT_QUALIFIER_CAP, extraQualifiers.length * VARIANT_QUALIFIER_PENALTY);
+    }
+
+    return { adjustment, sizeMismatch, countMismatch, extraQualifiers };
+}
+
+/**
+ * True when `winner` is a strong, tight, same-brand match for a branded query:
+ * the brand matches AND every non-brand food token of the query is covered AND
+ * the winner adds no identity descriptor beyond the query (its food tokens are a
+ * subset of the query's) AND it isn't otherwise demoted. Used to calibrate
+ * confidence UP for exact branded matches that the score-based formula
+ * under-credits (api score saturates at 0.45, so a clean branded exact match
+ * still tops out ~0.6 → conf ~0.73). Deliberately strict: it abstains whenever
+ * the winner carries an extra descriptor ("Wisconsin 6 Cheese Pizza" for
+ * "cheese pizza"), so it never lifts an ambiguous or specialty variant.
+ */
+function isStrongBrandedExactMatch(
+    winner: RerankCandidate,
+    rawText: string,
+    targetBrand: string | undefined,
+): boolean {
+    if (!targetBrand) return false;
+    const brandTok = tokenize(targetBrand)[0];
+    if (!brandTok) return false;
+    const winnerBrandTokens = new Set([...tokenize(winner.name), ...tokenize(winner.brandName ?? '')]);
+    if (!winnerBrandTokens.has(brandTok)) return false;
+
+    const exclude = brandExclusionTokens(targetBrand, winner.brandName);
+    const drop = (t: string) => exclude.has(t) || VARIANT_STOPWORDS.has(t)
+        || VARIANT_SIZE_ALL.has(t) || /^\d+$/.test(t);
+    const queryFood = tokenize(rawText).filter(t => !drop(t));
+    const winnerFood = tokenize(winner.name).filter(t => !drop(t));
+    if (queryFood.length === 0) return false;
+
+    const queryFoodSet = new Set(queryFood);
+    // Every query food token must be covered by the winner...
+    const covered = queryFood.every(qt => winnerFood.some(wt => tokensMatch(qt, wt)));
+    if (!covered) return false;
+    // ...and the winner must add no identity descriptor beyond the query.
+    const winnerAddsExtra = winnerFood.some(wt =>
+        !queryFoodSet.has(wt) && ![...queryFoodSet].some(qt => tokensMatch(qt, wt)));
+    return !winnerAddsExtra;
+}
+
+// ============================================================
 // Main Rerank Function
 // ============================================================
 
@@ -1557,6 +1736,22 @@ export function simpleRerank(
         return assessRankTimePlausibility(query, c.name, c.nutrition).floorHit;
     };
 
+    // Same-brand variant precision (restaurant/QSR fix, Jul 2026): honor the
+    // raw line's explicit size/count and penalize un-requested distinguishing
+    // qualifiers when the user named a brand. Reads the RAW line because the
+    // normalized rerank query frequently drops the size/count ("arbys curly
+    // fries medium" → "arbys curly fries"). Gated on a branded context so it
+    // never touches generic-ingredient golden cases.
+    // Kill-switch: RANK_BRAND_VARIANT="0" restores today's ordering.
+    const brandVariantActive = (isBranded || !!targetBrand)
+        && process.env.RANK_BRAND_VARIANT !== '0';
+    const brandVariantRawText = rawLine || query;
+    const emptyBrandVariant: BrandVariantBreakdown = {
+        adjustment: 0, sizeMismatch: false, countMismatch: false, extraQualifiers: [],
+    };
+    const brandVariantOf = (c: RerankCandidate): BrandVariantBreakdown =>
+        brandVariantActive ? computeBrandVariantAdjustment(brandVariantRawText, c, targetBrand) : emptyBrandVariant;
+
     // Score all candidates (base score + nutrition score + modifier constraints)
     const scored = candidates
         .map(c => {
@@ -1581,10 +1776,11 @@ export function simpleRerank(
             const servingLabelBoost = c.servingLabelMatch ? WEIGHTS.SERVING_LABEL_BOOST : 0;
             const decisiveBrandBoost = isDecisiveBrandCandidate(c) ? WEIGHTS.DECISIVE_BRAND_BOOST : 0;
             const grainCookedBoost = isCookedGrainCandidate(c) ? WEIGHTS.GRAIN_COOKED_VOLUME_BOOST : 0;
+            const brandVariant = brandVariantOf(c);
 
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score - constraintPenalty + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost,
+                score: baseScore + nutritionResult.score - constraintPenalty + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost + brandVariant.adjustment,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
@@ -1596,6 +1792,7 @@ export function simpleRerank(
                 grainCookedCoverage: grainCookedBoost > 0 ? grainRawCoverage(c) : 0,
                 plausibilityFloorHit: isPlausibilityFloorHit(c),
                 consensusOutlierPenalty: 0,
+                brandVariant,
             };
         })
         .filter((s): s is NonNullable<typeof s> => s !== null);
@@ -1619,9 +1816,10 @@ export function simpleRerank(
             const servingLabelBoost = c.servingLabelMatch ? WEIGHTS.SERVING_LABEL_BOOST : 0;
             const decisiveBrandBoost = isDecisiveBrandCandidate(c) ? WEIGHTS.DECISIVE_BRAND_BOOST : 0;
             const grainCookedBoost = isCookedGrainCandidate(c) ? WEIGHTS.GRAIN_COOKED_VOLUME_BOOST : 0;
+            const brandVariant = brandVariantOf(c);
             return {
                 candidate: c,
-                score: baseScore + nutritionResult.score + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost,
+                score: baseScore + nutritionResult.score + countLabelBoost + servingLabelBoost + decisiveBrandBoost + grainCookedBoost + brandVariant.adjustment,
                 baseScore,
                 nutritionScore: nutritionResult.score,
                 nutritionReason: nutritionResult.reason,
@@ -1633,6 +1831,7 @@ export function simpleRerank(
                 grainCookedCoverage: grainCookedBoost > 0 ? grainRawCoverage(c) : 0,
                 plausibilityFloorHit: isPlausibilityFloorHit(c),
                 consensusOutlierPenalty: 0,
+                brandVariant,
             };
         });
         scored.push(...fallbackScored);
@@ -1829,6 +2028,7 @@ export function simpleRerank(
                 `nutr=${s.nutritionScore.toFixed(3)} nutrDev=${nutrDev} constr=-${s.constraintPenalty.toFixed(3)} ` +
                 `cnt=${((s as any).countLabelBoost ?? 0).toFixed(2)} dbrand=${((s as any).decisiveBrandBoost ?? 0).toFixed(2)} ` +
                 `cons=-${((s as any).consensusOutlierPenalty ?? 0).toFixed(2)} ` +
+                `bvar=${((s as any).brandVariant?.adjustment ?? 0).toFixed(2)} ` +
                 `floor=${s.plausibilityFloorHit ? 1 : 0} src=${s.candidate.source}`
             );
         });
@@ -1877,6 +2077,40 @@ export function simpleRerank(
     if (grainSoftCooked && top.grainCookedBoost > 0) {
         confidence = Math.max(confidence, 0.75);
         reason = 'cooked_grain_preference';
+    }
+
+    // Branded-match confidence calibration (restaurant/QSR fix, Jul 2026): a
+    // clean same-brand exact match is systematically under-credited by the
+    // score→confidence formula — the API retrieval score saturates at
+    // min(score,1)*0.45, so even an exact branded record (retrieved at s≫1)
+    // tops out ~0.6 → conf ~0.73 and never clears the 0.85 cache gate. When the
+    // winner is a STRONG, tight, same-brand match (brand matches, full non-brand
+    // token coverage, adds no extra descriptor, no size/count/qualifier mismatch,
+    // not floor-hit or consensus-demoted), lift confidence over the gate. Strict
+    // by construction so it never inflates an ambiguous or specialty pick.
+    // Kill-switch: RANK_BRANDED_CALIBRATION="0".
+    if (brandVariantActive
+        && process.env.RANK_BRANDED_CALIBRATION !== '0'
+        && !top.plausibilityFloorHit
+        && top.consensusOutlierPenalty === 0
+        && !top.brandVariant.sizeMismatch
+        && !top.brandVariant.countMismatch
+        && top.brandVariant.extraQualifiers.length === 0
+        && isStrongBrandedExactMatch(top.candidate, brandVariantRawText, targetBrand)) {
+        const lifted = Math.max(confidence, 0.88);
+        if (lifted > confidence) {
+            logger.info('simple_rerank.branded_match_calibrated', {
+                query,
+                rawLine,
+                targetBrand,
+                winner: top.candidate.name,
+                winnerBrand: top.candidate.brandName,
+                from: confidence.toFixed(3),
+                to: lifted.toFixed(3),
+            });
+            confidence = lifted;
+            if (reason === 'simple_rerank' || reason === 'close_match') reason = 'branded_exact_match';
+        }
     }
 
     if (decisiveBrandActive && top.decisiveBrandBoost > 0) {


### PR DESCRIPTION
## Root cause

Two coupled defects in `src/lib/mapping/simple-rerank.ts` on branded restaurant/QSR queries. **Retrieval is not the problem** — the exact record is gathered at top score almost every time — but the reranker mis-selects a sibling variant, or the correct record lands just under the 0.85 cache gate.

Evidence came from `DEBUG_RERANK_SCORES` breakdowns on a 129-query restaurant warm run. Two structural facts drive both defects:
1. **Upstream normalization strips the distinguishing signal from the rerank query.** `"arbys curly fries medium"` → rerank query `"arbys curly fries"` (Small/Medium/Large then tie at 0.602 and Small wins on an ID tiebreak); `"wendys 10 piece nuggets"` → `"wendys chicken nuggets"` (count gone, 6-piece wins). The reranker still receives the **raw line**, which retains these tokens.
2. **The API retrieval score saturates** at `min(score, 1) * 0.45`. A branded exact match retrieved at s≫1 still tops out ~0.6 → `conf = 0.5 + 0.6*0.5 ≈ 0.73`, so it never caches.

## Changes (all in `simple-rerank.ts`)

**Class A/C — variant precision.** New `computeBrandVariantAdjustment()`, gated on a branded context (`isBranded || targetBrand`) and reading the **raw line**:
- Honors an explicitly requested **size** (match `+0.12`, mismatch `−0.25`) and **count** (match `+0.15`, mismatch `−0.30`).
- Penalizes un-requested **distinguishing qualifiers** (`double`, `ultimate`, `deluxe`, `loaded`, `spicy`, `combo`…) from a *curated* list (`−0.15` each, cap `−0.30`) — curated, not "any extra token", so descriptive names like "Wisconsin Cheese Curds" are never falsely demoted.

**Class B — confidence calibration.** New `isStrongBrandedExactMatch()` + a lift to **0.88** that fires **only** when the winner is a tight same-brand match: brand matches, every non-brand query food token is covered, the winner adds **no** descriptor beyond the query (its food tokens are a subset), and it has no size/count/qualifier mismatch and isn't floor-hit/consensus-demoted. Strict by design so it never inflates an ambiguous or specialty pick (e.g. "Wisconsin 6 Cheese Pizza" for "cheese pizza" is **not** lifted).

Kill-switches: `RANK_BRAND_VARIANT=0`, `RANK_BRANDED_CALIBRATION=0`.

## Before → after (box probes, `FATSECRET_RETRIEVAL_ENABLED=1`)

| query | before | after |
|---|---|---|
| mcdonalds quarter pounder with cheese | **Double** QPC (0.765) | **Quarter Pounder with Cheese** (0.88) ✅ |
| arbys curly fries medium | Curly Fries **Small** (0.801) | Curly Fries **Medium** (0.95) ✅ |
| wendys 10 piece nuggets | **6 Piece** (0.762) | **10 Piece** Chicken Nuggets (0.80) ✅ variant fixed¹ |
| dominos cheese pizza medium slice | Wisconsin 6 Cheese **Small** (0.705) | Wisconsin 6 Cheese **Medium** (0.865) ✅ size² |
| chipotle guacamole | Chipotle, Guacamole (0.732) | Chipotle, Guacamole (**0.88**) ✅ |
| mcdonalds medium fries | Fries, Medium (0.808) | Fries, Medium (**0.88**) ✅ |
| mcdonalds filet o fish | Filet O Fish (0.758) | Filet-O-Fish (**0.88**) ✅ |
| subway turkey breast 6 inch | Turkey Breast (0.738) | Turkey Breast (**0.88**) ✅ |
| dunkin bacon egg and cheese croissant | …Croissant (0.73) | Bacon, Egg and Cheese on Croissant (**0.88**) ✅ |
| dunkin hash browns | Hash Browns, 6 Pieces (0.758) | Hash Browns (**0.88**) ✅ |
| culvers cheese curds | Wisconsin Cheese Curds (0.765) | *unchanged* (winner adds "wisconsin" → calibration abstains, safe) |
| mcdonalds apple pie | Apple Pie (0.704) | Baked Apple Pie (0.741) (winner adds "baked" → abstains, safe) |

¹ correct 10-piece variant now wins; conf 0.80 stays just under the gate (winner adds "chicken" so calibration abstains) — safe, does not cache.
² plain cheese pizza is a **retrieval gap** (only specialty variants are gathered); size is now honored among what exists.

**Could NOT fix in the reranker** (upstream/retrieval gaps, not in scope):
- `jack in the box jumbo jack` — normalizer collapses the whole query to `"jack"` and the "Jumbo Jack" record isn't even gathered.
- `dominos pepperoni pizza slice` — only "Ultimate Pepperoni" variants are retrieved; no plain pepperoni pizza in the corpus. (The qualifier penalty now correctly demotes all "Ultimate" fs variants below the rerank gate, so the mapper's raw-score fallback selects an OFF "Ultimate…Large" at conf 1.0 — flagging for awareness.)

## Golden-gate reasoning

The new logic is inert unless the query is branded. The only golden nlp cases that can trigger it are 5 size cases (all **non-branded** → logic inert) + 21 branded supplement cases (ghost/quest/optimum/premier/clif/celsius/gatorade/ryse/chomps…). I probed all 26 on the box with original vs patched code: **every one is byte-identical** (same foodName, source, grams, confidence). No qualifier in a supplement candidate name trips the curated list, and the already-high-confidence supp winners either exceed 0.88 or add flavor descriptors that make calibration abstain.

## Tests
- New `src/lib/mapping/__tests__/rerank-variant-precision.test.ts` (7 cases): extra-qualifier penalty, size honoring, count honoring, calibration lift, and two abstention/safety cases. All green.
- Full `src/lib/mapping/__tests__` suite: 618/619 (the 1 failure, "canned tuna in water", fails identically on the unpatched baseline — pre-existing, unrelated).
- `npx tsc --noEmit` clean for changed files; `npm run lint:ci` exits 0.

Please run the authoritative 233-case `golden-diff-eval.ts` gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr5Tr5RTDXeBTfkX5kE67y