### PR TITLE
fix(mapping): branded query no longer resolves to a generic record (n-brand-02)

### DIFF
--- a/src/lib/mapping/__tests__/legacy-cache-brand-guard.test.ts
+++ b/src/lib/mapping/__tests__/legacy-cache-brand-guard.test.ts
@@ -1,0 +1,39 @@
+import { legacyHitReflectsBrand } from '../map-ingredient-with-fallback';
+
+// The brandless legacy cache key (deriveCacheKeyName) drops the detected brand,
+// so it can match a GENERIC record. legacyHitReflectsBrand blocks a fallback hit
+// that shows no trace of the detected brand (name or brandName), which is what
+// caused "one bar birthday cake" → generic "Birthday Cake".
+describe('legacyHitReflectsBrand', () => {
+    it('rejects a generic record for a branded query (the n-brand-02 bug)', () => {
+        expect(
+            legacyHitReflectsBrand({ foodName: 'Birthday Cake', brandName: null }, 'one bar'),
+        ).toBe(false);
+    });
+
+    it('accepts a record whose NAME carries the brand token', () => {
+        expect(
+            legacyHitReflectsBrand(
+                { foodName: 'One birthday cake protein bars', brandName: null },
+                'one bar',
+            ),
+        ).toBe(true);
+    });
+
+    it('accepts a record whose brandName carries the brand', () => {
+        expect(
+            legacyHitReflectsBrand({ foodName: 'Ketchup', brandName: 'Heinz' }, 'heinz'),
+        ).toBe(true);
+    });
+
+    it('rejects a different-brand generic record', () => {
+        expect(
+            legacyHitReflectsBrand({ foodName: 'Tomato Ketchup', brandName: 'Hunts' }, 'heinz'),
+        ).toBe(false);
+    });
+
+    it('does not block when the brand has no significant (≥3-char) token', () => {
+        // Nothing specific to match on — never block (conservative).
+        expect(legacyHitReflectsBrand({ foodName: 'Anything', brandName: null }, 'a')).toBe(true);
+    });
+});

--- a/src/lib/mapping/brand-detector.ts
+++ b/src/lib/mapping/brand-detector.ts
@@ -142,7 +142,7 @@ const KNOWN_BRANDS: string[] = [
     // ── Protein Bars & Snack Bars ─────────────────────────────
     'atkins', 'clif', 'cliff bar', 'epic', 'fit crunch', 'fulfil',
     'gatorade', 'greens first', 'kind', 'larabar', 'luna', 'lara bar',
-    'met-rx', 'nature valley', 'no cow', 'nutri-grain', 'one bar',
+    'met-rx', 'nature valley', 'no cow', 'nutri-grain',
     'perfect bar', 'power crunch', 'pure protein', 'quest', 'rx bar',
     'rxbar', 'ratio', 'skip', 'skyr', 'think thin', 'thinktin',
     'two moms in the raw', 'unreal', 'zone', 'zbar',
@@ -270,7 +270,7 @@ const KNOWN_BRANDS: string[] = [
 
     // ── Protein Bars / Better-for-you Snacks ──────────────────
     'no cow', 'gomacro', 'aloha', 'rxbar', 'quest', 'barebells', 'built',
-    'built bar', 'met-rx', 'power crunch', 'one bar',
+    'built bar', 'met-rx', 'power crunch',
 
     // ── Meat Snacks / Jerky ───────────────────────────────────
     'jack links', 'jack link\'s', 'chomps', 'country archer', 'old trapper',

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -93,6 +93,25 @@ async function lookupValidatedMappingWithLegacyFallback(
 
     const legacyHit = await getValidatedMappingByNormalizedName(legacyKey, 'fatsecret', rawLine);
     if (legacyHit) {
+        // Branded-query guard: the legacy key (deriveCacheKeyName) is BRANDLESS,
+        // so when a brand was detected and stripped it can wrongly match a
+        // GENERIC record — e.g. "one bar birthday cake" detects brand "one bar",
+        // normalizes to "birthday cake", and the legacy key hits a generic
+        // "Birthday Cake" instead of "One birthday cake protein bars". Only
+        // accept a legacy hit that actually reflects the detected brand (in its
+        // name or brandName); otherwise fall through to the full pipeline.
+        if (
+            brandDetection.matchedBrand &&
+            !legacyHitReflectsBrand(legacyHit, brandDetection.matchedBrand)
+        ) {
+            logger.debug('mapping.legacy_cache_key_brand_mismatch_skipped', {
+                rawLine,
+                legacyKey,
+                matchedBrand: brandDetection.matchedBrand,
+                cachedFood: legacyHit.foodName,
+            });
+            return null;
+        }
         logger.debug('mapping.legacy_cache_key_fallback_hit', {
             rawLine,
             symmetricKey,
@@ -100,6 +119,28 @@ async function lookupValidatedMappingWithLegacyFallback(
         });
     }
     return legacyHit;
+}
+
+/**
+ * True when a cached record reflects the detected brand — any significant brand
+ * token (≥3 chars) appears as a whole word in the record's name or brandName.
+ * Used to reject brandless-legacy-key hits on GENERIC records for branded
+ * queries (see lookupValidatedMappingWithLegacyFallback). Conservative: it only
+ * blocks a fallback hit that shows no trace of the brand at all.
+ */
+export function legacyHitReflectsBrand(
+    hit: Pick<CachedMappedIngredient, 'foodName' | 'brandName'>,
+    matchedBrand: string,
+): boolean {
+    const tokens = matchedBrand
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(t => t.length >= 3);
+    if (tokens.length === 0) return true; // nothing specific to match on — don't block
+    const hay = `${hit.foodName ?? ''} ${hit.brandName ?? ''}`.toLowerCase();
+    return tokens.some(t =>
+        new RegExp(`\\b${t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(hay),
+    );
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem (regression from #134, surfaced by the wave-1 deploy's run-eval)
`n-brand-02 "one bar birthday cake"` mapped to a generic **"Birthday Cake"** instead of **"One birthday cake protein bars"**.

Root cause: #134 added `"one bar"` to the brand lexicon. The brand is detected and **stripped** from the normalized name → query collapses to `"birthday cake"` → the #125 legacy cache-key fallback (which is **brandless**) hits a generic `"Birthday Cake"` record. Proof it's from #134: pre-#134 gating runs mapped it correctly (the brand wasn't detected/stripped, so the search kept "one").

## Fix (two parts)
1. **`legacyHitReflectsBrand`** guard in `lookupValidatedMappingWithLegacyFallback`: when a brand was detected, only accept a brandless-legacy-key hit whose name/brandName actually carries a significant brand token — otherwise fall through. Defense-in-depth against generic hits for *any* brand.
2. **Drop the `"one bar"` lexicon entry**: "one" is a common word *and* embedded in the real product name, so detecting+stripping it is net-negative (it was the specific trigger). Removing it restores correct fresh-mapping.

## Verified (box probe): `one bar birthday cake` → **"One birthday cake protein bars"** (0.95). 5 unit tests for the guard. Gated together with the wave-2 rerank/fs PRs via the 233-case golden-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)