### PR TITLE
fix(cache-key): the -es rule was chopping two characters off one-s stems

### DIFF
--- a/src/lib/mapping/__tests__/cache-key.test.ts
+++ b/src/lib/mapping/__tests__/cache-key.test.ts
@@ -1,5 +1,5 @@
 import { deriveCacheKeyName } from '../cache-key';
-import { canonicalizeCacheKey } from '../normalization-rules';
+import { canonicalizeCacheKey, singularize } from '../normalization-rules';
 import { parseIngredientLine } from '../../parse/ingredient-line';
 import type { ParsedIngredient } from '../../parse/ingredient-line';
 
@@ -176,5 +176,85 @@ describe('deriveCacheKeyName', () => {
                 expect(canonicalizeCacheKey(q)).toBe(canonicalizeCacheKey(q.replace(/'/g, '')));
             }
         });
+    });
+});
+
+// ==========================================================================
+// The -es family. One rule covered two different plurals: an -es genuinely
+// added after a sibilant stem (box -> boxes, glass -> glasses) and a bare -s
+// added to a stem that already ended in -se (cheese -> cheeses). Chopping two
+// characters is right for the first and wrong for the second, which produced
+// chees / hous / ros / dos. The doubled s tells them apart.
+// ==========================================================================
+describe('singularize: the -es family', () => {
+    describe('a sibilant stem keeps losing both characters', () => {
+        it.each([
+            ['glasses', 'glass'], ['dresses', 'dress'], ['classes', 'class'], ['masses', 'mass'],
+            ['boxes', 'box'], ['foxes', 'fox'], ['taxes', 'tax'], ['mixes', 'mix'],
+            ['buzzes', 'buzz'],
+            ['sandwiches', 'sandwich'], ['churches', 'church'], ['peaches', 'peach'], ['lunches', 'lunch'],
+            ['dishes', 'dish'], ['radishes', 'radish'], ['squashes', 'squash'], ['knishes', 'knish'],
+        ])('%s -> %s', (plural, singular) => {
+            expect(singularize(plural)).toBe(singular);
+        });
+    });
+
+    describe('a stem that already ended in -e loses only the s', () => {
+        it.each([
+            ['cheeses', 'cheese'], ['houses', 'house'], ['roses', 'rose'], ['doses', 'dose'],
+            ['bases', 'base'], ['noses', 'nose'], ['courses', 'course'], ['phases', 'phase'],
+        ])('%s -> %s', (plural, singular) => {
+            expect(singularize(plural)).toBe(singular);
+        });
+    });
+
+    describe('the words where the doubled-s signal misleads', () => {
+        it.each([
+            ['buses', 'bus'],       // single-s stem, no doubling to signal it
+            ['gases', 'gas'],
+            ['mousses', 'mousse'],  // doubled s, but the stem is -sse
+        ])('%s -> %s', (plural, singular) => {
+            expect(singularize(plural)).toBe(singular);
+        });
+    });
+
+    it('derives the possessive brand stem that used to need an explicit entry', () => {
+        // PR #149 had to hard-code `reeses: 'reese'` because the old rule chopped
+        // it to "rees", which was itself -s-eligible and so not a fixed point.
+        // The general rule now produces it, and the hard-coded entry is gone.
+        expect(singularize('reeses')).toBe('reese');
+        expect(canonicalizeCacheKey("reese's puffs")).toBe('puff reese');
+    });
+
+    it('leaves every output a fixed point', () => {
+        // cache-coverage.ts re-canonicalizes stored keys to count them, so a key
+        // that moves on a second pass makes the coverage metric under-report.
+        const words = [
+            'cheeses', 'houses', 'roses', 'doses', 'bases', 'noses', 'courses', 'phases',
+            'glasses', 'dresses', 'boxes', 'dishes', 'sandwiches', 'buses', 'gases', 'mousses',
+            'reeses', 'molasses', 'olives', 'noodles', 'tomatoes', 'berries',
+        ];
+        for (const w of words) {
+            const once = singularize(w);
+            expect(singularize(once)).toBe(once);
+        }
+    });
+
+    it('still defers to the blacklist for singulars that look plural', () => {
+        for (const w of ['molasses', 'hummus', 'couscous', 'asparagus', 'swiss', 'chips', 'strips']) {
+            expect(singularize(w)).toBe(w);
+        }
+    });
+
+    it('does not disturb the general -es and -s rules', () => {
+        const unaffected: Array<[string, string]> = [
+            ['olives', 'olive'], ['noodles', 'noodle'], ['sauces', 'sauce'], ['juices', 'juice'],
+            ['crepes', 'crepe'], ['pastes', 'paste'], ['tomatoes', 'tomato'], ['potatoes', 'potato'],
+            ['berries', 'berry'], ['cherries', 'cherry'], ['chilies', 'chili'],
+            ['leaves', 'leaf'], ['halves', 'half'], ['carrots', 'carrot'], ['eggs', 'egg'],
+        ];
+        for (const [plural, singular] of unaffected) {
+            expect(singularize(plural)).toBe(singular);
+        }
     });
 });

--- a/src/lib/mapping/normalization-rules.ts
+++ b/src/lib/mapping/normalization-rules.ts
@@ -624,18 +624,14 @@ const IRREGULAR_PLURALS: Record<string, string> = {
   selves: 'self',
   // Produce
   dice: 'die',  // but "diced" is already stripped as prep
-  // Possessive brand stems ending in a sibilant. Once apostrophes are deleted,
-  // "reese's" arrives here as "reeses", which the -ses rule chops to "rees" —
-  // and "rees" is itself -s-eligible, so the result is NOT a fixed point
-  // ("rees" -> "ree"). Every stored key is currently a fixed point and
-  // cache-coverage.ts:130 relies on that when it re-canonicalizes stored keys,
-  // so a non-fixed-point key would make the coverage metric under-report rows
-  // the cache actually serves. Mapping the whole form to its stem keeps the
-  // invariant. The general fix — guarding the -ses branch so it only fires for
-  // -ss stems (glasses->glass) and strips one s otherwise — also corrects
-  // cheeses->chees, houses->hous and roses->ros, but moves those keys too and
-  // needs its own migration.
-  reeses: 'reese',
+  // The -ses branch below reads a doubled s as the signal that the stem really
+  // ends in -ss. These are the words where that signal is absent but the stem
+  // still is not -se, so the general rule would over-restore an e
+  // ("buses" -> "buse"). Small and closed: English has very few single-s stems.
+  buses: 'bus',
+  gases: 'gas',
+  // ...and the mirror case: a doubled s whose stem is -sse, not -ss.
+  mousses: 'mousse',
 };
 
 /**
@@ -647,7 +643,8 @@ const IRREGULAR_PLURALS: Record<string, string> = {
  * 3. -ies → -y (berries → berry)
  * 4. -ves → -f (leaves → leaf) — handled by irregular map
  * 5. -oes → -o (tomatoes → tomato, potatoes → potato)
- * 6. -ses, -xes, -zes, -ches, -shes → strip -es
+ * 6. -xes, -zes, -ches, -shes and -sses → strip -es (boxes → box, glasses → glass);
+ *    bare -ses → strip -s only, because the stem kept its e (cheeses → cheese)
  * 7. -es (general, word > 4 chars) → strip -es
  * 8. -s (word > 3 chars) → strip -s
  */
@@ -683,8 +680,24 @@ export function singularize(word: string): string {
   }
 
   // -ses, -xes, -zes, -ches, -shes → strip -es
+  //
+  // Stripping two characters is right whenever the -es was added to a stem that
+  // already ended in a sibilant: box->boxes, buzz->buzzes, church->churches,
+  // dish->dishes, glass->glasses. It is wrong for -ses when the singular ends
+  // in -e, because then only the s was added: cheese->cheeses, rose->roses,
+  // house->houses, dose->doses. Chopping two there yields chees / ros / hous /
+  // dos — and those are not even fixed points ("chees" -> "chee"), which
+  // matters because cache-coverage.ts re-canonicalizes stored keys and would
+  // under-report any row whose key moves on a second pass.
+  //
+  // The doubled s is the discriminator: "-sses" means the stem really is -ss,
+  // anything else means the stem is -se. IRREGULAR_PLURALS carries the handful
+  // of words where that signal misleads (buses, gases, mousses).
   if (lower.length > 4 && /(?:ses|xes|zes|ches|shes)$/.test(lower)) {
-    return lower.slice(0, -2);
+    if (lower.endsWith('ses') && !lower.endsWith('sses')) {
+      return lower.slice(0, -1);  // cheeses -> cheese, roses -> rose
+    }
+    return lower.slice(0, -2);    // glasses -> glass, boxes -> box, dishes -> dish
   }
 
   // General -es (word > 4 chars) — but only if the stem looks like a real word


### PR DESCRIPTION
## The bug

`singularize()` handled two different plurals in one branch:

| shape | example | correct | old rule |
|---|---|---|---|
| `-es` added after a sibilant stem | `box` → `boxes` | strip 2 | ✅ `box` |
| bare `-s` added to a stem ending `-se` | `cheese` → `cheeses` | strip 1 | ❌ `chees` |

So `cheeses → chees`, `houses → hous`, `roses → ros`, `doses → dose`… `dos`.

Those outputs aren't even **fixed points** — `chees` ends in a single `s`, so a second pass gives `chee`. That matters because `cache-coverage.ts` re-canonicalizes stored keys when it counts them, and would under-report any row whose key moves on a second pass.

PR #149 ran into this from the other side and had to hard-code `reeses: 'reese'` to preserve the invariant. The general rule now derives that, so the entry is gone and a test pins the behaviour in its place.

## The fix

The doubled `s` is the discriminator — `-sses` means the stem really is `-ss`, anything else means it's `-se`:

```ts
if (lower.length > 4 && /(?:ses|xes|zes|ches|shes)$/.test(lower)) {
  if (lower.endsWith('ses') && !lower.endsWith('sses')) {
    return lower.slice(0, -1);  // cheeses -> cheese, roses -> rose
  }
  return lower.slice(0, -2);    // glasses -> glass, boxes -> box, dishes -> dish
}
```

Three words where that signal misleads move to `IRREGULAR_PLURALS`: `buses`/`gases` (single-s stems with no doubling to mark them) and `mousses` (a doubled `s` over an `-sse` stem).

## Measured before changing anything

Against the live cache on the box:

- **0 of 3,157 stored keys move**, and all remain fixed points.
- **0 of 5,288 distinct query forms** (3,129 event-log `normalizedForm`s + the 3,307-seed coverage corpus) compute a different key → **no orphaned rows, no migration needed.**
- **9 words corrected, 0 regressions** across a 55-word battery.

The second bullet is the one that matters. A stored key holding still is worthless if the lookup that reaches it starts computing something else — that's the trap PR #149's migration had to solve, and checking it is why this ships without a migration rather than hoping.

## Gate

- 56/56 in `cache-key.test.ts`, **1,456 passing across all 89 suites**
- `typecheck` clean, `lint:ci` 0 errors
- Eval ×2 to follow on the box before merge

## Left deliberately alone

Three cruder local `singularize()` copies shadow this one on the filter and retrieval paths — `filter-candidates.ts:113`, `gather-candidates.ts:847`, `map-ingredient-with-fallback.ts:435`. They strip two characters from *any* `-es`, so they produce `oliv`, `nood`, `sauc`. They feed fuzzy match/score signals rather than cache keys and share no invariant with this function, so widening the change to them would be a separate PR with its own eval gate. Worth filing — `getSingularPluralVariants` generating `oliv` may be costing real filter matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx