### PR TITLE
fix(filter): a brand named "Grill" is not evidence of an unrelated product

### DIFF
--- a/src/lib/mapping/__tests__/restaurant-brand-filter-relax.test.ts
+++ b/src/lib/mapping/__tests__/restaurant-brand-filter-relax.test.ts
@@ -95,3 +95,87 @@ describe('filterCandidatesByTokens — branded restaurant items survive', () => 
         expect(isMealProductMismatch('cinnamon sticks', 'Cinnamon Sticks', 'DiGiorno')).toBe(true);
     });
 });
+
+describe('disqualifier scan ignores the brand name', () => {
+    // The UNRELATED_INDICATORS list exists to reject unrelated PRODUCTS ("cadillac"
+    // for flaxseed meal). It was being tested against name + brandName, so every
+    // chain whose brand contains grill/kitchen/cafe/diner/bistro/restaurant had its
+    // whole catalogue rejected: 476 ingested FatSecret records across 66 brands.
+    // Observed live before the fix — "qdoba chicken burrito" gathered 8 Qdoba
+    // FatSecret records and 0 survived, all on disqualifier "grill".
+    const qdoba = [
+        'Chicken Queso Burrito', 'Cholula Hot & Sweet Chicken Burrito', 'Quesabirria Burrito',
+        'Southwest Steak Burrito', 'Grilled Chicken - Kids', 'Keto Bowl - Chicken',
+        'Grilled Adobo Chicken', 'Chicken Queso Bowl',
+    ];
+
+    it('keeps Qdoba Mexican Grill records for "qdoba chicken burrito"', () => {
+        const cands = qdoba.map(name => cand({
+            source: 'fatsecret',
+            name,
+            brandName: 'Qdoba Mexican Grill',
+            nutrition: { per100g: true, kcal: 185, protein: 9.5, fat: 6.2, carbs: 22 } as any,
+        }));
+        const { filtered } = filterCandidatesByTokens(cands, 'qdoba chicken burrito', {
+            rawLine: 'qdoba chicken burrito',
+        });
+        // The assembled burrito is the record the golden case n-mq-39 needs.
+        expect(filtered.map(c => c.name)).toContain('Chicken Queso Burrito');
+    });
+
+    it('keeps a venue-brand record when the brand word is only in the brand', () => {
+        const cands = [cand({
+            source: 'fatsecret',
+            name: 'Chipotle Chicken Burrito',
+            brandName: 'The Gym Kitchen',
+            nutrition: { per100g: true, kcal: 153, protein: 8.4, fat: 3.1, carbs: 22.5 } as any,
+        })];
+        const { filtered } = filterCandidatesByTokens(cands, 'chipotle chicken burrito', {
+            rawLine: 'chipotle chicken burrito',
+        });
+        expect(filtered.length).toBe(1);
+    });
+
+    it('spares an OFF record that bakes a venue brand into the name', () => {
+        // OFF stores the brand inside the name, so scanning the name alone would
+        // still see "grill" — brand-derived words are skipped explicitly.
+        const cands = [cand({
+            source: 'openfoodfacts',
+            name: 'Qdoba Mexican Grill, Chicken Queso Burrito',
+            brandName: 'Qdoba Mexican Grill',
+            nutrition: { per100g: true, kcal: 185, protein: 9.5, fat: 6.2, carbs: 22 } as any,
+        })];
+        const { filtered } = filterCandidatesByTokens(cands, 'qdoba chicken burrito', {
+            rawLine: 'qdoba chicken burrito',
+        });
+        expect(filtered.length).toBe(1);
+    });
+
+    it('STILL rejects an unrelated word that is in the product name', () => {
+        // The check must keep doing its job when the disqualifier is genuinely part
+        // of the product, not the brand — this is the case the list was written for.
+        const cands = [cand({
+            source: 'openfoodfacts',
+            name: 'Cadillac Margarita Mix',
+            brandName: 'Jose Cuervo',
+            nutrition: { per100g: true, kcal: 120, protein: 0, fat: 0, carbs: 30 } as any,
+        })];
+        const { filtered } = filterCandidatesByTokens(cands, 'flaxseed meal', {
+            rawLine: 'flaxseed meal',
+        });
+        expect(filtered.length).toBe(0);
+    });
+
+    it('STILL rejects a grill APPLIANCE for a food query', () => {
+        const cands = [cand({
+            source: 'openfoodfacts',
+            name: 'George Foreman Grill Cleaning Wipes',
+            brandName: 'George Foreman',
+            nutrition: { per100g: true, kcal: 0, protein: 0, fat: 0, carbs: 0 } as any,
+        })];
+        const { filtered } = filterCandidatesByTokens(cands, 'chicken breast', {
+            rawLine: 'chicken breast',
+        });
+        expect(filtered.length).toBe(0);
+    });
+});

--- a/src/lib/mapping/filter-candidates.ts
+++ b/src/lib/mapping/filter-candidates.ts
@@ -2724,12 +2724,33 @@ export function filterCandidatesByTokens(
             'auto', 'car', 'vehicle', 'truck', 'automotive'
         ]);
 
-        const candidateWords = candidateName.split(/\s+/).filter(w => w.length > 3);
+        // Scan the PRODUCT NAME, never the brand. A brand name is identity, not
+        // evidence of relatedness: "Qdoba Mexican Grill" says nothing about whether
+        // a Chicken Queso Burrito answers "qdoba chicken burrito". Because
+        // normalizeCandidateName() appends brandName, the word "grill" landed in the
+        // scanned text and rejected ALL 8 Qdoba FatSecret records — likewise "The Gym
+        // Kitchen" rejected its Chipotle Chicken Burrito on "kitchen". Measured on the
+        // box: 476 ingested FatSecret records across 66 brands were unreachable this
+        // way (grill 236, kitchen 107, restaurant 60, cafe 52, bistro 11, diner 10),
+        // and the blackout was invisible because the loop skips words present in the
+        // query — so it only spared you if you typed the brand's full legal name.
+        // candidateName (name + brand) is still correct for the must-have check above,
+        // where a query token legitimately matches the brand.
+        const brandWords = new Set(
+            (candidate.brandName ?? '').toLowerCase().split(/[^\w]+/).filter(w => w.length > 3)
+        );
+        const candidateWords = candidate.name.toLowerCase().split(/\s+/).filter(w => w.length > 3);
         const queryWords = new Set(normalizedName.toLowerCase().split(/\s+/).filter(w => w.length > 3));
 
         for (const word of candidateWords) {
             // Skip words that appear in query
             if (queryWords.has(word)) continue;
+
+            // Skip brand-derived words. Sources differ on where the brand lives: OFF
+            // bakes it into the name ("Qdoba, Tequila Lime Chicken") while FatSecret
+            // keeps it separate, so scanning the name alone is not enough to spare a
+            // venue-named brand on the OFF side.
+            if (brandWords.has(word)) continue;
 
             // Skip words that are related to must-have tokens
             if (mustHaveTokens.some(token => word.includes(token) || token.includes(word))) continue;


### PR DESCRIPTION
`UNRELATED_INDICATORS` rejects candidates carrying words that signal a completely different product — `cadillac` for flaxseed meal, `automotive`, `martini`. It also lists `grill, restaurant, cafe, diner, bistro, kitchen`, and it was tested against `normalizeCandidateName()`, **which appends `brandName`**. So every chain whose *brand* contains one of those words had its entire catalogue rejected before rerank ever saw it.

Observed on the box for `qdoba chicken burrito`: **8 Qdoba FatSecret records gathered, 0 survived**, every one on disqualifier `grill` — including `Chicken Queso Burrito` (fsId 1112991), the assembled record golden case `n-mq-39` needs. `chipotle chicken burrito` loses The Gym **Kitchen**'s `Chipotle Chicken Burrito` the same way.

## Scope
Measured against the ingested FatSecret store — **476 records across 66 brands unreachable**:

| word | brands | records |
|---|---|---|
| grill | 23 | 236 |
| kitchen | 19 | 107 |
| restaurant | 6 | 60 |
| cafe | 12 | 52 |
| bistro | 4 | 11 |
| diner | 2 | 10 |

OFF carries venue brands too, so the true figure is higher. The blackout was invisible because the loop skips words that appear in the query — it only spared you if you typed the brand's full legal name.

## Fix
Scan the product **name** for disqualifiers, and skip words that come from the brand. Both halves are needed because the sources disagree on where the brand lives: OFF bakes it into the name (`Qdoba, Tequila Lime Chicken`) while FatSecret keeps it separate. `candidateName` (name + brand) is left alone for the must-have-token check above it, where a query token legitimately matches the brand.

**This change can only ADMIT candidates, never remove ones that pass today** — so existing behaviour can shift only by rerank preferring a newly-admitted record, which is the point.

## Why this matters beyond the four composite cases
This was found while investigating composite→component drift, where the pinned diagnosis was "corpus gap — chains publish per-ingredient nutrition". That was wrong: the assembled records exist in our own Postgres. A follow-up theory blamed `filtered.slice(0,10)` starving the FatSecret lane; observing the real candidate pools showed starvation affects **1 of 4** cases. This filter is the dominant cause, and it is not specific to composite dishes — it is a systematic restaurant-chain blackout that would have silently poisoned the upcoming chain warm batches.

## Gate
992 tests / 52 suites (mapping, ops, parse, search). 5 new cases pin that Qdoba Mexican Grill survives, that a venue word in the brand alone is ignored, that an OFF record baking the brand into its name is spared, and that the check **still** rejects a Cadillac Margarita Mix for "flaxseed meal" and a George Foreman Grill cleaning product for "chicken breast". Full eval ×2 on the box after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx