### PR TITLE
fix(cache-key): an apostrophe should not fork the cache

### DIFF
--- a/scripts/migrate-possessive-keys.ts
+++ b/scripts/migrate-possessive-keys.ts
@@ -1,0 +1,163 @@
+/**
+ * migrate-possessive-keys.ts — one-shot key migration for the apostrophe fix.
+ *
+ * WHY: canonicalizeCacheKey used to keep apostrophes and then hand the possessive
+ * `s` to singularize(), so "mcdonald's fries" stored under "fry mcdonald'" while
+ * "mcdonalds fries" stored under "fry mcdonald". Because the key basis is whatever
+ * spelling the LLM emitted, which row a user hit was effectively random — live on
+ * the box before this migration, "mcdonalds fries" returned McDonald's Fries Medium
+ * (114g) and "mcdonald's fries" returned a generic unbranded Fries (250g). The fix
+ * deletes apostrophes before tokenizing; this script moves the 108 rows that were
+ * written under the old scheme so they stay reachable.
+ *
+ * THE TARGET KEY IS NOT canonicalizeCacheKey(storedKey). A stored key has already
+ * been singularized once, lossily: the raw token "reese's" was chopped to "reese'".
+ * Re-canonicalizing "reese'" gives "reese", but a live lookup for the raw name
+ * "reese's puffs" computes "rees"/"reese" from the ORIGINAL spelling — so the row
+ * would land on a key nothing asks for. This script restores the possessive first
+ * ("reese'" -> "reese's") and then canonicalizes, which reproduces exactly what the
+ * live lookup path will compute. Verified: 0 stranded rows, 0 non-fixed-point keys.
+ *
+ * MERGE POLICY: when a mangled key collides with an existing apostrophe-free twin,
+ * the twin wins and the mangled row is deleted. That direction was checked against
+ * all 11 real collisions on the box — in every case where the two rows disagreed on
+ * substance the apostrophe-free row held the better record, including two
+ * human-triage 0.99 rows ("Mandarin Orange Chicken", "Classic Lasagna with Meat").
+ * Note AI confidence pointed the WRONG way in the two worst cases (generic unbranded
+ * "Fries" carried 0.980 against McDonald's Fries Medium at 0.880), so a
+ * confidence-ranked merge would have picked the bad row. usedCount is summed and
+ * lastUsedAt keeps the later of the two so telemetry is not lost.
+ *
+ * SAFETY: if the row being deleted is human-triage and the surviving row is not,
+ * the script copies the human record onto the survivor rather than discarding a
+ * human decision. No FK references FoodMapping.normalizedForm, so renames are safe.
+ * Dry-run by default; --apply performs writes inside a transaction.
+ *
+ * Run (from repo root, DATABASE_URL pointing at the target DB):
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/migrate-possessive-keys.ts [--apply]
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { canonicalizeCacheKey } from '../src/lib/mapping/normalization-rules';
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes('--apply');
+
+/**
+ * Undo the old singularize() chop, then canonicalize under the new rules.
+ * A token ending in a bare apostrophe was "<token>'s" before singularize() ran.
+ */
+export function migrateKey(storedKey: string): string {
+    return canonicalizeCacheKey(storedKey.replace(/(\S)'(?=\s|$)/g, "$1's"));
+}
+
+interface Row {
+    normalizedForm: string;
+    foodName: string;
+    brandName: string | null;
+    source: string;
+    offBarcode: string | null;
+    fdcId: number | null;
+    fsId: string | null;
+    aiConfidence: number;
+    validatedBy: string;
+    usedCount: number;
+    lastUsedAt: Date;
+}
+
+async function main() {
+    const rows = (await prisma.foodMapping.findMany({
+        select: {
+            normalizedForm: true, foodName: true, brandName: true, source: true,
+            offBarcode: true, fdcId: true, fsId: true, aiConfidence: true,
+            validatedBy: true, usedCount: true, lastUsedAt: true,
+        },
+    })) as Row[];
+
+    const byKey = new Map(rows.map(r => [r.normalizedForm, r]));
+    const renames: Array<{ row: Row; to: string }> = [];
+    const merges: Array<{ loser: Row; winner: Row }> = [];
+
+    for (const row of rows) {
+        const to = migrateKey(row.normalizedForm);
+        if (to === row.normalizedForm) continue;
+        const winner = byKey.get(to);
+        if (winner) merges.push({ loser: row, winner });
+        else renames.push({ row, to });
+    }
+
+    // Two mangled keys can also collapse onto each other with no existing twin.
+    const renameTargets = new Map<string, Array<{ row: Row; to: string }>>();
+    for (const r of renames) {
+        if (!renameTargets.has(r.to)) renameTargets.set(r.to, []);
+        renameTargets.get(r.to)!.push(r);
+    }
+    const pairMerges: Array<{ loser: Row; winner: Row }> = [];
+    const cleanRenames: Array<{ row: Row; to: string }> = [];
+    for (const [, group] of renameTargets) {
+        if (group.length === 1) { cleanRenames.push(group[0]); continue; }
+        // Keep the most-used row; fold the rest into it.
+        const sorted = [...group].sort((a, b) => b.row.usedCount - a.row.usedCount);
+        cleanRenames.push(sorted[0]);
+        for (const l of sorted.slice(1)) pairMerges.push({ loser: l.row, winner: sorted[0].row });
+    }
+    const allMerges = [...merges, ...pairMerges];
+
+    console.log(`FoodMapping rows        : ${rows.length}`);
+    console.log(`renames                 : ${cleanRenames.length}`);
+    console.log(`merges (row deleted)    : ${allMerges.length}`);
+    console.log(`rows after              : ${rows.length - allMerges.length}`);
+    console.log('');
+
+    let humanRescues = 0;
+    for (const m of allMerges) {
+        const rescue = m.loser.validatedBy === 'human-triage' && m.winner.validatedBy !== 'human-triage';
+        if (rescue) humanRescues++;
+        console.log(`MERGE ${m.loser.normalizedForm}`);
+        console.log(`   drop  : ${m.loser.foodName} / ${m.loser.brandName ?? '-'} [${m.loser.validatedBy} ${m.loser.aiConfidence.toFixed(3)} used=${m.loser.usedCount}]`);
+        console.log(`   keep  : ${m.winner.foodName} / ${m.winner.brandName ?? '-'} [${m.winner.validatedBy} ${m.winner.aiConfidence.toFixed(3)} used=${m.winner.usedCount}]${rescue ? '  <-- HUMAN RECORD COPIED FROM DROPPED ROW' : ''}`);
+    }
+    if (humanRescues) console.log(`\n${humanRescues} merge(s) preserve a human-triage record from the dropped row.`);
+
+    if (!APPLY) {
+        console.log('\nDRY RUN — pass --apply to write. Snapshot FoodMapping first.');
+        for (const r of cleanRenames.slice(0, 10)) console.log(`  RENAME ${r.row.normalizedForm}  ->  ${r.to}`);
+        if (cleanRenames.length > 10) console.log(`  ... and ${cleanRenames.length - 10} more renames`);
+        await prisma.$disconnect();
+        return;
+    }
+
+    await prisma.$transaction(async tx => {
+        // Merges first: deleting the loser frees the key space before any rename
+        // could collide with it.
+        for (const m of allMerges) {
+            const data: Record<string, unknown> = {
+                usedCount: m.winner.usedCount + m.loser.usedCount,
+                lastUsedAt: m.loser.lastUsedAt > m.winner.lastUsedAt ? m.loser.lastUsedAt : m.winner.lastUsedAt,
+            };
+            if (m.loser.validatedBy === 'human-triage' && m.winner.validatedBy !== 'human-triage') {
+                Object.assign(data, {
+                    foodName: m.loser.foodName, brandName: m.loser.brandName, source: m.loser.source,
+                    offBarcode: m.loser.offBarcode, fdcId: m.loser.fdcId, fsId: m.loser.fsId,
+                    aiConfidence: m.loser.aiConfidence, validatedBy: m.loser.validatedBy,
+                });
+            }
+            await tx.foodMapping.delete({ where: { normalizedForm: m.loser.normalizedForm } });
+            await tx.foodMapping.update({ where: { normalizedForm: m.winner.normalizedForm }, data });
+        }
+        for (const r of cleanRenames) {
+            await tx.foodMapping.update({
+                where: { normalizedForm: r.row.normalizedForm },
+                data: { normalizedForm: r.to },
+            });
+        }
+    }, { timeout: 120_000 });
+
+    const after = await prisma.foodMapping.count();
+    const stillMangled = await prisma.foodMapping.count({ where: { normalizedForm: { contains: "'" } } });
+    console.log(`\nAPPLIED. rows now: ${after}  |  keys still holding an apostrophe: ${stillMangled} (expect 0)`);
+    await prisma.$disconnect();
+}
+
+main().catch(async e => { console.error(e); await prisma.$disconnect(); process.exit(1); });

--- a/src/lib/mapping/__tests__/cache-key.test.ts
+++ b/src/lib/mapping/__tests__/cache-key.test.ts
@@ -131,4 +131,50 @@ describe('deriveCacheKeyName', () => {
             expect(deriveCacheKeyName('milk', wholeMilk)).toBe(canonicalizeCacheKey('milk'));
         });
     });
+
+    // ======================================================================
+    // POSSESSIVE BRAND SPELLINGS
+    // Three spellings of one brand used to address three different cache rows:
+    // "mcdonald's" -> "mcdonald'" (apostrophe kept, then fed to singularize),
+    // "mcdonald’s" -> "mcdonald s" (curly form split into a stray token), and
+    // "mcdonalds"  -> "mcdonald". Since the key basis is whatever spelling the
+    // LLM emitted, which row a user hit was effectively random — live on the box
+    // "mcdonalds fries" returned McDonald's Fries Medium (114g) while
+    // "mcdonald's fries" returned a generic unbranded Fries (250g).
+    // ======================================================================
+    describe('possessive apostrophes collapse to one key', () => {
+        it.each([
+            ["mcdonald's fries", 'mcdonalds fries'],
+            ['mcdonald’s fries', 'mcdonalds fries'],
+            ["trader joe's orange chicken", 'trader joes orange chicken'],
+            ["stouffer's lasagna", 'stouffers lasagna'],
+            ["jimmy john's turkey tom", 'jimmy johns turkey tom'],
+        ])('%s === %s', (withApostrophe, without) => {
+            expect(canonicalizeCacheKey(withApostrophe)).toBe(canonicalizeCacheKey(without));
+        });
+
+        it('leaves no dangling apostrophe in the key', () => {
+            expect(canonicalizeCacheKey("mcdonald's fries")).toBe('fry mcdonald');
+            expect(canonicalizeCacheKey("portillo's hot dog")).toBe('dog hot portillo');
+        });
+
+        it('is a fixed point, so migrating a stored key is one-shot', () => {
+            for (const q of ["moe's chips", 'mcdonald’s fries', "trader joe's mandarin orange chicken"]) {
+                const once = canonicalizeCacheKey(q);
+                expect(canonicalizeCacheKey(once)).toBe(once);
+            }
+        });
+
+        it('does not fuse words across a non-possessive apostrophe', () => {
+            // "it's-it" is a real ice cream brand: dropping the apostrophe must not
+            // merge it into neighbouring tokens or drop the hyphen.
+            expect(canonicalizeCacheKey("it's-it ice cream sandwich")).toBe('cream ice its-it sandwich');
+        });
+
+        it('is inert on names without apostrophes', () => {
+            for (const q of ['impossible burger patty', '2% milk', 'half-and-half', 'greek yogurt']) {
+                expect(canonicalizeCacheKey(q)).toBe(canonicalizeCacheKey(q.replace(/'/g, '')));
+            }
+        });
+    });
 });

--- a/src/lib/mapping/normalization-rules.ts
+++ b/src/lib/mapping/normalization-rules.ts
@@ -624,6 +624,18 @@ const IRREGULAR_PLURALS: Record<string, string> = {
   selves: 'self',
   // Produce
   dice: 'die',  // but "diced" is already stripped as prep
+  // Possessive brand stems ending in a sibilant. Once apostrophes are deleted,
+  // "reese's" arrives here as "reeses", which the -ses rule chops to "rees" —
+  // and "rees" is itself -s-eligible, so the result is NOT a fixed point
+  // ("rees" -> "ree"). Every stored key is currently a fixed point and
+  // cache-coverage.ts:130 relies on that when it re-canonicalizes stored keys,
+  // so a non-fixed-point key would make the coverage metric under-report rows
+  // the cache actually serves. Mapping the whole form to its stem keeps the
+  // invariant. The general fix — guarding the -ses branch so it only fires for
+  // -ss stems (glasses->glass) and strips one s otherwise — also corrects
+  // cheeses->chees, houses->hous and roses->ros, but moves those keys too and
+  // needs its own migration.
+  reeses: 'reese',
 };
 
 /**
@@ -708,13 +720,26 @@ export function singularize(word: string): string {
  * - "Greek Yogurt" == "greek yogurt" (case)
  * - "creamy peanut butter" != "peanut butter" (meaningful modifier preserved)
  * - "red bell pepper" != "bell pepper" (color variant preserved)
+ * - "mcdonald's fries" == "mcdonalds fries" == "mcdonald’s fries" (possessive spelling)
+ *
+ * Apostrophes are DELETED before tokenizing, not kept and not turned into
+ * separators. Keeping them fed the possessive `s` to singularize() and left a
+ * dangling quote ("mcdonald's" -> "mcdonald'"), while the curly form was not in
+ * the keep-list at all and split into a stray token ("mcdonald’s" -> "mcdonald s").
+ * Three spellings of one brand therefore addressed three different cache rows, and
+ * because the key basis is whatever spelling the LLM emitted, which row a user hit
+ * was effectively random: "mcdonalds fries" resolved to McDonald's Fries Medium
+ * (114g) while "mcdonald's fries" resolved to a generic unbranded Fries (250g).
+ * Deleting the apostrophe collapses all three onto the apostrophe-free key, which
+ * is the spelling the existing rows already agree on.
  */
 export function canonicalizeCacheKey(normalizedName: string): string {
   if (!normalizedName) return '';
 
   return normalizedName
     .toLowerCase()
-    .replace(/[^a-z0-9%\s\-']/g, ' ')  // Keep %, hyphens, apostrophes
+    .replace(/['‘’ʼ`´]/g, '')  // Possessives collapse: see above
+    .replace(/[^a-z0-9%\s\-]/g, ' ')  // Keep %, hyphens
     .split(/\s+/)
     .filter(w => w.length > 0)
     .map(singularize)


### PR DESCRIPTION
`canonicalizeCacheKey` kept apostrophes and then handed the possessive `s` to `singularize()`, so `mcdonald's` became `mcdonald'`. The curly form wasn't in the keep-list at all and split into a stray token (`mcdonald s`). Three spellings of one brand addressed three different cache rows — and since the key basis is whatever spelling the LLM emitted, which row a user hit was **effectively random**.

Measured live on the box before this change:

| query | record | grams |
|---|---|---|
| `mcdonald's fries` | generic "Fries", no brand | 250g |
| `mcdonalds fries` | **McDonald's Fries, Medium** | 114g |
| `trader joe's orange chicken` | Trader Joe's Organic Free Range *raw* Chicken | 112g |
| `trader joes orange chicken` | **Mandarin Orange Chicken** | 140g |

Same intent, different answer — and the apostrophe-free spelling held the better record both times. 108 of 3,168 live keys carry the mangling.

## The fix
Delete apostrophes before tokenizing. All three spellings collapse onto the apostrophe-free key, which existing rows already agree on. Verified against every live key: **exactly 108 move, 3,060 are inert, and no apostrophe-free key shifts.**

`reeses -> 'reese'` joins `IRREGULAR_PLURALS` because the `-ses` rule chops `reeses` to `rees`, which is itself `-s`-eligible — so the result isn't a fixed point. Every stored key is currently a fixed point and `cache-coverage.ts:130` relies on that when it re-canonicalizes stored keys; a non-fixed-point key would make the coverage metric under-report rows the cache actually serves. The general fix (guard the `-ses` branch to fire only for `-ss` stems, also correcting `cheeses->chees`, `houses->hous`, `roses->ros`) moves those keys too and needs its own migration.

## The migration
`scripts/migrate-possessive-keys.ts`, 97 renames + 11 merges. Two things it deliberately does **not** do, both learned by measurement:

- **It does not target `canonicalizeCacheKey(storedKey)`.** A stored key was already singularized once, lossily: re-canonicalizing `puff reese'` gives `puff reese`, but a live lookup for "reese's puffs" computes `puff rees` — the row would land on a key nothing asks for. The script restores the possessive first, reproducing what the lookup path computes. Verified **0 stranded rows, 0 non-fixed-point targets**.
- **It does not rank merges by confidence.** In all 11 real collisions the apostrophe-free row held the better record whenever substance differed — including two `human-triage` 0.99 rows — while AI confidence pointed *backwards* in the two worst cases (generic unbranded "Fries" at 0.980 vs McDonald's Fries Medium at 0.880). The twin wins, `usedCount` is summed, and a human-triage record on the dropped side is copied onto the survivor rather than discarded.

## Coverage effect, stated plainly
35.7% → 36.1% of the committed corpus (+14 seeds, +0.42pt). A related investigation implied key form explained most of the coverage-vs-conversion gap; measured, apostrophes are a small part of it. **The reason to do this is correctness, not coverage.**

## Gate
967 tests / 49 suites (mapping, ops, parse). 9 new cache-key cases pin the three-way collapse, the fixed-point property, and no-fusion on the non-possessive brand `it's-it`. Pre-migration snapshot on the box at `/tmp/fm-pre-apostrophe-2026-07-25.sql` (3,168 rows). Full eval ×2 runs after deploy+migration, since the assertion under test is live key behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx