### PR TITLE
feat(flywheel): track corpus coverage as a trend, not a one-off

### DIFF
--- a/scripts/eval/coverage-corpus.tsv
+++ b/scripts/eval/coverage-corpus.tsv
@@ -1,0 +1,3308 @@
+domain	baseline	seed
+unlabeled	cached	oatmeal
+breakfast	new	steel cut oats
+breakfast	new	rolled oats
+breakfast	new	instant oatmeal
+breakfast	new	quaker instant oatmeal maple brown sugar
+breakfast	new	quaker oats old fashioned
+breakfast	new	quaker instant oatmeal apple cinnamon
+breakfast	new	overnight oats
+breakfast	new	cream of wheat
+breakfast	new	grits
+breakfast	new	cheese grits
+breakfast	new	shrimp and grits
+unlabeled	cached	cereal
+unlabeled	cached	corn flakes
+breakfast	new	bran flakes
+breakfast	new	shredded wheat
+breakfast	new	puffed rice cereal
+unlabeled	cached	cheerios
+unlabeled	cached	honey nut cheerios
+unlabeled	cached	frosted flakes
+unlabeled	cached	froot loops
+unlabeled	cached	cinnamon toast crunch
+unlabeled	cached	lucky charms
+breakfast	new	special k red berries
+breakfast	new	special k original
+breakfast	new	honey bunches of oats
+unlabeled	cached	raisin bran
+unlabeled	cached	cocoa puffs
+breakfast	new	corn pops
+unlabeled	cached	rice krispies
+unlabeled	cached	cap'n crunch
+breakfast	new	reese's puffs
+unlabeled	cached	fruity pebbles
+unlabeled	cached	cocoa pebbles
+breakfast	new	grape nuts
+breakfast	new	life cereal
+breakfast	new	kix
+breakfast	new	chex
+breakfast	new	cinnamon chex
+breakfast	new	total cereal
+unlabeled	cached	all bran
+breakfast	new	wheaties
+breakfast	new	golden grahams
+unlabeled	cached	trix
+unlabeled	cached	granola
+unlabeled	cached	granola bar
+unlabeled	cached	nature valley granola bar
+breakfast	new	quaker chewy granola bar
+breakfast	new	kind granola bar
+breakfast	new	kashi granola
+breakfast	new	granola with yogurt
+unlabeled	cached	pancakes
+unlabeled	cached	buttermilk pancakes
+breakfast	new	blueberry pancakes
+unlabeled	cached	eggo waffles
+breakfast	new	eggo homestyle waffles
+unlabeled	cached	belgian waffle
+unlabeled	cached	waffles
+unlabeled	cached	french toast
+unlabeled	cached	french toast sticks
+unlabeled	cached	breakfast sandwich
+breakfast	new	egg mcmuffin
+breakfast	new	sausage egg and cheese biscuit
+unlabeled	cached	breakfast burrito
+breakfast	new	bacon egg and cheese sandwich
+breakfast	new	sausage mcmuffin
+breakfast	new	bacon egg and cheese bagel
+breakfast	new	egg white breakfast sandwich
+unlabeled	cached	bacon
+unlabeled	cached	turkey bacon
+breakfast	new	sausage links
+breakfast	new	sausage patty
+breakfast	new	breakfast sausage
+breakfast	new	scrambled eggs
+unlabeled	cached	fried egg
+breakfast	new	poached egg
+breakfast	new	hard boiled egg
+unlabeled	cached	egg whites
+unlabeled	cached	omelette
+breakfast	new	western omelette
+unlabeled	cached	cheese omelette
+unlabeled	cached	veggie omelette
+breakfast	new	eggs benedict
+unlabeled	cached	over easy eggs
+breakfast	new	sunny side up eggs
+unlabeled	cached	bagel
+unlabeled	cached	plain bagel
+unlabeled	cached	everything bagel
+breakfast	new	blueberry bagel
+unlabeled	cached	bagel with cream cheese
+unlabeled	cached	cinnamon raisin bagel
+unlabeled	cached	muffin
+breakfast	new	blueberry muffin
+unlabeled	cached	english muffin
+unlabeled	cached	croissant
+unlabeled	cached	chocolate croissant
+breakfast	new	danish
+unlabeled	cached	cheese danish
+unlabeled	cached	cinnamon roll
+breakfast	new	pop tarts frosted brown sugar cinnamon
+unlabeled	cached	toaster strudel
+unlabeled	cached	toast
+breakfast	new	white toast
+unlabeled	cached	wheat toast
+unlabeled	cached	avocado toast
+breakfast	new	buttered toast
+breakfast	new	toast with peanut butter
+breakfast	new	sourdough toast
+breakfast	new	breakfast bowl
+unlabeled	cached	yogurt parfait
+breakfast	new	chobani oat vanilla
+unlabeled	cached	greek yogurt with granola
+unlabeled	cached	acai bowl
+breakfast	new	egg and potato breakfast bowl
+breakfast	new	ham
+unlabeled	cached	canadian bacon
+unlabeled	cached	hash browns
+unlabeled	cached	breakfast potatoes
+breakfast	new	biscuit
+breakfast	new	biscuits and gravy
+unlabeled	cached	black coffee
+unlabeled	cached	coffee
+unlabeled	cached	espresso
+coffee-tea	new	double espresso
+unlabeled	cached	americano
+coffee-tea	new	iced americano
+unlabeled	cached	latte
+unlabeled	cached	iced latte
+unlabeled	cached	cappuccino
+coffee-tea	new	macchiato
+coffee-tea	new	cortado
+unlabeled	cached	flat white
+unlabeled	cached	cold brew
+coffee-tea	new	nitro cold brew
+unlabeled	cached	iced coffee
+unlabeled	cached	mocha
+coffee-tea	new	iced mocha
+unlabeled	cached	vanilla latte
+coffee-tea	new	caramel latte
+unlabeled	cached	pumpkin spice latte
+coffee-tea	new	decaf coffee
+unlabeled	cached	starbucks caramel macchiato
+coffee-tea	new	starbucks pumpkin spice latte
+coffee-tea	new	starbucks pike place roast
+coffee-tea	new	starbucks caffe latte
+coffee-tea	new	starbucks cappuccino
+unlabeled	cached	starbucks cold brew
+unlabeled	cached	starbucks vanilla sweet cream cold brew
+coffee-tea	new	starbucks nitro cold brew
+unlabeled	cached	starbucks caramel frappuccino
+unlabeled	cached	starbucks mocha frappuccino
+coffee-tea	new	starbucks iced brown sugar oatmilk shaken espresso
+coffee-tea	new	starbucks white chocolate mocha
+coffee-tea	new	starbucks blonde vanilla latte
+coffee-tea	new	starbucks flat white
+coffee-tea	new	starbucks chai tea latte
+coffee-tea	new	starbucks matcha latte
+coffee-tea	new	starbucks london fog
+coffee-tea	new	starbucks americano
+unlabeled	cached	dunkin iced coffee
+coffee-tea	new	dunkin hot coffee
+coffee-tea	new	dunkin caramel craze latte
+coffee-tea	new	dunkin iced caramel craze latte
+coffee-tea	new	dunkin cold brew
+coffee-tea	new	dunkin macchiato
+coffee-tea	new	dunkin frozen coffee
+coffee-tea	new	dunkin matcha latte
+coffee-tea	new	dunkin chai latte
+coffee-tea	new	dunkin midnight coffee
+coffee-tea	new	dunkin french vanilla coffee
+coffee-tea	new	peet's coffee
+coffee-tea	new	peet's cold brew
+coffee-tea	new	peet's caffe mocha
+coffee-tea	new	caribou coffee
+coffee-tea	new	caribou coffee cooler
+coffee-tea	new	caribou northern lite latte
+coffee-tea	new	dutch bros iced coffee
+coffee-tea	new	dutch bros golden eagle
+coffee-tea	new	dutch bros americano
+coffee-tea	new	dutch bros caramelizer
+coffee-tea	new	tim hortons double double
+coffee-tea	new	tim hortons iced capp
+coffee-tea	new	tim hortons french vanilla
+coffee-tea	new	panera hazelnut coffee
+coffee-tea	new	panera dark roast coffee
+coffee-tea	new	starbucks frappuccino bottle
+coffee-tea	new	starbucks doubleshot espresso can
+coffee-tea	new	starbucks triple shot energy
+coffee-tea	new	la colombe draft latte
+coffee-tea	new	la colombe cold brew
+coffee-tea	new	chameleon cold brew
+coffee-tea	new	stok cold brew
+coffee-tea	new	califia farms cold brew coffee
+coffee-tea	new	high brew cold brew
+coffee-tea	new	coffee mate french vanilla creamer
+coffee-tea	new	coffee mate hazelnut creamer
+coffee-tea	new	coffee mate original creamer
+coffee-tea	new	coffee mate sweet italian creme creamer
+coffee-tea	new	half and half
+coffee-tea	new	heavy cream in coffee
+unlabeled	cached	oat milk latte
+coffee-tea	new	almond milk latte
+coffee-tea	new	coconut milk coffee
+unlabeled	cached	coffee with cream and sugar
+coffee-tea	new	coffee with milk
+coffee-tea	new	black coffee with sugar
+coffee-tea	new	sugar free vanilla latte
+unlabeled	cached	black tea
+unlabeled	cached	green tea
+coffee-tea	new	herbal tea
+coffee-tea	new	chamomile tea
+coffee-tea	new	chai tea
+coffee-tea	new	masala chai
+coffee-tea	new	earl grey tea
+coffee-tea	new	peppermint tea
+coffee-tea	new	ginger tea
+coffee-tea	new	oolong tea
+coffee-tea	new	white tea
+coffee-tea	new	rooibos tea
+unlabeled	cached	iced tea
+unlabeled	cached	sweet tea
+unlabeled	cached	unsweetened iced tea
+coffee-tea	new	arizona iced tea
+unlabeled	cached	arizona green tea
+coffee-tea	new	arizona arnold palmer
+coffee-tea	new	pure leaf iced tea
+coffee-tea	new	pure leaf unsweetened tea
+unlabeled	cached	gold peak sweet tea
+coffee-tea	new	gold peak unsweetened tea
+coffee-tea	new	snapple lemon tea
+unlabeled	cached	snapple peach tea
+coffee-tea	new	lipton iced tea
+unlabeled	cached	lipton green tea
+unlabeled	cached	matcha latte
+coffee-tea	new	iced matcha latte
+coffee-tea	new	matcha green tea
+coffee-tea	new	starbucks iced matcha latte
+unlabeled	cached	bubble tea
+coffee-tea	new	boba tea
+coffee-tea	new	taro milk tea
+coffee-tea	new	brown sugar boba milk tea
+unlabeled	cached	thai iced tea
+coffee-tea	new	honeydew milk tea
+coffee-tea	new	jasmine milk tea
+unlabeled	cached	hot chocolate
+coffee-tea	new	hot cocoa
+coffee-tea	new	starbucks hot chocolate
+coffee-tea	new	swiss miss hot chocolate
+coffee-tea	new	peppermint hot chocolate
+unlabeled	cached	coca-cola
+unlabeled	cached	diet coke
+unlabeled	cached	coke zero
+sodas-energy	new	coca-cola classic
+unlabeled	cached	pepsi
+sodas-energy	new	diet pepsi
+sodas-energy	new	pepsi zero sugar
+sodas-energy	new	dr pepper
+sodas-energy	new	diet dr pepper
+unlabeled	cached	sprite
+sodas-energy	new	sprite zero
+unlabeled	cached	mountain dew
+sodas-energy	new	diet mountain dew
+sodas-energy	new	mountain dew zero sugar
+sodas-energy	new	mountain dew baja blast
+unlabeled	cached	7up
+unlabeled	cached	fanta orange
+unlabeled	cached	root beer
+unlabeled	cached	ginger ale
+sodas-energy	new	club soda
+sodas-energy	new	tonic water
+unlabeled	cached	monster energy
+unlabeled	cached	monster ultra zero
+sodas-energy	new	monster mango loco
+unlabeled	cached	red bull
+sodas-energy	new	red bull sugar free
+sodas-energy	new	celsius sparkling kiwi guava
+unlabeled	cached	celsius sparkling orange
+sodas-energy	new	celsius arctic vibe
+unlabeled	cached	bang energy
+sodas-energy	new	bang cotton candy
+unlabeled	cached	alani nu energy drink
+unlabeled	cached	alani nu cosmic stardust
+sodas-energy	new	c4 energy drink
+sodas-energy	new	c4 original carbonated
+sodas-energy	new	ghost energy
+sodas-energy	new	ghost energy sour patch kids
+unlabeled	cached	reign total body fuel
+unlabeled	cached	rockstar energy
+sodas-energy	new	5-hour energy
+unlabeled	cached	gatorade
+unlabeled	cached	gatorade zero
+unlabeled	cached	gatorade fruit punch
+unlabeled	cached	gatorade cool blue
+unlabeled	cached	powerade
+sodas-energy	new	powerade zero
+unlabeled	cached	bodyarmor
+unlabeled	cached	bodyarmor lyte
+unlabeled	cached	prime hydration
+sodas-energy	new	prime hydration blue raspberry
+sodas-energy	new	liquid iv hydration multiplier
+sodas-energy	new	pedialyte
+sodas-energy	new	pedialyte freezer pops
+sodas-energy	new	nuun hydration tablets
+sodas-energy	new	lmnt electrolyte drink mix
+sodas-energy	new	la croix sparkling water
+sodas-energy	new	la croix pamplemousse
+unlabeled	cached	bubly sparkling water
+sodas-energy	new	bubly lime
+sodas-energy	new	waterloo sparkling water
+sodas-energy	new	topo chico mineral water
+sodas-energy	new	spindrift sparkling water
+sodas-energy	new	spindrift grapefruit
+sodas-energy	new	perrier sparkling water
+sodas-energy	new	san pellegrino sparkling water
+sodas-energy	new	sparkling water
+unlabeled	cached	orange juice
+unlabeled	cached	apple juice
+unlabeled	cached	tropicana orange juice
+unlabeled	cached	simply orange
+sodas-energy	new	simply lemonade
+sodas-energy	new	ocean spray cranberry juice
+sodas-energy	new	ocean spray cran-grape
+unlabeled	cached	capri sun
+unlabeled	cached	capri sun pacific cooler
+sodas-energy	new	minute maid orange juice
+sodas-energy	new	minute maid fruit punch
+sodas-energy	new	v8 vegetable juice
+sodas-energy	new	v8 splash
+sodas-energy	new	naked juice green machine
+sodas-energy	new	naked juice mighty mango
+unlabeled	cached	grape juice
+unlabeled	cached	pineapple juice
+unlabeled	cached	cranberry juice
+unlabeled	cached	grapefruit juice
+unlabeled	cached	lemonade
+sodas-energy	new	pink lemonade
+sodas-energy	new	country time lemonade
+sodas-energy	new	minute maid lemonade
+unlabeled	cached	kombucha
+unlabeled	cached	gt's kombucha
+sodas-energy	new	gt's kombucha gingerade
+unlabeled	cached	health-ade kombucha
+sodas-energy	new	health-ade pink lady apple
+unlabeled	cached	chocolate milk
+sodas-energy	new	yoo-hoo
+sodas-energy	new	crystal light
+sodas-energy	new	mio water enhancer
+unlabeled	cached	propel water
+sodas-energy	new	propel fitness water
+unlabeled	cached	vitamin water
+sodas-energy	new	smartwater
+sodas-energy	new	sparkling ice
+sodas-energy	new	sparkling ice black raspberry
+sodas-energy	new	fruit punch
+sodas-energy	new	hi-c
+sodas-energy	new	tampico
+sodas-energy	new	sunny d
+sodas-energy	new	coconut water
+sodas-energy	new	vita coco coconut water
+unlabeled	cached	sports drink
+unlabeled	cached	energy drink
+sodas-energy	new	diet soda
+unlabeled	cached	soda
+sodas-energy	new	starbucks doubleshot energy
+sodas-energy	new	celsius on-the-go
+sodas-energy	new	bang keto coffee
+sodas-energy	new	gatorlyte
+alcohol	new	bud light
+alcohol	new	michelob ultra
+alcohol	new	coors light
+alcohol	new	miller lite
+alcohol	new	modelo especial
+alcohol	new	corona extra
+alcohol	new	stella artois
+alcohol	new	guinness stout
+alcohol	new	heineken
+alcohol	new	budweiser
+alcohol	new	pbr
+alcohol	new	yuengling
+alcohol	new	sam adams boston lager
+alcohol	new	blue moon belgian white
+alcohol	new	ipa
+alcohol	new	hazy ipa
+alcohol	new	double ipa
+alcohol	new	pilsner
+unlabeled	cached	lager
+unlabeled	cached	stout
+alcohol	new	porter
+alcohol	new	sour beer
+alcohol	new	wheat beer
+alcohol	new	amber ale
+alcohol	new	white claw black cherry
+alcohol	new	white claw mango
+alcohol	new	white claw natural lime
+alcohol	new	truly wild berry
+alcohol	new	truly lemonade
+alcohol	new	truly strawberry lemonade
+alcohol	new	high noon watermelon
+alcohol	new	high noon peach
+alcohol	new	high noon pineapple
+alcohol	new	nutrl vodka seltzer
+alcohol	new	bud light seltzer
+alcohol	new	smirnoff ice
+alcohol	new	twisted tea original
+alcohol	new	twisted tea half and half
+alcohol	new	mike's hard lemonade
+alcohol	new	angry orchard hard cider
+alcohol	new	strongbow hard cider
+unlabeled	cached	red wine
+alcohol	new	cabernet sauvignon
+alcohol	new	pinot noir
+alcohol	new	merlot
+alcohol	new	malbec
+alcohol	new	zinfandel
+alcohol	new	shiraz
+alcohol	new	white wine
+alcohol	new	chardonnay
+alcohol	new	sauvignon blanc
+alcohol	new	pinot grigio
+alcohol	new	riesling
+alcohol	new	moscato
+unlabeled	cached	rose wine
+unlabeled	cached	prosecco
+unlabeled	cached	champagne
+alcohol	new	sparkling wine
+unlabeled	cached	white claw
+alcohol	new	truly
+alcohol	new	vodka
+alcohol	new	titos vodka
+alcohol	new	grey goose vodka
+alcohol	new	smirnoff vodka
+alcohol	new	absolut vodka
+alcohol	new	whiskey
+alcohol	new	jack daniels
+alcohol	new	jameson irish whiskey
+alcohol	new	crown royal
+alcohol	new	bourbon
+alcohol	new	makers mark
+alcohol	new	jim beam
+alcohol	new	woodford reserve
+alcohol	new	tequila
+alcohol	new	casamigos tequila
+alcohol	new	patron tequila
+alcohol	new	jose cuervo
+alcohol	new	gin
+alcohol	new	tanqueray gin
+alcohol	new	bombay sapphire
+alcohol	new	rum
+alcohol	new	bacardi rum
+alcohol	new	captain morgan
+alcohol	new	malibu rum
+alcohol	new	scotch
+alcohol	new	johnnie walker
+alcohol	new	glenlivet
+alcohol	new	sake
+unlabeled	cached	margarita
+unlabeled	cached	old fashioned
+unlabeled	cached	moscow mule
+unlabeled	cached	mojito
+unlabeled	cached	martini
+alcohol	new	espresso martini
+alcohol	new	negroni
+alcohol	new	whiskey sour
+alcohol	new	long island iced tea
+unlabeled	cached	pina colada
+alcohol	new	aperol spritz
+alcohol	new	daiquiri
+alcohol	new	cosmopolitan
+alcohol	new	manhattan
+unlabeled	cached	bloody mary
+alcohol	new	paloma
+unlabeled	cached	mimosa
+unlabeled	cached	sangria
+alcohol	new	white claw surge
+alcohol	new	high noon
+alcohol	new	truly punch
+alcohol	new	cutwater vodka soda
+alcohol	new	cutwater margarita
+alcohol	new	on the rocks cocktails margarita
+alcohol	new	crown royal peach
+alcohol	new	fireball whiskey
+alcohol	new	malibu black
+alcohol	new	seagrams 7
+alcohol	new	skinny margarita
+alcohol	new	irish coffee
+alcohol	new	mudslide
+alcohol	new	white russian
+alcohol	new	tequila sunrise
+alcohol	new	kahlua
+unlabeled	cached	mcdonalds big mac
+unlabeled	cached	mcdonalds quarter pounder with cheese
+burger-fastfood	new	mcdonalds double quarter pounder with cheese
+burger-fastfood	new	mcdonalds mcdouble
+burger-fastfood	new	mcdonalds cheeseburger
+burger-fastfood	new	mcdonalds hamburger
+unlabeled	cached	mcdonalds mcchicken
+unlabeled	cached	mcdonalds filet o fish
+burger-fastfood	new	mcdonalds 10 piece chicken mcnuggets
+burger-fastfood	new	mcdonalds 20 piece chicken mcnuggets
+unlabeled	cached	mcdonalds egg mcmuffin
+burger-fastfood	new	mcdonalds sausage mcmuffin with egg
+burger-fastfood	new	mcdonalds bacon egg and cheese biscuit
+burger-fastfood	new	mcdonalds hotcakes
+unlabeled	cached	mcdonalds hash browns
+burger-fastfood	new	mcdonalds french fries
+unlabeled	cached	mcdonalds mcflurry
+burger-fastfood	new	mcdonalds apple pie
+burger-fastfood	new	mcdonalds sausage burrito
+unlabeled	cached	burger king whopper
+burger-fastfood	new	burger king whopper jr
+burger-fastfood	new	burger king double whopper
+burger-fastfood	new	burger king bacon king
+burger-fastfood	new	burger king chicken fries
+burger-fastfood	new	burger king original chicken sandwich
+unlabeled	cached	burger king impossible whopper
+burger-fastfood	new	burger king croissan'wich
+burger-fastfood	new	burger king onion rings
+burger-fastfood	new	burger king french fries
+unlabeled	cached	wendys dave's single
+unlabeled	cached	wendys baconator
+burger-fastfood	new	wendys son of baconator
+unlabeled	cached	wendys spicy chicken sandwich
+burger-fastfood	new	wendys crispy chicken sandwich
+unlabeled	cached	wendys jr bacon cheeseburger
+unlabeled	cached	wendys frosty
+unlabeled	cached	wendys chili
+burger-fastfood	new	wendys biggie fries
+burger-fastfood	new	wendys grilled chicken sandwich
+unlabeled	cached	taco bell crunchwrap supreme
+unlabeled	cached	taco bell chalupa supreme
+burger-fastfood	new	taco bell crunchy taco
+burger-fastfood	new	taco bell soft taco
+burger-fastfood	new	taco bell doritos locos tacos
+burger-fastfood	new	taco bell beefy 5 layer burrito
+unlabeled	cached	taco bell quesarito
+unlabeled	cached	taco bell cheesy gordita crunch
+burger-fastfood	new	taco bell mexican pizza
+burger-fastfood	new	taco bell nachos bellgrande
+burger-fastfood	new	jack in the box jumbo jack
+burger-fastfood	new	jack in the box sourdough jack
+burger-fastfood	new	jack in the box curly fries
+unlabeled	cached	jack in the box tacos
+burger-fastfood	new	jack in the box bacon ultimate cheeseburger
+burger-fastfood	new	jack in the box breakfast jack
+unlabeled	cached	sonic cheeseburger
+burger-fastfood	new	sonic chili cheese tots
+unlabeled	cached	sonic mozzarella sticks
+unlabeled	cached	sonic corn dog
+unlabeled	cached	sonic slush
+burger-fastfood	new	sonic tater tots
+unlabeled	cached	whataburger burger
+unlabeled	cached	whataburger patty melt
+unlabeled	cached	whataburger honey butter chicken biscuit
+burger-fastfood	new	whataburger taquito
+burger-fastfood	new	whataburger onion rings
+burger-fastfood	new	in-n-out double double
+burger-fastfood	new	in-n-out cheeseburger
+burger-fastfood	new	in-n-out animal style fries
+burger-fastfood	new	in-n-out neapolitan shake
+burger-fastfood	new	five guys cheeseburger
+burger-fastfood	new	five guys bacon burger
+burger-fastfood	new	five guys little cheeseburger
+burger-fastfood	new	five guys cajun fries
+burger-fastfood	new	five guys hot dog
+unlabeled	cached	shake shack shackburger
+burger-fastfood	new	shake shack smokeshack
+burger-fastfood	new	shake shack chicken shack
+burger-fastfood	new	shake shack crinkle cut fries
+burger-fastfood	new	shake shack shroom burger
+unlabeled	cached	culvers butterburger
+burger-fastfood	new	culvers cheese curds
+burger-fastfood	new	culvers concrete mixer
+burger-fastfood	new	culvers crinkle cut fries
+burger-fastfood	new	steak n shake steakburger
+burger-fastfood	new	steak n shake double steakburger
+burger-fastfood	new	steak n shake frisco melt
+burger-fastfood	new	steak n shake chili
+burger-fastfood	new	checkers big buford
+burger-fastfood	new	checkers baconzilla
+burger-fastfood	new	checkers famous seasoned fries
+burger-fastfood	new	rallys big buford
+unlabeled	cached	white castle slider
+burger-fastfood	new	white castle cheese slider
+burger-fastfood	new	white castle chicken slider
+burger-fastfood	new	white castle onion rings
+unlabeled	cached	arbys classic roast beef
+burger-fastfood	new	arbys beef n cheddar
+burger-fastfood	new	arbys curly fries
+burger-fastfood	new	arbys jamocha shake
+burger-fastfood	new	arbys chicken tenders
+burger-fastfood	new	arbys reuben
+unlabeled	cached	dairy queen blizzard
+burger-fastfood	new	dairy queen dilly bar
+burger-fastfood	new	dairy queen gravy fries
+burger-fastfood	new	dairy queen chicken strip basket
+burger-fastfood	new	dairy queen deluxe cheeseburger
+burger-fastfood	new	hardees thickburger
+burger-fastfood	new	hardees famous star
+burger-fastfood	new	hardees biscuit
+burger-fastfood	new	carls jr famous star
+burger-fastfood	new	carls jr western bacon cheeseburger
+burger-fastfood	new	carls jr criss cut fries
+burger-fastfood	new	carls jr big carl
+burger-fastfood	new	mcdonalds mcrib
+burger-fastfood	new	mcdonalds mccafe latte
+burger-fastfood	new	mcdonalds sausage biscuit
+burger-fastfood	new	burger king double cheeseburger
+burger-fastfood	new	wendys 4 for 4
+burger-fastfood	new	taco bell power menu bowl
+burger-fastfood	new	taco bell baja blast freeze
+burger-fastfood	new	jack in the box egg rolls
+burger-fastfood	new	sonic footlong quarter pound coney
+burger-fastfood	new	whataburger dr pepper shake
+burger-fastfood	new	five guys milkshake
+burger-fastfood	new	shake shack cheese fries
+burger-fastfood	new	culvers walleye sandwich
+burger-fastfood	new	steak n shake three way chili
+burger-fastfood	new	arbys market fresh sandwich
+burger-fastfood	new	white castle fish slider
+burger-fastfood	new	dairy queen blizzard oreo
+burger-fastfood	new	hardees made from scratch biscuit
+burger-fastfood	new	carls jr the six dollar burger
+burger-fastfood	new	mcdonalds mccrispy
+burger-fastfood	new	burger king ch'king sandwich
+burger-fastfood	new	wendys asiago ranch chicken club
+burger-fastfood	new	sonic ocean water
+burger-fastfood	new	whataburger green chile double
+burger-fastfood	new	in-n-out grilled cheese
+burger-fastfood	new	five guys veggie sandwich
+burger-fastfood	new	jack in the box teriyaki bowl
+chicken-chains	new	chick-fil-a chicken sandwich
+chicken-chains	new	chick-fil-a spicy chicken sandwich
+chicken-chains	new	chick-fil-a spicy deluxe sandwich
+chicken-chains	new	chick-fil-a deluxe sandwich
+chicken-chains	new	chick-fil-a grilled chicken sandwich
+unlabeled	cached	chick-fil-a chicken nuggets
+chicken-chains	new	chick-fil-a grilled nuggets
+chicken-chains	new	chick-fil-a chick-n-strips
+chicken-chains	new	chick-fil-a waffle fries
+unlabeled	cached	chick-fil-a mac and cheese
+unlabeled	cached	chick-fil-a cobb salad
+chicken-chains	new	chick-fil-a market salad
+unlabeled	cached	chick-fil-a chicken biscuit
+chicken-chains	new	chick-fil-a chicken minis
+chicken-chains	new	chick-fil-a polynesian sauce
+chicken-chains	new	chick-fil-a chick-fil-a sauce
+chicken-chains	new	popeyes chicken sandwich
+unlabeled	cached	popeyes spicy chicken sandwich
+chicken-chains	new	popeyes classic chicken sandwich
+chicken-chains	new	popeyes blackened chicken sandwich
+chicken-chains	new	popeyes chicken tenders
+chicken-chains	new	popeyes red beans and rice
+chicken-chains	new	popeyes cajun fries
+chicken-chains	new	popeyes mashed potatoes with cajun gravy
+chicken-chains	new	popeyes buttermilk biscuit
+chicken-chains	new	popeyes coleslaw
+unlabeled	cached	popeyes mac and cheese
+chicken-chains	new	popeyes bonafide chicken
+unlabeled	cached	popeyes wings
+chicken-chains	new	kfc original recipe chicken
+chicken-chains	new	kfc extra crispy chicken
+chicken-chains	new	kfc chicken sandwich
+chicken-chains	new	kfc spicy chicken sandwich
+unlabeled	cached	kfc chicken tenders
+unlabeled	cached	kfc famous bowl
+unlabeled	cached	kfc mashed potatoes and gravy
+chicken-chains	new	kfc coleslaw
+chicken-chains	new	kfc mac and cheese
+unlabeled	cached	kfc biscuit
+chicken-chains	new	kfc pot pie
+chicken-chains	new	kfc popcorn nuggets
+chicken-chains	new	kfc wings
+unlabeled	cached	raising canes chicken fingers
+chicken-chains	new	raising canes 3 finger combo
+chicken-chains	new	raising canes texas toast
+chicken-chains	new	raising canes coleslaw
+chicken-chains	new	raising canes crinkle cut fries
+chicken-chains	new	raising canes cane's sauce
+chicken-chains	new	raising canes caniac combo
+chicken-chains	new	zaxbys chicken fingers
+chicken-chains	new	zaxbys wings
+chicken-chains	new	zaxbys boneless wings
+chicken-chains	new	zaxbys chicken sandwich
+chicken-chains	new	zaxbys coleslaw
+chicken-chains	new	zaxbys texas toast
+chicken-chains	new	zaxbys fried pickles
+chicken-chains	new	zaxbys zax sauce
+chicken-chains	new	zaxbys crinkle fries
+chicken-chains	new	zaxbys kickin chicken sandwich
+chicken-chains	new	bojangles chicken supremes
+unlabeled	cached	bojangles cajun filet biscuit
+chicken-chains	new	bojangles dirty rice
+chicken-chains	new	bojangles seasoned fries
+chicken-chains	new	bojangles biscuit
+chicken-chains	new	bojangles chicken supreme sandwich
+chicken-chains	new	bojangles mashed potatoes with gravy
+chicken-chains	new	bojangles bo-berry biscuit
+chicken-chains	new	churchs chicken tenders
+chicken-chains	new	churchs original chicken
+chicken-chains	new	churchs spicy chicken
+chicken-chains	new	churchs mashed potatoes and gravy
+chicken-chains	new	churchs jalapeno cheese bombers
+chicken-chains	new	churchs honey biscuit
+chicken-chains	new	churchs mac and cheese
+chicken-chains	new	churchs coleslaw
+chicken-chains	new	wingstop classic wings
+chicken-chains	new	wingstop boneless wings
+chicken-chains	new	wingstop 10 piece wings
+chicken-chains	new	wingstop lemon pepper wings
+chicken-chains	new	wingstop atomic wings
+chicken-chains	new	wingstop garlic parmesan wings
+chicken-chains	new	wingstop mango habanero wings
+chicken-chains	new	wingstop hawaiian wings
+chicken-chains	new	wingstop cajun fries
+chicken-chains	new	wingstop seasoned fries
+chicken-chains	new	wingstop ranch
+chicken-chains	new	wingstop chicken sandwich
+chicken-chains	new	buffalo wild wings traditional wings
+chicken-chains	new	buffalo wild wings boneless wings
+chicken-chains	new	buffalo wild wings honey bbq wings
+chicken-chains	new	buffalo wild wings mango habanero wings
+chicken-chains	new	buffalo wild wings parmesan garlic wings
+chicken-chains	new	buffalo wild wings asian zing wings
+chicken-chains	new	buffalo wild wings chicken tenders
+chicken-chains	new	buffalo wild wings potato wedges
+unlabeled	cached	buffalo wild wings mozzarella sticks
+chicken-chains	new	buffalo wild wings chicken sandwich
+chicken-chains	new	hooters wings
+chicken-chains	new	hooters boneless wings
+chicken-chains	new	hooters daytona wings
+chicken-chains	new	hooters original buffalo wings
+chicken-chains	new	hooters chicken tenders
+chicken-chains	new	hooters curly fries
+chicken-chains	new	hooters hooters sauce
+chicken-chains	new	el pollo loco pollo bowl
+chicken-chains	new	el pollo loco chicken tacos
+chicken-chains	new	el pollo loco chicken burrito
+chicken-chains	new	el pollo loco pollo asado
+chicken-chains	new	el pollo loco chicken quesadilla
+chicken-chains	new	el pollo loco original pollo bowl
+chicken-chains	new	el pollo loco fiesta salad
+chicken-chains	new	nandos peri peri chicken
+chicken-chains	new	nandos chicken sandwich
+chicken-chains	new	nandos chicken wings
+chicken-chains	new	nandos chicken thigh
+chicken-chains	new	nandos peri fries
+chicken-chains	new	nandos coleslaw
+chicken-chains	new	nandos garlic bread
+chicken-chains	new	daves hot chicken tenders
+chicken-chains	new	daves hot chicken slider
+chicken-chains	new	daves hot chicken mac and cheese
+chicken-chains	new	daves hot chicken kale slaw
+chicken-chains	new	daves hot chicken fries
+chicken-chains	new	slim chickens chicken tenders
+chicken-chains	new	slim chickens wings
+chicken-chains	new	slim chickens chicken sandwich
+chicken-chains	new	slim chickens mac and cheese
+chicken-chains	new	slim chickens fries
+chicken-chains	new	slim chickens texas toast
+chicken-chains	new	slim chickens coleslaw
+unlabeled	cached	chipotle chicken burrito bowl
+fast-casual	new	chipotle chicken burrito
+fast-casual	new	chipotle steak burrito bowl
+fast-casual	new	chipotle carnitas burrito
+unlabeled	cached	chipotle barbacoa bowl
+unlabeled	cached	chipotle sofritas bowl
+unlabeled	cached	chipotle chips and guacamole
+unlabeled	cached	chipotle guacamole
+fast-casual	new	chipotle white rice
+fast-casual	new	chipotle brown rice
+fast-casual	new	chipotle black beans
+fast-casual	new	chipotle pinto beans
+fast-casual	new	chipotle fajita veggies
+fast-casual	new	chipotle chicken quesadilla
+fast-casual	new	chipotle queso blanco
+unlabeled	cached	chipotle chips and queso
+fast-casual	new	chipotle tortilla on the side
+fast-casual	new	chipotle salad
+fast-casual	new	chipotle kids quesadilla
+fast-casual	new	chipotle mild salsa
+fast-casual	new	chipotle corn salsa
+fast-casual	new	chipotle sour cream
+fast-casual	new	chipotle lettuce
+fast-casual	new	qdoba chicken burrito
+fast-casual	new	qdoba chicken bowl
+fast-casual	new	qdoba steak bowl
+fast-casual	new	qdoba three cheese queso
+fast-casual	new	qdoba pulled pork bowl
+fast-casual	new	qdoba chips and queso
+fast-casual	new	qdoba guacamole
+fast-casual	new	qdoba loaded tortilla soup
+fast-casual	new	qdoba cilantro lime rice
+fast-casual	new	qdoba black beans
+fast-casual	new	qdoba chicken taco
+fast-casual	new	moe's homewrecker burrito
+fast-casual	new	moe's joey bag of donuts
+fast-casual	new	moe's earmuffs bowl
+fast-casual	new	moe's stack
+fast-casual	new	moe's queso
+fast-casual	new	moe's guac
+fast-casual	new	moe's chips
+fast-casual	new	moe's kid cutie quesadilla
+fast-casual	new	moe's art vandelay
+unlabeled	cached	panera broccoli cheddar soup
+fast-casual	new	panera chicken noodle soup
+fast-casual	new	panera you pick two
+fast-casual	new	panera fuji apple chicken salad
+unlabeled	cached	panera greek salad
+fast-casual	new	panera bacon turkey bravo sandwich
+fast-casual	new	panera napa almond chicken salad sandwich
+fast-casual	new	panera baked potato soup
+unlabeled	cached	panera mac and cheese
+unlabeled	cached	panera bread bowl
+fast-casual	new	panera green goddess cobb salad
+fast-casual	new	panera turkey chili
+unlabeled	cached	panera caesar salad
+fast-casual	new	panera cinnamon crunch bagel
+fast-casual	new	panera ten vegetable soup
+unlabeled	cached	subway footlong italian bmt
+fast-casual	new	subway turkey breast sandwich
+unlabeled	cached	subway chicken teriyaki sub
+fast-casual	new	subway meatball marinara sub
+fast-casual	new	subway tuna sandwich
+fast-casual	new	subway veggie delite
+unlabeled	cached	subway spicy italian
+unlabeled	cached	subway steak and cheese footlong
+fast-casual	new	subway cold cut combo
+fast-casual	new	subway chicken bacon ranch melt
+fast-casual	new	subway footlong club
+unlabeled	cached	subway sweet onion chicken teriyaki
+fast-casual	new	jersey mike's original italian
+fast-casual	new	jersey mike's club supreme
+fast-casual	new	jersey mike's chipotle cheese steak
+fast-casual	new	jersey mike's turkey and provolone
+fast-casual	new	jersey mike's big kahuna cheese steak
+fast-casual	new	jersey mike's club sub
+fast-casual	new	jimmy john's italian night club
+fast-casual	new	jimmy john's turkey tom
+fast-casual	new	jimmy john's beach club
+fast-casual	new	jimmy john's vito
+fast-casual	new	jimmy john's gargantuan
+fast-casual	new	jimmy john's ultimate porker
+fast-casual	new	jimmy john's country club
+fast-casual	new	firehouse subs hook and ladder
+fast-casual	new	firehouse subs italian
+fast-casual	new	firehouse subs meatball
+fast-casual	new	firehouse subs turkey bacon ranch
+fast-casual	new	firehouse subs smokehouse beef and cheddar brisket
+fast-casual	new	firehouse subs engine company sub
+fast-casual	new	potbelly turkey breast sandwich
+fast-casual	new	potbelly wreck sandwich
+fast-casual	new	potbelly italian sandwich
+fast-casual	new	potbelly mama's meatball sandwich
+fast-casual	new	potbelly turkey club sandwich
+fast-casual	new	potbelly mac and cheese
+fast-casual	new	potbelly chicken salad sandwich
+fast-casual	new	sweetgreen harvest bowl
+fast-casual	new	sweetgreen kale caesar
+fast-casual	new	sweetgreen chicken pesto parm
+fast-casual	new	sweetgreen guacamole greens
+fast-casual	new	sweetgreen shroomami bowl
+fast-casual	new	sweetgreen spicy sabzi
+fast-casual	new	sweetgreen curry cauliflower
+fast-casual	new	sweetgreen buffalo chicken ranch
+fast-casual	new	cava harissa avocado bowl
+fast-casual	new	cava greek salad
+fast-casual	new	cava spicy lamb meatballs bowl
+fast-casual	new	cava chicken pita
+fast-casual	new	cava braised lamb bowl
+fast-casual	new	cava roasted vegetable bowl
+fast-casual	new	cava spicy hummus
+fast-casual	new	cava harissa honey chicken
+fast-casual	new	cava falafel bowl
+unlabeled	cached	panda express orange chicken
+unlabeled	cached	panda express beijing beef
+unlabeled	cached	panda express kung pao chicken
+unlabeled	cached	panda express chow mein
+fast-casual	new	panda express fried rice
+unlabeled	cached	panda express broccoli beef
+unlabeled	cached	panda express honey walnut shrimp
+fast-casual	new	panda express string bean chicken breast
+fast-casual	new	panda express super greens
+fast-casual	new	panda express black pepper chicken
+fast-casual	new	noodles and company mac and cheese
+fast-casual	new	noodles and company pad thai
+fast-casual	new	noodles and company wisconsin mac and cheese
+fast-casual	new	noodles and company japanese pan noodles
+fast-casual	new	noodles and company penne rosa
+fast-casual	new	noodles and company buttered noodles
+fast-casual	new	noodles and company zucchini noodles
+fast-casual	new	noodles and company thai curry soup
+fast-casual	new	blaze pizza build your own pizza
+fast-casual	new	blaze pizza the red vine
+fast-casual	new	blaze pizza pepperoni pizza
+fast-casual	new	blaze pizza white top pizza
+fast-casual	new	blaze pizza keto crust pizza
+fast-casual	new	portillo's italian beef sandwich
+fast-casual	new	portillo's chicago style hot dog
+fast-casual	new	portillo's chopped salad
+fast-casual	new	portillo's chocolate cake shake
+fast-casual	new	portillo's italian sausage sandwich
+fast-casual	new	boston market rotisserie chicken
+fast-casual	new	boston market mashed potatoes
+fast-casual	new	boston market chicken pot pie
+fast-casual	new	boston market cornbread
+fast-casual	new	boston market mac and cheese
+fast-casual	new	boston market meatloaf
+fast-casual	new	pret a manger chicken caesar wrap
+fast-casual	new	pret a manger avocado and tomato sandwich
+fast-casual	new	pret a manger egg salad sandwich
+unlabeled	cached	dominos pepperoni pizza
+unlabeled	cached	dominos cheese pizza
+pizza	new	dominos hand tossed pizza
+pizza	new	dominos brooklyn style pizza
+pizza	new	dominos thin crust pizza
+pizza	new	dominos extravaganzza pizza
+pizza	new	dominos philly cheese steak pizza
+pizza	new	dominos deluxe pizza
+pizza	new	dominos meatzza pizza
+pizza	new	dominos ultimate pepperoni pizza
+unlabeled	cached	dominos parmesan bread bites
+pizza	new	dominos breadsticks
+pizza	new	dominos cheesy bread
+pizza	new	dominos cinnamon twists
+pizza	new	dominos garlic knots
+pizza	new	dominos boneless chicken wings
+pizza	new	dominos buffalo wings
+pizza	new	dominos marinara dipping cup
+pizza	new	dominos ranch dipping cup
+pizza	new	pizza hut pepperoni pizza
+pizza	new	pizza hut cheese pizza
+pizza	new	pizza hut pan pizza
+pizza	new	pizza hut thin n crispy pizza
+pizza	new	pizza hut hand tossed pizza
+pizza	new	pizza hut stuffed crust pizza
+pizza	new	pizza hut original stuffed crust pizza
+pizza	new	pizza hut supreme pizza
+pizza	new	pizza hut meat lovers pizza
+pizza	new	pizza hut veggie lovers pizza
+unlabeled	cached	pizza hut breadsticks
+pizza	new	pizza hut cheese sticks
+pizza	new	pizza hut cinnamon sticks
+pizza	new	pizza hut wings
+pizza	new	pizza hut garlic parmesan wings
+pizza	new	pizza hut honey bbq wings
+unlabeled	cached	papa johns pepperoni pizza
+unlabeled	cached	papa johns cheese pizza
+pizza	new	papa johns original crust pizza
+pizza	new	papa johns thin crust pizza
+pizza	new	papa johns works pizza
+pizza	new	papa johns garden fresh pizza
+pizza	new	papa johns bbq chicken bacon pizza
+pizza	new	papa johns papadia
+pizza	new	papa johns breadsticks
+pizza	new	papa johns cheesesticks
+unlabeled	cached	papa johns garlic knots
+pizza	new	papa johns chicken wings
+pizza	new	papa johns garlic parmesan wings
+pizza	new	papa johns papa bowl
+unlabeled	cached	little caesars pepperoni pizza
+pizza	new	little caesars hot n ready pizza
+pizza	new	little caesars cheese pizza
+pizza	new	little caesars deep dish pizza
+pizza	new	little caesars extramostbestest pizza
+pizza	new	little caesars stuffed crazy bread
+pizza	new	little caesars crazy bread
+pizza	new	little caesars crazy sauce
+pizza	new	little caesars caesar wings
+pizza	new	little caesars italian cheese bread
+pizza	new	marcos pepperoni pizza
+pizza	new	marcos cheese pizza
+pizza	new	marcos deluxe pizza
+pizza	new	marcos pepperoni magnifico pizza
+pizza	new	marcos cheezybread
+pizza	new	marcos garlic dip
+pizza	new	casey's pepperoni pizza
+pizza	new	casey's taco pizza
+pizza	new	casey's breakfast pizza
+pizza	new	casey's bacon cheeseburger pizza
+pizza	new	mod pizza mini pizza
+pizza	new	mod pizza calexico pizza
+pizza	new	cicis pepperoni pizza
+pizza	new	cicis cheese pizza
+pizza	new	cicis buffalo chicken pizza
+pizza	new	cicis breadsticks
+pizza	new	cicis cinnamon rolls
+pizza	new	new york style pizza slice
+pizza	new	new york cheese pizza slice
+pizza	new	chicago deep dish pizza
+pizza	new	detroit style pizza
+pizza	new	neapolitan pizza
+pizza	new	sicilian pizza slice
+pizza	new	thin crust cheese pizza
+pizza	new	pepperoni pizza slice
+pizza	new	plain cheese pizza slice
+pizza	new	supreme pizza slice
+pizza	new	veggie pizza slice
+pizza	new	white pizza slice
+pizza	new	buffalo chicken pizza slice
+pizza	new	hawaiian pizza slice
+pizza	new	digiorno rising crust pepperoni pizza
+pizza	new	digiorno rising crust four cheese pizza
+pizza	new	digiorno thin crispy crust pizza
+pizza	new	digiorno stuffed crust pizza
+pizza	new	digiorno pizza and cheesy breadsticks
+pizza	new	digiorno croissant crust pizza
+pizza	new	red baron classic crust pepperoni pizza
+pizza	new	red baron four cheese pizza
+pizza	new	red baron thin and crispy pizza
+pizza	new	tombstone original pepperoni pizza
+pizza	new	tombstone four meat pizza
+pizza	new	totinos party pizza pepperoni
+pizza	new	totinos party pizza cheese
+pizza	new	totinos pizza rolls pepperoni
+unlabeled	cached	totinos pizza rolls cheese
+pizza	new	california pizza kitchen margherita frozen pizza
+pizza	new	california pizza kitchen bbq chicken frozen pizza
+pizza	new	screamin sicilian pizza
+pizza	new	newmans own thin and crispy pepperoni pizza
+unlabeled	cached	amys cheese pizza
+pizza	new	amys margherita pizza
+unlabeled	cached	amys spinach pizza
+pizza	new	home run inn cheese pizza
+pizza	new	home run inn sausage pizza
+pizza	new	jacks original pizza
+pizza	new	jacks pepperoni pizza
+pizza	new	freschetta four cheese pizza
+pizza	new	freschetta brick oven crust pepperoni pizza
+salty-snacks	new	potato chips
+unlabeled	cached	lays classic
+salty-snacks	new	lays barbecue
+unlabeled	cached	ruffles cheddar and sour cream
+salty-snacks	new	kettle brand sea salt
+salty-snacks	new	cape cod original
+salty-snacks	new	utz crab chips
+salty-snacks	new	lays wavy
+unlabeled	cached	pringles original
+unlabeled	cached	pringles sour cream and onion
+salty-snacks	new	miss vickies jalapeno
+salty-snacks	new	sea salt potato chips
+unlabeled	cached	tortilla chips
+unlabeled	cached	doritos nacho cheese
+unlabeled	cached	doritos cool ranch
+unlabeled	cached	tostitos scoops
+salty-snacks	new	fritos original
+unlabeled	cached	takis fuego
+salty-snacks	new	santitas tortilla chips
+salty-snacks	new	late july sea salt
+salty-snacks	new	corn chips
+unlabeled	cached	cheetos crunchy
+unlabeled	cached	cheetos puffs
+salty-snacks	new	cheez it original
+salty-snacks	new	goldfish cheddar
+salty-snacks	new	pirates booty
+salty-snacks	new	whisps parmesan crisps
+salty-snacks	new	cheese crackers
+unlabeled	cached	ritz crackers
+unlabeled	cached	triscuit original
+unlabeled	cached	wheat thins original
+unlabeled	cached	club crackers
+unlabeled	cached	saltine crackers
+salty-snacks	new	sea salt crackers
+unlabeled	cached	pretzels
+salty-snacks	new	snyders of hanover pretzels
+unlabeled	cached	rold gold pretzels
+salty-snacks	new	dots pretzels
+salty-snacks	new	pretzel sticks
+salty-snacks	new	popcorn
+salty-snacks	new	skinnypop popcorn
+salty-snacks	new	boom chicka pop popcorn
+unlabeled	cached	smartfood white cheddar popcorn
+salty-snacks	new	orville redenbacher popcorn
+salty-snacks	new	movie theater popcorn
+salty-snacks	new	kettle corn
+unlabeled	cached	veggie straws
+salty-snacks	new	puffed cheese balls
+unlabeled	cached	trail mix
+salty-snacks	new	planters mixed nuts
+salty-snacks	new	blue diamond almonds
+salty-snacks	new	wonderful pistachios
+salty-snacks	new	sahale snacks trail mix
+unlabeled	cached	cashews
+unlabeled	cached	almonds
+salty-snacks	new	mixed nuts
+salty-snacks	new	roasted peanuts
+unlabeled	cached	beef jerky
+unlabeled	cached	jack links beef jerky
+salty-snacks	new	chomps meat stick
+unlabeled	cached	slim jim
+salty-snacks	new	country archer beef jerky
+salty-snacks	new	dukes smoked shorty sausages
+salty-snacks	new	pork rinds
+salty-snacks	new	seaweed snacks
+salty-snacks	new	roasted seaweed
+salty-snacks	new	hummus cup
+salty-snacks	new	guacamole cup
+unlabeled	cached	string cheese
+salty-snacks	new	cheese stick
+salty-snacks	new	mozzarella string cheese
+salty-snacks	new	olives
+salty-snacks	new	kalamata olives
+salty-snacks	new	pickles
+salty-snacks	new	dill pickle spear
+salty-snacks	new	pickle chips
+unlabeled	cached	lays sour cream and onion
+unlabeled	cached	ruffles original
+salty-snacks	new	kettle brand jalapeno
+salty-snacks	new	cape cod sea salt and vinegar
+salty-snacks	new	utz sour cream and onion
+unlabeled	cached	pringles bbq
+salty-snacks	new	miss vickies sea salt
+unlabeled	cached	doritos spicy sweet chili
+salty-snacks	new	tostitos original
+unlabeled	cached	fritos chili cheese
+salty-snacks	new	takis original
+salty-snacks	new	late july multigrain
+unlabeled	cached	cheetos flamin hot
+salty-snacks	new	cheez it white cheddar
+salty-snacks	new	goldfish original
+unlabeled	cached	crackers
+unlabeled	cached	ritz peanut butter crackers
+salty-snacks	new	wheat thins toasted chips
+salty-snacks	new	saltines
+salty-snacks	new	snyders honey mustard pretzels
+salty-snacks	new	rold gold tiny twists
+unlabeled	cached	skinnypop white cheddar popcorn
+salty-snacks	new	kettle corn popcorn
+salty-snacks	new	veggie chips
+salty-snacks	new	planters peanuts
+salty-snacks	new	blue diamond wasabi almonds
+salty-snacks	new	sahale almonds
+unlabeled	cached	pistachios
+unlabeled	cached	walnuts
+unlabeled	cached	pecans
+unlabeled	cached	jack links teriyaki beef jerky
+salty-snacks	new	slim jim smoked snack sticks
+unlabeled	cached	turkey jerky
+salty-snacks	new	salmon jerky
+salty-snacks	new	pork rinds spicy
+salty-snacks	new	nori snack
+salty-snacks	new	seaweed crisps
+salty-snacks	new	hummus and pretzels snack pack
+salty-snacks	new	babybel cheese
+unlabeled	cached	mozzarella sticks
+salty-snacks	new	green olives
+salty-snacks	new	sweet pickles
+salty-snacks	new	pickle spears
+salty-snacks	new	tortilla strips
+salty-snacks	new	takis xplosion
+salty-snacks	new	doritos flamas
+unlabeled	cached	tostitos hint of lime
+salty-snacks	new	fritos scoops
+salty-snacks	new	cheetos crunchy flamin hot
+salty-snacks	new	cheez it grooves
+salty-snacks	new	goldfish flavor blasted
+salty-snacks	new	ritz bits
+salty-snacks	new	triscuit thin crisps
+salty-snacks	new	wheat thins sundried tomato
+salty-snacks	new	club crackers original
+salty-snacks	new	sesame crackers
+salty-snacks	new	snyders pretzel pieces
+salty-snacks	new	dots honey mustard pretzels
+salty-snacks	new	mini pretzels
+salty-snacks	new	angies boomchickapop sweet and salty
+salty-snacks	new	orville redenbacher kettle corn
+salty-snacks	new	white cheddar popcorn
+salty-snacks	new	caramel popcorn
+salty-snacks	new	sour cream and onion chips
+salty-snacks	new	salt and vinegar chips
+salty-snacks	new	kettle brand honey dijon
+salty-snacks	new	cape cod jalapeno
+salty-snacks	new	utz ripples
+unlabeled	cached	pringles cheddar cheese
+salty-snacks	new	lays limon
+salty-snacks	new	sabritas chips
+salty-snacks	new	harvest snaps snap pea crisps
+salty-snacks	new	quaker rice cakes
+salty-snacks	new	popcorners
+candy	new	reeses peanut butter cups
+candy	new	reeses miniatures
+candy	new	reeses pieces
+candy	new	hersheys milk chocolate bar
+unlabeled	cached	hersheys kisses
+candy	new	hersheys special dark
+candy	new	snickers bar
+candy	new	snickers minis
+candy	new	twix bars
+candy	new	twix minis
+candy	new	kit kat bar
+candy	new	kit kat minis
+candy	new	milky way bar
+unlabeled	cached	3 musketeers bar
+unlabeled	cached	butterfinger bar
+unlabeled	cached	baby ruth bar
+unlabeled	cached	almond joy bar
+candy	new	mounds bar
+unlabeled	cached	crunch bar
+candy	new	take 5 bar
+unlabeled	cached	whatchamacallit bar
+candy	new	toblerone milk chocolate
+candy	new	toblerone dark chocolate
+unlabeled	cached	lindt lindor truffles
+candy	new	lindt excellence dark chocolate
+candy	new	ghirardelli dark chocolate squares
+candy	new	ghirardelli milk chocolate squares
+candy	new	dove dark chocolate
+candy	new	dove milk chocolate
+unlabeled	cached	haribo goldbears
+candy	new	haribo sour goldbears
+unlabeled	cached	haribo twin snakes
+unlabeled	cached	sour patch kids
+candy	new	sour patch kids watermelon
+unlabeled	cached	swedish fish
+unlabeled	cached	skittles original
+unlabeled	cached	skittles sour
+unlabeled	cached	starburst original
+candy	new	starburst sour
+candy	new	airheads bars
+candy	new	airheads xtremes
+candy	new	trolli sour brite crawlers
+candy	new	trolli sour bites
+candy	new	albanese gummy bears
+candy	new	albanese gummy worms
+unlabeled	cached	nerds gummy clusters
+candy	new	jolly rancher hard candy
+candy	new	jolly rancher gummies
+candy	new	werthers original caramel
+candy	new	life savers mints
+candy	new	life savers gummies
+candy	new	altoids peppermint mints
+candy	new	altoids curiously strong mints
+candy	new	tic tac mints
+candy	new	tic tac orange
+candy	new	mentos mint
+candy	new	mentos fruit
+candy	new	m and ms peanut
+candy	new	m and ms milk chocolate
+candy	new	m and ms pretzel
+candy	new	m and ms crispy
+candy	new	m and ms peanut butter
+candy	new	reeses peanut butter eggs
+candy	new	candy corn
+candy	new	cadbury creme egg
+candy	new	cadbury mini eggs
+candy	new	twizzlers strawberry twists
+candy	new	twizzlers pull n peel
+candy	new	red vines original red
+candy	new	kraft caramels
+candy	new	werthers caramel chews
+candy	new	jelly belly jelly beans
+candy	new	marshmallows
+candy	new	mini marshmallows
+candy	new	jet puffed marshmallows
+candy	new	chocolate covered almonds
+candy	new	chocolate covered pretzels
+candy	new	chocolate covered raisins
+candy	new	chocolate covered peanuts
+candy	new	extra spearmint gum
+candy	new	extra peppermint gum
+candy	new	trident spearmint gum
+candy	new	trident original bubblegum
+candy	new	5 gum cobalt
+candy	new	orbit spearmint gum
+candy	new	orbit peppermint gum
+candy	new	lindt dark chocolate 70%
+candy	new	ghirardelli intense dark chocolate
+candy	new	halva
+candy	new	sesame halva
+unlabeled	cached	york peppermint pattie
+candy	new	whoppers malted milk balls
+unlabeled	cached	milk duds
+unlabeled	cached	junior mints
+candy	new	raisinets
+candy	new	goobers
+candy	new	sweettarts
+unlabeled	cached	laffy taffy
+candy	new	now and later
+candy	new	bit o honey
+unlabeled	cached	tootsie roll
+candy	new	tootsie pop
+candy	new	charleston chew
+candy	new	pixy stix
+candy	new	dum dum lollipops
+candy	new	ring pop
+candy	new	warheads sour hard candy
+candy	new	big league chew
+candy	new	chewy sprees
+candy	new	runts candy
+candy	new	nerds candy
+candy	new	pop rocks
+candy	new	crunch bar dark chocolate
+candy	new	hersheys cookies n creme
+candy	new	hersheys gold bar
+candy	new	100 grand bar
+candy	new	payday candy bar
+candy	new	mr goodbar
+candy	new	skor toffee bar
+candy	new	heath toffee bar
+unlabeled	cached	whey protein
+unlabeled	cached	protein shake
+unlabeled	cached	protein bar
+unlabeled	cached	protein powder
+unlabeled	cached	protein cookie
+unlabeled	cached	optimum nutrition gold standard whey
+protein-supplements	new	optimum nutrition gold standard whey chocolate
+protein-supplements	new	optimum nutrition gold standard whey vanilla
+unlabeled	cached	dymatize iso100
+protein-supplements	new	dymatize iso100 chocolate
+protein-supplements	new	ghost whey protein
+protein-supplements	new	ghost whey protein chocolate
+unlabeled	cached	ryse loaded protein
+protein-supplements	new	ryse whey protein
+protein-supplements	new	legion whey protein
+protein-supplements	new	legion whey protein chocolate
+protein-supplements	new	transparent labs whey protein isolate
+protein-supplements	new	muscle milk protein powder
+protein-supplements	new	premier protein powder
+protein-supplements	new	orgain protein powder
+unlabeled	cached	orgain organic protein powder
+protein-supplements	new	vega protein powder
+protein-supplements	new	vega sport protein powder
+protein-supplements	new	isopure whey protein isolate
+unlabeled	cached	isopure zero carb
+unlabeled	cached	quest protein powder
+protein-supplements	new	ascent whey protein
+protein-supplements	new	nutricost whey protein
+protein-supplements	new	body fortress whey protein
+protein-supplements	new	six star whey protein
+unlabeled	cached	premier protein shake
+unlabeled	cached	premier protein shake chocolate
+protein-supplements	new	premier protein shake vanilla
+protein-supplements	new	fairlife core power shake
+protein-supplements	new	fairlife core power elite
+protein-supplements	new	muscle milk rtd shake
+unlabeled	cached	orgain protein shake
+protein-supplements	new	ensure protein shake
+unlabeled	cached	ensure max protein
+unlabeled	cached	boost high protein
+protein-supplements	new	boost protein drink
+unlabeled	cached	owyn protein shake
+unlabeled	cached	koia protein shake
+protein-supplements	new	shakeology shake
+unlabeled	cached	quest bar
+unlabeled	cached	quest bar chocolate chip cookie dough
+unlabeled	cached	quest bar cookies and cream
+protein-supplements	new	rxbar
+unlabeled	cached	rxbar chocolate sea salt
+unlabeled	cached	rxbar peanut butter
+unlabeled	cached	clif bar
+protein-supplements	new	clif builders bar
+protein-supplements	new	clif builders bar chocolate peanut butter
+protein-supplements	new	kind protein bar
+unlabeled	cached	pure protein bar
+unlabeled	cached	pure protein bar chocolate deluxe
+unlabeled	cached	built bar
+protein-supplements	new	built bar chocolate
+protein-supplements	new	one bar
+protein-supplements	new	one bar birthday cake
+protein-supplements	new	barebells protein bar
+protein-supplements	new	barebells protein bar chocolate dough
+protein-supplements	new	david protein bar
+protein-supplements	new	david protein bar chocolate chip cookie dough
+protein-supplements	new	no cow protein bar
+protein-supplements	new	perfect bar
+unlabeled	cached	perfect bar peanut butter
+protein-supplements	new	think protein bar
+protein-supplements	new	think high protein bar
+protein-supplements	new	power crunch protein bar
+protein-supplements	new	met-rx big 100 bar
+unlabeled	cached	gatorade protein bar
+protein-supplements	new	nature valley protein bar
+protein-supplements	new	nature valley protein bar chocolate peanut butter
+protein-supplements	new	lenny and larrys protein cookie
+protein-supplements	new	lenny and larrys protein puffs
+protein-supplements	new	quest protein chips
+protein-supplements	new	quest chips nacho cheese
+protein-supplements	new	wilde chips
+protein-supplements	new	wilde protein chips
+unlabeled	cached	greek yogurt
+unlabeled	cached	chobani greek yogurt
+protein-supplements	new	fage greek yogurt
+protein-supplements	new	oikos triple zero greek yogurt
+protein-supplements	new	two good greek yogurt
+protein-supplements	new	collagen peptides
+protein-supplements	new	vital proteins collagen peptides
+protein-supplements	new	vital proteins collagen powder
+protein-supplements	new	collagen protein powder
+unlabeled	cached	creatine monohydrate
+protein-supplements	new	optimum nutrition creatine monohydrate
+protein-supplements	new	creatine powder
+protein-supplements	new	c4 pre workout
+protein-supplements	new	c4 original pre workout
+unlabeled	cached	ghost pre workout
+unlabeled	cached	ghost legend pre workout
+protein-supplements	new	bucked up pre workout
+protein-supplements	new	alani nu pre workout
+unlabeled	cached	bcaa powder
+protein-supplements	new	scivation xtend bcaa
+protein-supplements	new	eaa powder
+protein-supplements	new	kaged aminos eaa
+protein-supplements	new	ag1 greens powder
+protein-supplements	new	athletic greens ag1
+protein-supplements	new	bloom greens powder
+protein-supplements	new	bloom nutrition greens
+protein-supplements	new	mass gainer
+protein-supplements	new	optimum nutrition serious mass
+protein-supplements	new	true mass gainer
+protein-supplements	new	muscle milk mass gainer
+unlabeled	cached	meal replacement shake
+protein-supplements	new	huel meal replacement shake
+protein-supplements	new	soylent meal replacement shake
+protein-supplements	new	electrolyte powder
+protein-supplements	new	liquid iv electrolyte powder
+protein-supplements	new	nuun electrolyte tablets
+protein-supplements	new	gatorade electrolyte powder
+protein-supplements	new	skratch labs electrolyte powder
+protein-supplements	new	whey protein isolate
+protein-supplements	new	whey protein concentrate
+protein-supplements	new	casein protein powder
+protein-supplements	new	optimum nutrition gold standard casein
+protein-supplements	new	plant protein powder
+unlabeled	cached	vegan protein powder
+protein-supplements	new	pea protein powder
+protein-supplements	new	egg white protein powder
+protein-supplements	new	premier protein bar
+protein-supplements	new	quest protein shake
+protein-supplements	new	muscle milk genuine protein shake
+protein-supplements	new	optimum nutrition amino energy
+protein-supplements	new	cellucor c4 sport pre workout
+protein-supplements	new	kaged pre workout
+protein-supplements	new	protein pancake mix
+unlabeled	cached	kodiak cakes protein pancake mix
+unlabeled	cached	whole milk
+dairy	new	2% milk
+dairy	new	1% milk
+unlabeled	cached	skim milk
+dairy	new	fairlife whole milk
+dairy	new	fairlife 2% milk
+unlabeled	cached	lactaid whole milk
+dairy	new	lactaid fat free milk
+unlabeled	cached	a2 whole milk
+dairy	new	raw milk
+unlabeled	cached	buttermilk
+unlabeled	cached	evaporated milk
+unlabeled	cached	sweetened condensed milk
+unlabeled	cached	heavy cream
+unlabeled	cached	oatly oat milk
+unlabeled	cached	chobani oat milk
+dairy	new	silk almond milk
+dairy	new	silk soy milk
+dairy	new	silk oat milk
+dairy	new	almond breeze almond milk
+dairy	new	ripple pea milk
+unlabeled	cached	califia farms almond milk
+dairy	new	califia farms oat milk
+unlabeled	cached	coconut milk
+unlabeled	cached	cashew milk
+dairy	new	chobani flip yogurt
+dairy	new	fage total 0% greek yogurt
+dairy	new	fage total 2% greek yogurt
+dairy	new	oikos triple zero yogurt
+unlabeled	cached	oikos greek yogurt
+dairy	new	yoplait original yogurt
+dairy	new	yoplait light yogurt
+dairy	new	dannon greek yogurt
+dairy	new	dannon activia yogurt
+dairy	new	siggi's icelandic yogurt
+dairy	new	siggi's 4% yogurt
+dairy	new	noosa yogurt
+unlabeled	cached	activia probiotic yogurt
+dairy	new	icelandic provisions skyr
+dairy	new	plain yogurt
+dairy	new	vanilla yogurt
+unlabeled	cached	skyr
+unlabeled	cached	kefir
+unlabeled	cached	lifeway kefir
+dairy	new	yogurt drink
+unlabeled	cached	cottage cheese
+dairy	new	good culture cottage cheese
+dairy	new	daisy cottage cheese
+dairy	new	breakstone's cottage cheese
+unlabeled	cached	sour cream
+unlabeled	cached	daisy sour cream
+unlabeled	cached	cream cheese
+unlabeled	cached	philadelphia cream cheese
+dairy	new	philadelphia strawberry cream cheese
+dairy	new	philadelphia chive and onion cream cheese
+unlabeled	cached	butter
+dairy	new	salted butter
+unlabeled	cached	unsalted butter
+dairy	new	kerrygold butter
+dairy	new	land o lakes butter
+dairy	new	country crock spread
+unlabeled	cached	ghee
+dairy	new	margarine
+unlabeled	cached	cheddar cheese
+dairy	new	sharp cheddar cheese
+dairy	new	mild cheddar cheese
+dairy	new	mozzarella cheese
+dairy	new	shredded mozzarella cheese
+dairy	new	fresh mozzarella cheese
+dairy	new	parmesan cheese
+dairy	new	grated parmesan cheese
+dairy	new	swiss cheese
+dairy	new	provolone cheese
+dairy	new	gouda cheese
+dairy	new	brie cheese
+unlabeled	cached	feta cheese
+dairy	new	crumbled feta cheese
+unlabeled	cached	goat cheese
+unlabeled	cached	blue cheese
+dairy	new	blue cheese crumbles
+dairy	new	american cheese slices
+dairy	new	pepper jack cheese
+dairy	new	colby jack cheese
+unlabeled	cached	queso fresco
+dairy	new	cotija cheese
+dairy	new	halloumi cheese
+dairy	new	ricotta cheese
+dairy	new	mascarpone cheese
+dairy	new	laughing cow cheese wedge
+dairy	new	shredded mexican blend cheese
+dairy	new	whole egg
+dairy	new	liquid egg whites
+dairy	new	egg beaters
+unlabeled	cached	whipped cream
+unlabeled	cached	cool whip
+unlabeled	cached	reddi wip
+dairy	new	violife cheddar shreds
+dairy	new	violife cream cheese
+dairy	new	kite hill almond milk yogurt
+dairy	new	kite hill cream cheese
+dairy	new	forager cashewmilk yogurt
+dairy	new	forager cashew milk
+dairy	new	oatly oat milk barista
+dairy	new	silk almond milk unsweetened
+dairy	new	almond breeze unsweetened vanilla almond milk
+dairy	new	chobani oat milk barista
+dairy	new	dannon light and fit yogurt
+dairy	new	yoplait greek yogurt
+dairy	new	fage yogurt honey
+dairy	new	noosa mango yogurt
+dairy	new	oikos triple zero vanilla yogurt
+dairy	new	two good vanilla yogurt
+dairy	new	siggi's vanilla yogurt
+dairy	new	lactose free milk
+dairy	new	whole milk powder
+dairy	new	nonfat dry milk
+unlabeled	cached	goat milk
+dairy	new	low fat cottage cheese
+unlabeled	cached	whipped cream cheese
+unlabeled	cached	neufchatel cheese
+dairy	new	laughing cow light cheese wedge
+dairy	new	babybel light cheese
+dairy	new	egg substitute
+dairy	new	liquid eggs
+dairy	new	pasteurized egg whites
+dairy	new	gouda cheese slices
+dairy	new	swiss cheese slices
+dairy	new	provolone cheese slices
+dairy	new	shredded cheddar cheese
+dairy	new	shredded parmesan cheese
+dairy	new	block cheddar cheese
+unlabeled	cached	almond milk
+unlabeled	cached	soy milk
+unlabeled	cached	oat milk
+dairy	new	coconut milk creamer
+dairy	new	half and half creamer
+frozen	new	frozen lean cuisine chicken fettuccine alfredo
+frozen	new	lean cuisine baked chicken
+frozen	new	stouffer's lasagna
+frozen	new	stouffer's mac and cheese
+frozen	new	stouffer's meatloaf
+unlabeled	cached	healthy choice power bowl
+frozen	new	healthy choice cafe steamers
+frozen	new	amy's kitchen burrito
+frozen	new	amy's kitchen bowl
+frozen	new	marie callender's chicken pot pie
+frozen	new	marie callender's turkey dinner
+unlabeled	cached	banquet chicken pot pie
+unlabeled	cached	banquet salisbury steak
+frozen	new	hungry-man salisbury steak dinner
+frozen	new	michelangelo's chicken parmesan
+frozen	new	real good foods chicken breast strips
+frozen	new	kevin's natural foods korean bbq chicken
+frozen	new	sweet earth veggie bowl
+frozen	new	evol burrito
+frozen	new	life cuisine cauliflower pizza bowl
+frozen	new	jimmy dean sausage biscuit sandwich
+frozen	new	jimmy dean croissant breakfast sandwich
+frozen	new	eggo blueberry waffles
+frozen	new	kodiak cakes frozen waffles
+frozen	new	frozen breakfast burrito
+unlabeled	cached	tyson chicken nuggets
+frozen	new	tyson chicken strips
+frozen	new	perdue chicken tenders
+frozen	new	just bare chicken nuggets
+frozen	new	applegate chicken nuggets
+frozen	new	frozen chicken patties
+frozen	new	gorton's fish fillets
+frozen	new	gorton's fish sticks
+frozen	new	van de kamp's fish sticks
+frozen	new	frozen salmon fillet
+frozen	new	frozen shrimp
+frozen	new	frozen fish sticks
+frozen	new	ore-ida tater tots
+frozen	new	ore-ida french fries
+frozen	new	ore-ida hash browns
+frozen	new	alexia sweet potato fries
+frozen	new	alexia waffle fries
+frozen	new	frozen broccoli
+frozen	new	frozen mixed vegetables
+frozen	new	frozen corn
+frozen	new	frozen edamame
+frozen	new	frozen spinach
+frozen	new	frozen blueberries
+frozen	new	frozen strawberries
+frozen	new	frozen mango chunks
+frozen	new	sambazon acai packs
+frozen	new	frozen mozzarella sticks
+frozen	new	frozen egg rolls
+frozen	new	frozen potstickers
+frozen	new	bibigo chicken dumplings
+frozen	new	bibigo pork dumplings
+frozen	new	tgi fridays mozzarella sticks
+frozen	new	tgi fridays potato skins
+frozen	new	el monterey beef and bean burrito
+frozen	new	el monterey breakfast burrito
+frozen	new	amy's kitchen bean and cheese burrito
+frozen	new	trader joe's orange chicken
+frozen	new	trader joe's chicken tikka masala
+frozen	new	trader joe's mandarin orange chicken
+frozen	new	trader joe's soyaki vegetable stir fry
+unlabeled	cached	trader joe's cauliflower gnocchi
+frozen	new	beyond meat burger patty
+frozen	new	beyond meat sausage
+frozen	new	impossible burger patty
+frozen	new	impossible sausage patty
+frozen	new	boca veggie burger
+frozen	new	boca chicken patties
+frozen	new	morningstar farms veggie burger
+frozen	new	morningstar farms chik'n patty
+frozen	new	morningstar farms sausage links
+frozen	new	gardein chick'n tenders
+frozen	new	gardein beefless burger
+frozen	new	frozen rice bowl
+frozen	new	frozen chicken fried rice bowl
+frozen	new	frozen teriyaki chicken bowl
+frozen	new	frozen quinoa bowl
+frozen	new	frozen buttermilk pancakes
+frozen	new	frozen chocolate chip pancakes
+frozen	new	lean cuisine spaghetti with meat sauce
+frozen	new	lean cuisine sweet and sour chicken
+frozen	new	stouffer's chicken alfredo
+frozen	new	stouffer's french bread pizza
+frozen	new	amy's kitchen mac and cheese
+frozen	new	amy's kitchen enchilada
+frozen	new	healthy choice fettuccine alfredo
+frozen	new	marie callender's beef pot pie
+frozen	new	banquet chicken fried steak
+frozen	new	hungry-man boneless fried chicken
+frozen	new	real good foods pizza bowl
+frozen	new	kevin's natural foods chicken tikka masala
+frozen	new	sweet earth breakfast burrito
+frozen	new	evol chicken burrito
+frozen	new	life cuisine spinach artichoke pizza bowl
+frozen	new	jimmy dean stuffed hash browns
+frozen	new	eggo minis waffles
+frozen	new	frozen breakfast sandwich
+frozen	new	tyson any'tizers chicken wings
+frozen	new	tyson chicken breast fillets
+frozen	new	just bare chicken breast strips
+frozen	new	applegate turkey burger
+frozen	new	frozen fish fillets
+frozen	new	frozen calamari rings
+frozen	new	ore-ida crinkle cut fries
+frozen	new	ore-ida onion rings
+frozen	new	frozen brussels sprouts
+frozen	new	frozen peas
+frozen	new	frozen green beans
+frozen	new	frozen cauliflower rice
+frozen	new	frozen raspberries
+frozen	new	frozen cherries
+frozen	new	frozen samosas
+frozen	new	bibigo mandu
+frozen	new	totino's pizza rolls
+frozen	new	el monterey chicken and cheese burrito
+frozen	new	trader joe's vegetable gyoza
+frozen	new	beyond meat chicken tenders
+frozen	new	impossible chicken nuggets
+frozen	new	morningstar farms buffalo wings
+frozen	new	gardein meatless meatballs
+frozen	new	frozen shepherd's pie
+frozen	new	frozen chicken fajita bowl
+frozen	new	frozen teriyaki vegetables
+frozen	new	frozen churros
+frozen	new	frozen naan bread
+frozen	new	frozen garlic bread
+frozen	new	frozen pierogies
+frozen	new	frozen falafel
+unlabeled	cached	white bread
+unlabeled	cached	whole wheat bread
+bread-bakery	new	whole grain bread
+unlabeled	cached	sourdough bread
+unlabeled	cached	rye bread
+unlabeled	cached	pumpernickel bread
+unlabeled	cached	multigrain bread
+bread-bakery	new	brioche bread
+unlabeled	cached	texas toast
+unlabeled	cached	italian bread
+unlabeled	cached	french bread
+unlabeled	cached	potato bread
+unlabeled	cached	oat bread
+unlabeled	cached	dave's killer bread
+bread-bakery	new	dave's killer bread 21 whole grains and seeds
+bread-bakery	new	dave's killer bread white bread done right
+bread-bakery	new	nature's own whole wheat bread
+bread-bakery	new	nature's own honey wheat bread
+bread-bakery	new	nature's own butterbread
+bread-bakery	new	sara lee white bread
+unlabeled	cached	sara lee whole wheat bread
+bread-bakery	new	pepperidge farm white bread
+bread-bakery	new	pepperidge farm cinnamon swirl bread
+bread-bakery	new	pepperidge farm whole grain bread
+unlabeled	cached	wonder bread
+bread-bakery	new	wonder classic white bread
+bread-bakery	new	arnold whole wheat bread
+bread-bakery	new	oroweat whole wheat bread
+bread-bakery	new	oroweat country white bread
+unlabeled	cached	ezekiel bread
+bread-bakery	new	ezekiel sprouted grain bread
+bread-bakery	new	canyon bakehouse gluten free bread
+bread-bakery	new	hamburger bun
+bread-bakery	new	whole wheat hamburger bun
+unlabeled	cached	hot dog bun
+unlabeled	cached	hawaiian rolls
+bread-bakery	new	king's hawaiian rolls
+bread-bakery	new	king's hawaiian hot dog buns
+unlabeled	cached	brioche bun
+unlabeled	cached	dinner roll
+unlabeled	cached	pretzel bun
+bread-bakery	new	sub roll
+bread-bakery	new	hoagie roll
+bread-bakery	new	ciabatta roll
+unlabeled	cached	kaiser roll
+bread-bakery	new	thomas' plain bagel
+bread-bakery	new	thomas' everything bagel
+bread-bakery	new	dave's killer bread bagel
+bread-bakery	new	mini bagel
+bread-bakery	new	bagel thins
+bread-bakery	new	thomas' english muffin
+bread-bakery	new	thomas' cinnamon raisin english muffin
+unlabeled	cached	flour tortilla
+unlabeled	cached	corn tortilla
+bread-bakery	new	whole wheat tortilla
+bread-bakery	new	mission flour tortilla
+bread-bakery	new	mission corn tortilla
+bread-bakery	new	la banderita flour tortilla
+unlabeled	cached	low carb tortilla
+bread-bakery	new	tortilla wrap
+bread-bakery	new	spinach tortilla wrap
+bread-bakery	new	flatout wrap
+bread-bakery	new	flatout flatbread
+unlabeled	cached	pita bread
+bread-bakery	new	whole wheat pita bread
+unlabeled	cached	naan
+unlabeled	cached	garlic naan
+unlabeled	cached	lavash
+bread-bakery	new	butter croissant
+bread-bakery	new	pillsbury croissant
+bread-bakery	new	pillsbury biscuits
+bread-bakery	new	pillsbury grands biscuits
+bread-bakery	new	canned biscuits
+unlabeled	cached	buttermilk biscuit
+unlabeled	cached	chocolate chip muffin
+bread-bakery	new	otis spunkmeyer muffin
+bread-bakery	new	costco muffin
+unlabeled	cached	bran muffin
+unlabeled	cached	glazed donut
+bread-bakery	new	boston creme donut
+unlabeled	cached	chocolate donut
+bread-bakery	new	cake donut
+bread-bakery	new	krispy kreme glazed donut
+unlabeled	cached	dunkin donut
+unlabeled	cached	dunkin munchkins
+bread-bakery	new	entenmann's donuts
+bread-bakery	new	entenmann's crumb donuts
+bread-bakery	new	pillsbury cinnamon rolls
+bread-bakery	new	cinnabon cinnamon roll
+bread-bakery	new	apple turnover
+bread-bakery	new	cherry turnover
+unlabeled	cached	scone
+bread-bakery	new	blueberry scone
+unlabeled	cached	pop tarts
+bread-bakery	new	pop tarts frosted strawberry
+unlabeled	cached	cornbread
+bread-bakery	new	jiffy cornbread
+bread-bakery	new	focaccia bread
+unlabeled	cached	baguette
+bread-bakery	new	french baguette
+unlabeled	cached	soft pretzel
+bread-bakery	new	auntie anne's pretzel
+bread-bakery	new	croutons
+bread-bakery	new	caesar croutons
+bread-bakery	new	breadcrumbs
+bread-bakery	new	panko breadcrumbs
+bread-bakery	new	italian breadcrumbs
+bread-bakery	new	pancake mix
+bread-bakery	new	bisquick pancake mix
+unlabeled	cached	kodiak cakes pancake mix
+bread-bakery	new	waffle mix
+unlabeled	cached	flatbread
+bread-bakery	new	sandwich thins
+bread-bakery	new	arnold sandwich thins
+bread-bakery	new	potato roll
+meat-seafood	new	grilled chicken breast
+meat-seafood	new	baked chicken breast
+meat-seafood	new	roasted chicken breast
+meat-seafood	new	raw chicken breast
+unlabeled	cached	chicken thigh
+meat-seafood	new	grilled chicken thigh
+meat-seafood	new	baked chicken thigh
+meat-seafood	new	boneless skinless chicken thigh
+unlabeled	cached	chicken wing
+meat-seafood	new	buffalo chicken wing
+unlabeled	cached	chicken drumstick
+unlabeled	cached	chicken tenderloin
+meat-seafood	new	whole roasted chicken
+unlabeled	cached	rotisserie chicken
+meat-seafood	new	shredded chicken
+meat-seafood	new	ground chicken
+meat-seafood	new	chicken sausage
+meat-seafood	new	fried chicken
+meat-seafood	new	air fried chicken breast
+unlabeled	cached	chicken liver
+meat-seafood	new	ground beef 93/7
+meat-seafood	new	ground beef 80/20
+meat-seafood	new	ground beef 85/15
+unlabeled	cached	ground beef 90/10
+meat-seafood	new	93% lean ground beef
+meat-seafood	new	lean ground beef
+unlabeled	cached	ribeye steak
+meat-seafood	new	grilled ribeye
+unlabeled	cached	sirloin steak
+meat-seafood	new	top sirloin steak
+unlabeled	cached	filet mignon
+unlabeled	cached	new york strip steak
+unlabeled	cached	flank steak
+unlabeled	cached	skirt steak
+unlabeled	cached	brisket
+meat-seafood	new	smoked brisket
+unlabeled	cached	chuck roast
+meat-seafood	new	short rib
+meat-seafood	new	beef stew meat
+unlabeled	cached	corned beef
+unlabeled	cached	prime rib
+meat-seafood	new	hamburger patty
+meat-seafood	new	grilled hamburger patty
+meat-seafood	new	london broil
+unlabeled	cached	beef tenderloin
+unlabeled	cached	pork chop
+meat-seafood	new	grilled pork chop
+meat-seafood	new	baked pork chop
+unlabeled	cached	pork tenderloin
+meat-seafood	new	pork loin
+unlabeled	cached	pulled pork
+unlabeled	cached	pork belly
+unlabeled	cached	crispy bacon
+meat-seafood	new	spiral ham
+meat-seafood	new	honey baked ham
+unlabeled	cached	prosciutto
+unlabeled	cached	pancetta
+unlabeled	cached	italian sausage
+unlabeled	cached	bratwurst
+unlabeled	cached	chorizo
+unlabeled	cached	hot dog
+meat-seafood	new	beef hot dog
+unlabeled	cached	kielbasa
+meat-seafood	new	polish sausage
+meat-seafood	new	andouille sausage
+unlabeled	cached	turkey breast
+unlabeled	cached	roasted turkey breast
+meat-seafood	new	ground turkey
+unlabeled	cached	deli turkey
+meat-seafood	new	deli turkey breast
+meat-seafood	new	whole roast turkey
+meat-seafood	new	smoked turkey
+unlabeled	cached	lamb chop
+meat-seafood	new	grilled lamb chop
+meat-seafood	new	ground lamb
+meat-seafood	new	leg of lamb
+meat-seafood	new	rack of lamb
+unlabeled	cached	salmon
+meat-seafood	new	grilled salmon
+meat-seafood	new	baked salmon
+meat-seafood	new	atlantic salmon
+meat-seafood	new	sockeye salmon
+unlabeled	cached	smoked salmon
+unlabeled	cached	lox
+meat-seafood	new	tuna steak
+meat-seafood	new	seared tuna steak
+meat-seafood	new	canned tuna in water
+meat-seafood	new	canned tuna in oil
+unlabeled	cached	tilapia
+meat-seafood	new	grilled tilapia
+meat-seafood	new	baked tilapia
+unlabeled	cached	cod
+meat-seafood	new	baked cod
+unlabeled	cached	halibut
+meat-seafood	new	mahi mahi
+unlabeled	cached	swordfish
+unlabeled	cached	sardines
+meat-seafood	new	canned sardines
+unlabeled	cached	anchovies
+unlabeled	cached	mackerel
+unlabeled	cached	trout
+unlabeled	cached	rainbow trout
+unlabeled	cached	shrimp
+meat-seafood	new	grilled shrimp
+meat-seafood	new	boiled shrimp
+unlabeled	cached	prawns
+meat-seafood	new	crab
+unlabeled	cached	crab legs
+meat-seafood	new	snow crab legs
+meat-seafood	new	king crab legs
+unlabeled	cached	lobster tail
+unlabeled	cached	scallops
+meat-seafood	new	seared scallops
+unlabeled	cached	mussels
+meat-seafood	new	steamed mussels
+unlabeled	cached	clams
+unlabeled	cached	oysters
+meat-seafood	new	raw oysters
+unlabeled	cached	calamari
+meat-seafood	new	fried calamari
+unlabeled	cached	octopus
+meat-seafood	new	grilled octopus
+unlabeled	cached	imitation crab
+meat-seafood	new	boar's head turkey breast
+meat-seafood	new	boar's head ham
+meat-seafood	new	applegate turkey
+meat-seafood	new	applegate chicken breast
+meat-seafood	new	oscar mayer bacon
+meat-seafood	new	oscar mayer turkey bacon
+unlabeled	cached	oscar mayer deli ham
+meat-seafood	new	hillshire farm smoked sausage
+meat-seafood	new	hillshire farm deli turkey
+meat-seafood	new	land o'frost ham
+meat-seafood	new	land o'frost turkey
+unlabeled	cached	carne asada
+meat-seafood	new	beef fajita strips
+meat-seafood	new	pork carnitas
+meat-seafood	new	chicken carnitas
+meat-seafood	new	smoked pork shoulder
+meat-seafood	new	beef short ribs braised
+unlabeled	cached	apple
+unlabeled	cached	honeycrisp apple
+unlabeled	cached	gala apple
+unlabeled	cached	granny smith apple
+unlabeled	cached	banana
+unlabeled	cached	orange
+unlabeled	cached	clementine
+unlabeled	cached	grapes
+unlabeled	cached	strawberries
+unlabeled	cached	blueberries
+unlabeled	cached	raspberries
+unlabeled	cached	blackberries
+unlabeled	cached	watermelon
+unlabeled	cached	cantaloupe
+produce	new	honeydew
+unlabeled	cached	pineapple
+unlabeled	cached	mango
+unlabeled	cached	peach
+unlabeled	cached	nectarine
+unlabeled	cached	plum
+unlabeled	cached	pear
+unlabeled	cached	kiwi
+unlabeled	cached	cherries
+unlabeled	cached	pomegranate
+unlabeled	cached	papaya
+unlabeled	cached	dragon fruit
+unlabeled	cached	guava
+unlabeled	cached	passion fruit
+unlabeled	cached	apricot
+unlabeled	cached	fig
+unlabeled	cached	date
+unlabeled	cached	medjool dates
+unlabeled	cached	grapefruit
+unlabeled	cached	lemon
+unlabeled	cached	lime
+unlabeled	cached	avocado
+produce	new	coconut
+produce	new	star fruit
+unlabeled	cached	persimmon
+unlabeled	cached	lychee
+unlabeled	cached	jackfruit
+unlabeled	cached	prunes
+unlabeled	cached	raisins
+produce	new	dried cranberries
+produce	new	dried mango
+produce	new	banana chips
+produce	new	applesauce
+produce	new	fruit cup
+produce	new	freeze dried strawberries
+unlabeled	cached	broccoli
+unlabeled	cached	cauliflower
+unlabeled	cached	spinach
+unlabeled	cached	kale
+unlabeled	cached	arugula
+unlabeled	cached	romaine lettuce
+unlabeled	cached	iceberg lettuce
+produce	new	spring mix
+unlabeled	cached	cabbage
+unlabeled	cached	brussels sprouts
+unlabeled	cached	asparagus
+produce	new	green beans
+produce	new	peas
+unlabeled	cached	snap peas
+unlabeled	cached	carrots
+unlabeled	cached	baby carrots
+unlabeled	cached	celery
+unlabeled	cached	cucumber
+unlabeled	cached	tomato
+unlabeled	cached	cherry tomatoes
+unlabeled	cached	roma tomato
+unlabeled	cached	red bell pepper
+produce	new	green bell pepper
+unlabeled	cached	yellow bell pepper
+unlabeled	cached	jalapeno
+produce	new	serrano pepper
+unlabeled	cached	poblano pepper
+unlabeled	cached	yellow onion
+unlabeled	cached	red onion
+produce	new	white onion
+unlabeled	cached	shallot
+unlabeled	cached	garlic
+unlabeled	cached	leek
+produce	new	scallion
+unlabeled	cached	zucchini
+produce	new	yellow squash
+unlabeled	cached	butternut squash
+unlabeled	cached	acorn squash
+unlabeled	cached	spaghetti squash
+unlabeled	cached	pumpkin
+unlabeled	cached	eggplant
+unlabeled	cached	mushrooms
+produce	new	cremini mushrooms
+unlabeled	cached	portobello mushroom
+unlabeled	cached	shiitake mushrooms
+unlabeled	cached	sweet potato
+unlabeled	cached	russet potato
+produce	new	red potato
+unlabeled	cached	yukon gold potato
+unlabeled	cached	beet
+unlabeled	cached	radish
+unlabeled	cached	turnip
+unlabeled	cached	parsnip
+unlabeled	cached	corn on the cob
+unlabeled	cached	artichoke
+unlabeled	cached	okra
+unlabeled	cached	bok choy
+unlabeled	cached	swiss chard
+produce	new	collard greens
+produce	new	seaweed
+produce	new	sprouts
+produce	new	hearts of palm
+unlabeled	cached	jicama
+produce	new	roasted vegetables
+produce	new	steamed broccoli
+produce	new	air fried brussels sprouts
+unlabeled	cached	mashed potatoes
+produce	new	sauteed spinach
+produce	new	grilled asparagus
+unlabeled	cached	side salad
+unlabeled	cached	coleslaw
+unlabeled	cached	guacamole
+unlabeled	cached	pico de gallo
+unlabeled	cached	salsa
+unlabeled	cached	sauerkraut
+unlabeled	cached	kimchi
+produce	new	canned corn
+produce	new	canned green beans
+produce	new	bartlett pear
+produce	new	red grapes
+produce	new	green grapes
+produce	new	mandarin orange
+produce	new	cara cara orange
+unlabeled	cached	blood orange
+produce	new	mini cucumbers
+produce	new	english cucumber
+produce	new	heirloom tomato
+produce	new	sun dried tomatoes
+produce	new	green cabbage
+unlabeled	cached	red cabbage
+produce	new	napa cabbage
+unlabeled	cached	purple sweet potato
+produce	new	white mushrooms
+unlabeled	cached	pearl onions
+produce	new	pumpkin puree
+produce	new	mixed berries
+unlabeled	cached	tangerine
+grains-pantry	new	dry white rice
+unlabeled	cached	cooked white rice
+grains-pantry	new	dry brown rice
+grains-pantry	new	cooked brown rice
+grains-pantry	new	dry jasmine rice
+grains-pantry	new	cooked jasmine rice
+grains-pantry	new	dry basmati rice
+grains-pantry	new	cooked basmati rice
+grains-pantry	new	sushi rice
+grains-pantry	new	cooked sushi rice
+unlabeled	cached	wild rice
+grains-pantry	new	cooked wild rice
+unlabeled	cached	arborio rice
+unlabeled	cached	cauliflower rice
+grains-pantry	new	minute rice
+grains-pantry	new	uncle ben's ready rice
+grains-pantry	new	ben's original ready rice
+unlabeled	cached	spanish rice
+unlabeled	cached	fried rice
+grains-pantry	new	coconut rice
+unlabeled	cached	rice pilaf
+unlabeled	cached	spaghetti
+grains-pantry	new	cooked spaghetti
+grains-pantry	new	penne
+grains-pantry	new	cooked penne
+grains-pantry	new	rigatoni
+unlabeled	cached	fettuccine
+unlabeled	cached	linguine
+grains-pantry	new	farfalle
+grains-pantry	new	rotini
+unlabeled	cached	macaroni
+grains-pantry	new	cooked macaroni
+unlabeled	cached	orzo
+unlabeled	cached	angel hair pasta
+grains-pantry	new	lasagna noodles
+unlabeled	cached	ravioli
+grains-pantry	new	cheese ravioli
+unlabeled	cached	tortellini
+grains-pantry	new	cheese tortellini
+unlabeled	cached	gnocchi
+grains-pantry	new	egg noodles
+grains-pantry	new	ramen noodles
+grains-pantry	new	instant ramen noodles
+grains-pantry	new	rice noodles
+grains-pantry	new	soba noodles
+grains-pantry	new	udon noodles
+grains-pantry	new	whole wheat pasta
+grains-pantry	new	chickpea pasta
+grains-pantry	new	banza pasta
+grains-pantry	new	protein pasta
+grains-pantry	new	shirataki noodles
+unlabeled	cached	quinoa
+unlabeled	cached	cooked quinoa
+grains-pantry	new	dry quinoa
+unlabeled	cached	couscous
+grains-pantry	new	cooked couscous
+unlabeled	cached	farro
+grains-pantry	new	cooked farro
+unlabeled	cached	barley
+grains-pantry	new	pearl barley
+unlabeled	cached	bulgur
+unlabeled	cached	millet
+grains-pantry	new	buckwheat
+unlabeled	cached	buckwheat groats
+unlabeled	cached	polenta
+unlabeled	cached	cornmeal
+grains-pantry	new	instant oats
+grains-pantry	new	oat bran
+grains-pantry	new	wheat berries
+grains-pantry	new	freekeh
+grains-pantry	new	black beans
+grains-pantry	new	canned black beans
+grains-pantry	new	pinto beans
+grains-pantry	new	canned pinto beans
+grains-pantry	new	kidney beans
+grains-pantry	new	canned kidney beans
+unlabeled	cached	chickpeas
+grains-pantry	new	canned chickpeas
+grains-pantry	new	garbanzo beans
+grains-pantry	new	navy beans
+grains-pantry	new	cannellini beans
+grains-pantry	new	great northern beans
+grains-pantry	new	lima beans
+unlabeled	cached	black eyed peas
+unlabeled	cached	red lentils
+grains-pantry	new	green lentils
+grains-pantry	new	brown lentils
+grains-pantry	new	cooked lentils
+grains-pantry	new	split peas
+grains-pantry	new	refried beans
+grains-pantry	new	baked beans
+unlabeled	cached	edamame
+grains-pantry	new	shelled edamame
+grains-pantry	new	canned diced tomatoes
+grains-pantry	new	canned crushed tomatoes
+unlabeled	cached	tomato paste
+unlabeled	cached	tomato sauce
+grains-pantry	new	canned tuna
+grains-pantry	new	canned chicken
+grains-pantry	new	campbell's chicken noodle soup
+grains-pantry	new	campbell's tomato soup
+grains-pantry	new	progresso chicken noodle soup
+grains-pantry	new	amy's minestrone soup
+grains-pantry	new	chicken broth
+grains-pantry	new	beef broth
+grains-pantry	new	bone broth
+grains-pantry	new	canned coconut milk
+unlabeled	cached	canned pumpkin
+grains-pantry	new	all purpose flour
+grains-pantry	new	bread flour
+unlabeled	cached	almond flour
+unlabeled	cached	coconut flour
+unlabeled	cached	oat flour
+grains-pantry	new	sugar
+unlabeled	cached	brown sugar
+grains-pantry	new	powdered sugar
+grains-pantry	new	bisquick baking mix
+grains-pantry	new	cornstarch
+grains-pantry	new	yeast
+unlabeled	cached	cocoa powder
+unlabeled	cached	white rice
+unlabeled	cached	brown rice
+grains-pantry	new	long grain rice
+grains-pantry	new	short grain rice
+unlabeled	cached	ketchup
+unlabeled	cached	heinz ketchup
+unlabeled	cached	yellow mustard
+unlabeled	cached	dijon mustard
+unlabeled	cached	spicy brown mustard
+unlabeled	cached	honey mustard
+unlabeled	cached	mayonnaise
+unlabeled	cached	hellmanns mayonnaise
+condiments	new	dukes mayonnaise
+condiments	new	kewpie mayonnaise
+condiments	new	light mayonnaise
+condiments	new	relish
+condiments	new	horseradish
+unlabeled	cached	tartar sauce
+unlabeled	cached	cocktail sauce
+unlabeled	cached	ranch dressing
+condiments	new	hidden valley ranch dressing
+unlabeled	cached	blue cheese dressing
+unlabeled	cached	thousand island dressing
+unlabeled	cached	caesar dressing
+unlabeled	cached	italian dressing
+condiments	new	balsamic vinaigrette
+condiments	new	greek dressing
+condiments	new	honey mustard dressing
+condiments	new	bolthouse farms yogurt dressing
+condiments	new	skinnygirl dressing
+unlabeled	cached	sriracha
+unlabeled	cached	tabasco
+condiments	new	cholula hot sauce
+condiments	new	franks redhot
+condiments	new	valentina hot sauce
+condiments	new	tapatio hot sauce
+condiments	new	crystal hot sauce
+condiments	new	truff hot sauce
+condiments	new	chili crisp
+unlabeled	cached	gochujang
+condiments	new	sambal oelek
+unlabeled	cached	harissa
+unlabeled	cached	soy sauce
+condiments	new	low sodium soy sauce
+unlabeled	cached	teriyaki sauce
+unlabeled	cached	hoisin sauce
+unlabeled	cached	oyster sauce
+unlabeled	cached	fish sauce
+condiments	new	ponzu sauce
+unlabeled	cached	sweet chili sauce
+condiments	new	peanut sauce
+condiments	new	curry paste
+unlabeled	cached	miso paste
+unlabeled	cached	sweet baby rays bbq sauce
+condiments	new	kc masterpiece bbq sauce
+unlabeled	cached	bbq sauce
+unlabeled	cached	marinara sauce
+condiments	new	raos marinara sauce
+unlabeled	cached	prego pasta sauce
+condiments	new	classico pasta sauce
+unlabeled	cached	alfredo sauce
+unlabeled	cached	vodka sauce
+unlabeled	cached	pesto
+condiments	new	bolognese sauce
+unlabeled	cached	salsa verde
+unlabeled	cached	queso dip
+unlabeled	cached	hummus
+unlabeled	cached	sabra hummus
+unlabeled	cached	tzatziki
+condiments	new	french onion dip
+unlabeled	cached	buffalo sauce
+condiments	new	ranch dip
+unlabeled	cached	olive oil
+condiments	new	extra virgin olive oil
+unlabeled	cached	avocado oil
+unlabeled	cached	canola oil
+unlabeled	cached	vegetable oil
+unlabeled	cached	coconut oil
+unlabeled	cached	sesame oil
+condiments	new	cooking spray
+condiments	new	pam cooking spray
+unlabeled	cached	balsamic vinegar
+unlabeled	cached	apple cider vinegar
+unlabeled	cached	rice vinegar
+unlabeled	cached	red wine vinegar
+unlabeled	cached	peanut butter
+unlabeled	cached	jif peanut butter
+unlabeled	cached	skippy peanut butter
+condiments	new	natural peanut butter
+unlabeled	cached	almond butter
+unlabeled	cached	cashew butter
+unlabeled	cached	sunflower seed butter
+unlabeled	cached	nutella
+unlabeled	cached	grape jelly
+unlabeled	cached	strawberry jam
+condiments	new	raspberry jam
+condiments	new	apricot preserves
+unlabeled	cached	honey
+unlabeled	cached	maple syrup
+condiments	new	agave nectar
+condiments	new	molasses
+unlabeled	cached	apple butter
+condiments	new	biscoff cookie butter
+condiments	new	stevia
+condiments	new	splenda
+condiments	new	monk fruit sweetener
+condiments	new	truvia
+condiments	new	erythritol
+condiments	new	allulose
+condiments	new	brown gravy
+condiments	new	turkey gravy
+condiments	new	chicken gravy
+condiments	new	marinade
+condiments	new	steak marinade
+condiments	new	teriyaki marinade
+condiments	new	everything but the bagel seasoning
+condiments	new	old bay seasoning
+unlabeled	cached	taco seasoning
+condiments	new	ranch seasoning packet
+condiments	new	garlic powder
+condiments	new	onion powder
+condiments	new	chili powder
+unlabeled	cached	cinnamon
+unlabeled	cached	salt
+unlabeled	cached	black pepper
+unlabeled	cached	paprika
+unlabeled	cached	cumin
+unlabeled	cached	italian seasoning
+condiments	new	red pepper flakes
+unlabeled	cached	worcestershire sauce
+condiments	new	a1 steak sauce
+unlabeled	cached	duck sauce
+condiments	new	frenchs mustard
+unlabeled	cached	kraft mayo
+condiments	new	sir kensingtons ketchup
+condiments	new	lawrys seasoned salt
+condiments	new	mrs dash seasoning
+condiments	new	better than bouillon
+desserts	new	ben and jerrys half baked
+desserts	new	ben and jerrys cherry garcia
+unlabeled	cached	ben and jerrys chocolate chip cookie dough
+desserts	new	haagen dazs vanilla
+unlabeled	cached	haagen dazs chocolate
+desserts	new	haagen dazs strawberry
+unlabeled	cached	halo top vanilla bean
+unlabeled	cached	halo top chocolate
+desserts	new	breyers natural vanilla
+desserts	new	blue bell homemade vanilla
+unlabeled	cached	talenti sea salt caramel gelato
+unlabeled	cached	talenti vanilla bean gelato
+desserts	new	tillamook mudslide
+desserts	new	turkey hill vanilla
+desserts	new	enlightened chocolate peanut butter
+desserts	new	yasso chocolate fudge bar
+unlabeled	cached	yasso mint chocolate chip bar
+desserts	new	nicks swedish chocolate ice cream
+desserts	new	jenis brambleberry crisp
+desserts	new	store brand vanilla ice cream
+unlabeled	cached	vanilla ice cream
+unlabeled	cached	chocolate ice cream
+unlabeled	cached	strawberry ice cream
+unlabeled	cached	ice cream sandwich
+unlabeled	cached	klondike bar
+desserts	new	drumstick ice cream cone
+unlabeled	cached	popsicle
+desserts	new	outshine strawberry bar
+desserts	new	outshine mango bar
+unlabeled	cached	magnum ice cream bar
+desserts	new	fudgsicle
+desserts	new	creamsicle
+desserts	new	choco taco
+desserts	new	dippin dots
+desserts	new	frozen yogurt
+desserts	new	soft serve
+unlabeled	cached	vanilla milkshake
+unlabeled	cached	chocolate milkshake
+desserts	new	root beer float
+unlabeled	cached	oreo
+unlabeled	cached	oreo double stuf
+unlabeled	cached	chips ahoy
+unlabeled	cached	nutter butter
+desserts	new	thin mints
+unlabeled	cached	samoas
+unlabeled	cached	tagalongs
+desserts	new	milano cookie
+desserts	new	lotus biscoff cookie
+desserts	new	tates bake shop chocolate chip cookie
+desserts	new	famous amos chocolate chip cookie
+unlabeled	cached	chocolate chip cookie
+unlabeled	cached	sugar cookie
+desserts	new	snickerdoodle
+unlabeled	cached	oatmeal raisin cookie
+desserts	new	crumbl cookie
+desserts	new	insomnia cookies deluxe
+desserts	new	gingerbread cookie
+unlabeled	cached	peanut butter cookie
+unlabeled	cached	macaron
+unlabeled	cached	chocolate cake
+unlabeled	cached	birthday cake
+unlabeled	cached	cheesecake
+desserts	new	strawberry cheesecake
+unlabeled	cached	carrot cake
+unlabeled	cached	red velvet cake
+desserts	new	pound cake
+unlabeled	cached	angel food cake
+unlabeled	cached	tiramisu
+unlabeled	cached	apple pie
+unlabeled	cached	pumpkin pie
+desserts	new	pecan pie
+unlabeled	cached	key lime pie
+unlabeled	cached	banana bread
+unlabeled	cached	brownie
+unlabeled	cached	blondie
+desserts	new	lava cake
+desserts	new	funnel cake
+desserts	new	cupcake
+unlabeled	cached	little debbie swiss rolls
+unlabeled	cached	little debbie oatmeal creme pies
+unlabeled	cached	little debbie zebra cakes
+unlabeled	cached	hostess twinkies
+unlabeled	cached	hostess ding dongs
+unlabeled	cached	hostess cupcakes
+desserts	new	hostess fruit pie
+desserts	new	entenmanns chocolate chip cookies
+desserts	new	jello chocolate pudding
+desserts	new	jello vanilla pudding
+unlabeled	cached	chocolate pudding
+unlabeled	cached	rice pudding
+desserts	new	flan
+unlabeled	cached	creme brulee
+desserts	new	chocolate mousse
+unlabeled	cached	churro
+desserts	new	cannoli
+unlabeled	cached	baklava
+desserts	new	mochi
+desserts	new	mochi ice cream
+unlabeled	cached	gelato
+unlabeled	cached	sorbet
+desserts	new	lemon sorbet
+unlabeled	cached	banana pudding
+desserts	new	smores
+desserts	new	rice krispie treat
+desserts	new	cotton candy
+desserts	new	caramel apple
+desserts	new	strawberry shortcake
+desserts	new	chocolate eclair
+desserts	new	napoleon pastry
+unlabeled	cached	tres leches cake
+desserts	new	black forest cake
+desserts	new	german chocolate cake
+desserts	new	lemon bars
+desserts	new	peach cobbler
+desserts	new	apple crisp
+desserts	new	bread pudding
+desserts	new	ice cream cake
+desserts	new	soft serve vanilla cone
+desserts	new	vanilla wafers
+unlabeled	cached	graham crackers
+desserts	new	fruit tart
+desserts	new	italian ice
+desserts	new	snow cone
+desserts	new	custard
+unlabeled	cached	tacos al pastor
+mexican	new	carne asada taco
+unlabeled	cached	carnitas taco
+unlabeled	cached	fish taco
+mexican	new	shrimp taco
+unlabeled	cached	birria taco
+unlabeled	cached	breakfast taco
+mexican	new	ground beef taco
+mexican	new	chicken taco
+mexican	new	street tacos
+unlabeled	cached	bean and cheese burrito
+mexican	new	california burrito
+mexican	new	wet burrito
+mexican	new	chimichanga
+mexican	new	chicken enchiladas
+mexican	new	cheese enchiladas
+mexican	new	beef enchiladas
+mexican	new	enchiladas verdes
+mexican	new	enchiladas suizas
+unlabeled	cached	quesadilla
+unlabeled	cached	chicken quesadilla
+mexican	new	steak quesadilla
+mexican	new	cheese quesadilla
+unlabeled	cached	tostada
+mexican	new	bean tostada
+unlabeled	cached	sopes
+unlabeled	cached	gorditas
+unlabeled	cached	tamale
+mexican	new	pork tamale
+mexican	new	chicken tamale
+mexican	new	cheese tamale
+mexican	new	sweet tamale
+unlabeled	cached	pozole
+mexican	new	pozole rojo
+unlabeled	cached	menudo
+mexican	new	birria
+mexican	new	birria de res
+unlabeled	cached	barbacoa
+unlabeled	cached	carnitas
+mexican	new	al pastor
+unlabeled	cached	chile relleno
+mexican	new	mole
+mexican	new	chicken mole
+unlabeled	cached	chilaquiles
+mexican	new	chilaquiles verdes
+mexican	new	chilaquiles rojos
+unlabeled	cached	huevos rancheros
+mexican	new	migas
+unlabeled	cached	elote
+mexican	new	esquites
+mexican	new	nachos
+mexican	new	loaded nachos
+unlabeled	cached	chicken fajitas
+mexican	new	steak fajitas
+mexican	new	shrimp fajitas
+unlabeled	cached	taco salad
+mexican	new	arroz con pollo
+mexican	new	rice and beans
+mexican	new	mexican rice
+mexican	new	queso fundido
+unlabeled	cached	ceviche
+mexican	new	shrimp ceviche
+mexican	new	aguachile
+mexican	new	tortilla soup
+unlabeled	cached	horchata
+mexican	new	agua fresca
+mexican	new	jarritos
+mexican	new	salsa roja
+mexican	new	salsa macha
+mexican	new	salsa taquera
+unlabeled	cached	empanadas
+mexican	new	beef empanadas
+mexican	new	chicken empanadas
+unlabeled	cached	pupusas
+mexican	new	pupusas de queso
+mexican	new	pupusas revueltas
+mexican	new	fried plantains
+mexican	new	maduros
+mexican	new	mangonada
+mexican	new	paletas
+mexican	new	huarache
+mexican	new	taco de lengua
+mexican	new	taco de tripa
+mexican	new	taco de cabeza
+mexican	new	suadero taco
+mexican	new	carne en su jugo
+mexican	new	caldo de res
+mexican	new	caldo de pollo
+mexican	new	sopa de fideo
+mexican	new	frijoles charros
+mexican	new	picadillo
+mexican	new	tinga de pollo
+mexican	new	cochinita pibil
+mexican	new	huitlacoche quesadilla
+mexican	new	esquites con queso
+mexican	new	michelada
+mexican	new	jamaica agua fresca
+mexican	new	tamarindo agua fresca
+mexican	new	conchas
+mexican	new	pan dulce
+mexican	new	cemita
+asian	new	chicken pad thai
+unlabeled	cached	pad see ew
+asian	new	drunken noodles
+asian	new	green curry chicken
+asian	new	red curry chicken
+unlabeled	cached	massaman curry
+asian	new	panang curry
+unlabeled	cached	tom yum soup
+unlabeled	cached	tom kha gai
+asian	new	larb
+unlabeled	cached	papaya salad
+asian	new	thai fried rice
+unlabeled	cached	mango sticky rice
+asian	new	chicken satay
+unlabeled	cached	orange chicken
+asian	new	general tso's chicken
+asian	new	sesame chicken
+unlabeled	cached	kung pao chicken
+asian	new	beef and broccoli
+asian	new	mongolian beef
+unlabeled	cached	lo mein
+unlabeled	cached	chow mein
+asian	new	egg roll
+unlabeled	cached	spring roll
+asian	new	crab rangoon
+unlabeled	cached	wonton soup
+asian	new	egg drop soup
+unlabeled	cached	hot and sour soup
+asian	new	pork dumplings
+unlabeled	cached	potstickers
+asian	new	steamed pork bun
+unlabeled	cached	char siu
+unlabeled	cached	mapo tofu
+asian	new	dan dan noodles
+asian	new	salt and pepper shrimp
+unlabeled	cached	california roll
+asian	new	spicy tuna roll
+asian	new	rainbow roll
+asian	new	dragon roll
+asian	new	philadelphia roll
+asian	new	salmon nigiri
+asian	new	tuna sashimi
+unlabeled	cached	poke bowl
+unlabeled	cached	tonkotsu ramen
+asian	new	shoyu ramen
+asian	new	miso ramen
+asian	new	udon noodle soup
+asian	new	tempura shrimp
+unlabeled	cached	chicken katsu
+asian	new	tonkatsu
+unlabeled	cached	katsu curry
+unlabeled	cached	teriyaki chicken
+asian	new	hibachi chicken
+asian	new	hibachi steak
+unlabeled	cached	gyoza
+unlabeled	cached	miso soup
+unlabeled	cached	onigiri
+unlabeled	cached	takoyaki
+asian	new	japanese curry
+unlabeled	cached	bibimbap
+unlabeled	cached	bulgogi
+asian	new	korean bbq short ribs
+asian	new	galbi
+unlabeled	cached	japchae
+unlabeled	cached	tteokbokki
+unlabeled	cached	kimchi jjigae
+unlabeled	cached	korean fried chicken
+asian	new	kimbap
+unlabeled	cached	sundubu jjigae
+unlabeled	cached	korean corn dog
+unlabeled	cached	pho
+unlabeled	cached	banh mi
+asian	new	vermicelli bowl
+asian	new	vietnamese summer rolls
+unlabeled	cached	vietnamese iced coffee
+asian	new	bun bo hue
+unlabeled	cached	chicken tikka masala
+unlabeled	cached	butter chicken
+unlabeled	cached	chana masala
+unlabeled	cached	palak paneer
+unlabeled	cached	saag paneer
+unlabeled	cached	dal
+asian	new	dal makhani
+unlabeled	cached	chicken biryani
+unlabeled	cached	tandoori chicken
+unlabeled	cached	samosa
+unlabeled	cached	roti
+asian	new	chapati
+unlabeled	cached	dosa
+asian	new	idli
+unlabeled	cached	aloo gobi
+asian	new	chicken korma
+asian	new	lamb vindaloo
+unlabeled	cached	raita
+asian	new	mango lassi
+asian	new	paneer tikka
+unlabeled	cached	chicken adobo
+unlabeled	cached	lumpia
+unlabeled	cached	pancit
+unlabeled	cached	sinigang
+asian	new	lechon
+asian	new	shrimp lo mein
+asian	new	beef chow fun
+unlabeled	cached	scallion pancake
+asian	new	sweet and sour chicken
+asian	new	black pepper beef
+asian	new	szechuan chicken
+asian	new	orange beef
+asian	new	honey walnut shrimp
+asian	new	unagi roll
+asian	new	shrimp tempura roll
+asian	new	vegetable tempura
+asian	new	chicken teriyaki bowl
+asian	new	beef bulgogi bowl
+asian	new	spicy pork bulgogi
+unlabeled	cached	kimchi fried rice
+asian	new	japchae noodles
+asian	new	seaweed salad
+asian	new	chicken pho
+asian	new	beef pho
+asian	new	vietnamese spring rolls
+asian	new	lamb biryani
+asian	new	vegetable biryani
+asian	new	paneer butter masala
+asian	new	malai kofta
+asian	new	chettinad chicken
+asian	new	masala dosa
+asian	new	pad kra pao
+unlabeled	cached	thai basil chicken
+asian	new	khao soi
+asian	new	chicken satay skewers
+asian	new	shrimp pad thai
+american-home	new	spaghetti and meatballs
+unlabeled	cached	chicken parmesan
+american-home	new	eggplant parmesan
+unlabeled	cached	fettuccine alfredo
+unlabeled	cached	chicken alfredo
+american-home	new	lasagna
+american-home	new	baked ziti
+american-home	new	penne vodka
+unlabeled	cached	carbonara
+american-home	new	cacio e pepe
+unlabeled	cached	shrimp scampi
+american-home	new	chicken piccata
+american-home	new	chicken marsala
+unlabeled	cached	risotto
+unlabeled	cached	meatball sub
+unlabeled	cached	garlic bread
+unlabeled	cached	bruschetta
+unlabeled	cached	caprese salad
+american-home	new	minestrone
+unlabeled	cached	meatloaf
+american-home	new	pot roast
+american-home	new	beef stew
+american-home	new	chili
+american-home	new	turkey chili
+unlabeled	cached	shepherd's pie
+american-home	new	chicken pot pie
+unlabeled	cached	tuna casserole
+unlabeled	cached	green bean casserole
+american-home	new	mac and cheese
+american-home	new	baked mac and cheese
+american-home	new	chicken and waffles
+american-home	new	chicken fried steak
+american-home	new	bbq ribs
+unlabeled	cached	pulled pork sandwich
+american-home	new	brisket plate
+american-home	new	sloppy joe
+american-home	new	salisbury steak
+american-home	new	stuffed peppers
+american-home	new	chicken and rice
+american-home	new	jambalaya
+american-home	new	gumbo
+american-home	new	crawfish etouffee
+unlabeled	cached	clam chowder
+unlabeled	cached	lobster roll
+american-home	new	crab cakes
+american-home	new	fish and chips
+unlabeled	cached	philly cheesesteak
+american-home	new	reuben
+american-home	new	blt
+unlabeled	cached	club sandwich
+american-home	new	grilled cheese
+unlabeled	cached	tuna salad sandwich
+american-home	new	chicken salad sandwich
+american-home	new	egg salad sandwich
+unlabeled	cached	turkey sandwich
+american-home	new	chili dog
+unlabeled	cached	corn dog
+unlabeled	cached	chicken noodle soup
+unlabeled	cached	tomato soup
+american-home	new	broccoli cheddar soup
+unlabeled	cached	potato soup
+american-home	new	split pea soup
+unlabeled	cached	lentil soup
+unlabeled	cached	french onion soup
+unlabeled	cached	chicken tortilla soup
+american-home	new	beef barley soup
+unlabeled	cached	butternut squash soup
+unlabeled	cached	caesar salad
+unlabeled	cached	chicken caesar salad
+unlabeled	cached	cobb salad
+unlabeled	cached	greek salad
+unlabeled	cached	garden salad
+american-home	new	chef salad
+american-home	new	wedge salad
+unlabeled	cached	spinach salad
+unlabeled	cached	kale salad
+unlabeled	cached	pasta salad
+american-home	new	potato salad
+unlabeled	cached	macaroni salad
+american-home	new	broccoli salad
+american-home	new	three bean salad
+unlabeled	cached	quinoa salad
+unlabeled	cached	chicken salad
+unlabeled	cached	tuna salad
+american-home	new	egg salad
+american-home	new	baked potato
+american-home	new	loaded baked potato
+american-home	new	french fries
+american-home	new	sweet potato fries
+unlabeled	cached	tater tots
+unlabeled	cached	stuffing
+unlabeled	cached	deviled eggs
+american-home	new	mac salad
+american-home	new	cole slaw
+american-home	new	onion rings
+american-home	new	hush puppies
+american-home	new	chicken parmesan sandwich
+american-home	new	eggplant rollatini
+american-home	new	stuffed shells
+american-home	new	manicotti
+unlabeled	cached	spaghetti carbonara
+american-home	new	italian wedding soup
+american-home	new	sausage and peppers
+american-home	new	chicken cacciatore
+unlabeled	cached	osso buco
+american-home	new	veal parmesan
+american-home	new	tortellini soup
+american-home	new	zuppa toscana
+american-home	new	pasta e fagioli
+american-home	new	antipasto salad
+unlabeled	cached	italian sub
+american-home	new	meatball parmesan sandwich
+american-home	new	prosciutto and melon
+american-home	new	chicken tetrazzini
+american-home	new	king ranch chicken
+american-home	new	beef stroganoff
+american-home	new	swedish meatballs
+american-home	new	chicken divan
+unlabeled	cached	scalloped potatoes
+american-home	new	au gratin potatoes
+american-home	new	turkey pot pie
+american-home	new	beef pot pie
+american-home	new	country fried steak
+american-home	new	smothered chicken
+american-home	new	chicken fried rice
+american-home	new	pepper steak
+american-home	new	beef fajitas
+american-home	new	buffalo chicken sandwich
+american-home	new	buffalo chicken salad
+american-home	new	crab bisque
+american-home	new	new england clam chowder
+american-home	new	manhattan clam chowder
+american-home	new	seafood gumbo
+american-home	new	chicken and dumplings
+american-home	new	turkey club sandwich
+unlabeled	cached	ham and cheese sandwich
+american-home	new	italian beef sandwich
+american-home	new	meatball soup
+american-home	new	sausage and peppers sandwich
+american-home	new	chicken parmesan pasta
+mediterranean-global	new	gyro
+unlabeled	cached	chicken gyro
+mediterranean-global	new	lamb gyro
+unlabeled	cached	souvlaki
+unlabeled	cached	spanakopita
+mediterranean-global	new	moussaka
+unlabeled	cached	pastitsio
+unlabeled	cached	dolma
+unlabeled	cached	feta
+mediterranean-global	new	avgolemono
+mediterranean-global	new	loukoumades
+unlabeled	cached	greek yogurt bowl
+mediterranean-global	new	keftedes
+mediterranean-global	new	saganaki
+mediterranean-global	new	tiropita
+mediterranean-global	new	galaktoboureko
+mediterranean-global	new	greek lemon potatoes
+unlabeled	cached	falafel
+mediterranean-global	new	chicken shawarma
+mediterranean-global	new	beef shawarma
+unlabeled	cached	baba ganoush
+unlabeled	cached	tabbouleh
+unlabeled	cached	fattoush
+unlabeled	cached	kebab
+mediterranean-global	new	shish kebab
+mediterranean-global	new	kofta
+unlabeled	cached	kibbeh
+mediterranean-global	new	mujadara
+unlabeled	cached	shakshuka
+unlabeled	cached	labneh
+unlabeled	cached	halloumi
+mediterranean-global	new	za'atar manakish
+mediterranean-global	new	chicken kabob plate
+mediterranean-global	new	harissa chicken
+mediterranean-global	new	chicken tawook
+mediterranean-global	new	muhammara
+mediterranean-global	new	foul medames
+mediterranean-global	new	fatteh
+mediterranean-global	new	lebanese lentil soup
+mediterranean-global	new	couscous tagine
+mediterranean-global	new	harira
+mediterranean-global	new	merguez
+unlabeled	cached	pierogi
+unlabeled	cached	borscht
+unlabeled	cached	stuffed cabbage
+mediterranean-global	new	goulash
+unlabeled	cached	schnitzel
+mediterranean-global	new	bratwurst plate
+unlabeled	cached	spaetzle
+mediterranean-global	new	blintz
+mediterranean-global	new	latke
+mediterranean-global	new	kasha
+mediterranean-global	new	chicken paprikash
+mediterranean-global	new	pelmeni
+mediterranean-global	new	kolache
+unlabeled	cached	jerk chicken
+mediterranean-global	new	oxtail
+unlabeled	cached	curry goat
+unlabeled	cached	rice and peas
+unlabeled	cached	plantains
+unlabeled	cached	tostones
+mediterranean-global	new	mofongo
+mediterranean-global	new	ropa vieja
+unlabeled	cached	cuban sandwich
+unlabeled	cached	arepa
+unlabeled	cached	feijoada
+mediterranean-global	new	churrasco
+mediterranean-global	new	chimichurri steak
+mediterranean-global	new	ceviche peruano
+unlabeled	cached	lomo saltado
+mediterranean-global	new	pollo a la brasa
+mediterranean-global	new	tres leches
+unlabeled	cached	pernil
+mediterranean-global	new	mondongo
+mediterranean-global	new	sancocho
+mediterranean-global	new	arroz con gandules
+mediterranean-global	new	alcapurria
+mediterranean-global	new	mangu
+unlabeled	cached	jollof rice
+mediterranean-global	new	injera
+unlabeled	cached	doro wat
+unlabeled	cached	suya
+mediterranean-global	new	bobotie
+unlabeled	cached	egusi soup
+unlabeled	cached	fufu
+mediterranean-global	new	kelewele
+mediterranean-global	new	fried catfish
+mediterranean-global	new	smothered pork chops
+mediterranean-global	new	oxtail stew
+unlabeled	cached	candied yams
+mediterranean-global	new	cornbread dressing
+mediterranean-global	new	chitterlings
+mediterranean-global	new	okra and tomatoes
+mediterranean-global	new	fried okra
+mediterranean-global	new	red beans and rice
+mediterranean-global	new	hoppin john
+mediterranean-global	new	matzo ball soup
+mediterranean-global	new	pastrami on rye
+mediterranean-global	new	knish
+mediterranean-global	new	bagel and lox
+unlabeled	cached	challah
+store-brands	new	kirkland signature rotisserie chicken
+store-brands	new	kirkland signature organic chicken breast
+store-brands	new	kirkland signature protein bars
+store-brands	new	kirkland signature almonds
+store-brands	new	kirkland signature extra virgin olive oil
+store-brands	new	kirkland signature quinoa
+store-brands	new	kirkland signature greek yogurt
+store-brands	new	kirkland signature chocolate covered almonds
+store-brands	new	kirkland signature muffins
+store-brands	new	kirkland signature croissants
+store-brands	new	kirkland signature wild salmon
+store-brands	new	kirkland signature ground beef
+store-brands	new	kirkland signature shredded mozzarella cheese
+store-brands	new	kirkland signature granola
+store-brands	new	kirkland signature trail mix
+store-brands	new	kirkland signature bacon
+store-brands	new	kirkland signature creamy peanut butter
+store-brands	new	kirkland signature mixed nuts
+store-brands	new	kirkland signature protein shake
+store-brands	new	kirkland signature organic eggs
+store-brands	new	kirkland signature dried mango
+store-brands	new	kirkland signature cashews
+store-brands	new	kirkland signature turkey bacon
+store-brands	new	kirkland signature chicken sausage
+store-brands	new	trader joes cauliflower gnocchi
+store-brands	new	trader joes everything but the bagel seasoning
+store-brands	new	trader joes mandarin orange chicken
+store-brands	new	trader joes chili onion crunch
+unlabeled	cached	trader joes dark chocolate peanut butter cups
+store-brands	new	trader joes unexpected cheddar
+store-brands	new	trader joes joe joes
+store-brands	new	trader joes soy chorizo
+store-brands	new	trader joes frozen orange chicken
+store-brands	new	trader joes cold brew
+store-brands	new	trader joes hold the cone
+store-brands	new	trader joes elote dip
+store-brands	new	trader joes tzatziki
+store-brands	new	trader joes protein pasta
+store-brands	new	trader joes cornbread crunch
+store-brands	new	trader joes vegetable gyoza
+store-brands	new	trader joes chicken tikka masala
+store-brands	new	trader joes pumpkin spice granola
+store-brands	new	trader joes speculoos cookie butter
+store-brands	new	trader joes gone bananas
+store-brands	new	trader joes scandinavian swimmers
+store-brands	new	trader joes kung pao chicken burrito
+store-brands	new	trader joes vanilla almondmilk yogurt
+store-brands	new	trader joes turkey burgers
+store-brands	new	great value shredded cheddar cheese
+store-brands	new	great value 2 percent milk
+store-brands	new	great value creamy peanut butter
+unlabeled	cached	great value white bread
+store-brands	new	great value greek yogurt
+store-brands	new	great value frozen chicken breast
+unlabeled	cached	great value trail mix
+store-brands	new	great value granola bars
+store-brands	new	great value orange juice
+store-brands	new	great value large eggs
+store-brands	new	great value macaroni and cheese
+store-brands	new	great value almonds
+store-brands	new	great value string cheese
+store-brands	new	good and gather chicken breast
+store-brands	new	good and gather greek yogurt
+store-brands	new	good and gather trail mix
+store-brands	new	good and gather almond butter
+store-brands	new	good and gather sparkling water
+store-brands	new	good and gather rotisserie chicken
+store-brands	new	good and gather granola
+store-brands	new	favorite day ice cream sandwiches
+store-brands	new	favorite day chocolate chip cookies
+store-brands	new	simply nature organic peanut butter
+store-brands	new	millville honey nut toasted oats
+store-brands	new	clancys tortilla chips
+store-brands	new	fit and active protein shake
+store-brands	new	specially selected croissants
+store-brands	new	simply nature almond butter
+store-brands	new	millville granola bars
+store-brands	new	clancys pretzels
+store-brands	new	365 organic peanut butter
+store-brands	new	365 greek yogurt
+store-brands	new	365 organic chicken broth
+store-brands	new	365 trail mix
+store-brands	new	365 organic tortilla chips
+store-brands	new	365 organic quinoa
+store-brands	new	365 organic whole milk
+store-brands	new	simple truth organic chicken breast
+store-brands	new	simple truth greek yogurt
+store-brands	new	simple truth almond butter
+store-brands	new	kroger shredded cheddar cheese
+store-brands	new	kroger 2 percent milk
+store-brands	new	simple truth emerge protein bar
+store-brands	new	kroger peanut butter
+store-brands	new	publix deli fried chicken
+store-brands	new	publix pecan pie
+store-brands	new	publix key lime pie
+store-brands	new	publix greenwise chicken breast
+store-brands	new	publix sub sandwich
+store-brands	new	wegmans organic greek yogurt
+store-brands	new	wegmans italian classics chicken parmesan
+store-brands	new	wegmans trail mix
+store-brands	new	wegmans salted caramel gelato
+store-brands	new	signature select sparkling water
+store-brands	new	signature select greek yogurt
+store-brands	new	signature select trail mix
+store-brands	new	signature select butter
+store-brands	new	heb rotisserie chicken
+store-brands	new	heb greek yogurt
+store-brands	new	heb creamy peanut butter
+store-brands	new	heb tortillas
+store-brands	new	members mark rotisserie chicken
+store-brands	new	members mark greek yogurt
+store-brands	new	members mark trail mix
+store-brands	new	members mark almonds
+store-brands	new	members mark protein bar
+store-brands	new	members mark chicken breast
+store-brands	new	sprouts organic peanut butter
+store-brands	new	sprouts trail mix
+store-brands	new	sprouts almond butter
+store-brands	new	sprouts brand granola
+store-brands	new	amazon fresh greek yogurt
+store-brands	new	amazon fresh chicken breast
+store-brands	new	amazon fresh trail mix
+store-brands	new	amazon fresh almond butter
+sitdown-chains	new	applebees bourbon street chicken
+sitdown-chains	new	applebees fiesta lime chicken
+unlabeled	cached	applebees riblets
+sitdown-chains	new	applebees three cheese chicken penne
+sitdown-chains	new	applebees oriental chicken salad
+sitdown-chains	new	applebees classic bacon cheeseburger
+sitdown-chains	new	applebees boneless wings
+sitdown-chains	new	chilis molten lava cake
+unlabeled	cached	chilis baby back ribs
+sitdown-chains	new	chilis chicken crispers
+sitdown-chains	new	chilis fajitas
+sitdown-chains	new	chilis triple dipper
+unlabeled	cached	chilis queso
+sitdown-chains	new	chilis southwestern eggrolls
+unlabeled	cached	olive garden breadsticks
+sitdown-chains	new	olive garden fettuccine alfredo
+sitdown-chains	new	olive garden lasagna classico
+sitdown-chains	new	olive garden zuppa toscana
+sitdown-chains	new	olive garden chicken parmigiana
+sitdown-chains	new	olive garden tour of italy
+sitdown-chains	new	olive garden five cheese ziti al forno
+sitdown-chains	new	olive garden shrimp scampi
+unlabeled	cached	texas roadhouse rolls
+unlabeled	cached	texas roadhouse cactus blossom
+sitdown-chains	new	texas roadhouse fried pickles
+sitdown-chains	new	texas roadhouse country fried sirloin
+sitdown-chains	new	texas roadhouse dallas filet
+sitdown-chains	new	texas roadhouse cinnamon butter
+sitdown-chains	new	texas roadhouse grilled bbq chicken
+sitdown-chains	new	outback bloomin onion
+sitdown-chains	new	outback alice springs chicken
+sitdown-chains	new	outback bushman bread
+sitdown-chains	new	outback aussie cheese fries
+sitdown-chains	new	outback baby back ribs
+sitdown-chains	new	outback toowoomba chicken
+sitdown-chains	new	longhorn parmesan crusted chicken
+sitdown-chains	new	longhorn renegade sirloin
+sitdown-chains	new	longhorn wild west shrimp
+sitdown-chains	new	longhorn firecracker chicken wraps
+sitdown-chains	new	cheesecake factory original cheesecake
+sitdown-chains	new	cheesecake factory chicken madeira
+sitdown-chains	new	cheesecake factory avocado eggrolls
+sitdown-chains	new	cheesecake factory bang bang chicken and shrimp
+sitdown-chains	new	cheesecake factory louisiana chicken pasta
+sitdown-chains	new	cheesecake factory oreo dream extreme cheesecake
+unlabeled	cached	red lobster cheddar bay biscuits
+sitdown-chains	new	red lobster ultimate feast
+sitdown-chains	new	red lobster walts favorite shrimp
+sitdown-chains	new	red lobster garlic shrimp scampi
+sitdown-chains	new	red lobster admirals feast
+sitdown-chains	new	tgi fridays loaded potato skins
+sitdown-chains	new	tgi fridays jack daniels glazed ribs
+sitdown-chains	new	tgi fridays sesame jack chicken strips
+sitdown-chains	new	buffalo wild wings ultimate nachos
+unlabeled	cached	cracker barrel chicken and dumplings
+sitdown-chains	new	cracker barrel country fried steak
+sitdown-chains	new	cracker barrel meatloaf
+unlabeled	cached	cracker barrel hashbrown casserole
+sitdown-chains	new	cracker barrel sunday homestyle chicken
+sitdown-chains	new	cracker barrel pancakes
+sitdown-chains	new	ihop 2 x 2 x 2
+sitdown-chains	new	ihop rooty tooty fresh n fruity
+sitdown-chains	new	ihop original buttermilk pancakes
+sitdown-chains	new	ihop colorado omelette
+sitdown-chains	new	ihop cinn a stack pancakes
+sitdown-chains	new	ihop philly cheese steak stacker
+unlabeled	cached	dennys grand slam
+sitdown-chains	new	dennys moons over my hammy
+sitdown-chains	new	dennys lumberjack slam
+sitdown-chains	new	dennys country fried steak and eggs
+sitdown-chains	new	waffle house waffle
+sitdown-chains	new	waffle house hashbrowns
+sitdown-chains	new	waffle house all star special
+sitdown-chains	new	waffle house bacon cheese steak melt
+sitdown-chains	new	first watch avocado toast
+sitdown-chains	new	first watch quinoa power bowl
+sitdown-chains	new	first watch million dollar bacon
+sitdown-chains	new	first watch chickichanga
+sitdown-chains	new	red robin whiskey river bbq burger
+sitdown-chains	new	red robin bonzai burger
+sitdown-chains	new	red robin bottomless steak fries
+sitdown-chains	new	red robin tavern double burger
+sitdown-chains	new	bjs pizookie
+sitdown-chains	new	bjs deep dish pizza
+sitdown-chains	new	bjs avocado eggrolls
+sitdown-chains	new	bjs brewhouse burger
+sitdown-chains	new	yard house nashville hot chicken sandwich
+sitdown-chains	new	yard house poke nachos
+sitdown-chains	new	yard house garlic noodles
+sitdown-chains	new	pf changs orange chicken
+sitdown-chains	new	pf changs dynamite shrimp
+sitdown-chains	new	pf changs mongolian beef
+sitdown-chains	new	pf changs chicken lettuce wraps
+sitdown-chains	new	cheddars scratch made croissants
+sitdown-chains	new	cheddars monte cristo sandwich
+sitdown-chains	new	cheddars painted hills sirloin
+sitdown-chains	new	carrabbas chicken bryan
+sitdown-chains	new	carrabbas lasagne verde
+sitdown-chains	new	carrabbas tagliarini picchi pacchiu
+sitdown-chains	new	maggianos rigatoni d
+sitdown-chains	new	maggianos chicken parmesan
+sitdown-chains	new	maggianos moms lasagna
+sitdown-chains	new	bonefish grill bang bang shrimp
+sitdown-chains	new	bonefish grill chilean sea bass
+sitdown-chains	new	bonefish grill saucy shrimp
+sitdown-chains	new	ruths chris filet mignon
+sitdown-chains	new	ruths chris sweet potato casserole
+sitdown-chains	new	ruths chris bone in ribeye
+sitdown-chains	new	dave and busters bourbon bacon burger
+sitdown-chains	new	chuys chicken flauta
+sitdown-chains	new	chuys creamy jalapeno dip
+sitdown-chains	new	on the border stacked enchiladas
+sitdown-chains	new	on the border queso
+sitdown-chains	new	ruby tuesday garden bar
+sitdown-chains	new	ruby tuesday triple prime burger
+sitdown-chains	new	golden corral pot roast
+sitdown-chains	new	golden corral yeast rolls
+sitdown-chains	new	golden corral fried chicken
+sitdown-chains	new	golden corral bourbon street chicken
+kids-misc	new	lunchables ham and cheese
+kids-misc	new	uncrustables peanut butter and jelly
+kids-misc	new	gogo squeez applesauce pouch
+kids-misc	new	welch's fruit snacks
+kids-misc	new	mott's fruit snacks
+kids-misc	new	fruit roll ups
+kids-misc	new	gushers
+unlabeled	cached	animal crackers
+kids-misc	new	teddy grahams
+unlabeled	cached	nilla wafers
+kids-misc	new	danimals smoothie
+kids-misc	new	yoplait go-gurt
+kids-misc	new	pb and j sandwich
+kids-misc	new	ants on a log
+kids-misc	new	apple slices with peanut butter
+unlabeled	cached	kraft mac and cheese
+kids-misc	new	easy mac
+kids-misc	new	spaghettios
+unlabeled	cached	chef boyardee ravioli
+kids-misc	new	ramen packet
+kids-misc	new	cup noodles
+unlabeled	cached	hot pockets
+unlabeled	cached	bagel bites
+kids-misc	new	pop-tarts
+kids-misc	new	rice krispies treats
+kids-misc	new	nutri-grain bars
+unlabeled	cached	belvita breakfast biscuits
+kids-misc	new	taquito
+kids-misc	new	beef stick
+kids-misc	new	slurpee
+kids-misc	new	big gulp
+unlabeled	cached	sunflower seeds
+kids-misc	new	gum
+unlabeled	cached	rice cakes
+kids-misc	new	corn thins
+kids-misc	new	cauliflower crust pizza
+kids-misc	new	egg bites
+kids-misc	new	starbucks egg bites
+unlabeled	cached	chia pudding
+unlabeled	cached	smoothie
+unlabeled	cached	protein smoothie
+kids-misc	new	green juice
+kids-misc	new	celery juice
+kids-misc	new	meal prep bowl
+kids-misc	new	gerber puree
+kids-misc	new	baby oatmeal
+kids-misc	new	gerber puffs
+kids-misc	new	plum organics pouch
+kids-misc	new	fiber gummies
+kids-misc	new	multivitamin gummy
+kids-misc	new	airborne
+kids-misc	new	emergen-c
+kids-misc	new	water
+kids-misc	new	ice
+kids-misc	new	leftover pizza
+kids-misc	new	leftover chinese food
+kids-misc	new	homemade smoothie
+kids-misc	new	protein oatmeal
+kids-misc	new	salad with chicken
+kids-misc	new	lunchables pizza
+kids-misc	new	lunchables turkey and cheddar
+kids-misc	new	uncrustables chocolate hazelnut
+kids-misc	new	danimals smoothie squeeze
+kids-misc	new	gushers tropical
+kids-misc	new	fruit by the foot
+kids-misc	new	kraft easy mac cups
+kids-misc	new	chef boyardee mini ravioli
+kids-misc	new	maruchan ramen
+kids-misc	new	nissin cup noodles
+unlabeled	cached	hot pockets pepperoni pizza
+kids-misc	new	bagel bites pepperoni
+kids-misc	new	nature valley oats and honey bar
+kids-misc	new	quaker granola bar
+kids-misc	new	belvita blueberry
+kids-misc	new	combos
+kids-misc	new	pringles single serve
+unlabeled	cached	jello cup
+kids-misc	new	pudding cup
+kids-misc	new	applesauce cup
+kids-misc	new	horizon organic milk box
+kids-misc	new	gerber baby food stage 2
+kids-misc	new	gerber teether biscuits
+kids-misc	new	happy baby puffs
+kids-misc	new	plum organics baby food
+kids-misc	new	munchkin snack cup
+kids-misc	new	world's finest chocolate bar
+kids-misc	new	takis
+kids-misc	new	rice krispies treats big
+unlabeled	cached	kind bar
+kids-misc	new	clif bar kids
+kids-misc	new	lara bar
+kids-misc	new	special k bar
+kids-misc	new	kellogg's pop tarts brown sugar
+kids-misc	new	oreo cakesters
+kids-misc	new	uncrustables strawberry
+kids-misc	new	gushers berry
+kids-misc	new	nature's bakery fig bar
+kids-misc	new	frito lay variety pack
+kids-misc	new	quaker granola bar chocolate chip
+kids-misc	new	gogo squeez yogurtz
+kids-misc	new	stonyfield yokids
+kids-misc	new	chobani kids yogurt tube
+kids-misc	new	go-gurt strawberry
+kids-misc	new	horizon organic string cheese
+kids-misc	new	mott's applesauce cup
+kids-misc	new	nutri-grain strawberry
+kids-misc	new	egg white bites
+kids-misc	new	cottage cheese bowl

--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -27,6 +27,13 @@
  *      a warning in the report and NEVER changes the sweep's exit code or
  *      gating. Logic: src/lib/ops/seg-replay.ts. Cost ~N LLM calls (default
  *      20, --seg-replay-top).
+ *      4c. CORPUS COVERAGE (REPORT-ONLY) — share of a FIXED representative
+ *      seed corpus (scripts/eval/coverage-corpus.tsv, 3,307 seeds) whose
+ *      canonical key already exists in FoodMapping, overall and per domain,
+ *      trended against the previous sweep. Answers "is the cache big enough
+ *      yet?" (baseline 28.8% on 2026-07-24, stop signal >70-80%) as opposed to
+ *      the warm run's cache_hit, which answers "did it hold?". Read-only and
+ *      never gates. Logic: src/lib/ops/cache-coverage.ts.
  *   5. REPORT     — results/flywheel-<ts>.{json,md}; --publish-dir copies the
  *      markdown (dated + flywheel-latest.md) somewhere Syncthing carries it
  *      (e.g. sync-docs/) so every machine sees the nightly report.
@@ -45,6 +52,9 @@
  * writes only results/stuck-keys-<ts>.json) — no warm, no eval, no publish.
  * --seg-replay-only likewise runs JUST the seg replay-diff step (reads the DB,
  * ~N LLM calls, writes only results/seg-replay-<ts>.json).
+ * --coverage-only runs JUST the coverage read — no API calls, no LLM, no
+ * writes at all. Cheap enough to run between warm batches to watch a domain
+ * fill in; use --coverage-corpus <path> to measure a different seed list.
  */
 
 // Load .env before any src/lib import: the seg replay-diff step calls the LLM
@@ -65,6 +75,10 @@ import {
     formatSegReplaySection, SegReplayReport, SegReplayTrend, SEG_REPLAY_DEFAULT_TOP_N,
 } from '../../src/lib/ops/seg-replay';
 import { segmentTextWithAi } from '../../src/lib/nlp/ai-segmenter';
+import {
+    CacheCoverageReport, collectCacheCoverage, computeCoverageTrend, CoverageTrend,
+    findPreviousCoverage, formatCoverageSection,
+} from '../../src/lib/ops/cache-coverage';
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
@@ -83,9 +97,13 @@ const STUCK_ONLY = args.includes('--stuck-keys-only');
 const SEG_REPLAY_TOP = Number(argValue('--seg-replay-top') ?? SEG_REPLAY_DEFAULT_TOP_N);
 const SEG_REPLAY_ONLY = args.includes('--seg-replay-only');
 const PUBLISH_DIR = argValue('--publish-dir');
+const SKIP_COVERAGE = args.includes('--skip-coverage');
+const COVERAGE_ONLY = args.includes('--coverage-only');
 
 const RESULTS_DIR = path.join(__dirname, 'results');
 const REPO_ROOT = path.join(__dirname, '..', '..');
+const COVERAGE_CORPUS = argValue('--coverage-corpus')
+    ?? path.join(__dirname, 'coverage-corpus.tsv');
 
 // ---------------------------------------------------------------------------
 // 1. Telemetry
@@ -462,7 +480,8 @@ function buildFunnelSection(warm: WarmRunReport | null): string[] {
 
 function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport | null,
     seedCount: number, telemetrySeedCount: number, diff: WarmDiff | null, gate: EvalGate | null,
-    stuck: StuckKeysRun | null, segReplay: SegReplayRun | null): string {
+    stuck: StuckKeysRun | null, segReplay: SegReplayRun | null,
+    coverage: { report: CacheCoverageReport; trend: CoverageTrend | null } | null): string {
     const lines: string[] = [];
     lines.push(`# Flywheel sweep — ${ranAt}`);
     lines.push('');
@@ -489,6 +508,16 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
                 lines.push(`- ${kind}: ${s.pass}/${s.total} · p50 ${s.p50ms}ms · p95 ${s.p95ms}ms`);
             }
         }
+    }
+    lines.push('');
+
+    // Second only to the gate: the gate says the cache is CORRECT, this says
+    // whether it is yet BIG enough to be worth being correct about.
+    lines.push('## Corpus coverage');
+    if (!coverage) {
+        lines.push('_skipped (--skip-coverage)_');
+    } else {
+        lines.push(...formatCoverageSection(coverage.report, coverage.trend));
     }
     lines.push('');
 
@@ -567,9 +596,36 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Corpus coverage — read-only, and the only step that answers "is the cache big
+ * enough yet?" rather than "did it hold?". Never gates: a coverage number can't
+ * be wrong in a way that should stop a deploy.
+ */
+async function runCoverageStep(ranAt: string, stamp: string): Promise<{
+    report: CacheCoverageReport; trend: CoverageTrend | null;
+}> {
+    const prisma = new PrismaClient();
+    let report: CacheCoverageReport;
+    try {
+        report = await collectCacheCoverage(prisma, COVERAGE_CORPUS, ranAt);
+    } finally {
+        await prisma.$disconnect().catch(() => {});
+    }
+    const previous = findPreviousCoverage(RESULTS_DIR, `flywheel-${stamp}.json`);
+    return { report, trend: computeCoverageTrend(report, previous) };
+}
+
 async function main() {
     const ranAt = new Date().toISOString();
     const stamp = ranAt.replace(/[:.]/g, '-');
+
+    if (COVERAGE_ONLY) {
+        console.log(`Coverage-only read @ ${ranAt} · corpus ${path.basename(COVERAGE_CORPUS)}`);
+        const cov = await runCoverageStep(ranAt, stamp);
+        console.log('');
+        console.log(formatCoverageSection(cov.report, cov.trend).join('\n'));
+        return;
+    }
 
     if (STUCK_ONLY) {
         console.log(`Stuck-keys-only report @ ${ranAt} (window ${DAYS}d)`);
@@ -638,6 +694,20 @@ async function main() {
     const segReplay = await runSegReplayStep(ranAt, stamp);
     console.log(segReplaySummaryLine(segReplay));
 
+    // Report-only coverage read. Runs LAST so it measures the state this sweep
+    // leaves behind, which is what "coverage now" has to mean.
+    let coverage: { report: CacheCoverageReport; trend: CoverageTrend | null } | null = null;
+    if (SKIP_COVERAGE) {
+        console.log('\n[4c] Corpus coverage skipped (--skip-coverage)');
+    } else {
+        console.log('\n[4c] Corpus coverage (report-only)…');
+        coverage = await runCoverageStep(ranAt, stamp);
+        console.log(coverage.report.ok
+            ? `  ${coverage.report.pct}% of ${coverage.report.total} seeds cached` +
+              `${coverage.trend ? ` (${coverage.trend.deltaPct >= 0 ? '+' : ''}${coverage.trend.deltaPct}pt)` : ''}`
+            : `  unavailable: ${coverage.report.error}`);
+    }
+
     fs.mkdirSync(RESULTS_DIR, { recursive: true });
     const jsonPath = path.join(RESULTS_DIR, `flywheel-${stamp}.json`);
     fs.writeFileSync(jsonPath, JSON.stringify({
@@ -659,9 +729,12 @@ async function main() {
             driftRate: segReplay.report.driftRate,
             trend: segReplay.trend, report: segReplay.outPath,
         },
+        // findPreviousCoverage reads this block back out of the previous
+        // sweep's JSON — it IS the coverage history, so keep the shape stable.
+        coverage: coverage ? { ...coverage.report, trend: coverage.trend } : null,
     }, null, 1));
 
-    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate, stuck, segReplay);
+    const md = buildMarkdown(ranAt, telemetry, warm, seedCount, telemetrySeeds.length, diff, gate, stuck, segReplay, coverage);
     const mdPath = path.join(RESULTS_DIR, `flywheel-${stamp}.md`);
     fs.writeFileSync(mdPath, md);
     console.log(`\nReport: ${mdPath}`);

--- a/src/lib/ops/__tests__/cache-coverage.test.ts
+++ b/src/lib/ops/__tests__/cache-coverage.test.ts
@@ -1,0 +1,163 @@
+/**
+ * cache-coverage — corpus coverage read.
+ *
+ * The load-bearing behaviour is key canonicalization: stored FoodMapping keys
+ * are token-SORTED, so raw-string matching would under-report coverage and the
+ * trend would look flat while the cache was actually filling up.
+ */
+
+// normalization-rules imports the shared db module, which constructs a
+// PrismaClient at import time and needs DATABASE_URL. This step never touches
+// that client — it takes its own — so stub it out and keep the suite runnable
+// without an env.
+jest.mock('../../db', () => ({ prisma: {} }));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    collectCacheCoverage, computeCoverageTrend, findPreviousCoverage,
+    formatCoverageSection, loadCoverageCorpus, CoverageDbClient,
+} from '../cache-coverage';
+
+function tmpdir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-test-'));
+}
+
+function writeCorpus(dir: string, rows: string[]): string {
+    const p = path.join(dir, 'corpus.tsv');
+    fs.writeFileSync(p, ['domain\tbaseline\tseed', ...rows].join('\n') + '\n');
+    return p;
+}
+
+function db(keys: string[]): CoverageDbClient {
+    return { foodMapping: { findMany: async () => keys.map(normalizedForm => ({ normalizedForm })) } };
+}
+
+const RAN_AT = '2026-07-25T00:00:00.000Z';
+
+describe('loadCoverageCorpus', () => {
+    it('parses rows and canonicalizes the key, skipping the header', () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['produce\tnew\tred bell peppers', 'chains\tcached\tbig mac']);
+        const seeds = loadCoverageCorpus(p);
+        expect(seeds).toHaveLength(2);
+        expect(seeds[0]).toMatchObject({ domain: 'produce', baseline: 'new', seed: 'red bell peppers' });
+        // lowercased, singularized, token-sorted
+        expect(seeds[0].key).toBe('bell pepper red');
+        expect(seeds[1].baseline).toBe('cached');
+    });
+});
+
+describe('collectCacheCoverage', () => {
+    it('matches a stored key whose tokens are in a different order', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['dairy\tnew\tplain greek yogurt']);
+        // How the mapper actually stores it: sorted.
+        const report = await collectCacheCoverage(db(['greek plain yogurt']), p, RAN_AT);
+        expect(report.ok).toBe(true);
+        expect(report.cached).toBe(1);
+        expect(report.pct).toBe(100);
+    });
+
+    it('separates whole-corpus coverage from growth on the then-uncached seeds', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, [
+            'unlabeled\tcached\tbanana',
+            'unlabeled\tcached\tegg',
+            'chains\tnew\tbig mac',
+            'frozen\tnew\tdigiorno pepperoni pizza',
+        ]);
+        // Both baseline rows plus one of the two new ones are now cached.
+        const report = await collectCacheCoverage(db(['banana', 'egg', 'big mac']), p, RAN_AT);
+        expect(report.total).toBe(4);
+        expect(report.cached).toBe(3);
+        expect(report.pct).toBe(75);
+        // Growth ignores the seeds that were already covered at corpus cut.
+        expect(report.growthTotal).toBe(2);
+        expect(report.growthCached).toBe(1);
+        expect(report.growthPct).toBe(50);
+    });
+
+    it('reports per-domain over the new seeds only, least-covered first', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, [
+            'chains\tnew\tbig mac',
+            'chains\tnew\twhopper',
+            'frozen\tnew\thot pocket',
+            'unlabeled\tcached\tbanana',
+        ]);
+        const report = await collectCacheCoverage(db(['big mac', 'whopper', 'banana']), p, RAN_AT);
+        expect(report.perDomain.map(d => d.domain)).toEqual(['frozen', 'chains']);
+        expect(report.perDomain[0]).toMatchObject({ domain: 'frozen', cached: 0, total: 1, pct: 0 });
+        expect(report.perDomain[1]).toMatchObject({ domain: 'chains', cached: 2, total: 2, pct: 100 });
+        // 'unlabeled' is baseline-cached, so it never enters the domain table.
+        expect(report.perDomain.find(d => d.domain === 'unlabeled')).toBeUndefined();
+    });
+
+    it('fails soft when the corpus is missing rather than throwing', async () => {
+        const report = await collectCacheCoverage(db([]), '/nonexistent/corpus.tsv', RAN_AT);
+        expect(report.ok).toBe(false);
+        expect(report.error).toBeTruthy();
+        expect(formatCoverageSection(report, null)[0]).toContain('coverage step failed');
+    });
+});
+
+describe('trend', () => {
+    it('reads the previous reading out of the last sweep JSON that carried one', () => {
+        const dir = tmpdir();
+        // Newest first by sort order, but this one predates the coverage step.
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-07-24.json'), JSON.stringify({ coverage: { ok: true, pct: 28.8 } }));
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-07-25.json'), JSON.stringify({ gate: {} }));
+        const prev = findPreviousCoverage(dir);
+        expect(prev).toEqual({ file: 'flywheel-2026-07-24.json', pct: 28.8 });
+    });
+
+    it('skips a report whose coverage step errored', () => {
+        const dir = tmpdir();
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-07-23.json'), JSON.stringify({ coverage: { ok: true, pct: 20 } }));
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-07-24.json'), JSON.stringify({ coverage: { ok: false, pct: 0 } }));
+        expect(findPreviousCoverage(dir)?.pct).toBe(20);
+    });
+
+    it('excludes this run\'s own file so a sweep cannot trend against itself', () => {
+        const dir = tmpdir();
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-07-25.json'), JSON.stringify({ coverage: { ok: true, pct: 40 } }));
+        expect(findPreviousCoverage(dir, 'flywheel-2026-07-25.json')).toBeNull();
+    });
+
+    it('computes the delta in points', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana', 'a\tnew\tegg']);
+        const report = await collectCacheCoverage(db(['banana']), p, RAN_AT);
+        const trend = computeCoverageTrend(report, { file: 'prev.json', pct: 28.8 });
+        expect(report.pct).toBe(50);
+        expect(trend?.deltaPct).toBe(21.2);
+    });
+
+    it('has no trend on the first run', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana']);
+        const report = await collectCacheCoverage(db([]), p, RAN_AT);
+        expect(computeCoverageTrend(report, null)).toBeNull();
+    });
+});
+
+describe('formatCoverageSection', () => {
+    it('marks the stop signal only once coverage clears it', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana', 'a\tnew\tegg', 'a\tnew\tmilk', 'a\tnew\trice']);
+        const low = await collectCacheCoverage(db(['banana']), p, RAN_AT);
+        expect(formatCoverageSection(low, null)[0]).toContain('📈');
+
+        const high = await collectCacheCoverage(db(['banana', 'egg', 'milk', 'rice']), p, RAN_AT);
+        expect(formatCoverageSection(high, null)[0]).toContain('✅');
+    });
+
+    it('states which quantity it is, so it cannot be read as funnel cache_hit', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana']);
+        const report = await collectCacheCoverage(db(['banana']), p, RAN_AT);
+        expect(formatCoverageSection(report, null).join('\n')).toContain('NOT the warm run');
+    });
+});

--- a/src/lib/ops/cache-coverage.ts
+++ b/src/lib/ops/cache-coverage.ts
@@ -1,0 +1,247 @@
+/**
+ * cache-coverage.ts — what share of a realistic query distribution the cache
+ * can already answer.
+ *
+ * Row count is not progress. A cache can grow for weeks and still miss what
+ * people actually type, which is exactly what the 2026-07-24 corpus read found:
+ * produce was 69.9% covered while store-brands sat at 2.4% and sit-down chains
+ * at 8.4%, because every prior warm wave had been produce-and-pantry shaped.
+ * This step turns that one-off finding into a tracked number.
+ *
+ * Method: canonicalize each corpus seed with the SAME `canonicalizeCacheKey`
+ * the mapper writes keys with, then intersect against the live `FoodMapping`
+ * key set. Raw-string matching would silently under-count — stored keys are
+ * token-SORTED ("0 fage greek plain total yogurt").
+ *
+ * TWO NUMBERS, deliberately distinct, because conflating them is the trap:
+ *
+ *   coverage  — cached share of the WHOLE corpus. The honest read. Baseline
+ *               28.8% (951/3,307) on 2026-07-24; stop signal is >70-80%.
+ *   growth    — cached share of just the seeds that were UNCACHED when the
+ *               corpus was cut. Starts at 0% by construction and rises only as
+ *               warming closes the known gap, so it measures the work, per
+ *               domain, without produce's existing saturation drowning it out.
+ *
+ * Neither is the nightly telemetry replay's cache_hit, which re-warms keys that
+ * are already cached and so reports near-100% by construction. It answers "did
+ * the cache hold?", not "is the cache big enough yet?".
+ *
+ * The corpus is COMMITTED (scripts/eval/coverage-corpus.tsv) so the denominator
+ * is fixed. Changing it breaks comparability with every earlier reading — cut a
+ * new file under a new name instead, and restate the baseline.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { canonicalizeCacheKey } from '../mapping/normalization-rules';
+
+/** Coverage on a fresh representative batch at which warming can stop. */
+export const COVERAGE_STOP_SIGNAL_PCT = 70;
+
+/** Minimal shape of the client this step needs — keeps it unit-testable. */
+export interface CoverageDbClient {
+    foodMapping: {
+        findMany(args: { select: { normalizedForm: true } }): Promise<{ normalizedForm: string }[]>;
+    };
+}
+
+export interface CoverageSeed {
+    domain: string;
+    /** 'new' = uncached when the corpus was cut; 'cached' = already covered then. */
+    baseline: 'new' | 'cached';
+    seed: string;
+    key: string;
+}
+
+export interface CoverageDomainRow {
+    domain: string;
+    total: number;
+    cached: number;
+    pct: number;
+}
+
+export interface CacheCoverageReport {
+    ok: boolean;
+    error?: string;
+    ranAt: string;
+    corpus: string;
+    liveKeys: number;
+    /** Whole-corpus coverage — the headline. */
+    total: number;
+    cached: number;
+    pct: number;
+    /** Restricted to seeds that were uncached at corpus cut — measures the work. */
+    growthTotal: number;
+    growthCached: number;
+    growthPct: number;
+    /** Per-domain, over the 'new' seeds only (the labelled ones), worst first. */
+    perDomain: CoverageDomainRow[];
+}
+
+export interface CoverageTrend {
+    previousFile: string;
+    previousPct: number;
+    deltaPct: number;
+}
+
+function pct(n: number, d: number): number {
+    return d > 0 ? Math.round((1000 * n) / d) / 10 : 0;
+}
+
+/** Parse the committed corpus TSV: `domain \t baseline \t seed`. */
+export function loadCoverageCorpus(corpusPath: string): CoverageSeed[] {
+    const raw = fs.readFileSync(corpusPath, 'utf8');
+    const out: CoverageSeed[] = [];
+    for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('domain\t')) continue;
+        const [domain, baseline, ...rest] = trimmed.split('\t');
+        const seed = rest.join('\t').trim();
+        if (!seed) continue;
+        out.push({
+            domain: domain || 'unlabeled',
+            baseline: baseline === 'cached' ? 'cached' : 'new',
+            seed,
+            key: canonicalizeCacheKey(seed),
+        });
+    }
+    return out;
+}
+
+export async function collectCacheCoverage(
+    prisma: CoverageDbClient,
+    corpusPath: string,
+    ranAt: string,
+): Promise<CacheCoverageReport> {
+    const empty: CacheCoverageReport = {
+        ok: false, ranAt, corpus: path.basename(corpusPath), liveKeys: 0,
+        total: 0, cached: 0, pct: 0,
+        growthTotal: 0, growthCached: 0, growthPct: 0, perDomain: [],
+    };
+    try {
+        const seeds = loadCoverageCorpus(corpusPath);
+        if (seeds.length === 0) return { ...empty, error: `corpus ${corpusPath} is empty` };
+
+        const rows = await prisma.foodMapping.findMany({ select: { normalizedForm: true } });
+        // Canonicalize the stored keys too. They are already written in this
+        // form, so this is a no-op for well-formed rows — but it is exactly the
+        // idempotency the corpus port was validated on, and it keeps a
+        // malformed legacy row from reading as a permanent miss.
+        const live = new Set(rows.map(r => canonicalizeCacheKey(r.normalizedForm)));
+
+        const byDomain = new Map<string, { total: number; cached: number }>();
+        let cached = 0, growthTotal = 0, growthCached = 0;
+        for (const s of seeds) {
+            const hit = live.has(s.key);
+            if (hit) cached++;
+            if (s.baseline === 'new') {
+                growthTotal++;
+                if (hit) growthCached++;
+                const d = byDomain.get(s.domain) ?? { total: 0, cached: 0 };
+                d.total++;
+                if (hit) d.cached++;
+                byDomain.set(s.domain, d);
+            }
+        }
+
+        const perDomain = [...byDomain.entries()]
+            .map(([domain, d]) => ({ domain, total: d.total, cached: d.cached, pct: pct(d.cached, d.total) }))
+            .sort((a, b) => a.pct - b.pct || b.total - a.total);
+
+        return {
+            ok: true, ranAt, corpus: path.basename(corpusPath), liveKeys: live.size,
+            total: seeds.length, cached, pct: pct(cached, seeds.length),
+            growthTotal, growthCached, growthPct: pct(growthCached, growthTotal),
+            perDomain,
+        };
+    } catch (e) {
+        return { ...empty, error: e instanceof Error ? e.message : String(e) };
+    }
+}
+
+/**
+ * Previous coverage reading, taken from the last flywheel report that carried
+ * one. No separate artifact: the sweep's own JSON is the history.
+ */
+export function findPreviousCoverage(
+    resultsDir: string,
+    excludeFile?: string,
+): { file: string; pct: number } | null {
+    let names: string[];
+    try {
+        names = fs.readdirSync(resultsDir);
+    } catch {
+        return null;
+    }
+    const candidates = names
+        .filter(n => n.startsWith('flywheel-') && n.endsWith('.json'))
+        .filter(n => !excludeFile || n !== path.basename(excludeFile))
+        .sort()
+        .reverse();
+    for (const name of candidates) {
+        try {
+            const parsed = JSON.parse(fs.readFileSync(path.join(resultsDir, name), 'utf8'));
+            const prev = parsed?.coverage;
+            if (prev && prev.ok === true && typeof prev.pct === 'number') {
+                return { file: name, pct: prev.pct };
+            }
+        } catch {
+            // Unreadable or partial report — keep looking further back.
+        }
+    }
+    return null;
+}
+
+export function computeCoverageTrend(
+    report: CacheCoverageReport,
+    previous: { file: string; pct: number } | null,
+): CoverageTrend | null {
+    if (!report.ok || !previous) return null;
+    return {
+        previousFile: previous.file,
+        previousPct: previous.pct,
+        deltaPct: Math.round((report.pct - previous.pct) * 10) / 10,
+    };
+}
+
+export function formatCoverageSection(
+    report: CacheCoverageReport,
+    trend: CoverageTrend | null,
+    worstN = 12,
+): string[] {
+    const lines: string[] = [];
+    if (!report.ok) {
+        lines.push(`⚠️ coverage step failed: ${report.error ?? 'unknown error'}`);
+        return lines;
+    }
+
+    const delta = trend
+        ? ` (${trend.deltaPct >= 0 ? '+' : ''}${trend.deltaPct}pt vs ${trend.previousFile})`
+        : '';
+    const reached = report.pct >= COVERAGE_STOP_SIGNAL_PCT;
+    lines.push(
+        `${reached ? '✅' : '📈'} **${report.pct}%** of \`${report.corpus}\` is cached ` +
+        `(${report.cached}/${report.total})${delta} · stop signal >${COVERAGE_STOP_SIGNAL_PCT}%`,
+    );
+    lines.push('');
+    lines.push(
+        `Growth since the corpus was cut: **${report.growthPct}%** ` +
+        `(${report.growthCached}/${report.growthTotal} of the then-uncached seeds) · ` +
+        `live keys ${report.liveKeys}`,
+    );
+    lines.push('');
+    lines.push('_Key overlap on a fixed representative corpus — NOT the warm run\'s ' +
+        'funnel `cache_hit`, which measures whether a pick survived the gates._');
+
+    if (report.perDomain.length) {
+        lines.push('');
+        lines.push(`### Least-covered domains (of the ${report.growthTotal} then-uncached seeds)`);
+        lines.push('');
+        lines.push('| domain | cached | of | % |');
+        lines.push('|---|---:|---:|---:|');
+        for (const d of report.perDomain.slice(0, worstN)) {
+            lines.push(`| ${d.domain} | ${d.cached} | ${d.total} | ${d.pct}% |`);
+        }
+    }
+    return lines;
+}


### PR DESCRIPTION
Row count is not progress. The 2026-07-24 corpus read found produce **69.9%**
covered while store-brands sat at **2.4%** and sit-down chains at **8.4%** —
every prior warm wave had been produce-and-pantry shaped. But reproducing that
number cost a 28-agent run, so it was destined to be measured once and then
quoted for weeks while the cache moved underneath it.

This makes it a nightly line.

## What it does

Sweep step **4c**: canonicalize a fixed corpus of 3,307 realistic seeds with the
same `canonicalizeCacheKey` the mapper writes keys with, then intersect against
the live `FoodMapping` key set. Raw-string matching would silently under-count —
stored keys are token-SORTED (`"0 fage greek plain total yogurt"`).

Read-only. No API calls, no LLM, no writes. It never gates: a coverage number
can't be wrong in a way that should stop a deploy.

## Two numbers, kept separate on purpose

| | what it is |
|---|---|
| **coverage** | cached share of the WHOLE corpus. Baseline 28.8% (951/3,307), stop signal >70–80% |
| **growth** | cached share of only the seeds that were UNCACHED at corpus cut. Starts at 0% by construction |

Growth exists because produce is already 69.9% saturated, and left in the
denominator it drowns out the per-domain signal that says where to warm next.

Neither is the warm run's funnel `cache_hit`, which re-warms already-cached keys
and so reports near-100% by construction. The report section says this in situ,
because the corpus README's own warning is that these get conflated.

## First live read (box, this branch)

```
📈 31.1% of coverage-corpus.tsv is cached (1030/3307) · stop signal >70%
Growth since the corpus was cut: 3.4% (79/2356) · live keys 2992

| domain      | cached | of  | %  |
| fast-casual |      0 | 128 | 0% |
| frozen      |      0 | 127 | 0% |
| store-brands|      0 | 120 | 0% |
| pizza       |      0 | 107 | 0% |
| alcohol     |      0 | 106 | 0% |
```

31.1% against the 28.8% baseline is real movement — 79 of the then-uncached
seeds have been warmed since the corpus was cut. The twelve 0% domains are the
warm order.

## Notes

- The corpus is **committed** so the denominator is fixed. A moving corpus makes
  every earlier reading incomparable — cut a new file under a new name instead.
- `--coverage-only` runs just this step, cheap enough to check between warm
  batches. `--coverage-corpus <path>` measures a different list.
- 12 unit tests, including that a token-reordered seed still matches and that a
  sweep can't trend against its own report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx