### PR TITLE
fix(nutrition): stop shipping fabricated zero nutrition (funnel fix 1)

### DIFF
--- a/scripts/ops/backfill-fatsecret-grams.ts
+++ b/scripts/ops/backfill-fatsecret-grams.ts
@@ -1,0 +1,418 @@
+#!/usr/bin/env ts-node
+/**
+ * backfill-fatsecret-grams.ts — repair FatSecretFood rows whose
+ * nutrientsPer100g is `{}` because their only serving is measured in ML.
+ *
+ * The defect: derivePer100gFromServings (src/lib/mapping/fatsecret-lane.ts)
+ * only accepts a serving with metric_serving_unit === 'g' or an explicit
+ * serving_weight_grams. A serving reported as "1 cup (240 ml)" persists as
+ * FatSecretServing.volumeMl = 240 with grams = NULL, so the food is written
+ * with nutrientsPer100g = {} — it serves 0 kcal everywhere downstream, and
+ * every one of its servings is invisible to the serving-option paths that
+ * filter on `grams != null && grams > 0`
+ * (build-fatsecret-result.ts usableServings, /api/foods/[id]/serving).
+ *
+ * Measured on the production DB: 3,504 foods carry an empty per-100g panel.
+ *   - 976 are the ML class — recoverable, and the ONLY class this script
+ *     touches: grams = volumeMl x category density.
+ *   - 2,528 are the "1 serving" class, with neither grams nor volumeMl. Their
+ *     per-100g is genuinely underivable and this script LEAVES THEM ALONE.
+ *     Do not "fix" them by assuming a serving weight — that fabricates data.
+ *
+ * Density comes from inferCategoryFromName(food.name) -> categoryDensity(...)
+ * (src/lib/units/density.ts), defaulting to 1.0 g/ml (water) when the name
+ * matches no category. This class is overwhelmingly beverages/condiments, so
+ * water is the right neutral prior: it is exact for the drinks that dominate
+ * the class and errs small (<=10%) for the sauces that do not.
+ *
+ * Grams are written for EVERY serving of a repaired food that has volumeMl > 0
+ * and grams IS NULL (not just the per-100g anchor) — the density applies
+ * equally to "1 cup" and "1 fl oz", and it is what un-breaks serving options.
+ * Existing non-null grams are never overwritten.
+ *
+ * nutrientsPer100g is then recomputed by mirroring derivePer100gFromServings
+ * exactly: the serving with the LARGEST derived grams that carries calories,
+ * scaled by 100/grams, keys `calories`/`protein`/`carbs`/`fat` plus optional
+ * `fiber`/`sugars`/`saturatedFat` rounded to 2dp, and `sodium` converted from
+ * fatsecret's mg to GRAMS (Math.round(mg * factor) / 1000) to match the
+ * OffFood convention.
+ *
+ * Any result that lands above the physical ceilings (>900 kcal/100g, or
+ * protein+carbs+fat > 105 g/100g) is logged and SKIPPED, not written: it means
+ * the density guess or the source panel is wrong, and a corrupt panel is worse
+ * than an empty one.
+ *
+ * DRY-RUN BY DEFAULT — nothing is written without --apply.
+ *
+ * Run (from repo root; DATABASE_URL must point at the target DB):
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     scripts/ops/backfill-fatsecret-grams.ts [--apply] [--limit N] [--verbose]
+ *
+ * Flags:
+ *   --dry-run   report only (the default; accepted for explicitness)
+ *   --apply     actually write the grams + per-100g panels
+ *   --limit N   stop after examining N candidate foods (foods whose panel is
+ *               actually empty — so a small --limit is a real smoke test)
+ *   --verbose   print a before -> after sample table
+ *
+ * Idempotent: a repaired food no longer has an empty panel, so re-runs skip it.
+ */
+import 'dotenv/config';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { inferCategoryFromName, categoryDensity } from '../../src/lib/units/density';
+
+const prisma = new PrismaClient();
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+const APPLY = args.includes('--apply');
+const VERBOSE = args.includes('--verbose');
+const LIMIT = argValue('--limit') ? parseInt(argValue('--limit')!, 10) : undefined;
+
+const READ_PAGE = 500;
+const WRITE_BATCH = 200;
+const SAMPLE_ROWS = 25;
+
+/** Water, for names that match no density category. */
+const FALLBACK_DENSITY_GML = 1.0;
+
+// Physical ceilings — pure fat is 900 kcal/100g, and macros cannot exceed the
+// mass they are measured in (105 leaves headroom for label rounding).
+const MAX_KCAL_PER_100G = 900;
+const MAX_MACRO_SUM_PER_100G = 105;
+
+/** Per-100g shape written to FatSecretFood.nutrientsPer100g. Mirrors
+ *  FsNutrientsPer100g in src/lib/mapping/fatsecret-lane.ts. */
+interface Per100g {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    fiber?: number;
+    sugars?: number;
+    sodium?: number;
+    saturatedFat?: number;
+}
+
+interface ServingRow {
+    id: string;
+    description: string;
+    grams: number | null;
+    volumeMl: number | null;
+    nutrients: Prisma.JsonValue | null;
+}
+
+interface FoodRow {
+    fsId: string;
+    name: string;
+    nutrientsPer100g: Prisma.JsonValue;
+    servings: ServingRow[];
+}
+
+interface Repair {
+    fsId: string;
+    name: string;
+    category: string;
+    densityGml: number;
+    /** servingId -> derived grams, for every ml serving missing grams. */
+    gramsByServing: Array<{ id: string; grams: number }>;
+    anchorMl: number;
+    anchorGrams: number;
+    per100: Per100g;
+}
+
+interface Rejection {
+    fsId: string;
+    name: string;
+    reason: string;
+}
+
+/** True when the stored panel carries nothing at all (JSON null or `{}`).
+ *  Deliberately strict: a partially-populated panel is somebody else's bug. */
+function isEmptyPer100g(v: Prisma.JsonValue): boolean {
+    if (v === null || v === undefined) return true;
+    if (typeof v !== 'object' || Array.isArray(v)) return false;
+    return Object.keys(v).length === 0;
+}
+
+/** Finite numeric field out of a FatSecretServing.nutrients Json blob. */
+function num(nutrients: Prisma.JsonValue | null, key: string): number | undefined {
+    if (!nutrients || typeof nutrients !== 'object' || Array.isArray(nutrients)) return undefined;
+    const v = (nutrients as Record<string, unknown>)[key];
+    return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+function round2(v: number): number {
+    return Math.round(v * 100) / 100;
+}
+
+/** Density for a food name: category default, else water. */
+function densityFor(name: string): { category: string; densityGml: number } {
+    const category = inferCategoryFromName(name);
+    const density = categoryDensity(category);
+    return {
+        category: category ?? 'none',
+        densityGml: density ?? FALLBACK_DENSITY_GML,
+    };
+}
+
+/**
+ * Scale one serving's raw macros to 100 g. Byte-for-byte the same key names,
+ * units and rounding as derivePer100gFromServings — including sodium mg -> g.
+ */
+function per100FromServing(nutrients: Prisma.JsonValue | null, grams: number): Per100g | null {
+    if (!(grams > 0)) return null;
+    const factor = 100 / grams;
+    const scale = (v: number | undefined): number | undefined =>
+        v === undefined ? undefined : round2(v * factor);
+
+    const per100: Per100g = {
+        calories: scale(num(nutrients, 'calories')) ?? 0,
+        protein: scale(num(nutrients, 'protein')) ?? 0,
+        carbs: scale(num(nutrients, 'carbohydrate')) ?? 0,
+        fat: scale(num(nutrients, 'fat')) ?? 0,
+    };
+
+    const fiber = scale(num(nutrients, 'fiber'));
+    if (fiber !== undefined) per100.fiber = fiber;
+    const sugars = scale(num(nutrients, 'sugar'));
+    if (sugars !== undefined) per100.sugars = sugars;
+    // fatsecret sodium is mg per serving; OffFood convention stores grams.
+    const sodiumMg = num(nutrients, 'sodium');
+    if (sodiumMg !== undefined) per100.sodium = Math.round(sodiumMg * factor) / 1000;
+    const saturatedFat = scale(num(nutrients, 'saturatedFat'));
+    if (saturatedFat !== undefined) per100.saturatedFat = saturatedFat;
+
+    return per100;
+}
+
+/** Physical-plausibility gate. Returns a reason string when the panel is refused. */
+function sanityRefusal(per100: Per100g): string | null {
+    if (per100.calories > MAX_KCAL_PER_100G) {
+        return `calories ${per100.calories}/100g > ${MAX_KCAL_PER_100G}`;
+    }
+    const macroSum = per100.protein + per100.carbs + per100.fat;
+    if (macroSum > MAX_MACRO_SUM_PER_100G) {
+        return `macro sum ${round2(macroSum)}g/100g > ${MAX_MACRO_SUM_PER_100G}`;
+    }
+    return null;
+}
+
+/** Build the repair for one food, or explain why it is not repairable. */
+function planRepair(food: FoodRow): { repair?: Repair; rejection?: Rejection } {
+    const { category, densityGml } = densityFor(food.name);
+
+    // Derive grams for every ml serving that lacks them; never clobber real grams.
+    const derived = food.servings
+        .filter(s => s.grams == null && s.volumeMl != null && s.volumeMl > 0)
+        .map(s => ({ serving: s, grams: round2(s.volumeMl! * densityGml) }))
+        .filter(d => d.grams > 0);
+
+    if (derived.length === 0) {
+        return { rejection: { fsId: food.fsId, name: food.name, reason: 'no ml serving to convert' } };
+    }
+
+    // Same preference as derivePer100gFromServings: LARGEST usable grams that
+    // carries calories. (The exact-100g-metric-panel short circuit cannot fire
+    // here — by construction none of these servings is a gram panel.)
+    let anchor: { serving: ServingRow; grams: number } | null = null;
+    for (const d of derived) {
+        if (num(d.serving.nutrients, 'calories') === undefined) continue;
+        if (!anchor || d.grams > anchor.grams) anchor = d;
+    }
+    if (!anchor) {
+        return { rejection: { fsId: food.fsId, name: food.name, reason: 'no ml serving carries calories' } };
+    }
+
+    const per100 = per100FromServing(anchor.serving.nutrients, anchor.grams);
+    if (!per100) {
+        return { rejection: { fsId: food.fsId, name: food.name, reason: 'anchor serving derived 0 g' } };
+    }
+
+    const refusal = sanityRefusal(per100);
+    if (refusal) {
+        return {
+            rejection: {
+                fsId: food.fsId,
+                name: food.name,
+                reason: `implausible (${refusal}) from ${anchor.serving.volumeMl}ml x ${densityGml} = ${anchor.grams}g`,
+            },
+        };
+    }
+
+    return {
+        repair: {
+            fsId: food.fsId,
+            name: food.name,
+            category,
+            densityGml,
+            gramsByServing: derived.map(d => ({ id: d.serving.id, grams: d.grams })),
+            anchorMl: anchor.serving.volumeMl!,
+            anchorGrams: anchor.grams,
+            per100,
+        },
+    };
+}
+
+/** Write one batch of repairs atomically. */
+async function flush(batch: Repair[]): Promise<void> {
+    if (batch.length === 0) return;
+    const ops: Prisma.PrismaPromise<unknown>[] = [];
+    for (const r of batch) {
+        for (const s of r.gramsByServing) {
+            ops.push(
+                prisma.fatSecretServing.update({
+                    where: { id: s.id },
+                    data: { grams: s.grams },
+                })
+            );
+        }
+        ops.push(
+            prisma.fatSecretFood.update({
+                where: { fsId: r.fsId },
+                data: { nutrientsPer100g: r.per100 as unknown as Prisma.InputJsonObject },
+            })
+        );
+    }
+    await prisma.$transaction(ops);
+}
+
+function printSample(repairs: Repair[]): void {
+    console.log('\nsample (before -> after):');
+    console.log(
+        '  ' +
+        'food'.padEnd(42) +
+        'ml'.padStart(8) +
+        'dens'.padStart(7) +
+        '  ' + 'category'.padEnd(11) +
+        'grams'.padStart(9) +
+        'kcal/100g'.padStart(11)
+    );
+    for (const r of repairs.slice(0, SAMPLE_ROWS)) {
+        const name = r.name.length > 40 ? r.name.slice(0, 39) + '…' : r.name;
+        console.log(
+            '  ' +
+            name.padEnd(42) +
+            String(r.anchorMl).padStart(8) +
+            r.densityGml.toFixed(2).padStart(7) +
+            '  ' + r.category.padEnd(11) +
+            r.anchorGrams.toFixed(1).padStart(9) +
+            r.per100.calories.toFixed(1).padStart(11)
+        );
+    }
+    if (repairs.length > SAMPLE_ROWS) {
+        console.log(`  ... and ${repairs.length - SAMPLE_ROWS} more`);
+    }
+}
+
+async function main() {
+    console.log(
+        `backfill-fatsecret-grams — mode: ${APPLY ? 'APPLY (writing)' : 'dry-run (report only)'}` +
+        (LIMIT ? `, limit ${LIMIT}` : '')
+    );
+
+    let scanned = 0;
+    let candidates = 0;
+    let repaired = 0;
+    let skippedSanity = 0;
+    let skippedNoUsable = 0;
+    const repairs: Repair[] = [];
+    const rejections: Rejection[] = [];
+    let batch: Repair[] = [];
+    let cursor: string | undefined;
+    let done = false;
+
+    while (!done) {
+        // Relation filter narrows the read to the ml class; the empty-panel
+        // test runs in JS so it never depends on Json-equality semantics.
+        const page: FoodRow[] = await prisma.fatSecretFood.findMany({
+            where: { servings: { some: { volumeMl: { gt: 0 } } } },
+            select: {
+                fsId: true,
+                name: true,
+                nutrientsPer100g: true,
+                servings: {
+                    select: {
+                        id: true,
+                        description: true,
+                        grams: true,
+                        volumeMl: true,
+                        nutrients: true,
+                    },
+                },
+            },
+            orderBy: { fsId: 'asc' },
+            take: READ_PAGE,
+            ...(cursor ? { skip: 1, cursor: { fsId: cursor } } : {}),
+        });
+        if (page.length === 0) break;
+        cursor = page[page.length - 1].fsId;
+        if (page.length < READ_PAGE) done = true;
+
+        for (const food of page) {
+            scanned++;
+            if (!isEmptyPer100g(food.nutrientsPer100g)) continue;
+
+            candidates++;
+            const { repair, rejection } = planRepair(food);
+            if (rejection) {
+                rejections.push(rejection);
+                if (rejection.reason.startsWith('implausible')) skippedSanity++;
+                else skippedNoUsable++;
+            } else if (repair) {
+                repaired++;
+                repairs.push(repair);
+                batch.push(repair);
+                if (batch.length >= WRITE_BATCH) {
+                    if (APPLY) await flush(batch);
+                    console.log(`  ...${repaired} repaired`);
+                    batch = [];
+                }
+            }
+
+            if (LIMIT && candidates >= LIMIT) {
+                done = true;
+                break;
+            }
+        }
+    }
+
+    if (APPLY) await flush(batch);
+
+    if (rejections.length > 0) {
+        console.log(`\nskipped (${rejections.length}):`);
+        for (const r of rejections.slice(0, SAMPLE_ROWS)) {
+            console.log(`  fs_${r.fsId}  "${r.name}"  — ${r.reason}`);
+        }
+        if (rejections.length > SAMPLE_ROWS) {
+            console.log(`  ... and ${rejections.length - SAMPLE_ROWS} more`);
+        }
+    }
+
+    if (VERBOSE && repairs.length > 0) printSample(repairs);
+
+    const servingWrites = repairs.reduce((n, r) => n + r.gramsByServing.length, 0);
+    console.log(
+        `\nsummary: scanned ${scanned} (${candidates} with an empty per-100g panel), ` +
+        `${APPLY ? 'repaired' : 'would repair'} ${repaired} foods (${servingWrites} serving grams), ` +
+        `skipped-by-sanity ${skippedSanity}, skipped-no-usable-serving ${skippedNoUsable}`
+    );
+
+    if (!APPLY) {
+        console.log('dry-run: nothing written. Re-run with --apply to persist.');
+    } else {
+        console.log('done. The 2,528 "1 serving" foods remain empty by design — their per-100g is underivable.');
+    }
+}
+
+main()
+    .catch(err => {
+        console.error('❌ Crashed:', err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -160,7 +160,9 @@ export async function POST(req: NextRequest) {
     const { forceSegmentText } = await import('@/lib/nlp/heuristic-segmenter');
     const { parseIngredientLine } = await import('@/lib/parse/ingredient-line');
     const { mapIngredientWithFallback } = await import('@/lib/mapping/map-ingredient-with-fallback');
-    const { resolveFoodDetails } = await import('@/lib/nlp/resolve-payload');
+    const { resolveFoodDetails, isDegenerateNutrition, per100gFromBilledMacros } =
+      await import('@/lib/nlp/resolve-payload');
+    const { logger } = await import('@/lib/logger');
 
     const body = await req.json();
     const { text, items: inputItems } = body;
@@ -339,6 +341,24 @@ export async function POST(req: NextRequest) {
 
       const details = await resolveFoodDetails(mapped.foodId, mapped.servingDescription);
 
+      // `nutrition` below reads mapped.* (authoritative for this line) while
+      // nutritionPer100g came wholly from the food-row re-read. When the row
+      // isn't there yet — every first sighting of a fatsecret food, which is
+      // persisted by a background task — that split shipped correct serving
+      // calories next to kcal100: 0, and the client rescales by kcal100. Fall
+      // back to the line's own macros so the two can't contradict each other.
+      const derivedPer100g = isDegenerateNutrition(details.nutritionPer100g)
+        ? per100gFromBilledMacros(mapped)
+        : null;
+      const nutritionPer100g = derivedPer100g
+        ? { ...details.nutritionPer100g, ...derivedPer100g }
+        : details.nutritionPer100g;
+      if (derivedPer100g) {
+        logger.debug('parse.per100g_derived_from_billed', {
+          foodId: mapped.foodId, foodName: mapped.foodName, grams: mapped.grams,
+        });
+      }
+
       const scale = mapped.grams / 100;
       const nutrition = {
         calories: Number(mapped.kcal.toFixed(1)),
@@ -374,7 +394,7 @@ export async function POST(req: NextRequest) {
         unit,
         grams: mapped.grams,
         nutrition,
-        nutritionPer100g: details.nutritionPer100g,
+        nutritionPer100g,
         servingOptions: details.servingOptions,
         // Funnel taxonomy (sprint F1) — diagnostic class IDs, additive. Lets
         // offline warm batches (scripts/eval/warm-cache.ts) read each seed's

--- a/src/lib/mapping/__tests__/fatsecret-lane.test.ts
+++ b/src/lib/mapping/__tests__/fatsecret-lane.test.ts
@@ -301,6 +301,105 @@ describe('per-100g derivation', () => {
             { description: 'cup', grams: 240 }, // measurementDescription fallback
         ]);
     });
+
+    // ml servings (funnel first read, Jul 2026). 976 of the 3,504 foods that
+    // ended up with an empty nutrientsPer100g in production had a single
+    // ml-only serving; rejecting the unit discarded complete nutrition.
+    it('derives grams from an ml-only serving, falling back to water density', async () => {
+        const per100 = lane.derivePer100gFromServings(
+            [
+                serving({
+                    id: 'pouch',
+                    description: '1 pouch',
+                    metricServingAmount: 177,
+                    metricServingUnit: 'ml',
+                    calories: 90,
+                    carbohydrate: 25,
+                    protein: 0,
+                    fat: 0,
+                }),
+            ],
+            'Zorbex', // no category keyword → 1.0 g/ml
+        );
+
+        // 177 ml * 1.0 g/ml -> 177 g; 90 kcal / 177 g * 100 = 50.85
+        expect(per100).toMatchObject({ calories: 50.85, carbs: 14.12 });
+    });
+
+    it('routes a juice pouch through the fruit density, not the water default', async () => {
+        const per100 = lane.derivePer100gFromServings(
+            [
+                serving({
+                    id: 'pouch',
+                    description: '1 pouch',
+                    metricServingAmount: 177,
+                    metricServingUnit: 'ml',
+                    calories: 90,
+                }),
+            ],
+            'Capri Sun 100% Juice - Berry',
+        );
+
+        // 177 ml * 0.95 (fruit) -> 168.15 g; 90 / 168.15 * 100 = 53.52
+        expect(per100?.calories).toBeCloseTo(53.52, 1);
+    });
+
+    it('applies category density rather than a flat 1.0 when the name implies one', async () => {
+        const per100 = lane.derivePer100gFromServings(
+            [
+                serving({
+                    id: 'tbsp',
+                    description: '1 tbsp',
+                    metricServingAmount: 15,
+                    metricServingUnit: 'ml',
+                    calories: 120,
+                }),
+            ],
+            'Olive Oil',
+        );
+
+        // oil density 0.91 -> 13.65 g; 120 / 13.65 * 100 = 879.12
+        expect(per100?.calories).toBeCloseTo(879.12, 1);
+    });
+
+    it('still prefers a gram-bearing serving over an ml one', async () => {
+        const per100 = lane.derivePer100gFromServings(
+            [
+                serving({
+                    id: 'ml',
+                    description: '1 cup',
+                    metricServingAmount: 240,
+                    metricServingUnit: 'ml',
+                    calories: 500,
+                }),
+                metric100Serving(),
+            ],
+            'Whole Milk',
+        );
+
+        // The exact 100 g panel short-circuits regardless of ml servings.
+        expect(per100).toMatchObject({ calories: 250, protein: 20 });
+    });
+
+    it('persists the density-derived grams so serving options stop being empty', async () => {
+        const hit = summary({
+            servings: [
+                serving({
+                    id: 'bottle',
+                    description: '1 bottle',
+                    metricServingAmount: 591,
+                    metricServingUnit: 'ml',
+                    calories: 140,
+                }),
+            ],
+        });
+
+        await lane.persistFatSecretHits([hit]);
+
+        const servingWrite = mockPrisma.fatSecretServing.upsert.mock.calls[0][0];
+        expect(servingWrite.create.grams).toBe(591); // 591 ml * 1.0
+        expect(servingWrite.create.volumeMl).toBe(591); // raw ml still retained
+    });
 });
 
 // ============================================================

--- a/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
+++ b/src/lib/mapping/__tests__/validated-mapping-save-gates.test.ts
@@ -528,6 +528,66 @@ describe('save-time macro-plausibility gate interplay', () => {
     });
 });
 
+// Degenerate-nutrition gate (funnel first read, Jul 2026). FoodMapping stores
+// identity only, so caching a pick that hydrates to nothing pins the key to a
+// 0 kcal record for every later request.
+describe('zero-macro save gate', () => {
+    it('rejects a pick whose per-100g macros are all zero', async () => {
+        await saveValidatedMapping(
+            'glazed munchkins',
+            makeMapping({ foodId: 'fs_68758329', foodName: 'Glazed Munchkins' }),
+            validation,
+            { nutrientsPer100g: { kcal: 0, protein: 0, carbs: 0, fat: 0 } },
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+        expect(mockFoodMappingFindUnique).not.toHaveBeenCalled(); // pre-DB, like the other macro gates
+    });
+
+    it('tags the rejection as save_rejected:zero_macros', async () => {
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+        await saveValidatedMapping(
+            'moussaka',
+            makeMapping({ foodId: 'fs_1', foodName: 'Moussaka' }),
+            validation,
+            { nutrientsPer100g: { kcal: 0, protein: 0, carbs: 0, fat: 0 }, telemetry },
+        );
+        expect(telemetry.funnelStage).toBe('save_rejected');
+        expect(telemetry.dropReason).toBe('save_rejected:zero_macros');
+    });
+
+    it('treats absent macros the same as zero ones', async () => {
+        await saveValidatedMapping(
+            'gyro',
+            makeMapping({ foodId: 'fs_2697224', foodName: 'Gyro' }),
+            validation,
+            { nutrientsPer100g: {} },
+        );
+        expect(mockFoodMappingUpsert).not.toHaveBeenCalled();
+    });
+
+    it('lets a single non-zero macro through — only ALL-zero is degenerate', async () => {
+        // Zero-calorie foods that still carry a macro reading are real data.
+        // (Deliberately not a produce name: the plausibility gate's own
+        // produce floor would reject 0 kcal there for a different reason.)
+        await saveValidatedMapping(
+            'test food',
+            makeMapping({ foodId: 'off_1111111111111', foodName: 'Test Food' }),
+            validation,
+            { nutrientsPer100g: { kcal: 0, protein: 0, carbs: 3, fat: 0 } },
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when the caller supplies no macros at all (grams<=0 path stays ungated)', async () => {
+        await saveValidatedMapping(
+            'diet coke',
+            makeMapping({ foodId: 'off_1111111111111', foodName: 'Diet Coke', grams: 0 }),
+            validation,
+        );
+        expect(mockFoodMappingUpsert).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('FIX 3: bare-category takeover save gate', () => {
     it('rejects "special k red berries" collapsing into a bare "Cereal"', async () => {
         await saveValidatedMapping(

--- a/src/lib/mapping/fatsecret-lane.ts
+++ b/src/lib/mapping/fatsecret-lane.ts
@@ -28,6 +28,7 @@ import {
 import type { UnifiedCandidate } from './gather-candidates';
 import { registerBackgroundTask } from './deferred-hydration';
 import { queryTokenCoverage } from '../search/query-token-coverage';
+import { inferCategoryFromName, categoryDensity } from '../units/density';
 
 // ============================================================
 // Client Singleton (lazy; unit tests inject their own)
@@ -78,8 +79,22 @@ export interface FsNutrientsPer100g {
     saturatedFat?: number;
 }
 
-/** Usable gram weight of a serving, or null. */
-function servingGramsOf(s: FatSecretApiServing): number | null {
+/**
+ * Usable gram weight of a serving, or null.
+ *
+ * `foodName` is optional only so the volume branch can degrade to water
+ * density; pass it wherever it's available.
+ *
+ * The ml branch matters more than it looks. fatsecret reports a large share of
+ * beverages and condiments with `metric_serving_unit = "ml"` and no gram weight
+ * at all — 976 of the 3,504 foods that ended up with an empty
+ * `nutrientsPer100g` in production had exactly that shape (Capri Sun 177 ml,
+ * Gatorade 591 ml, Heinz relish 15 ml). Returning null for them threw away
+ * complete, correct nutrition over a unit we can convert. The legacy lane's
+ * `gramsForServing` has always applied category density here; this restores
+ * parity. `volumeMl` is persisted separately, so nothing is lost by deriving.
+ */
+function servingGramsOf(s: FatSecretApiServing, foodName?: string | null): number | null {
     if (
         s.metricServingUnit?.toLowerCase() === 'g' &&
         typeof s.metricServingAmount === 'number' &&
@@ -94,6 +109,15 @@ function servingGramsOf(s: FatSecretApiServing): number | null {
         s.servingWeightGrams > 0
     ) {
         return s.servingWeightGrams;
+    }
+    const ml = servingVolumeMlOf(s);
+    if (ml != null) {
+        // 1.0 g/ml (water-like) is the right default here rather than a
+        // refusal: the ml servings fatsecret reports are overwhelmingly
+        // beverages, whose density is within a few percent of water.
+        const category = foodName ? inferCategoryFromName(foodName) : null;
+        const density = (category ? categoryDensity(category) : undefined) ?? 1.0;
+        return round2(ml * density);
     }
     return null;
 }
@@ -125,7 +149,8 @@ function round2(v: number): number {
  * as OFF rows without nutrientsPer100g).
  */
 export function derivePer100gFromServings(
-    servings: FatSecretApiServing[] | undefined | null
+    servings: FatSecretApiServing[] | undefined | null,
+    foodName?: string | null
 ): FsNutrientsPer100g | null {
     if (!servings || servings.length === 0) return null;
 
@@ -142,7 +167,7 @@ export function derivePer100gFromServings(
             chosenGrams = 100;
             break; // exact per-100g panel — done
         }
-        const grams = servingGramsOf(s);
+        const grams = servingGramsOf(s, foodName);
         if (grams != null && grams > chosenGrams) {
             chosen = s;
             chosenGrams = grams;
@@ -202,12 +227,12 @@ function toUnifiedCandidate(
     index: number,
     query: string
 ): UnifiedCandidate {
-    const per100 = derivePer100gFromServings(hit.servings);
+    const per100 = derivePer100gFromServings(hit.servings, hit.name);
 
     const servings = (hit.servings ?? [])
         .map(s => ({
             description: (s.description ?? s.measurementDescription ?? '').trim(),
-            grams: servingGramsOf(s),
+            grams: servingGramsOf(s, hit.name),
         }))
         .filter((s): s is { description: string; grams: number } =>
             Boolean(s.description) && s.grams != null
@@ -281,7 +306,7 @@ export async function persistFatSecretHits(hits: FatSecretFoodSummary[]): Promis
 
     for (const hit of hits) {
         try {
-            const per100 = derivePer100gFromServings(hit.servings);
+            const per100 = derivePer100gFromServings(hit.servings, hit.name);
             const defaultServingId = hit.servings?.[0]?.id ?? null;
 
             const foodData = {
@@ -308,7 +333,7 @@ export async function persistFatSecretHits(hits: FatSecretFoodSummary[]): Promis
                 const servingData = {
                     description,
                     measurementDescription: s.measurementDescription ?? null,
-                    grams: servingGramsOf(s),
+                    grams: servingGramsOf(s, hit.name),
                     volumeMl: servingVolumeMlOf(s),
                     numberOfUnits: s.numberOfUnits ?? null,
                     // omit when null: Json? columns reject plain JS null writes

--- a/src/lib/mapping/macro-plausibility.ts
+++ b/src/lib/mapping/macro-plausibility.ts
@@ -25,6 +25,29 @@ export interface MacroPlausibilityInput {
     fat?: number | null;
 }
 
+/**
+ * True when every macro reads as zero (or is absent) — a record carrying no
+ * nutrition at all.
+ *
+ * Deliberately NOT folded into assessMacroPlausibility: that function's bounds
+ * layer is shared with rank time, where an all-zero candidate is already
+ * handled by hasNullOrInvalidMacros, and where a hard drop would change
+ * ranking. This is a save-time-only signal.
+ *
+ * Absent and zero are treated alike on purpose. A record that omits every
+ * macro is no more informative than one that reports them as zero, and the
+ * per-100g blocks reaching this code are built by division (kcal / grams), so
+ * a missing input surfaces as an explicit 0 about as often as as a null.
+ */
+export function isAllZeroMacros(n?: MacroPlausibilityInput | null): boolean {
+    if (!n) return false;
+    const kcal = n.kcal ?? n.calories ?? 0;
+    return (kcal ?? 0) === 0
+        && (n.protein ?? 0) === 0
+        && (n.carbs ?? 0) === 0
+        && (n.fat ?? 0) === 0;
+}
+
 export interface MacroPlausibilityResult {
     /** True when no checks fired. */
     plausible: boolean;

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -15,7 +15,7 @@ import { normalizeQuery } from '../search/normalize';
 import { logger } from '../logger';
 import { hasCoreTokenMismatch } from './filter-candidates';
 import { isCorruptExclusionEnabled } from './corrupt-mark';
-import { assessSaveTimePlausibility } from './macro-plausibility';
+import { assessSaveTimePlausibility, isAllZeroMacros } from './macro-plausibility';
 import type { MacroPlausibilityInput, ExpectedNutritionPer100g } from './macro-plausibility';
 import { detectBrandInQuery } from './brand-detector';
 import { markSaveRejected, normalizeClassId, type FunnelSink } from './funnel';
@@ -555,6 +555,31 @@ export async function saveValidatedMapping(
             foodName: mapping.foodName,
             brandName: mapping.brandName,
         });
+    }
+
+    // Degenerate-nutrition gate (funnel first read, Jul 2026): a pick whose
+    // per-100g macros are ALL zero has no nutrition to give. The plausibility
+    // gate below can't catch it — all-zero passes every bounds check (nothing
+    // is negative, the macro sum is 0) and Atwater compares 0 against 0 — so
+    // such a pick sailed through at confidence 0.95-1.00. FoodMapping stores
+    // identity only, so caching one pins the key to a record that hydrates to
+    // 0 kcal for every later request, long after this one.
+    //
+    // Genuinely zero-calorie foods exist (water, black coffee, diet soda), but
+    // an all-zero row is far more often a data gap than a real measurement, and
+    // declining to CACHE it costs only a repeat lookup — this request is served
+    // either way. Water and ice short-circuit at the fast path and never
+    // reach a save.
+    if (options?.nutrientsPer100g && isAllZeroMacros(options.nutrientsPer100g)) {
+        logger.warn('validated_mapping.save_rejected_zero_macros', {
+            rawIngredient,
+            normalizedForm,
+            foodName: mapping.foodName,
+            brandName: mapping.brandName,
+            foodId: mapping.foodId,
+        });
+        markSaveRejected(options?.telemetry, 'zero_macros');
+        return;
     }
 
     // Save-time macro-plausibility gate (PR D, Jul 2026): picks that survive

--- a/src/lib/nlp/__tests__/resolve-payload-per100g.test.ts
+++ b/src/lib/nlp/__tests__/resolve-payload-per100g.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-100g fallback for lines whose food row can't supply nutrition.
+ *
+ * Guards the fatsecret persist race: FatSecretFood rows are written by a
+ * background task, so the first-ever sighting of one resolves against a row
+ * that isn't there yet. Before this fallback the API returned a correct
+ * serving value next to kcal100 = 0, and the mobile client rescales portions
+ * by multiplying kcal100 — so nudging the portion control zeroed the entry.
+ */
+
+// Both functions under test are pure, but the module imports prisma at load.
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: { findUnique: jest.fn() },
+        offFood: { findUnique: jest.fn() },
+        fdcFood: { findUnique: jest.fn() },
+    },
+}));
+
+import { isDegenerateNutrition, per100gFromBilledMacros } from '../resolve-payload';
+
+const EMPTY = {
+    kcal100: 0, protein100: 0, carbs100: 0, fat100: 0,
+    fiber100: 0, sugar100: 0, sodium100: 0,
+};
+
+describe('isDegenerateNutrition', () => {
+    it('flags the all-zero block resolveFoodDetails starts from', () => {
+        expect(isDegenerateNutrition(EMPTY)).toBe(true);
+    });
+
+    it('does not flag a block carrying any macro', () => {
+        expect(isDegenerateNutrition({ ...EMPTY, kcal100: 656 })).toBe(false);
+        expect(isDegenerateNutrition({ ...EMPTY, protein100: 14.3 })).toBe(false);
+        expect(isDegenerateNutrition({ ...EMPTY, carbs100: 12.3 })).toBe(false);
+        expect(isDegenerateNutrition({ ...EMPTY, fat100: 66.4 })).toBe(false);
+    });
+
+    it('ignores fiber/sugar/sodium — those are absent often enough to mean nothing', () => {
+        expect(isDegenerateNutrition({ ...EMPTY, sodium100: 0.4 })).toBe(true);
+    });
+});
+
+describe('per100gFromBilledMacros', () => {
+    it('reproduces the value the food row would have carried', () => {
+        // Measured on the box: cold "kohlrabi fritters" billed 53.5 kcal at
+        // 15 g and reported kcal100 = 0; the next request read the persisted
+        // row and returned 357.
+        expect(per100gFromBilledMacros({
+            grams: 15, kcal: 53.5, protein: 1.4, carbs: 6.2, fat: 2.7,
+        })).toEqual({ kcal100: 356.67, protein100: 9.33, carbs100: 41.33, fat100: 18 });
+    });
+
+    it('is exact at 100 g', () => {
+        expect(per100gFromBilledMacros({
+            grams: 100, kcal: 656, protein: 14.32, carbs: 12.27, fat: 66.43,
+        })).toEqual({ kcal100: 656, protein100: 14.32, carbs100: 12.27, fat100: 66.43 });
+    });
+
+    it('keeps per100g * grams == the billed macros, so client rescaling stays consistent', () => {
+        // This invariant is the whole point: it holds even when `grams` is an
+        // estimate, because both sides are derived from the same number.
+        const billed = { grams: 905, kcal: 1810, protein: 90, carbs: 120, fat: 100 };
+        const per100 = per100gFromBilledMacros(billed)!;
+        expect((per100.kcal100 * billed.grams) / 100).toBeCloseTo(billed.kcal, 1);
+        expect((per100.protein100 * billed.grams) / 100).toBeCloseTo(billed.protein, 1);
+    });
+
+    it('returns null when grams is zero or negative — nothing to divide by', () => {
+        expect(per100gFromBilledMacros({ grams: 0, kcal: 100, protein: 1, carbs: 1, fat: 1 })).toBeNull();
+        expect(per100gFromBilledMacros({ grams: -5, kcal: 100, protein: 1, carbs: 1, fat: 1 })).toBeNull();
+    });
+
+    it('returns null when the line itself has no macros — never invents nutrition', () => {
+        expect(per100gFromBilledMacros({ grams: 100, kcal: 0, protein: 0, carbs: 0, fat: 0 })).toBeNull();
+    });
+
+    it('derives from a partial line (a macro-only record with no calories)', () => {
+        expect(per100gFromBilledMacros({
+            grams: 50, kcal: 0, protein: 10, carbs: 0, fat: 0,
+        })).toEqual({ kcal100: 0, protein100: 20, carbs100: 0, fat100: 0 });
+    });
+});

--- a/src/lib/nlp/resolve-payload.ts
+++ b/src/lib/nlp/resolve-payload.ts
@@ -19,6 +19,74 @@ export function getServingType(label: string): 'weight' | 'volume' | 'count' {
   return 'count';
 }
 
+/** Per-100g block as resolveFoodDetails returns it. */
+export interface ResolvedNutritionPer100g {
+  kcal100: number;
+  protein100: number;
+  carbs100: number;
+  fat100: number;
+  fiber100: number;
+  sugar100: number;
+  sodium100: number;
+}
+
+/**
+ * True when a resolved per-100g block carries no nutrition at all.
+ *
+ * resolveFoodDetails starts from an all-zero literal and overwrites it only if
+ * the food row is found AND that row has nutrients, so all-zero is how this
+ * module spells "unknown" — it cannot distinguish that from a genuine zero.
+ */
+export function isDegenerateNutrition(n: ResolvedNutritionPer100g): boolean {
+  return n.kcal100 === 0 && n.protein100 === 0 && n.carbs100 === 0 && n.fat100 === 0;
+}
+
+/**
+ * Per-100g values implied by a line's own billed macros.
+ *
+ * Used when the food row can't supply nutrition. The mapper is authoritative
+ * for the line — it billed these macros off the candidate that actually won —
+ * whereas resolveFoodDetails re-reads the food row, and the two disagree
+ * whenever the row isn't there yet.
+ *
+ * That gap is routine, not exotic: fatsecret hits are written by a background
+ * task (persistFatSecretHits), so the FIRST-EVER sighting of a fatsecret food
+ * resolves against a row that does not exist or is still empty. Measured on
+ * the box: a cold "kohlrabi fritters" returned a correct serving value of 53.5
+ * kcal alongside kcal100 = 0; the very next identical request returned 357.
+ * Since the mobile client rescales portions by multiplying kcal100
+ * (api-contract §4), the user could log a food correctly and then zero it out
+ * just by nudging the portion control.
+ *
+ * per100g * grams == the billed macros by construction, so a portion change
+ * stays exactly consistent with what was shown even when `grams` is itself an
+ * estimate (fatsecret restaurant items with no metric serving, where grams
+ * comes from an energy-density guess). The absolute weight may be approximate;
+ * the ratio is not.
+ *
+ * Returns null when there is nothing to derive from.
+ */
+export function per100gFromBilledMacros(billed: {
+  grams: number;
+  kcal: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}): Pick<ResolvedNutritionPer100g, 'kcal100' | 'protein100' | 'carbs100' | 'fat100'> | null {
+  if (!(billed.grams > 0)) return null;
+  if (!(billed.kcal > 0) && !(billed.protein > 0) && !(billed.carbs > 0) && !(billed.fat > 0)) {
+    return null;
+  }
+  const factor = 100 / billed.grams;
+  const round2 = (v: number) => Math.round(v * factor * 100) / 100;
+  return {
+    kcal100: round2(billed.kcal),
+    protein100: round2(billed.protein),
+    carbs100: round2(billed.carbs),
+    fat100: round2(billed.fat),
+  };
+}
+
 export async function resolveFoodDetails(foodId: string, matchedServingDescription?: string | null) {
   let name = '';
   let brandName: string | null = null;


### PR DESCRIPTION
First fix off the funnel read (`sync-docs/funnel_first_read_2026-07-24.md`). A 1,158-seed cold warm produced **61 results with all-zero macros**. Investigating them turned up three distinct causes — and corrected the original diagnosis.

## 1. The fatsecret persist race — the real user-facing bug

`persistFatSecretHits` runs as a **background task**, so the first-ever sighting of a fatsecret food resolves `nutritionPer100g` against a row that isn't written yet.

Reproduced on the box:

```
--- CALL 1 (cold) ---
fs_3768 Matzo Fritters | serving kcal= 53.5 | per100g kcal= 0
--- CALL 2 (after persist) ---
fs_3768 Matzo Fritters | serving kcal= 54   | per100g kcal= 357
```

The response shipped **correct serving calories next to `kcal100: 0`**. The mobile client rescales portions by multiplying `kcal100` (api-contract §4) — so a user could log a food correctly and then zero it out just by nudging the portion control.

This also explains why well-formed foods showed zeros in the warm run: Brazil Nuts (656 kcal/100g in the DB), Buckwheat, Boiled Potatoes were all first sightings. **It is not a data-corruption bug**, which is what the original triage concluded.

Fix: the parse route already had the authoritative numbers — `nutrition` is built from `mapped.*`, only `nutritionPer100g` re-read the food row. Derive per-100g from the line's own billed macros when the row can't supply it. `per100g * grams == billed macros` by construction, so a portion change stays exactly consistent even when `grams` is itself an estimate.

## 2. ml-only servings were discarded outright

`servingGramsOf` accepted metric unit `g` or `serving_weight_grams` and returned null for everything else — so a serving reported in **ml** took `nutrientsPer100g` to `{}`. That is **976 of the 3,504** empty-panel foods in production: Capri Sun 177 ml, Gatorade 591 ml, Heinz relish 15 ml.

Apply category density, as the legacy lane's `gramsForServing` has always done. `volumeMl` is still persisted separately, so nothing is lost. Also un-breaks serving options, which filter on `grams != null`.

I checked whether `food.get.v4` returns richer servings than the search summary — **it does not**, same single serving. So re-fetching would not have helped; the unit was the whole problem.

## 3. Nothing stopped an all-zero pick from being cached

All-zero passes every plausibility check — nothing is negative, the macro sum is 0, Atwater compares 0 against 0 — so such picks were saved at confidence 0.95–1.00. `FoodMapping` stores identity only, so the row pins the key to a record that hydrates to 0 kcal for every later request. New gate, new funnel class `save_rejected:zero_macros`.

Scope note: 16 cache rows currently point at empty-panel fs foods, so this gate is a safety net rather than the headline — the race was.

## Backfill

`scripts/ops/backfill-fatsecret-grams.ts`, **dry-run by default**, repairs the 976 ml-serving rows. The other 2,528 are restaurant items with no metric serving at all (`"1 serving"`, no amount) where per-100g is genuinely underivable — deliberately left alone rather than fabricated. All 2,528 do carry correct per-serving macros.

## Verification

- 19 new tests; full suite **1025 passing**, same single pre-existing failure as master (`canned tuna in water` fast-path — confirmed by stashing).
- `lint:ci` 0 errors, `typecheck` clean, `next build` green.
- Box eval gate to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx