### PR TITLE
feat(mapping): funnel instrumentation — make every drop observable (sprint F1)

### DIFF
--- a/prisma/migrations/20260724120000_add_mapping_event_log_funnel/migration.sql
+++ b/prisma/migrations/20260724120000_add_mapping_event_log_funnel/migration.sql
@@ -1,0 +1,20 @@
+-- Funnel taxonomy columns on MappingEventLog (sprint F1, Jul 2026).
+-- Additive and nullable: existing rows keep NULL, which reads as "logged before
+-- the funnel existed" rather than as a stage.
+--
+-- funnelStage is the coarse bucket a line ended in (cache_hit | saved |
+-- under_gate | save_rejected | no_match | no_candidates | all_filtered |
+-- fast_path | error). The one that motivated this sprint is 'under_gate':
+-- 0.3 <= confidence < 0.85, where the pick serves the user but is never offered
+-- to the validated cache — previously invisible, and exactly the population that
+-- cache-warming exists to convert.
+--
+-- dropReason is the fine-grained class ID, '<stage>:<class>[:<detail>]'. It is
+-- normalized (interpolated measurements stripped) by src/lib/mapping/funnel.ts so
+-- it stays low-cardinality and groups cleanly.
+
+ALTER TABLE "MappingEventLog" ADD COLUMN "funnelStage" TEXT;
+ALTER TABLE "MappingEventLog" ADD COLUMN "dropReason" TEXT;
+
+CREATE INDEX "MappingEventLog_funnelStage_idx" ON "MappingEventLog"("funnelStage");
+CREATE INDEX "MappingEventLog_dropReason_idx" ON "MappingEventLog"("dropReason");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -731,12 +731,24 @@ model MappingEventLog {
   latencyMs      Int?
   noCache        Boolean  @default(false) // request ran with the admin nocache flag (cold run)
   segCacheHit    Boolean? // true = segmentation served from SegmentationCache; false = AI segmentation ran; null = line never reached AI segmentation (item-form input or single-item fast path)
+  // Funnel taxonomy (sprint F1, Jul 2026 — src/lib/mapping/funnel.ts). funnelStage
+  // is the coarse bucket the line ended in: cache_hit | saved | under_gate |
+  // save_rejected | no_match | no_candidates | all_filtered | fast_path | error.
+  // 'under_gate' (0.3 <= confidence < 0.85 — served but never offered to the cache)
+  // was previously unobservable and is the population cache-warming converts.
+  funnelStage    String?
+  // Namespaced class ID for WHY a line dropped: '<stage>:<class>[:<detail>]', e.g.
+  // 'save_rejected:implausible_macros:floor:produce_kcal_below'. Null for
+  // cache_hit/saved. Normalized (numbers stripped) so it groups.
+  dropReason     String?
   createdAt      DateTime @default(now())
 
   @@index([createdAt])
   @@index([normalizedForm])
   @@index([cacheHit])
   @@index([servingTier])
+  @@index([funnelStage])
+  @@index([dropReason])
 }
 
 // AI segmentation-result cache (magic-log): repeat free-text lines skip the

--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -389,6 +389,77 @@ function fmtTable(rows: string[][], header: string[]): string {
     return all.length > 1 ? md.join('\n') : '_none_';
 }
 
+/**
+ * Roll a namespaced dropReason up to its class level for the report: keep
+ * '<stage>:<class>' and drop the detail suffix. The stored column keeps full
+ * granularity (Diego, 2026-07-24 decision 3) — this is display only.
+ */
+function dropReasonClass(reason: string): string {
+    return reason.split(':').slice(0, 2).join(':');
+}
+
+/**
+ * Funnel breakdown for a warm batch (sprint F1). Turns "our fixes felt
+ * systematic" into a measurable conversion rate: what share of seeds reached a
+ * cache row, and which class the rest died in.
+ */
+function buildFunnelSection(warm: WarmRunReport | null): string[] {
+    const lines: string[] = ['## Funnel'];
+    if (!warm) {
+        lines.push('_skipped (--skip-warm)_');
+        return lines;
+    }
+
+    const results = warm.results ?? [];
+    const staged = results.filter(r => r.funnelStage);
+    if (staged.length === 0) {
+        // The sweep talks to the box over HTTP: an API that predates F1 returns
+        // no funnel fields. Say so rather than reporting a funnel of all zeros.
+        lines.push('_no funnel data — the API being swept predates the funnel instrumentation (sprint F1)_');
+        return lines;
+    }
+
+    const byStage = new Map<string, number>();
+    for (const r of staged) byStage.set(r.funnelStage!, (byStage.get(r.funnelStage!) ?? 0) + 1);
+
+    const total = staged.length;
+    const pct = (n: number) => `${((n / total) * 100).toFixed(1)}%`;
+    const stageRows = [...byStage.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([stage, n]) => [stage, String(n), pct(n)]);
+    lines.push(fmtTable(stageRows, ['stage', 'n', '%']));
+    lines.push('');
+
+    // Conversion = seeds that ended with a cache row. 'saved' is what THIS batch
+    // converted; 'cache_hit' was already converted by an earlier batch.
+    const saved = byStage.get('saved') ?? 0;
+    const cacheHit = byStage.get('cache_hit') ?? 0;
+    lines.push(`**Conversion**: ${pct(saved)} newly saved · ${pct(saved + cacheHit)} cached overall (${saved + cacheHit}/${total})`);
+
+    const underGate = byStage.get('under_gate') ?? 0;
+    if (underGate > 0) {
+        lines.push(`**Under-gate** (served but never cached — the warm target): ${underGate} (${pct(underGate)})`);
+    }
+    lines.push('');
+
+    const byClass = new Map<string, number>();
+    for (const r of staged) {
+        if (!r.dropReason) continue;
+        const cls = dropReasonClass(r.dropReason);
+        byClass.set(cls, (byClass.get(cls) ?? 0) + 1);
+    }
+    const drops = [...byClass.values()].reduce((a, b) => a + b, 0);
+    lines.push(`### Top drop classes (${drops} drops)`);
+    const classRows = [...byClass.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 15)
+        .map(([cls, n]) => [cls, String(n), drops > 0 ? `${((n / drops) * 100).toFixed(1)}%` : '—']);
+    lines.push(fmtTable(classRows, ['class', 'n', '% of drops']));
+    if (byClass.size > 15) lines.push(`\n_(${byClass.size - 15} further classes not shown)_`);
+
+    return lines;
+}
+
 function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport | null,
     seedCount: number, telemetrySeedCount: number, diff: WarmDiff | null, gate: EvalGate | null,
     stuck: StuckKeysRun | null, segReplay: SegReplayRun | null): string {
@@ -428,6 +499,9 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
         const s = warm.summary;
         lines.push(`ok ${s.ok} · errors ${s.errors} · low-conf (not cached) ${s.lowConf} · sources ${JSON.stringify(s.bySource)}`);
     }
+    lines.push('');
+
+    lines.push(...buildFunnelSection(warm));
     lines.push('');
 
     lines.push('## Diff vs previous warm run');

--- a/scripts/eval/warm-cache.ts
+++ b/scripts/eval/warm-cache.ts
@@ -150,6 +150,10 @@ export interface WarmResult {
     grams?: number;
     matchConfidence?: number;
     per100g?: { kcal?: number; protein?: number; carbs?: number; fat?: number };
+    /** Funnel bucket this seed ended in (sprint F1) — 'saved' is a conversion. */
+    funnelStage?: string;
+    /** Namespaced class ID for why the seed failed to convert. */
+    dropReason?: string;
     error?: string;
 }
 
@@ -191,6 +195,7 @@ async function warmOne(seed: string, base: string, apiKey: string, timeoutMs: nu
                 foodId: it.foodId, foodName: it.foodName, brandName: it.brandName ?? undefined,
                 source: it.source, grams: it.grams, matchConfidence: it.matchConfidence,
                 per100g: { kcal: n.kcal100, protein: n.protein100, carbs: n.carbs100, fat: n.fat100 },
+                funnelStage: it.funnelStage, dropReason: it.dropReason,
             };
         } catch (err) {
             if (attempt === 1) {

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -249,6 +249,7 @@ export async function POST(req: NextRequest) {
       brandName: string | null; source: string | null; confidence: number | null;
       servingTier: string | null; grams: number | null; totalKcal: number | null;
       latencyMs: number; noCache: boolean; segCacheHit: boolean | null;
+      funnelStage: string | null; dropReason: string | null;
     };
     const eventRows: EventRow[] = [];
     const telemetryEnabled = process.env.MAPPING_EVENT_LOG_ENABLED !== 'false';
@@ -292,6 +293,10 @@ export async function POST(req: NextRequest) {
           latencyMs: mapLatencyMs,
           noCache,
           segCacheHit,
+          // Funnel taxonomy (sprint F1). A line the mapper never classified
+          // (it threw, or returned a 'pending' lock status) has no stage.
+          funnelStage: telemetry.funnelStage ?? null,
+          dropReason: telemetry.dropReason ?? null,
         });
       }
 
@@ -327,6 +332,8 @@ export async function POST(req: NextRequest) {
             sodium100: 0,
           },
           servingOptions: [],
+          funnelStage: telemetry.funnelStage,
+          dropReason: telemetry.dropReason,
         };
       }
 
@@ -369,6 +376,12 @@ export async function POST(req: NextRequest) {
         nutrition,
         nutritionPer100g: details.nutritionPer100g,
         servingOptions: details.servingOptions,
+        // Funnel taxonomy (sprint F1) — diagnostic class IDs, additive. Lets
+        // offline warm batches (scripts/eval/warm-cache.ts) read each seed's
+        // funnel outcome straight off the response instead of re-deriving it
+        // from MappingEventLog. Clients ignore unknown fields.
+        funnelStage: telemetry.funnelStage,
+        dropReason: telemetry.dropReason,
       };
     }));
 

--- a/src/lib/mapping/__tests__/funnel.test.ts
+++ b/src/lib/mapping/__tests__/funnel.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Funnel taxonomy (sprint F1).
+ *
+ * The class IDs this module produces are stored in MappingEventLog.dropReason
+ * and grouped by the nightly sweep, so the property that actually matters is
+ * CARDINALITY: the vocabularies being reused were written for human-readable
+ * logs and interpolate live measurements into their reason strings
+ * (`atwater:kcal_412_exceeds_computed_388.5`). Stored raw, every row would carry
+ * a unique "class" and the funnel table would be noise. These tests pin the
+ * normalization that keeps a class a class.
+ */
+
+import { normalizeClassId, funnelReason, markSaveRejected, type FunnelSink } from '../funnel';
+
+describe('normalizeClassId', () => {
+    it('strips interpolated measurements but keeps the surrounding words', () => {
+        // macro-plausibility: `atwater:kcal_${kcal}_exceeds_computed_${computed}`
+        expect(normalizeClassId('atwater:kcal_412_exceeds_computed_388.5'))
+            .toBe('atwater:kcal_exceeds_computed');
+        expect(normalizeClassId('floor:produce_kcal_12.3_below_20'))
+            .toBe('floor:produce_kcal_below');
+        expect(normalizeClassId('bounds:kcal_over_900'))
+            .toBe('bounds:kcal_over');
+    });
+
+    it('drops parenthesized detail from confidenceGate reasons', () => {
+        expect(normalizeClassId('confidence_below_threshold(0.42)'))
+            .toBe('confidence_below_threshold');
+        expect(normalizeClassId('margin_too_small(0.03)'))
+            .toBe('margin_too_small');
+    });
+
+    it('leaves an already-clean class ID untouched', () => {
+        expect(normalizeClassId('category:protein_food_with_zero_protein'))
+            .toBe('category:protein_food_with_zero_protein');
+        expect(normalizeClassId('brand_mismatch')).toBe('brand_mismatch');
+    });
+
+    it('collapses distinct measurements of the SAME defect onto one class', () => {
+        // This is the whole point: three rows, one class.
+        const a = normalizeClassId('bounds:macro_sum_over_105g(112.4)');
+        const b = normalizeClassId('bounds:macro_sum_over_105g(230.9)');
+        const c = normalizeClassId('bounds:macro_sum_over_105g(101.1)');
+        expect(new Set([a, b, c]).size).toBe(1);
+    });
+
+    it('caps segment count so a long path cannot grow unbounded', () => {
+        expect(normalizeClassId('a:b:c:d:e')).toBe('a:b:c');
+        expect(normalizeClassId('a:b:c:d:e', { maxSegments: 2 })).toBe('a:b');
+    });
+
+    it('falls back to "unknown" rather than emitting an empty class', () => {
+        expect(normalizeClassId(undefined)).toBe('unknown');
+        expect(normalizeClassId(null)).toBe('unknown');
+        expect(normalizeClassId('')).toBe('unknown');
+        expect(normalizeClassId('   ')).toBe('unknown');
+        // A reason that is nothing but numbers has no class content left.
+        expect(normalizeClassId('12345')).toBe('unknown');
+    });
+
+    it('bounds segment length', () => {
+        const long = 'x'.repeat(200);
+        for (const segment of normalizeClassId(long).split(':')) {
+            expect(segment.length).toBeLessThanOrEqual(40);
+        }
+    });
+});
+
+describe('funnelReason', () => {
+    it('namespaces the class under its stage', () => {
+        expect(funnelReason('no_match', 'confidence_too_low'))
+            .toBe('no_match:confidence_too_low');
+        expect(funnelReason('no_candidates', 'dataset_gap'))
+            .toBe('no_candidates:dataset_gap');
+    });
+
+    it('normalizes the class it is given', () => {
+        expect(funnelReason('under_gate', 'confidence_below_threshold(0.42)'))
+            .toBe('under_gate:confidence_below_threshold');
+    });
+
+    it('never produces a bare stage with a dangling colon', () => {
+        expect(funnelReason('error')).toBe('error:unknown');
+    });
+});
+
+describe('markSaveRejected', () => {
+    it('downgrades an optimistically-saved line and records the blocking gate', () => {
+        const sink: FunnelSink = { funnelStage: 'saved' };
+        markSaveRejected(sink, 'brand_mismatch');
+        expect(sink.funnelStage).toBe('save_rejected');
+        expect(sink.dropReason).toBe('save_rejected:brand_mismatch');
+    });
+
+    it('keeps the macro-plausibility detail suffix as a groupable class', () => {
+        const sink: FunnelSink = { funnelStage: 'saved' };
+        markSaveRejected(sink, `implausible_macros:${normalizeClassId('floor:produce_kcal_12.3_below_20', { maxSegments: 2 })}`);
+        // Full granularity in the stored column (Diego, 2026-07-24 decision 3);
+        // the nightly table rolls this up to 'save_rejected:implausible_macros'.
+        expect(sink.dropReason).toBe('save_rejected:implausible_macros:floor:produce_kcal_below');
+    });
+
+    it('is a no-op when no sink was passed (alias saves, direct callers)', () => {
+        expect(() => markSaveRejected(undefined, 'brand_mismatch')).not.toThrow();
+    });
+});

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -36,6 +36,7 @@ jest.mock('../../db', () => ({
 import { saveValidatedMapping, getValidatedMappingByNormalizedName } from '../validated-mapping-helpers';
 import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
 import type { AIValidationResult } from '../ai-validation';
+import type { FunnelSink } from '../funnel';
 
 const validation = { confidence: 0.95 } as AIValidationResult;
 
@@ -576,5 +577,55 @@ describe('FIX 3: bare-category takeover save gate', () => {
             validation,
         );
         expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('funnel tagging on the save gates (sprint F1)', () => {
+    it('tags a brand-mismatch rejection with its class, downgrading "saved"', async () => {
+        // The caller marks the line 'saved' optimistically before the write.
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+        await saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Protein Rice' }),
+            validation,
+            { telemetry },
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+        expect(telemetry.funnelStage).toBe('save_rejected');
+        expect(telemetry.dropReason).toBe('save_rejected:brand_mismatch');
+    });
+
+    it('tags a bare-category-takeover rejection with its own distinct class', async () => {
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+        await saveValidatedMapping(
+            'special k red berries',
+            makeMapping({ foodName: 'Cereal' }),
+            validation,
+            { telemetry },
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+        expect(telemetry.dropReason).toBe('save_rejected:bare_category_takeover');
+    });
+
+    it('leaves the line "saved" when no gate blocks the write', async () => {
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+        await saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Loaded Protein Powder', brandName: 'RYSE' }),
+            validation,
+            { telemetry },
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+        expect(telemetry.funnelStage).toBe('saved');
+        expect(telemetry.dropReason).toBeUndefined();
+    });
+
+    it('stays silent when no sink is passed — an alias save must not relabel its parent line', async () => {
+        await expect(saveValidatedMapping(
+            'ryse protein',
+            makeMapping({ foodName: 'Protein Rice' }),
+            validation,
+        )).resolves.toBeUndefined();
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/mapping/funnel.ts
+++ b/src/lib/mapping/funnel.ts
@@ -1,0 +1,117 @@
+/**
+ * Mapping funnel taxonomy (sprint F1, Jul 2026).
+ *
+ * Every ingredient line that enters the mapper ends in exactly one FunnelStage.
+ * Until now only the two cache outcomes were observable — in particular a pick
+ * with 0.3 <= confidence < 0.85 served the user and was silently never offered
+ * to the cache, with no log line at all. That "under_gate" population is the
+ * bulk of what cache-warming exists to convert, and it was only reconstructable
+ * after the fact by SQL inference (src/lib/ops/stuck-keys.ts).
+ *
+ * These types carry no runtime dependencies on the mapper so that both
+ * map-ingredient-with-fallback.ts (which owns MappingTelemetry) and
+ * validated-mapping-helpers.ts (which owns the save gates) can import them
+ * without a cycle.
+ */
+
+/**
+ * Coarse funnel bucket: where the line ended up. Exactly one is set per line.
+ */
+export type FunnelStage =
+    /** A FoodMapping row served the line (early or normalized cache layer). */
+    | 'cache_hit'
+    /** Fresh pick cleared the >=0.85 save gate and was written to the cache. */
+    | 'saved'
+    /** 0.3 <= confidence < 0.85: served to the user, never offered to the cache. */
+    | 'under_gate'
+    /** confidence >= 0.85 but a save gate blocked the write. */
+    | 'save_rejected'
+    /** Best pick scored below MIN_ACCEPTABLE_CONFIDENCE -> null. */
+    | 'no_match'
+    /** Retrieval returned nothing at all — a dataset gap, not a ranking gap. */
+    | 'no_candidates'
+    /** Candidates existed but every one was dropped before ranking. */
+    | 'all_filtered'
+    /** Zero-calorie short-circuit (water/ice) — never consults the corpus. */
+    | 'fast_path'
+    /** The mapper threw. */
+    | 'error';
+
+/**
+ * The funnel-writable slice of MappingTelemetry. The save path takes this
+ * rather than the full telemetry object: it has no business touching
+ * cacheHit/normalizedForm, and depending on the narrow shape keeps
+ * validated-mapping-helpers.ts free of an import cycle back into the mapper.
+ */
+export interface FunnelSink {
+    funnelStage?: FunnelStage;
+    dropReason?: string;
+}
+
+/**
+ * Downgrade an optimistically-'saved' line to 'save_rejected' with the class ID
+ * of whichever gate blocked the write.
+ */
+export function markSaveRejected(sink: FunnelSink | undefined, classId: string): void {
+    if (!sink) return;
+    sink.funnelStage = 'save_rejected';
+    sink.dropReason = funnelReason('save_rejected', classId);
+}
+
+/** Confidence at/above which a fresh pick is offered to the validated cache. */
+export const SAVE_GATE_CONFIDENCE = 0.85;
+
+/** Confidence below which a pick is rejected outright as a garbage match. */
+export const MIN_ACCEPTABLE_CONFIDENCE = 0.3;
+
+/**
+ * Collapse a raw reason string into a stable, low-cardinality class token.
+ *
+ * The vocabularies we reuse were built for human-readable logs, not for
+ * GROUP BY: macro-plausibility interpolates live measurements into its reason
+ * IDs (`atwater:kcal_412_exceeds_computed_388.5`), confidenceGate parenthesizes
+ * thresholds (`confidence_below_threshold(0.42)`), and selectionReason can
+ * carry free-form AI rationale (`fallback_simplified: <sentence>`). Stored raw,
+ * dropReason would be near-unique per row and useless as a class label.
+ *
+ * So each colon-separated segment is: cut at the first '(' , stripped of
+ * embedded numbers, lowercased, reduced to [a-z0-9_], and length-capped. That
+ * turns the examples above into `atwater:kcal_exceeds_computed`,
+ * `confidence_below_threshold` and `fallback_simplified` — the detail suffix
+ * Diego asked to keep, without the unbounded tail.
+ */
+export function normalizeClassId(
+    raw: string | null | undefined,
+    opts?: { maxSegments?: number },
+): string {
+    const maxSegments = opts?.maxSegments ?? 3;
+    if (!raw) return 'unknown';
+
+    const segments = String(raw)
+        .split(':')
+        .map(segment => segment
+            // Drop parenthesized detail: "confidence_below_threshold(0.42)".
+            .split('(')[0]
+            .toLowerCase()
+            // Strip interpolated measurements, keeping the surrounding words:
+            // "kcal_412_exceeds_computed_388.5" -> "kcal_exceeds_computed".
+            .replace(/\d+(?:\.\d+)?/g, ' ')
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .slice(0, 40)
+            .replace(/_+$/g, ''))
+        .filter(Boolean)
+        .slice(0, maxSegments);
+
+    return segments.length > 0 ? segments.join(':') : 'unknown';
+}
+
+/**
+ * Build a namespaced drop reason: `"<stage>:<class>[:<detail>]"`.
+ *
+ * `classId` may itself be colon-separated (macro-plausibility reasons already
+ * are); it is normalized as a path so the stage prefix is never duplicated.
+ */
+export function funnelReason(stage: FunnelStage, classId?: string | null): string {
+    return `${stage}:${normalizeClassId(classId)}`;
+}

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -11,6 +11,7 @@
 import { parseIngredientLine, type ParsedIngredient } from '../parse/ingredient-line';
 import { normalizeIngredientName } from './normalization-rules';
 import { gatherCandidates, confidenceGate, type UnifiedCandidate, type GatherOptions } from './gather-candidates';
+import { funnelReason, type FunnelStage, type FunnelSink } from './funnel';
 import {
     filterCandidatesByTokens,
     hasCriticalModifierMismatch,
@@ -273,13 +274,34 @@ export type FatsecretMappedIngredient = {
  * facts survive the mapper's many internal return paths without threading
  * them through every result construction.
  */
-export interface MappingTelemetry {
+export interface MappingTelemetry extends FunnelSink {
     /** The mapper's own cache-key input (post-normalization), not the segmenter hint. */
     normalizedForm?: string;
     /** Set when a FoodMapping row served the line: which cache layer hit. */
     cacheHit?: 'early' | 'normalized';
     /** Set when a cached row existed but was bypassed: 'early:grain_cooked', 'normalized:core_token_mismatch', ... */
     cacheEscape?: string;
+    // funnelStage / dropReason come from FunnelSink — the funnel bucket this
+    // line ended in and, when it dropped, the namespaced class ID for why.
+}
+
+/**
+ * Record the funnel outcome for a line. Later calls win: a fresh pick is marked
+ * 'saved' optimistically and downgraded to 'save_rejected' by whichever save
+ * gate blocks the write.
+ */
+function markFunnel(
+    telemetry: MappingTelemetry | undefined,
+    stage: FunnelStage,
+    classId?: string | null,
+): void {
+    if (!telemetry) return;
+    telemetry.funnelStage = stage;
+    // Successful stages carry no drop reason; clear any earlier one so a
+    // recovered line (e.g. fallback search after a cache miss) isn't tagged.
+    telemetry.dropReason = (stage === 'cache_hit' || stage === 'saved')
+        ? undefined
+        : funnelReason(stage, classId);
 }
 
 /**
@@ -656,6 +678,7 @@ export async function mapIngredientWithFallback(
     const baseNameLowerForWaterCheck = baseName.toLowerCase().trim().replace(/^\d+(?:\.\d+)?\s*%\s*/, '');
     if (ZERO_CALORIE_INGREDIENTS.includes(baseNameLowerForWaterCheck)) {
         logger.info('mapping.zero_calorie_default', { rawLine: trimmed, baseName });
+        markFunnel(telemetry, 'fast_path', 'zero_calorie');
 
         // Calculate grams from parsed quantity using standard conversions
         const WATER_UNIT_GRAMS: Record<string, number> = {
@@ -1056,6 +1079,7 @@ export async function mapIngredientWithFallback(
                     // Track cache hit for metrics
                     incrementCacheHit();
                     if (telemetry) telemetry.cacheHit = 'early';
+                    markFunnel(telemetry, 'cache_hit');
 
                     // Log the early cache hit
                     if (ENABLE_MAPPING_ANALYSIS) {
@@ -1421,6 +1445,7 @@ export async function mapIngredientWithFallback(
                     confidence = normalizedCache.confidence;
                     selectionReason = 'normalized_cache_hit';
                     if (telemetry) telemetry.cacheHit = 'normalized';
+                    markFunnel(telemetry, 'cache_hit');
                 }
             }
 
@@ -2092,6 +2117,16 @@ export async function mapIngredientWithFallback(
                     failureReason: 'no_candidates_found',
                 });
             }
+            // Separate a dataset gap (retrieval found nothing to rank) from a
+            // filter gap (records existed but every one was dropped pre-rank)
+            // from a selection gap — they need completely different fixes.
+            if (allCandidates.length === 0) {
+                markFunnel(telemetry, 'no_candidates', 'dataset_gap');
+            } else if (filtered.length === 0) {
+                markFunnel(telemetry, 'all_filtered', 'no_candidate_survived_filters');
+            } else {
+                markFunnel(telemetry, 'no_match', 'no_winner_selected');
+            }
             return null; // Return null if truly failed
         }
 
@@ -2142,6 +2177,7 @@ export async function mapIngredientWithFallback(
                     failureReason: `confidence_too_low (${confidence.toFixed(3)} < ${MIN_ACCEPTABLE_CONFIDENCE})`,
                 });
             }
+            markFunnel(telemetry, 'no_match', 'confidence_too_low');
             return null;
         }
 
@@ -2611,11 +2647,16 @@ export async function mapIngredientWithFallback(
                 confidence: aiNutritionEstimate.confidence,
             } : undefined;
 
+            // Optimistic: a save gate inside saveValidatedMapping downgrades
+            // this to 'save_rejected' (with its own class ID) if it blocks.
+            markFunnel(telemetry, 'saved');
+
             await saveValidatedMapping(rawLine, result, {
                 approved: true,
                 confidence,
                 reason: selectionReason,
             }, {
+                telemetry,               // save gates tag their own rejection class
                 canonicalBase: cacheKey,  // Use normalizedName as cache key
                 persistCanonicalBase: aiCanonicalBase,   // AI base identity → canonicalBase column (grouping only)
                 persistCookingModifier: aiCookingModifier,
@@ -2661,6 +2702,23 @@ export async function mapIngredientWithFallback(
                     expectedNutrition,
                 }).catch(() => { }); // Best effort, ignore duplicates
             }
+        } else if (selectionReason !== 'normalized_cache_hit') {
+            // THE SILENT CLASS (sprint F1): 0.3 <= confidence < 0.85. This pick
+            // serves the user but is never offered to the cache — historically
+            // with no log line at all, so the population cache-warming exists to
+            // convert was only reconstructable by after-the-fact SQL inference.
+            // Tag it with the reason the selection cascade settled where it did.
+            // Only the FIRST segment of selectionReason is kept as the class:
+            // 'fallback_simplified: <AI rationale>' would otherwise make this an
+            // unbounded-cardinality column.
+            markFunnel(telemetry, 'under_gate', selectionReason.split(':')[0]);
+            logger.debug('mapping.under_save_gate', {
+                rawLine: trimmed,
+                normalizedName,
+                confidence,
+                selectionReason,
+                foodId: result.foodId,
+            });
         }
 
         // Log success

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -18,6 +18,7 @@ import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { assessSaveTimePlausibility } from './macro-plausibility';
 import type { MacroPlausibilityInput, ExpectedNutritionPer100g } from './macro-plausibility';
 import { detectBrandInQuery } from './brand-detector';
+import { markSaveRejected, normalizeClassId, type FunnelSink } from './funnel';
 import { hasDecisiveBrandContext, candidateMatchesTargetBrand } from './simple-rerank';
 import { parseIngredientLine } from '../parse/ingredient-line';
 import { normalizeIngredientName, canonicalizeCacheKey } from './normalization-rules';
@@ -448,6 +449,11 @@ export async function saveValidatedMapping(
         persistCookingModifier?: string; // e.g. "grilled", "scrambled"
         nutrientsPer100g?: MacroPlausibilityInput | null;      // Pick's per-100g macros for the save-time gate
         expectedNutrition?: ExpectedNutritionPer100g | null;   // AI normalize estimate to cross-check against
+        // Funnel sink (sprint F1): the caller marks the line 'saved' optimistically;
+        // whichever gate below blocks the write downgrades it to 'save_rejected'
+        // with that gate's class ID. Pass ONLY for the primary save — an alias
+        // save being rejected must not relabel the line it was derived from.
+        telemetry?: FunnelSink;
     }
 ): Promise<void> {
     // Priority: canonicalBase > normalizedForm > computed from rawIngredient
@@ -484,6 +490,7 @@ export async function saveValidatedMapping(
             brandName: mapping.brandName,
             namedBrand: detectedBrand,
         });
+        markSaveRejected(options?.telemetry, 'brand_mismatch');
         return;
     }
 
@@ -516,6 +523,7 @@ export async function saveValidatedMapping(
             namedBrand: detectedBrand,
             specificTokenCount,
         });
+        markSaveRejected(options?.telemetry, 'bare_category_takeover');
         return;
     }
 
@@ -538,6 +546,7 @@ export async function saveValidatedMapping(
                 foodName: mapping.foodName,
                 brandName: mapping.brandName,
             });
+            markSaveRejected(options?.telemetry, 'core_token_mismatch');
             return; // Don't save this invalid mapping
         }
         logger.info('validated_mapping.save_core_token_brand_rescued', {
@@ -569,6 +578,13 @@ export async function saveValidatedMapping(
                 brandName: mapping.brandName,
                 reasons: gate.reasons,
             });
+            // Fold the first plausibility reason in as the detail suffix —
+            // normalizeClassId strips the interpolated measurements that would
+            // otherwise make this class ID unique per row.
+            markSaveRejected(
+                options?.telemetry,
+                `implausible_macros:${normalizeClassId(gate.reasons[0], { maxSegments: 2 })}`,
+            );
             return;
         }
     }
@@ -638,6 +654,7 @@ export async function saveValidatedMapping(
                     attemptedFoodName: mapping.foodName,
                 });
             }
+            markSaveRejected(options?.telemetry, 'human_row');
             return;
         }
 
@@ -710,6 +727,7 @@ export async function saveValidatedMapping(
                         keptTarget: existingTargetKey,
                         rejectedTarget: newTargetKey,
                     });
+                    markSaveRejected(options?.telemetry, 'serving_downgrade');
                     return;
                 }
             }
@@ -737,6 +755,7 @@ export async function saveValidatedMapping(
                         incumbentConfidence,
                         challengerConfidence: clampedConfidence,
                     });
+                    markSaveRejected(options?.telemetry, 'cross_source_margin');
                     return;
                 }
             }


### PR DESCRIPTION
## What

Sprint **F1** of the funnel-instrumentation spec (`sync-docs/funnel_instrumentation_sprint_spec_2026-07-24.md`). Per Diego's decision: **F1 only** — make the funnel visible, review real batches, then design F2–F4 against the observed drop distribution.

Every ingredient line now ends in exactly one `FunnelStage`, persisted per line on `MappingEventLog`.

## Why

The cache-save gate is `confidence >= 0.85`. A pick with `0.3 <= confidence < 0.85` fell through an **else-less branch** in `map-ingredient-with-fallback.ts` — it served the user and was **never offered to the cache, with no log line at all**. That `under_gate` population is exactly what cache-warming exists to convert, and it was only reconstructable after the fact by SQL inference (`src/lib/ops/stuck-keys.ts`). It's now a first-class queryable bucket.

## Taxonomy — `src/lib/mapping/funnel.ts`

- **`FunnelStage`** (coarse): `cache_hit | saved | under_gate | save_rejected | no_match | no_candidates | all_filtered | fast_path | error`
- **`dropReason`** (fine): namespaced `<stage>:<class>[:<detail>]`, built by **reusing the reason vocabularies that already existed** — the six named save-gate log events, macro-plausibility's `reasons[]`, and `selectionReason`. No new vocabulary invented.

### The load-bearing detail: cardinality

Those vocabularies were written for human-readable logs. They interpolate **live measurements** into reason strings (`atwater:kcal_412_exceeds_computed_388.5`), parenthesize thresholds (`confidence_below_threshold(0.42)`), and in one case carry free-form AI rationale (`fallback_simplified: <sentence>`). Stored raw, `dropReason` would be near-unique per row — useless to `GROUP BY`, i.e. not a class label at all.

`normalizeClassId` strips embedded numbers and parenthesized detail per segment and caps segment count/length, so:

| raw | stored class |
|---|---|
| `atwater:kcal_412_exceeds_computed_388.5` | `atwater:kcal_exceeds_computed` |
| `floor:produce_kcal_12.3_below_20` | `floor:produce_kcal_below` |
| `confidence_below_threshold(0.42)` | `confidence_below_threshold` |

This keeps the detail suffix Diego asked to preserve (decision 3) while collapsing different *measurements of the same defect* onto one class. Pinned by test.

## Wiring

- **9 classification branches** in the mapper set the stage (incl. splitting total failure into `no_candidates` = dataset gap vs `all_filtered` = filter gap vs `no_match` — different fixes).
- **The 7 save gates** in `validated-mapping-helpers.ts` tag their own rejection class via a narrow `FunnelSink` structural type — this keeps that module free of an import cycle back into the mapper. A line is marked `saved` optimistically and downgraded to `save_rejected` by whichever gate blocks the write.
- The sink is passed for the **primary save only**: a rejected *alias* save must not relabel its parent line.
- `MappingEventLog` gains `funnelStage`/`dropReason` (nullable, indexed), wired through the parse route's `EventRow` and returned on the response so offline warm batches read the funnel directly instead of re-deriving it.
- `flywheel-sweep`'s nightly report gains a **Funnel** section: stage table, conversion rate (newly saved vs cached overall), under-gate count, and top drop classes rolled up to `<stage>:<class>`.

## Gates run locally

- `lint:ci` — **0 errors** (434 warnings, cap 700)
- `typecheck` — **clean**
- `next build` — **succeeds**
- `jest` — **1302 passed**, 17 new tests added

Pre-existing failures unchanged: the `does NOT fast-path "canned tuna in water"` case **fails identically on clean master** (verified by stashing), and `seed-curated` needs a live DB.

**Bundle/CI notes:** no ONNX/bundle change (server + script side only), so no Vercel 250MB impact. No new `process.env.*`, so `env-example-check` is unaffected. The migration is additive/nullable on `MappingEventLog` only.

## Not in this PR

F2 (failure-class registry), F3 (triage driver), F4 (multi-agent triage workflow) — deliberately deferred until there's real funnel data to design against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx