### PR TITLE
feat(eval): F2 failure-class registry + F3 warm-and-triage driver

### DIFF
--- a/scripts/debug-retrieval-probe.ts
+++ b/scripts/debug-retrieval-probe.ts
@@ -1,0 +1,136 @@
+/**
+ * debug-retrieval-probe.ts — for each query, dump what EACH retrieval source returns.
+ *
+ * Answers "why did this line drop?" by separating a DATASET gap (nothing exists in
+ * any lane) from a LANE/RANKING gap (records exist, retrieval or rerank lost them).
+ *
+ * ---------------------------------------------------------------------------
+ * COST + SIDE EFFECTS (read this before running it over hundreds of drops)
+ * ---------------------------------------------------------------------------
+ * - NO LLM CALLS. Nothing here reaches OpenRouter/Ollama. `gatherCandidates` does
+ *   keyword search (Typesense `off_foods` + Postgres FDC) and, only when
+ *   SEMANTIC_SEARCH_ENABLED=true, a LOCAL ONNX query embedding — no paid tokens.
+ * - IT IS NOT PURELY READ-ONLY. `searchFatSecretLane` fires
+ *   `persistFatSecretHits` as a registered background task, which UPSERTS
+ *   FatSecretFood / FatSecretServing rows (corpus hydration of FS API results —
+ *   it never touches FoodMapping, so it cannot change a cached pick). For a
+ *   strictly read-only run set FATSECRET_RETRIEVAL_ENABLED=false BEFORE this
+ *   module is loaded; the lane then returns [] without calling the API.
+ * - FatSecret API quota IS consumed per query (Premier tier), twice per query in
+ *   fact: once by the direct lane call and once inside gatherCandidates. Pass
+ *   `{ skipFatSecretLaneCall: true }` to drop the direct call and rely on the
+ *   gather pass alone.
+ *
+ * Usage (unchanged):
+ *   ts-node ... scripts/debug-retrieval-probe.ts '<query1>' '<query2>' ...
+ *   ts-node ... scripts/debug-retrieval-probe.ts --file <queries.txt>
+ */
+import * as nodeFs from 'fs';
+import { searchFatSecretLane } from '../src/lib/mapping/fatsecret-lane';
+import { gatherCandidates } from '../src/lib/mapping/gather-candidates';
+
+/** One candidate, flattened to the fields a triage reader needs. */
+export interface ProbeCandidate {
+    /** `off_<barcode>` | `fdc_<id>` | `fs_<fsId>` — the repoint target vocabulary. */
+    id: string | null;
+    source: string | null;
+    name: string | null;
+    brand: string | null;
+    score: number | null;
+}
+
+export interface RetrievalProbe {
+    query: string;
+    /** Direct FatSecret lane call. `null` when skipped, `{error}` when it threw. */
+    fatsecret: { count: number; top: ProbeCandidate[] } | { error: string } | null;
+    /** Combined OFF + FDC + FS through gatherCandidates (branded path forces OFF on). */
+    gather: { total: number; bySource: Record<string, number>; top: ProbeCandidate[] } | { error: string };
+}
+
+export interface RetrievalProbeOptions {
+    /** How many candidates per source to ask for (default 8, same as the pipeline). */
+    maxPerSource?: number;
+    /** How many candidates to keep in the report (default 6). */
+    topN?: number;
+    /** Skip the direct FatSecret lane call — halves FS API quota per query. */
+    skipFatSecretLaneCall?: boolean;
+}
+
+function toProbeCandidate(c: unknown): ProbeCandidate {
+    const r = c as { id?: string; source?: string; foodName?: string; name?: string; brandName?: string | null; score?: number };
+    return {
+        id: r.id ?? null,
+        source: r.source ?? null,
+        name: r.foodName ?? r.name ?? null,
+        brand: r.brandName ?? null,
+        score: typeof r.score === 'number' ? +r.score.toFixed(3) : null,
+    };
+}
+
+/**
+ * Probe every retrieval lane for one query. Never throws: per-lane failures are
+ * captured as `{ error }` so a batch caller keeps going.
+ */
+export async function probeRetrieval(query: string, opts: RetrievalProbeOptions = {}): Promise<RetrievalProbe> {
+    const maxPerSource = opts.maxPerSource ?? 8;
+    const topN = opts.topN ?? 6;
+    const out: RetrievalProbe = { query, fatsecret: null, gather: { error: 'not run' } };
+
+    if (!opts.skipFatSecretLaneCall) {
+        try {
+            const fs = await searchFatSecretLane(query, maxPerSource);
+            out.fatsecret = { count: fs.length, top: fs.slice(0, topN).map(toProbeCandidate) };
+        } catch (e) {
+            out.fatsecret = { error: (e as Error)?.message ?? String(e) };
+        }
+    }
+
+    try {
+        const cands = await gatherCandidates(query, null, query, { isBrandedQuery: true, maxPerSource });
+        const bySource: Record<string, number> = {};
+        for (const c of cands) bySource[c.source ?? '?'] = (bySource[c.source ?? '?'] ?? 0) + 1;
+        out.gather = {
+            total: cands.length,
+            bySource,
+            top: cands.slice(0, topN).map(toProbeCandidate),
+        };
+    } catch (e) {
+        out.gather = { error: (e as Error)?.message ?? String(e) };
+    }
+    return out;
+}
+
+/** Every gathered candidate that survived to the report, flattened. */
+export function probeCandidates(probe: RetrievalProbe): ProbeCandidate[] {
+    const out: ProbeCandidate[] = [];
+    if (probe.gather && !('error' in probe.gather)) out.push(...probe.gather.top);
+    if (probe.fatsecret && !('error' in probe.fatsecret)) out.push(...probe.fatsecret.top);
+    return out;
+}
+
+function readQueriesFromArgv(argv: string[]): string[] {
+    const fileIdx = argv.indexOf('--file');
+    if (fileIdx >= 0) {
+        return nodeFs
+            .readFileSync(argv[fileIdx + 1], 'utf8')
+            .split('\n')
+            .map(s => s.trim())
+            .filter(Boolean);
+    }
+    return argv.filter(a => !a.startsWith('--'));
+}
+
+async function main(): Promise<void> {
+    const queries = readQueriesFromArgv(process.argv.slice(2));
+    for (const q of queries) {
+        console.log(JSON.stringify(await probeRetrieval(q)));
+    }
+    process.exit(0);
+}
+
+if (require.main === module) {
+    main().catch(e => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/scripts/eval/__tests__/failure-classes.test.ts
+++ b/scripts/eval/__tests__/failure-classes.test.ts
@@ -23,15 +23,20 @@ import {
     classStages,
     classifyRow,
     contentTokens,
+    deriveFunnelCacheKey,
     dropClassOf,
+    effectiveKcalPer100g,
+    fromDbBlindSpots,
     hasDropClass,
     isCompositeQuery,
+    keyFidelityOf,
     makeFunnelRow,
     probeLineFor,
     uncoveredTokens,
     type FixKind,
+    type FunnelRowInput,
 } from '../failure-classes';
-import { aggregate, attachIncumbents, renderDoc, type PrismaLike } from '../classify-drops';
+import { aggregate, attachIncumbents, measureInputFidelity, renderDoc, type PrismaLike } from '../classify-drops';
 
 const FIX_KINDS: FixKind[] = ['pipeline', 'data', 'ingest', 'healthy'];
 
@@ -275,6 +280,101 @@ describe('finding 2 — cacheKey is canonicalized, normalizedForm is not', () =>
 });
 
 // ---------------------------------------------------------------------------
+// Finding 2, second half: canonicalizeCacheKey is NOT the FoodMapping key
+// ---------------------------------------------------------------------------
+
+describe('finding 2 — the key is the DERIVED key, not canonicalizeCacheKey alone', () => {
+    // Every literal below was verified on 2026-07-25 by calling the pipeline's own
+    // deriveMappingCacheKey(name, parseIngredientLine(rawLine), null, rawLine). It is
+    // asserted here as a literal rather than by importing that function, because
+    // importing src/lib/mapping/cache-key.ts loads simple-rerank -> config.ts and warms
+    // the ONNX embedder (measured: it logs `embedding.model_loaded`), which is exactly
+    // what the eval tooling must never do. Re-verify with:
+    //   deriveMappingCacheKey(nf ?? raw, parseIngredientLine(raw), null, raw)
+
+    it('appends the identity discriminators the save path appends (IDENTITY_UNIT_HINTS)', () => {
+        // canonicalizeCacheKey alone read "egg" here — a different food's key.
+        expect(makeFunnelRow({ rawLine: '3 egg whites', normalizedForm: 'egg' }).cacheKey).toBe('egg white');
+    });
+
+    it('appends IDENTITY_QUALIFIERS, so cooked does not share a key with dry', () => {
+        expect(makeFunnelRow({ rawLine: '1 cup cooked oats', normalizedForm: 'oats' }).cacheKey).toBe('cooked oat');
+    });
+
+    it("collapses duplicate tokens — the brief's own 'rolled rolled oats' example", () => {
+        expect(makeFunnelRow({ rawLine: 'rolled rolled oats' }).cacheKey).toBe('oat rolled');
+    });
+
+    it('still canonicalizes, singularizes and token-sorts (finding 2, first half)', () => {
+        expect(makeFunnelRow({ rawLine: 'x', normalizedForm: 'chicken breast' }).cacheKey).toBe('breast chicken');
+        expect(makeFunnelRow({ rawLine: 'x', normalizedForm: 'eggs' }).cacheKey).toBe('egg');
+    });
+
+    it('is idempotent under an already-discriminated form', () => {
+        expect(makeFunnelRow({ rawLine: 'egg white', normalizedForm: 'egg white' }).cacheKey).toBe('egg white');
+        expect(makeFunnelRow({ rawLine: 'whole milk', normalizedForm: 'milk' }).cacheKey).toBe('milk');
+    });
+
+    it('PINS the one step that is still missing — the brand prefix — instead of implying it is closed', () => {
+        // deriveMappingCacheKey WRITES "bar protein quest" / "casein dymatize powder
+        // protein" for these lines, because the query names the brand decisively. The
+        // event log records neither the detected brand nor options.brand, so this
+        // reads the generic key and hadIncumbent can be false-negative. If this test
+        // ever fails because the keys now agree, the caveat
+        // cachekey-is-the-read-key-not-always-the-write-key must be updated too.
+        expect(makeFunnelRow({ rawLine: 'quest protein bar', normalizedForm: 'protein bar' }).cacheKey)
+            .toBe('bar protein');
+        expect(makeFunnelRow({ rawLine: 'dymatize casein', normalizedForm: 'casein protein powder' }).cacheKey)
+            .toBe('casein powder protein');
+    });
+
+    it('degrades to the canonical key rather than losing a row the parser rejects', () => {
+        expect(deriveFunnelCacheKey('---', 'pretzels')).toBe('pretzel');
+        expect(deriveFunnelCacheKey('', 'eggs')).toBe('egg');
+    });
+
+    it('measures its own fidelity, so hadIncumbent is never read as per-row truth', () => {
+        const adjusted = keyFidelityOf(makeFunnelRow({ rawLine: '3 egg whites', normalizedForm: 'egg' }));
+        expect(adjusted).toMatchObject({
+            canonicalOnly: 'egg', discriminatorApplied: true, carriesDiscriminatorToken: true,
+        });
+        const plain = keyFidelityOf(makeFunnelRow({ rawLine: 'pretzels', normalizedForm: 'pretzels' }));
+        expect(plain).toMatchObject({ discriminatorApplied: false, carriesDiscriminatorToken: false });
+    });
+
+    it('WARNS in the classify-drops report when rows carry discriminator-bearing tokens', () => {
+        const report = aggregate([
+            makeFunnelRow({ rawLine: '3 egg whites', normalizedForm: 'egg', funnelStage: 'cache_hit', foodName: 'Egg White', grams: 33, kcalPer100g: 55 }),
+            makeFunnelRow({ rawLine: 'cooked quinoa', normalizedForm: 'quinoa', funnelStage: 'cache_hit', foodName: 'Quinoa', grams: 185, kcalPer100g: 120 }),
+        ], { inputLabel: 'test' });
+        expect(report.inputFidelity.discriminatorTokenRows).toBe(2);
+        expect(report.inputFidelity.discriminatorAdjustedRows).toBe(2);
+        expect(report.inputFidelity.warnings.some(w => w.startsWith('KEY FIDELITY'))).toBe(true);
+        expect(report.inputFidelity.warnings.join(' ')).toContain('hadIncumbent');
+        expect(report.inputFidelity.discriminatorExamples[0]).toMatchObject({
+            rawLine: '3 egg whites', cacheKey: 'egg white', canonicalOnly: 'egg',
+        });
+    });
+
+    it('does not cry wolf on rows whose key needed no discriminator', () => {
+        const report = aggregate([makeFunnelRow({
+            rawLine: 'pretzels', normalizedForm: 'pretzels', funnelStage: 'save_rejected',
+            dropReason: 'save_rejected:cross_source_margin', kcalPer100g: 380, grams: 3,
+        })], { inputLabel: 'test' });
+        expect(report.inputFidelity.warnings.some(w => w.startsWith('KEY FIDELITY'))).toBe(false);
+    });
+
+    it('states the identity-discriminator direction in the caveat, not just the brand one', () => {
+        const caveat = FUNNEL_CAVEATS.find(c => c.id === 'cachekey-is-the-read-key-not-always-the-write-key')!;
+        expect(caveat.note).toContain('IDENTITY DISCRIMINATORS');
+        expect(caveat.note).toContain('egg white');
+        expect(caveat.note).toContain('brand');
+        // and it must not be duplicated by a second entry
+        expect(FUNNEL_CAVEATS.filter(c => c.id === caveat.id)).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Finding 3: under_gate's dropReason carries no signal
 // ---------------------------------------------------------------------------
 
@@ -363,6 +463,149 @@ describe('finding 4 — a successful stage can still be a defect', () => {
     it('marks an ai_estimated backfill so an ingest gap is not mistaken for a ranking gap', () => {
         const row = makeFunnelRow({ rawLine: 'qdoba steak bowl', funnelStage: 'all_filtered', source: 'ai_estimated', grams: 100 });
         expect(row.quality.aiEstimated).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The --from-db row shape: no per-100g panel
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebuild an exemplar exactly as classify-drops' readFromDb would deliver it:
+ * MappingEventLog stores grams and totalKcal and NO per-100g macros
+ * (prisma/schema.prisma:717-752). This is the highest-value test in the file — the
+ * whole `corrupt-panel-served` class was dead in this mode and its rows were being
+ * counted as HEALTHY, and nothing failed.
+ */
+function asDbRow(input: FunnelRowInput): FunnelRowInput {
+    const withDerivedTotal = makeFunnelRow(input);
+    return {
+        ...input,
+        totalKcal: withDerivedTotal.totalKcal,
+        kcalPer100g: null,
+        proteinPer100g: null,
+        carbsPer100g: null,
+        fatPer100g: null,
+    };
+}
+
+describe('--from-db row shape (grams + totalKcal, no macro panel)', () => {
+    it('inverts kcal/100g exactly out of grams and totalKcal', () => {
+        const row = makeFunnelRow(asDbRow({
+            rawLine: 'lemon', funnelStage: 'cache_hit', foodName: 'Lemon', grams: 58, kcalPer100g: 383,
+        }));
+        expect(row.kcalPer100g).toBeNull();
+        expect(effectiveKcalPer100g(row)).toBeCloseTo(383, 6);
+        // and nothing is invented when the row billed nothing
+        expect(effectiveKcalPer100g(makeFunnelRow({ rawLine: 'x', grams: 0, totalKcal: 0 }))).toBeNull();
+        expect(effectiveKcalPer100g(makeFunnelRow({ rawLine: 'x' }))).toBeNull();
+    });
+
+    // THE loop the review asked for: every class, every exemplar, panel stripped.
+    for (const cls of FAILURE_CLASSES) {
+        for (const input of cls.exemplarRows) {
+            const blind = (cls.fromDbBlind ?? []).find(b => b.exemplar === input.rawLine);
+            const label = blind
+                ? `"${input.rawLine}" is DECLARED blind from --from-db`
+                : `"${input.rawLine}" still classifies as ${cls.id} from --from-db`;
+            it(`${cls.id}: ${label}`, () => {
+                const row = makeFunnelRow(asDbRow(input));
+                if (blind) {
+                    // Declared losses must be REAL. If this fails the detector improved —
+                    // delete the fromDbBlind entry (and its doc text) rather than this test.
+                    expect(cls.detector(row)).toBe(false);
+                    expect(blind.why.length).toBeGreaterThan(40);
+                } else {
+                    expect(cls.detector(row)).toBe(true);
+                    expect(classifyRow(row).classId).toBe(cls.id);
+                }
+            });
+        }
+    }
+
+    it('catches the physically-impossible panel from --from-db (the arm that must not be lost)', () => {
+        const carrot = makeFunnelRow(asDbRow({
+            rawLine: 'carrot', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Carrots',
+            grams: 61, kcalPer100g: 1720, proteinPer100g: 0.9, carbsPer100g: 9.6, fatPer100g: 0.2,
+        }));
+        expect(classifyRow(carrot).classId).toBe('corrupt-panel-served');
+    });
+
+    it('declares — rather than hides — where a blind exemplar lands instead', () => {
+        const lemon = makeFunnelRow(asDbRow({
+            rawLine: 'lemon', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Lemon',
+            grams: 58, kcalPer100g: 383, proteinPer100g: 0.4, carbsPer100g: 9.3, fatPer100g: 0.3,
+        }));
+        // This IS the failure the review found: a corrupt panel counted as clean. It is
+        // unfixable from this input (Atwater needs macros), so it must be DECLARED.
+        expect(classifyRow(lemon).classId).toBe('cache-hit-healthy');
+        const spots = fromDbBlindSpots();
+        expect(spots.map(s => `${s.classId}:${s.exemplar}`)).toContain('corrupt-panel-served:lemon');
+        expect(spots.every(s => s.why.includes('MappingEventLog') || s.why.includes('Atwater'))).toBe(true);
+    });
+
+    it('classify-drops REPORTS the inert detectors when no row carries a panel', () => {
+        const fid = measureInputFidelity([
+            makeFunnelRow(asDbRow({ rawLine: 'lemon', funnelStage: 'cache_hit', foodName: 'Lemon', grams: 58, kcalPer100g: 383 })),
+            makeFunnelRow(asDbRow({ rawLine: 'carrot', funnelStage: 'saved', foodName: 'Carrots', grams: 61, kcalPer100g: 1720 })),
+        ]);
+        expect(fid.rowsWithPanel).toBe(0);
+        expect(fid.inertDetectors.map(d => d.classId)).toContain('corrupt-panel-served');
+        expect(fid.warnings[0]).toContain('NO PER-100g MACRO PANEL');
+        expect(fid.warnings.join(' ')).toContain('NOT evidence of absence');
+    });
+
+    it('says nothing about inert detectors when the input DOES carry panels', () => {
+        const fid = measureInputFidelity([makeFunnelRow({
+            rawLine: 'lemon', funnelStage: 'cache_hit', foodName: 'Lemon', grams: 58,
+            kcalPer100g: 383, proteinPer100g: 0.4, carbsPer100g: 9.3, fatPer100g: 0.3,
+        })]);
+        expect(fid.rowsWithPanel).toBe(1);
+        expect(fid.warnings.some(w => w.includes('NO PER-100g MACRO PANEL'))).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// no_candidates is a corpus gap, never a filter blackout
+// ---------------------------------------------------------------------------
+
+describe('no_candidates routing', () => {
+    it('routes a no_candidates row to ingest-gap-no-candidates', () => {
+        const row = makeFunnelRow({
+            rawLine: 'shrimp scampi', normalizedForm: 'shrimp scampi', funnelStage: 'no_candidates',
+            dropReason: 'no_candidates:dataset_gap', source: 'ai_estimated', foodName: 'Shrimp Scampi',
+            grams: 100, kcalPer100g: 220, proteinPer100g: 12, carbsPer100g: 10, fatPer100g: 14,
+        });
+        expect(classifyRow(row).classId).toBe('ingest-gap-no-candidates');
+        expect(classifyRow(row).cls?.fixKind).toBe('ingest');
+    });
+
+    it('routes a VENUE-WORDED no_candidates row to the ingest gap, not the blackout tripwire', () => {
+        // The blackout was a FILTER bug: candidates were gathered, then rejected — that is
+        // all_filtered by definition. Claiming no_candidates too made this row a "closed"
+        // pipeline tripwire and burned the session ingest-gap exists to save.
+        for (const rawLine of ['restaurant shrimp scampi', 'chipotle grill chicken bowl', 'corner cafe muffin']) {
+            const row = makeFunnelRow({
+                rawLine, funnelStage: 'no_candidates', dropReason: 'no_candidates:dataset_gap',
+                source: 'ai_estimated', grams: 100, kcalPer100g: 200,
+            });
+            expect(classifyRow(row).classId).toBe('ingest-gap-no-candidates');
+        }
+    });
+
+    it('keeps the tripwire on all_filtered, where a filter blackout actually shows up', () => {
+        const tripwire = classById('venue-brand-blackout-tripwire')!;
+        expect(classStages(tripwire)).toEqual(['all_filtered']);
+        const row = makeFunnelRow({
+            rawLine: 'restaurant shrimp scampi', funnelStage: 'all_filtered',
+            dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', grams: 100, kcalPer100g: 220,
+        });
+        expect(classifyRow(row).classId).toBe('venue-brand-blackout-tripwire');
+    });
+
+    it('leaves no_candidates owned by exactly one class', () => {
+        const owners = FAILURE_CLASSES.filter(c => classStages(c).includes('no_candidates'));
+        expect(owners.map(c => c.id)).toEqual(['ingest-gap-no-candidates']);
     });
 });
 

--- a/scripts/eval/__tests__/failure-classes.test.ts
+++ b/scripts/eval/__tests__/failure-classes.test.ts
@@ -1,0 +1,479 @@
+/**
+ * failure-classes.test.ts — every detector tested against its own exemplars.
+ *
+ * THIS IS A HARD REQUIREMENT, not a nicety. The recorded lesson from the
+ * nutrition-corruption detector (PR #119) is that guard regexes silently stopped
+ * matching their own documented examples: the file said "jerky at 1285 g = mg-as-g"
+ * while the guard that was supposed to catch it had drifted. A taxonomy whose
+ * detectors no longer fire on the rows that motivated them is worse than no
+ * taxonomy, because the report then reads as "class closed".
+ *
+ * So: for every class, every exemplar row must classify to THAT class through the
+ * full precedence chain (not merely satisfy its own detector), and every counter
+ * row must fail its detector. Plus a coverage test that all 19 measured live
+ * dropReasons resolve to some class.
+ */
+
+import {
+    FAILURE_CLASSES,
+    FUNNEL_CAVEATS,
+    LIVE_DROP_REASONS,
+    UNCLASSIFIED,
+    classById,
+    classStages,
+    classifyRow,
+    contentTokens,
+    dropClassOf,
+    hasDropClass,
+    isCompositeQuery,
+    makeFunnelRow,
+    probeLineFor,
+    uncoveredTokens,
+    type FixKind,
+} from '../failure-classes';
+import { aggregate, attachIncumbents, renderDoc, type PrismaLike } from '../classify-drops';
+
+const FIX_KINDS: FixKind[] = ['pipeline', 'data', 'ingest', 'healthy'];
+
+// ---------------------------------------------------------------------------
+// Registry hygiene
+// ---------------------------------------------------------------------------
+
+describe('registry hygiene', () => {
+    it('has unique class ids', () => {
+        const ids = FAILURE_CLASSES.map(c => c.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('declares a valid fixKind and status on every class', () => {
+        for (const c of FAILURE_CLASSES) {
+            expect(FIX_KINDS).toContain(c.fixKind);
+            expect(['open', 'fixing', 'closed', 'by-design']).toContain(c.status);
+        }
+    });
+
+    it("marks every 'healthy' class as by-design (a healthy drop is not open work)", () => {
+        for (const c of FAILURE_CLASSES.filter(c => c.fixKind === 'healthy')) {
+            expect(c.status).toBe('by-design');
+        }
+    });
+
+    it('carries an absolute ISO discovery date, never a relative one', () => {
+        for (const c of FAILURE_CLASSES) {
+            expect(c.discoveredAt).toMatch(/^\d{4}-\d{2}-\d{2}/);
+            expect(Number.isNaN(new Date(c.discoveredAt).getTime())).toBe(false);
+        }
+    });
+
+    it('keeps residual buckets last within their stage so specific classes win', () => {
+        // A residual must never precede a non-residual class that shares its stage.
+        FAILURE_CLASSES.forEach((cls, i) => {
+            if (!cls.residual) return;
+            const later = FAILURE_CLASSES.slice(i + 1)
+                .filter(o => !o.residual && classStages(o).some(s => classStages(cls).includes(s)));
+            expect(later.map(o => o.id)).toEqual([]);
+        });
+    });
+
+    it('has a description long enough to route a fix (not a one-liner label)', () => {
+        for (const c of FAILURE_CLASSES) {
+            expect(c.description.length).toBeGreaterThan(120);
+        }
+    });
+
+    it('documents the funnel caveats that cannot be detected from a row', () => {
+        const ids = FUNNEL_CAVEATS.map(c => c.id);
+        expect(ids).toContain('error-stage-is-dead-code');
+        expect(ids).toContain('fdc-bypasses-two-save-guards');
+        expect(ids).toContain('zero-macros-gate-skipped-at-zero-grams');
+        expect(ids).toContain('event-log-key-is-not-the-cache-key');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// META-TEST: every class matches its own exemplars, and rejects a counter row
+// ---------------------------------------------------------------------------
+
+describe('every class detector matches its own exemplars', () => {
+    it('every class declares at least one exemplar, exemplar row and counter row', () => {
+        for (const c of FAILURE_CLASSES) {
+            expect(c.exemplars.length).toBeGreaterThanOrEqual(1);
+            expect(c.exemplarRows.length).toBeGreaterThanOrEqual(1);
+            expect(c.counterRows.length).toBeGreaterThanOrEqual(1);
+        }
+    });
+
+    it('every exemplar row is anchored to a listed exemplar query', () => {
+        for (const c of FAILURE_CLASSES) {
+            for (const r of c.exemplarRows) {
+                expect(c.exemplars).toContain(r.rawLine);
+            }
+        }
+    });
+
+    it('every exemplar row lands on a stage the class declares', () => {
+        for (const c of FAILURE_CLASSES) {
+            const stages = classStages(c);
+            for (const r of c.exemplarRows) {
+                expect(stages).toContain(r.funnelStage);
+            }
+        }
+    });
+
+    // The load-bearing one: full precedence chain, not just the class's own detector.
+    for (const cls of FAILURE_CLASSES) {
+        describe(cls.id, () => {
+            for (const input of cls.exemplarRows) {
+                it(`classifies "${input.rawLine}" as ${cls.id}`, () => {
+                    const row = makeFunnelRow(input);
+                    expect(cls.detector(row)).toBe(true);
+                    expect(classifyRow(row).classId).toBe(cls.id);
+                });
+            }
+            for (const input of cls.counterRows) {
+                it(`does NOT match "${input.rawLine}"`, () => {
+                    expect(cls.detector(makeFunnelRow(input))).toBe(false);
+                });
+            }
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 1: the raw histogram is misleading
+// ---------------------------------------------------------------------------
+
+describe('finding 1 — the biggest dropReason is healthy, not a defect', () => {
+    it('routes cross_source_margin to a healthy, by-design class', () => {
+        const row = makeFunnelRow({
+            rawLine: 'brussels sprouts',
+            funnelStage: 'save_rejected',
+            dropReason: 'save_rejected:cross_source_margin',
+            hadIncumbent: true,
+        });
+        const { cls } = classifyRow(row);
+        expect(cls?.id).toBe('gate-cross-source-margin');
+        expect(cls?.fixKind).toBe('healthy');
+        expect(cls?.status).toBe('by-design');
+    });
+
+    it('keeps healthy classes out of the defect table even when they dominate by count', () => {
+        const rows = [
+            // 400 events of healthy incumbent protection on 2 keys...
+            ...Array.from({ length: 400 }, (_, i) => makeFunnelRow({
+                rawLine: i % 2 === 0 ? 'brussels sprouts' : 'pretzels',
+                funnelStage: 'save_rejected',
+                dropReason: 'save_rejected:cross_source_margin',
+                hadIncumbent: true,
+            })),
+            // ...versus 3 real defects on 3 keys.
+            makeFunnelRow({ rawLine: 'cream of wheat', funnelStage: 'save_rejected', dropReason: 'save_rejected:brand_mismatch', foodName: 'Wheat', brandName: 'First Street', hadIncumbent: false }),
+            makeFunnelRow({ rawLine: 'grape nuts', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:fresh_produce_kcal_over', foodName: 'Grape nuts', brandName: 'Post', hadIncumbent: false }),
+            makeFunnelRow({ rawLine: 'shrimp scampi', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:lean_cut_protein_below_floor', foodName: 'Shrimp scampi', hadIncumbent: false }),
+        ];
+        const report = aggregate(rows, { inputLabel: 'test' });
+
+        expect(report.defects.map(d => d.classId)).not.toContain('gate-cross-source-margin');
+        expect(report.healthy.map(d => d.classId)).toContain('gate-cross-source-margin');
+        expect(report.healthyEvents).toBe(400);
+        expect(report.defectEvents).toBe(3);
+        // Ranked by distinct keys, so the 400-event healthy class cannot head the list.
+        expect(report.defects[0].distinctKeys).toBe(1);
+    });
+
+    it('reports the hadIncumbent split, so a cold hit on an incumbent-only gate is visible', () => {
+        const rows = [
+            makeFunnelRow({ rawLine: 'pretzels', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', hadIncumbent: true }),
+            makeFunnelRow({ rawLine: 'brussels sprouts', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', hadIncumbent: false }),
+            makeFunnelRow({ rawLine: 'red bell pepper', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin' }),
+        ];
+        const report = aggregate(rows, { inputLabel: 'test' });
+        const cls = report.healthy.find(c => c.classId === 'gate-cross-source-margin')!;
+        expect(cls.withIncumbent).toBe(1);
+        expect(cls.withoutIncumbent).toBe(1);
+        expect(cls.incumbentUnknown).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2: the cache key is not the logged form
+// ---------------------------------------------------------------------------
+
+describe('finding 2 — cacheKey is canonicalized, normalizedForm is not', () => {
+    it('canonicalizes the logged form into the key FoodMapping actually stores', () => {
+        expect(makeFunnelRow({ rawLine: 'x', normalizedForm: 'chicken breast' }).cacheKey).toBe('breast chicken');
+        expect(makeFunnelRow({ rawLine: 'x', normalizedForm: 'eggs' }).cacheKey).toBe('egg');
+        expect(makeFunnelRow({ rawLine: 'x', normalizedForm: 'pretzels' }).cacheKey).toBe('pretzel');
+    });
+
+    it('keeps the pre-canonical form intact alongside it', () => {
+        const row = makeFunnelRow({ rawLine: '6 oz chicken breast', normalizedForm: 'chicken breast' });
+        expect(row.normalizedForm).toBe('chicken breast');
+        expect(row.cacheKey).toBe('breast chicken');
+        expect(row.cacheKey).not.toBe(row.normalizedForm);
+    });
+
+    it('falls back to rawLine when the event carried no normalizedForm (fast_path rows)', () => {
+        expect(makeFunnelRow({ rawLine: '2 cups water', funnelStage: 'fast_path' }).cacheKey).toBe('2 cup water');
+    });
+
+    it('collapses possessive spellings onto one key, as the cache does', () => {
+        const a = makeFunnelRow({ rawLine: "mcdonald's fries" }).cacheKey;
+        const b = makeFunnelRow({ rawLine: 'mcdonalds fries' }).cacheKey;
+        expect(a).toBe(b);
+    });
+
+    describe('attachIncumbents', () => {
+        /** Fake prisma: records what it was asked for, answers from a canonical-key set. */
+        function fakePrisma(cached: string[]): { prisma: PrismaLike; queries: string[][] } {
+            const queries: string[][] = [];
+            const prisma: PrismaLike = {
+                mappingEventLog: { findMany: async () => [] },
+                foodMapping: {
+                    findMany: async (args: unknown) => {
+                        const where = (args as { where: { normalizedForm: { in: string[] } } }).where;
+                        queries.push(where.normalizedForm.in);
+                        return where.normalizedForm.in
+                            .filter(k => cached.includes(k))
+                            .map(normalizedForm => ({ normalizedForm }));
+                    },
+                },
+                $disconnect: async () => { },
+            };
+            return { prisma, queries };
+        }
+
+        it('joins on the CANONICAL key, so a cached row is not reported as cold', async () => {
+            // FoodMapping stores the token-sorted singular form.
+            const { prisma } = fakePrisma(['breast chicken', 'egg', 'pretzel']);
+            const rows = [
+                makeFunnelRow({ rawLine: '6 oz chicken breast', normalizedForm: 'chicken breast' }),
+                makeFunnelRow({ rawLine: '2 eggs', normalizedForm: 'eggs' }),
+                makeFunnelRow({ rawLine: 'pretzels', normalizedForm: 'pretzels' }),
+                makeFunnelRow({ rawLine: 'sea urchin', normalizedForm: 'sea urchin' }),
+            ];
+            await attachIncumbents(prisma, rows);
+            expect(rows.map(r => r.hadIncumbent)).toEqual([true, true, true, false]);
+        });
+
+        it('batches the lookups instead of one query per row', async () => {
+            const { prisma, queries } = fakePrisma([]);
+            const rows = Array.from({ length: 250 }, (_, i) => makeFunnelRow({ rawLine: `food ${i}` }));
+            await attachIncumbents(prisma, rows, 100);
+            expect(queries.length).toBe(3);
+            expect(queries[0].length).toBe(100);
+        });
+
+        it('deduplicates keys so a hot key is looked up once', async () => {
+            const { prisma, queries } = fakePrisma(['pretzel']);
+            const rows = Array.from({ length: 40 }, () => makeFunnelRow({ rawLine: 'pretzels' }));
+            await attachIncumbents(prisma, rows);
+            expect(queries).toEqual([['pretzel']]);
+            expect(rows.every(r => r.hadIncumbent === true)).toBe(true);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3: under_gate's dropReason carries no signal
+// ---------------------------------------------------------------------------
+
+describe("finding 3 — under_gate classes are decided by the row, not by the reason string", () => {
+    const base = {
+        funnelStage: 'under_gate' as const,
+        grams: 120,
+        kcalPer100g: 180,
+        proteinPer100g: 10,
+        carbsPer100g: 15,
+        fatPer100g: 8,
+        confidence: 0.74,
+    };
+
+    it('gives the SAME dropReason two different classes when the rows differ', () => {
+        const hijack = makeFunnelRow({
+            ...base, rawLine: 'just bare chicken breast strips', dropReason: 'under_gate:simple_rerank',
+            foodName: 'Boneless Skinless Chicken Breast Strips', brandName: 'Buckley Farms',
+        });
+        const nearMiss = makeFunnelRow({
+            ...base, rawLine: 'ground turkey', dropReason: 'under_gate:simple_rerank',
+            foodName: '85% lean ground turkey',
+        });
+        expect(classifyRow(hijack).classId).toBe('identity-brand-substituted');
+        expect(classifyRow(nearMiss).classId).toBe('under-gate-ranking-residual');
+    });
+
+    it('gives DIFFERENT dropReasons the same class when the rows are the same shape', () => {
+        const forReason = (dropReason: string) => classifyRow(makeFunnelRow({
+            ...base, rawLine: 'ground turkey', dropReason, foodName: '85% lean ground turkey',
+        })).classId;
+        expect(forReason('under_gate:close_match')).toBe('under-gate-ranking-residual');
+        expect(forReason('under_gate:clear_winner')).toBe('under-gate-ranking-residual');
+        expect(forReason('under_gate:simple_rerank')).toBe('under-gate-ranking-residual');
+        expect(forReason('under_gate:single_candidate')).toBe('under-gate-ranking-residual');
+    });
+
+    it('reports the under_gate residual as frontier, not as a diagnosed defect', () => {
+        const report = aggregate([makeFunnelRow({
+            ...base, rawLine: 'ground turkey', dropReason: 'under_gate:close_match', foodName: '85% lean ground turkey',
+        })], { inputLabel: 'test' });
+        expect(report.frontier.map(c => c.classId)).toContain('under-gate-ranking-residual');
+        expect(report.defects.map(c => c.classId)).not.toContain('under-gate-ranking-residual');
+        // The raw reasons survive so a recurring shape can be promoted.
+        expect(report.frontier[0].dropReasons[0].dropReason).toBe('under_gate:close_match');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 4: converted, but poisoned
+// ---------------------------------------------------------------------------
+
+describe('finding 4 — a successful stage can still be a defect', () => {
+    it('flags an all-zero-macro row that the funnel counted as saved', () => {
+        const row = makeFunnelRow({
+            rawLine: 'brazil nuts', funnelStage: 'saved', source: 'fatsecret', foodName: 'Brazil Nuts',
+            grams: 100, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.98,
+        });
+        expect(row.quality.degenerateMacros).toBe(true);
+        const { cls } = classifyRow(row);
+        expect(cls?.id).toBe('degenerate-macros-served');
+        expect(cls?.fixKind).toBe('data');
+    });
+
+    it('detects degeneracy from totalKcal alone, because MappingEventLog has no per-100g panel', () => {
+        const row = makeFunnelRow({
+            rawLine: 'barbecue sauce', funnelStage: 'saved', foodName: 'Barbecue Sauce', grams: 15.6, totalKcal: 0,
+        });
+        expect(row.kcalPer100g).toBeNull();
+        expect(row.quality.degenerateMacros).toBe(true);
+        expect(classifyRow(row).classId).toBe('degenerate-macros-served');
+    });
+
+    it('does not call a 0-gram abstention degenerate (nothing was billed)', () => {
+        const row = makeFunnelRow({ rawLine: 'chipotle chicken burrito', funnelStage: 'no_match', grams: 0, totalKcal: 0 });
+        expect(row.quality.degenerateMacros).toBe(false);
+    });
+
+    it('flags a flat-100g serving but respects an explicitly resolved weight tier', () => {
+        const flat = makeFunnelRow({ rawLine: 'spinach', funnelStage: 'cache_hit', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3 });
+        const asked = makeFunnelRow({ rawLine: '100g spinach', funnelStage: 'cache_hit', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3, servingTier: 'weight_unit' });
+        expect(flat.quality.flat100gServing).toBe(true);
+        expect(asked.quality.flat100gServing).toBe(false);
+    });
+
+    it('marks an ai_estimated backfill so an ingest gap is not mistaken for a ranking gap', () => {
+        const row = makeFunnelRow({ rawLine: 'qdoba steak bowl', funnelStage: 'all_filtered', source: 'ai_estimated', grams: 100 });
+        expect(row.quality.aiEstimated).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Live-dropReason coverage: the whole point of seeding from measured data
+// ---------------------------------------------------------------------------
+
+describe('live coverage', () => {
+    it('measured 19 dropReason classes on the live box', () => {
+        expect(LIVE_DROP_REASONS).toHaveLength(19);
+    });
+
+    it.each(LIVE_DROP_REASONS.map(l => [l.dropReason, l] as const))(
+        '%s resolves to a class',
+        (_dropReason, live) => {
+            const row = makeFunnelRow({ rawLine: probeLineFor(live), funnelStage: live.stage, dropReason: live.dropReason });
+            const { classId, cls } = classifyRow(row);
+            expect(cls).not.toBeNull();
+            expect(classId).not.toBe(UNCLASSIFIED);
+        },
+    );
+
+    it('routes fast_path:zero_calorie to the healthy class, not the hijack tripwire', () => {
+        // The two fast_path classes are separated by the LINE, so the coverage probe
+        // must be a real water query or the audit misreports the owner.
+        const live = LIVE_DROP_REASONS.find(l => l.dropReason === 'fast_path:zero_calorie')!;
+        const row = makeFunnelRow({ rawLine: probeLineFor(live), funnelStage: live.stage, dropReason: live.dropReason });
+        expect(classifyRow(row).classId).toBe('fast-path-zero-calorie');
+    });
+
+    it('covers all 19 measured dropReasons with no gaps', () => {
+        const report = aggregate(
+            LIVE_DROP_REASONS.map(l => makeFunnelRow({ rawLine: probeLineFor(l), funnelStage: l.stage, dropReason: l.dropReason })),
+            { inputLabel: 'coverage' },
+        );
+        expect(report.uncoveredLiveDropReasons).toEqual([]);
+        expect(report.unclassifiedEvents).toBe(0);
+        expect(report.unclassifiedRate).toBe(0);
+    });
+
+    it('still reports a genuinely novel shape as unclassified rather than swallowing it', () => {
+        // A stage no class claims: the frontier must remain observable.
+        const row = makeFunnelRow({ rawLine: 'something that threw', funnelStage: 'error' });
+        expect(classifyRow(row).classId).toBe(UNCLASSIFIED);
+        const report = aggregate([row], { inputLabel: 'test' });
+        expect(report.unclassified?.events).toBe(1);
+        expect(report.unclassifiedRate).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers the detectors lean on
+// ---------------------------------------------------------------------------
+
+describe('token helpers', () => {
+    it('treats a spelling variant as covered but a missing brand as uncovered', () => {
+        expect(uncoveredTokens("moe's guac", 'Guacamole', 'Morrisons')).toEqual(['moes']);
+        expect(uncoveredTokens('honey bunches of oats', 'Honey Bunches of Oats', 'Post')).toEqual([]);
+        expect(uncoveredTokens('ground beef 90/10', 'Ground Beef 85% Lean 15% Fat', "Rastelli's")).toEqual([]);
+    });
+
+    it('drops measure words and bare numbers from identity tokens', () => {
+        expect(contentTokens('2 cups cooked white rice')).toEqual(['cooked', 'white', 'rice']);
+    });
+
+    it('recognises assembled dishes without calling every two-word food composite', () => {
+        expect(isCompositeQuery('chipotle chicken burrito')).toBe(true);
+        expect(isCompositeQuery('qdoba chicken bowl')).toBe(true);
+        expect(isCompositeQuery('mac and cheese')).toBe(true);
+        expect(isCompositeQuery('chicken breast')).toBe(false);
+        expect(isCompositeQuery('brazil nuts')).toBe(false);
+    });
+
+    it('normalizes interpolated measurements out of a dropReason so it groups', () => {
+        expect(dropClassOf('save_rejected', 'save_rejected:implausible_macros:atwater:kcal_412_exceeds_computed_388.5'))
+            .toBe('implausible_macros:atwater:kcal_exceeds_computed');
+        expect(dropClassOf('under_gate', 'under_gate:confidence_below_threshold(0.42)'))
+            .toBe('confidence_below_threshold');
+        expect(dropClassOf('saved', null)).toBe('');
+    });
+
+    it('matches dropClass patterns exactly or by prefix', () => {
+        const row = makeFunnelRow({
+            rawLine: 'x', funnelStage: 'save_rejected',
+            dropReason: 'save_rejected:implausible_macros:estimate:kcal_vs_expected',
+        });
+        expect(hasDropClass(row, 'implausible_macros:estimate:*')).toBe(true);
+        expect(hasDropClass(row, 'implausible_macros:estimate:kcal_vs_expected')).toBe(true);
+        expect(hasDropClass(row, 'implausible_macros:category:*')).toBe(false);
+        expect(hasDropClass(row, 'cross_source_margin')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The generated doc must stay in step with the registry
+// ---------------------------------------------------------------------------
+
+describe('generated doc', () => {
+    const doc = renderDoc();
+
+    it('lists every class', () => {
+        for (const c of FAILURE_CLASSES) expect(doc).toContain(`\`${c.id}\``);
+    });
+
+    it('states the fixKind routing rule for ingest classes', () => {
+        expect(classById('ingest-gap-no-candidates')?.fixKind).toBe('ingest');
+        expect(doc).toContain('NEVER a fix-agent');
+    });
+
+    it('carries the live coverage table and the caveats', () => {
+        expect(doc).toContain('save_rejected:cross_source_margin');
+        expect(doc).toContain('error-stage-is-dead-code');
+    });
+});

--- a/scripts/eval/__tests__/triage-drops.test.ts
+++ b/scripts/eval/__tests__/triage-drops.test.ts
@@ -1,0 +1,830 @@
+/**
+ * triage-drops.test.ts — the pure parts of the F3 driver.
+ *
+ * NO NETWORK, NO DATABASE. The probes are injected (`ProbeSet`), so nothing here
+ * loads debug-retrieval-probe / filter-trace-probe — which would construct a
+ * Prisma client and warm the ONNX embedder at import time — and nothing calls
+ * mapIngredientWithFallback, which writes.
+ *
+ * What is worth testing here, in order of how badly a bug would hurt:
+ *   1. the cap and the dedupe REPORT what they dropped (silent truncation reads as
+ *      "covered everything" when it did not);
+ *   2. drop-stage filtering (a cache_hit is not a drop, and a row with no stage is
+ *      invisible rather than clean — see the F1 caveat that 'error' is dead code);
+ *   3. input parsing across all three warm shapes, including warm-names' `query`
+ *      key: read it wrong and a whole file parses to ZERO rows;
+ *   4. verdicts — that probe evidence can OVERRIDE the row-only class, and that
+ *      healthy/residual classes never count as confirmed defects.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    COARSE_BY_CLASS_ID,
+    DROP_STAGES,
+    buildReport,
+    coarseClassOf,
+    decideVerdict,
+    deriveEvidence,
+    isDropStage,
+    parseInputText,
+    probeQueryFor,
+    readInputRows,
+    recordToInput,
+    renderMarkdown,
+    resolveOutBase,
+    runProbes,
+    selectDrops,
+    type DossierProbes,
+    type ProbeSet,
+    type TriageDossier,
+} from '../triage-drops';
+import { FAILURE_CLASSES, classById, makeFunnelRow, type FunnelRow, type FunnelRowInput } from '../failure-classes';
+import type { RetrievalProbe } from '../../debug-retrieval-probe';
+import type { FilterTrace } from '../../filter-trace-probe';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** under_gate + a dropped query token -> identity-query-token-dropped (pipeline). */
+const TOKEN_DROPPED: FunnelRowInput = {
+    rawLine: "michelangelo's chicken parmesan",
+    normalizedForm: "michelangelo's chicken parmesan",
+    funnelStage: 'under_gate',
+    dropReason: 'under_gate:simple_rerank',
+    source: 'fatsecret',
+    foodId: 'fs_111',
+    foodName: 'Chicken Parmesan',
+    grams: 159,
+    kcalPer100g: 160,
+    proteinPer100g: 14,
+    carbsPer100g: 9,
+    fatPer100g: 8,
+    confidence: 0.73,
+};
+
+/** save_rejected:cross_source_margin -> gate-cross-source-margin (HEALTHY). */
+const HEALTHY_GATE: FunnelRowInput = {
+    rawLine: 'pretzels',
+    normalizedForm: 'pretzels',
+    funnelStage: 'save_rejected',
+    dropReason: 'save_rejected:cross_source_margin',
+    source: 'fatsecret',
+    foodName: 'Pretzels',
+    grams: 3,
+    kcalPer100g: 380,
+    proteinPer100g: 10,
+    carbsPer100g: 80,
+    fatPer100g: 3,
+    confidence: 0.98,
+    hadIncumbent: true,
+};
+
+/** no_candidates -> ingest-gap-no-candidates (INGEST). */
+const INGEST_GAP: FunnelRowInput = {
+    rawLine: 'cooked oats',
+    normalizedForm: 'cooked oats',
+    funnelStage: 'no_candidates',
+    dropReason: 'no_candidates:dataset_gap',
+    source: 'ai_estimated',
+    foodName: 'Cooked Oats',
+    grams: 100,
+    kcalPer100g: 71,
+    proteinPer100g: 2.5,
+    carbsPer100g: 12,
+    fatPer100g: 1.4,
+    confidence: 0.5,
+};
+
+/** all_filtered -> all-filtered-over-rejection (RESIDUAL). */
+const RESIDUAL_ALL_FILTERED: FunnelRowInput = {
+    rawLine: 'qdoba steak bowl',
+    normalizedForm: 'steak bowl',
+    funnelStage: 'all_filtered',
+    dropReason: 'all_filtered:no_candidate_survived_filters',
+    source: 'ai_estimated',
+    foodName: 'Qdoba Steak Bowl',
+    grams: 100,
+    kcalPer100g: 250,
+    proteinPer100g: 12,
+    carbsPer100g: 25,
+    fatPer100g: 10,
+    confidence: 0.64,
+};
+
+/** cache_hit — NOT a drop stage. */
+const NOT_A_DROP: FunnelRowInput = {
+    rawLine: 'yellow bell pepper',
+    normalizedForm: 'yellow bell pepper',
+    funnelStage: 'cache_hit',
+    source: 'openfoodfacts',
+    foodName: 'Yellow Bell Pepper',
+    grams: 164,
+    kcalPer100g: 27,
+    proteinPer100g: 1,
+    carbsPer100g: 6,
+    fatPer100g: 0.2,
+};
+
+function rows(...inputs: FunnelRowInput[]): FunnelRow[] {
+    return inputs.map(makeFunnelRow);
+}
+
+function retrievalProbe(opts: {
+    total: number;
+    top?: { id: string; name: string; brand?: string | null; source?: string; score?: number }[];
+    fsCount?: number;
+}): RetrievalProbe {
+    return {
+        query: 'q',
+        fatsecret: opts.fsCount != null ? { count: opts.fsCount, top: [] } : null,
+        gather: {
+            total: opts.total,
+            bySource: { openfoodfacts: opts.total },
+            top: (opts.top ?? []).map(c => ({
+                id: c.id,
+                source: c.source ?? 'openfoodfacts',
+                name: c.name,
+                brand: c.brand ?? null,
+                score: c.score ?? 1,
+            })),
+        },
+    };
+}
+
+function filterTrace(opts: {
+    gathered: number;
+    survivors: number;
+    removedByTokenFilter?: number;
+    droppedByCoreToken?: number;
+    candidates?: { id: string; name: string; brand?: string | null; kept: boolean; score?: number }[];
+}): FilterTrace {
+    return {
+        query: 'q',
+        gathered: opts.gathered,
+        mustHaveTokens: ['chicken'],
+        keptAfterTokenFilter: opts.survivors + (opts.droppedByCoreToken ?? 0),
+        removedByTokenFilter: opts.removedByTokenFilter ?? 0,
+        tokenFilterReason: null,
+        droppedByCoreToken: opts.droppedByCoreToken ?? 0,
+        survivors: opts.survivors,
+        candidates: (opts.candidates ?? []).map(c => ({
+            id: c.id,
+            source: 'openfoodfacts',
+            name: c.name,
+            brand: c.brand ?? null,
+            score: c.score ?? 1,
+            fate: c.kept ? 'KEPT' as const : 'DROPPED@filterCandidatesByTokens' as const,
+        })),
+    };
+}
+
+function dossierOf(input: FunnelRowInput, cap = 25): TriageDossier {
+    const sel = selectDrops(rows(input), { perClassCap: cap });
+    expect(sel.selected).toHaveLength(1);
+    return sel.selected[0];
+}
+
+// ---------------------------------------------------------------------------
+// 1. Input parsing
+// ---------------------------------------------------------------------------
+
+describe('input parsing', () => {
+    it('parses a warm-cache document ({results:[...]}), pretty-printed', () => {
+        const text = JSON.stringify({ base: 'x', results: [{ seed: 'a' }, { seed: 'b' }] }, null, 2);
+        expect(parseInputText(text).map(r => r.seed)).toEqual(['a', 'b']);
+    });
+
+    it('parses a bare JSON array', () => {
+        expect(parseInputText('[{"seed":"a"},{"seed":"b"}]')).toHaveLength(2);
+    });
+
+    it('parses JSONL', () => {
+        const text = '{"seed":"a"}\n{"seed":"b"}\n\n{"seed":"c"}\n';
+        expect(parseInputText(text).map(r => r.seed)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('parses a single pretty-printed object that is not a {results} wrapper', () => {
+        expect(parseInputText('{\n "seed": "a"\n}')).toEqual([{ seed: 'a' }]);
+    });
+
+    it('returns [] for empty input rather than throwing', () => {
+        expect(parseInputText('   \n ')).toEqual([]);
+    });
+
+    it('names the offending line when JSONL is malformed', () => {
+        expect(() => parseInputText('{"seed":"a"}\nnot json\n')).toThrow(/line 2/);
+    });
+
+    it("accepts warm-names' `query` key as the raw line (reading only `seed` yields ZERO rows)", () => {
+        const input = recordToInput({ query: 'ghost vegan protein', funnelStage: 'under_gate' });
+        expect(input?.rawLine).toBe('ghost vegan protein');
+    });
+
+    it('accepts `seed`, `rawLine` and `query`, in that precedence', () => {
+        expect(recordToInput({ seed: 's', rawLine: 'r', query: 'q' })?.rawLine).toBe('s');
+        expect(recordToInput({ rawLine: 'r', query: 'q' })?.rawLine).toBe('r');
+        expect(recordToInput({ query: 'q' })?.rawLine).toBe('q');
+    });
+
+    it('drops records with no raw line at all instead of inventing one', () => {
+        expect(recordToInput({ funnelStage: 'under_gate' })).toBeNull();
+    });
+
+    it('lifts the per100g panel and prefers matchConfidence over confidence', () => {
+        const input = recordToInput({
+            seed: 'x', per100g: { kcal: 100, protein: 5, carbs: 10, fat: 2 },
+            matchConfidence: 0.9, confidence: 0.1,
+        })!;
+        expect(input.kcalPer100g).toBe(100);
+        expect(input.proteinPer100g).toBe(5);
+        expect(input.confidence).toBe(0.9);
+    });
+
+    it('reads a file end-to-end and canonicalizes the cache key (never the raw logged form)', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'f3-'));
+        const file = path.join(dir, 'warm.jsonl');
+        // "chicken breast" in the event log is "breast chicken" in the cache — the
+        // whole point of finding 2. If readInputRows skipped canonicalization the
+        // incumbent join would report every one of these as cold.
+        fs.writeFileSync(file, '{"seed":"chicken breast","funnelStage":"under_gate"}\n'
+            + '{"seed":"eggs","funnelStage":"under_gate"}\n');
+        const parsed = readInputRows(file);
+        expect(parsed.map(r => r.cacheKey)).toEqual(['breast chicken', 'egg']);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Drop-stage filtering
+// ---------------------------------------------------------------------------
+
+describe('drop-stage filtering', () => {
+    it('claims exactly the five drop stages', () => {
+        expect([...DROP_STAGES].sort()).toEqual(
+            ['all_filtered', 'no_candidates', 'no_match', 'save_rejected', 'under_gate']);
+    });
+
+    it('does not treat served stages as drops', () => {
+        for (const stage of ['cache_hit', 'saved', 'fast_path', 'error']) {
+            expect(isDropStage(stage)).toBe(false);
+        }
+        expect(isDropStage(null)).toBe(false);
+        expect(isDropStage(undefined)).toBe(false);
+    });
+
+    it('keeps drop rows and skips the rest, counting both', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED, NOT_A_DROP, HEALTHY_GATE), { perClassCap: 25 });
+        expect(sel.rowCount).toBe(3);
+        expect(sel.dropRowCount).toBe(2);
+        expect(sel.selected.map(d => d.seed).sort()).toEqual(['michelangelo\'s chicken parmesan', 'pretzels']);
+        expect(sel.stageCounts).toEqual({ under_gate: 1, cache_hit: 1, save_rejected: 1 });
+        expect(sel.dropStageCounts).toEqual({ under_gate: 1, save_rejected: 1 });
+    });
+
+    it('logs what the stage filter skipped, with the per-stage breakdown', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED, NOT_A_DROP), { perClassCap: 25 });
+        const line = sel.log.find(l => l.startsWith('stage filter'))!;
+        expect(line).toContain('kept 1');
+        expect(line).toContain('skipped 1');
+        expect(line).toContain('cache_hit 1');
+    });
+
+    it('calls out stage-less rows explicitly — they are invisible, not clean', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED, { rawLine: 'mystery line' }), { perClassCap: 25 });
+        expect(sel.log.some(l => l.includes('NO funnelStage'))).toBe(true);
+        expect(sel.selected).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Dedupe + per-class cap (truncation reporting)
+// ---------------------------------------------------------------------------
+
+describe('dedupe and per-class cap', () => {
+    it('collapses rows that share a canonical cache key and keeps the count', () => {
+        const sel = selectDrops(rows(
+            { ...TOKEN_DROPPED, rawLine: 'eggs', normalizedForm: 'eggs' },
+            { ...TOKEN_DROPPED, rawLine: 'egg', normalizedForm: 'egg' },
+            { ...TOKEN_DROPPED, rawLine: 'EGGS', normalizedForm: 'EGGS' },
+        ), { perClassCap: 25 });
+        expect(sel.selected).toHaveLength(1);
+        expect(sel.selected[0].occurrences).toBe(3);
+        expect(sel.selected[0].variants).toEqual(['eggs', 'egg', 'EGGS']);
+        expect(sel.duplicateEventsCollapsed).toBe(2);
+        expect(sel.log.some(l => l.startsWith('dedupe:') && l.includes('2 duplicate events'))).toBe(true);
+    });
+
+    it('does not log a dedupe line when nothing was collapsed', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED, HEALTHY_GATE), { perClassCap: 25 });
+        expect(sel.duplicateEventsCollapsed).toBe(0);
+        expect(sel.log.some(l => l.startsWith('dedupe:'))).toBe(false);
+    });
+
+    it('caps per class and REPORTS every dossier the cap dropped', () => {
+        const many = Array.from({ length: 7 }, (_, i) => ({
+            ...TOKEN_DROPPED,
+            rawLine: `michelangelos chicken parmesan ${i}`,
+            normalizedForm: `michelangelos chicken parmesan ${i}`,
+        }));
+        const sel = selectDrops(rows(...many), { perClassCap: 3 });
+        expect(sel.selected).toHaveLength(3);
+        expect(sel.droppedByCap).toBe(4);
+        expect(sel.truncation).toEqual([
+            { classId: 'identity-query-token-dropped', seen: 7, kept: 3, dropped: 4 },
+        ]);
+        const line = sel.log.find(l => l.includes('PER-CLASS CAP'))!;
+        expect(line).toContain('DROPPED 4');
+        expect(line).toContain('identity-query-token-dropped kept 3/7');
+        expect(line).toContain('does NOT cover');
+    });
+
+    it('caps each class independently', () => {
+        const inputs = [
+            ...Array.from({ length: 4 }, (_, i) => ({ ...TOKEN_DROPPED, rawLine: `parmesan chicken alpha${i}`, normalizedForm: `parmesan chicken alpha${i}` })),
+            ...Array.from({ length: 4 }, (_, i) => ({ ...INGEST_GAP, rawLine: `cooked beta${i}`, normalizedForm: `cooked beta${i}` })),
+        ];
+        const sel = selectDrops(rows(...inputs), { perClassCap: 2 });
+        expect(sel.selected).toHaveLength(4);
+        expect(sel.truncation.map(t => t.classId).sort())
+            .toEqual(['identity-query-token-dropped', 'ingest-gap-no-candidates']);
+        expect(sel.droppedByCap).toBe(4);
+    });
+
+    it('treats a cap of 0 as unlimited and says so', () => {
+        const many = Array.from({ length: 5 }, (_, i) => ({
+            ...TOKEN_DROPPED, rawLine: `chicken parmesan gamma${i}`, normalizedForm: `chicken parmesan gamma${i}`,
+        }));
+        const sel = selectDrops(rows(...many), { perClassCap: 0 });
+        expect(sel.selected).toHaveLength(5);
+        expect(sel.droppedByCap).toBe(0);
+        expect(sel.log.some(l => l.includes('nothing dropped'))).toBe(true);
+    });
+
+    it('states positively that nothing was dropped when the cap was not reached', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        expect(sel.log.some(l => l.includes('nothing dropped'))).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Probe orchestration + dossier merging
+// ---------------------------------------------------------------------------
+
+describe('probe orchestration', () => {
+    function probeSet(calls: { retrieval: string[]; filter: string[] }): ProbeSet {
+        return {
+            retrieval: async q => {
+                calls.retrieval.push(q);
+                return retrievalProbe({ total: 2, top: [{ id: 'off_1', name: 'Chicken Parmesan Michelangelos' }] });
+            },
+            filterTrace: async q => {
+                calls.filter.push(q);
+                return filterTrace({ gathered: 2, survivors: 1, candidates: [{ id: 'off_1', name: 'Chicken Parmesan Michelangelos', kept: true }] });
+            },
+        };
+    }
+
+    it('probes every dossier exactly once, even at concurrency > 1', async () => {
+        const inputs = Array.from({ length: 10 }, (_, i) => ({
+            ...TOKEN_DROPPED, rawLine: `chicken parmesan delta${i}`, normalizedForm: `chicken parmesan delta${i}`,
+        }));
+        const sel = selectDrops(rows(...inputs), { perClassCap: 25 });
+        const calls = { retrieval: [] as string[], filter: [] as string[] };
+        const seen: number[] = [];
+        await runProbes(sel.selected, probeSet(calls), { concurrency: 4, onProgress: d => seen.push(d) });
+        expect(calls.retrieval).toHaveLength(10);
+        expect(new Set(calls.retrieval).size).toBe(10);
+        expect(calls.filter).toHaveLength(10);
+        expect(seen).toHaveLength(10);
+        expect(sel.selected.every(d => d.probes !== null && d.evidence.probed)).toBe(true);
+    });
+
+    it('probes the mapper\'s query (normalizedForm), not the raw quantity line', async () => {
+        const sel = selectDrops(rows({
+            ...TOKEN_DROPPED, rawLine: '2 cups michelangelos chicken parmesan', normalizedForm: 'michelangelos chicken parmesan',
+        }), { perClassCap: 25 });
+        const calls = { retrieval: [] as string[], filter: [] as string[] };
+        await runProbes(sel.selected, probeSet(calls), { concurrency: 1 });
+        expect(calls.retrieval).toEqual(['michelangelos chicken parmesan']);
+    });
+
+    it('falls back to the raw line when no normalizedForm was logged', () => {
+        expect(probeQueryFor({ rawLine: 'raw line', normalizedForm: null } as FunnelRow)).toBe('raw line');
+        expect(probeQueryFor({ rawLine: 'raw line', normalizedForm: '  ' } as FunnelRow)).toBe('raw line');
+        expect(probeQueryFor({ rawLine: 'raw line', normalizedForm: 'norm' } as FunnelRow)).toBe('norm');
+    });
+
+    it('records a thrown probe as an error instead of losing the dossier', async () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        await runProbes(sel.selected, {
+            retrieval: async () => { throw new Error('typesense down'); },
+            filterTrace: async () => filterTrace({ gathered: 0, survivors: 0 }),
+        }, { concurrency: 2 });
+        expect(sel.selected[0].evidence.probeErrors).toEqual(['retrieval: typesense down']);
+        expect(sel.selected[0].evidence.probed).toBe(true);
+    });
+
+    it('merges both probes into ONE dossier record', async () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        const calls = { retrieval: [] as string[], filter: [] as string[] };
+        await runProbes(sel.selected, probeSet(calls), { concurrency: 1 });
+        const d = sel.selected[0];
+        expect(d.probes?.retrieval).not.toBeNull();
+        expect(d.probes?.filterTrace).not.toBeNull();
+        expect(d.evidence.candidateCount).toBe(2);
+        expect(d.evidence.survivors).toBe(1);
+        expect(d.evidence.mustHaveTokens).toEqual(['chicken']);
+        // and the row facts survived the merge
+        expect(d.classId).toBe('identity-query-token-dropped');
+        expect(d.served.foodName).toBe('Chicken Parmesan');
+        expect(d.quality.uncoveredQueryTokens.length).toBeGreaterThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Evidence derivation
+// ---------------------------------------------------------------------------
+
+describe('deriveEvidence', () => {
+    const base = { seed: "michelangelo's chicken parmesan", quality: makeFunnelRow(TOKEN_DROPPED).quality, served: dossierOf(TOKEN_DROPPED).served };
+
+    it('marks nothing probed and proposes nothing when probes are disabled', () => {
+        const ev = deriveEvidence(base, null, 'q');
+        expect(ev.probed).toBe(false);
+        expect(ev.betterCandidate).toBeNull();
+        expect(ev.candidateCount).toBeNull();
+        expect(ev.notes.join(' ')).toContain('--no-probes');
+    });
+
+    it('flags a corpus gap only when every lane came back empty', () => {
+        const empty: DossierProbes = { retrieval: retrievalProbe({ total: 0, fsCount: 0 }), filterTrace: filterTrace({ gathered: 0, survivors: 0 }) };
+        expect(deriveEvidence(base, empty, 'q').corpusGap).toBe(true);
+
+        const fsOnly: DossierProbes = { retrieval: retrievalProbe({ total: 0, fsCount: 3 }), filterTrace: null };
+        expect(deriveEvidence(base, fsOnly, 'q').corpusGap).toBe(false);
+    });
+
+    it('flags a filter wipeout when candidates existed and none survived', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 6 }),
+            filterTrace: filterTrace({ gathered: 6, survivors: 0, removedByTokenFilter: 5, droppedByCoreToken: 1 }),
+        };
+        const ev = deriveEvidence(base, probes, 'q');
+        expect(ev.filterWipeout).toBe(true);
+        expect(ev.corpusGap).toBe(false);
+        expect(ev.removedByTokenFilter).toBe(5);
+        expect(ev.droppedByCoreToken).toBe(1);
+    });
+
+    it('proposes a better candidate only when it covers the DROPPED tokens', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 2 }),
+            filterTrace: filterTrace({
+                gathered: 2, survivors: 2, candidates: [
+                    { id: 'off_generic', name: 'Chicken Parmesan', kept: true, score: 9 },
+                    { id: 'off_right', name: "Michelangelo's Chicken Parmesan", kept: true, score: 1 },
+                ],
+            }),
+        };
+        const ev = deriveEvidence(base, probes, 'q');
+        // off_generic scores higher but still drops "michelangelo"; only off_right covers it.
+        expect(ev.betterCandidate?.id).toBe('off_right');
+        expect(ev.betterCandidate?.coversUncovered).toEqual(base.quality.uncoveredQueryTokens);
+    });
+
+    it('prefers a candidate the pipeline filters KEPT over a higher-scoring one they dropped', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 2 }),
+            filterTrace: filterTrace({
+                gathered: 2, survivors: 1, candidates: [
+                    { id: 'off_dropped', name: "Michelangelo's Chicken Parmesan Family Size", kept: false, score: 9 },
+                    { id: 'off_kept', name: "Michelangelo's Chicken Parmesan", kept: true, score: 2 },
+                ],
+            }),
+        };
+        expect(deriveEvidence(base, probes, 'q').betterCandidate?.id).toBe('off_kept');
+    });
+
+    it('never proposes the record that was already served', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 1, top: [{ id: 'fs_111', name: "Michelangelo's Chicken Parmesan" }] }),
+            filterTrace: null,
+        };
+        // fs_111 IS dossier.served.foodId.
+        const ev = deriveEvidence(base, probes, 'q');
+        expect(ev.betterCandidate).toBeNull();
+        expect(ev.notes.join(' ')).toContain('no candidate in the probed pool covers');
+    });
+
+    it('says so, rather than staying silent, when nothing covers the dropped tokens', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 3, top: [{ id: 'off_x', name: 'Chicken Parmesan' }] }),
+            filterTrace: null,
+        };
+        const ev = deriveEvidence(base, probes, 'q');
+        expect(ev.betterCandidate).toBeNull();
+        expect(ev.notes.some(n => n.includes('michelangelo'))).toBe(true);
+    });
+
+    it('falls back to the filter trace for the candidate count when gather errored', () => {
+        const probes: DossierProbes = {
+            retrieval: { query: 'q', fatsecret: null, gather: { error: 'boom' } },
+            filterTrace: filterTrace({ gathered: 4, survivors: 2 }),
+        };
+        const ev = deriveEvidence(base, probes, 'q');
+        expect(ev.candidateCount).toBe(4);
+        expect(ev.probeErrors).toEqual(['gather: boom']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Verdicts
+// ---------------------------------------------------------------------------
+
+describe('decideVerdict', () => {
+    function verdictFor(input: FunnelRowInput, probes: DossierProbes | null) {
+        const d = dossierOf(input);
+        const ev = deriveEvidence(d, probes, 'q');
+        return decideVerdict({ dossier: d, cls: classById(d.classId) ?? null, evidence: ev });
+    }
+
+    it('never confirms a healthy class, and records the incumbent split in the note', () => {
+        const v = verdictFor(HEALTHY_GATE, null);
+        expect(v.confirmed).toBe(false);
+        expect(v.cls).toBe('healthy');
+        expect(v.action).toBe('none');
+        expect(v.note).toContain('incumbent=true');
+    });
+
+    it('never confirms a residual bucket — a catch-all is not a diagnosis', () => {
+        const v = verdictFor(RESIDUAL_ALL_FILTERED, null);
+        expect(v.confirmed).toBe(false);
+        expect(v.action).toBe('triage');
+        expect(v.note).toContain('residual bucket');
+    });
+
+    it('routes an ingest class to the ingest queue with no target', () => {
+        const v = verdictFor(INGEST_GAP, null);
+        expect(v).toMatchObject({ confirmed: true, cls: 'ingest-gap', action: 'ingest', targetId: null });
+    });
+
+    it('routes a pipeline class to a code fix when no target was found', () => {
+        const v = verdictFor(TOKEN_DROPPED, null);
+        expect(v).toMatchObject({ confirmed: true, cls: 'identity', action: 'pipeline-fix', targetId: null });
+        expect(v.note).toContain('--no-probes');
+    });
+
+    it('upgrades to a repoint with the candidate id when the probe found a covering record', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 2 }),
+            filterTrace: filterTrace({
+                gathered: 2, survivors: 1,
+                candidates: [{ id: 'off_right', name: "Michelangelo's Chicken Parmesan", kept: true }],
+            }),
+        };
+        const v = verdictFor(TOKEN_DROPPED, probes);
+        expect(v.action).toBe('repoint');
+        expect(v.targetId).toBe('off_right');
+        expect(v.extraActions).toContain('pipeline-fix');
+        expect(v.note).toContain("today's cache row");
+    });
+
+    it('RECLASSIFIES a pipeline class as an ingest gap when retrieval returned nothing', () => {
+        const empty: DossierProbes = {
+            retrieval: retrievalProbe({ total: 0, fsCount: 0 }),
+            filterTrace: filterTrace({ gathered: 0, survivors: 0 }),
+        };
+        const v = verdictFor(TOKEN_DROPPED, empty);
+        expect(v).toMatchObject({ confirmed: true, cls: 'ingest-gap', action: 'ingest', reclassifiedByProbe: true });
+        expect(v.note).toContain('NEVER a fix-agent');
+    });
+
+    it('calls a filter wipeout a filter defect, not a bad row', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 8 }),
+            filterTrace: filterTrace({ gathered: 8, survivors: 0, removedByTokenFilter: 7, droppedByCoreToken: 1 }),
+        };
+        const v = verdictFor(TOKEN_DROPPED, probes);
+        expect(v).toMatchObject({ confirmed: true, cls: 'ranking-gap', action: 'pipeline-fix' });
+        expect(v.note).toContain('NONE survived the filters');
+    });
+
+    it('warns when the probe CONTRADICTS an ingest class (the lane was not empty)', () => {
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 16 }),
+            filterTrace: filterTrace({ gathered: 16, survivors: 5 }),
+        };
+        const v = verdictFor(INGEST_GAP, probes);
+        expect(v.action).toBe('ingest');
+        expect(v.note).toContain('CAUTION');
+        expect(v.note).toContain('specific form/variant');
+    });
+
+    it('sends an unclassified row to the frontier, never to an action', () => {
+        const d = dossierOf(TOKEN_DROPPED);
+        const v = decideVerdict({ dossier: { ...d, classId: 'unclassified' }, cls: null, evidence: deriveEvidence(d, null, 'q') });
+        expect(v).toMatchObject({ confirmed: false, cls: 'frontier', action: 'triage' });
+        expect(v.note).toContain('true');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Report shaping
+// ---------------------------------------------------------------------------
+
+describe('buildReport', () => {
+    function report(inputs: FunnelRowInput[], perClassCap = 25) {
+        const sel = selectDrops(rows(...inputs), { perClassCap });
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        return buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap });
+    }
+
+    it('keeps the 2026-07-21 keys so existing readers still work', () => {
+        const r = report([TOKEN_DROPPED, HEALTHY_GATE, INGEST_GAP]);
+        for (const key of ['screened', 'suspectCount', 'confirmedCount', 'byClass', 'confirmed', 'dismissed']) {
+            expect(Object.keys(r)).toContain(key);
+        }
+        expect(typeof r.screened).toBe('string');
+        expect(Array.isArray(r.confirmed)).toBe(true);
+        expect(Array.isArray(r.dismissed)).toBe(true);
+    });
+
+    it('emits every legacy field on every confirmed row', () => {
+        const r = report([TOKEN_DROPPED]);
+        const row = r.confirmed[0];
+        expect(Object.keys(row)).toEqual(
+            expect.arrayContaining(['seed', 'confirmed', 'cls', 'action', 'targetId', 'note']));
+        expect(row.seed).toBe("michelangelo's chicken parmesan");
+        expect(row.confirmed).toBe(true);
+        // extensions, additive
+        expect(row.classId).toBe('identity-query-token-dropped');
+        expect(row.fixKind).toBe('pipeline');
+        expect(row.dossier.cacheKey).toBeTruthy();
+    });
+
+    it('counts a healthy drop as neither a suspect nor a confirmation', () => {
+        const r = report([TOKEN_DROPPED, HEALTHY_GATE]);
+        expect(r.suspectCount).toBe(1);
+        expect(r.confirmedCount).toBe(1);
+        expect(r.dismissed.map(d => d.seed)).toEqual(['pretzels']);
+        expect(r.byClass.healthy).toBeUndefined();
+    });
+
+    it('keys byClass on the COARSE vocabulary and counts confirmed rows only', () => {
+        const r = report([TOKEN_DROPPED, INGEST_GAP, RESIDUAL_ALL_FILTERED]);
+        expect(r.byClass).toEqual({ identity: 1, 'ingest-gap': 1 });
+        expect(r.byFailureClass['all-filtered-over-rejection']).toBe(1);
+    });
+
+    it('reports the F2 class and fixKind histograms alongside the coarse one', () => {
+        const r = report([TOKEN_DROPPED, INGEST_GAP]);
+        expect(r.byFailureClass).toEqual({
+            'identity-query-token-dropped': 1,
+            'ingest-gap-no-candidates': 1,
+        });
+        expect(r.byFixKind).toEqual({ pipeline: 1, ingest: 1 });
+        expect(r.byAction).toEqual({ 'pipeline-fix': 1, ingest: 1 });
+    });
+
+    it('states the truncation in the log and carries it structurally', () => {
+        const many = Array.from({ length: 5 }, (_, i) => ({
+            ...TOKEN_DROPPED, rawLine: `chicken parmesan eps${i}`, normalizedForm: `chicken parmesan eps${i}`,
+        }));
+        const r = report(many, 2);
+        expect(r.droppedByCap).toBe(3);
+        expect(r.truncation[0]).toMatchObject({ classId: 'identity-query-token-dropped', dropped: 3 });
+        expect(r.log.some(l => l.includes('PER-CLASS CAP'))).toBe(true);
+    });
+
+    it('summarises the screen in `screened`, including how many were actually triaged', () => {
+        const r = report([TOKEN_DROPPED, NOT_A_DROP, INGEST_GAP]);
+        expect(r.screened).toContain('3 rows');
+        expect(r.screened).toContain('2 drop-stage');
+        expect(r.screened).toContain('fixture');
+    });
+
+    it('orders confirmed rows by how often the key was seen', () => {
+        const r = report([
+            { ...TOKEN_DROPPED, rawLine: 'chicken parmesan zeta', normalizedForm: 'chicken parmesan zeta' },
+            INGEST_GAP,
+            { ...INGEST_GAP, rawLine: 'cooked oats', normalizedForm: 'cooked oats' },
+        ]);
+        expect(r.confirmed[0].seed).toBe('cooked oats');
+        expect(r.confirmed[0].dossier.occurrences).toBe(2);
+    });
+
+    it('carries the funnel caveats so a reader cannot draw a conclusion without them', () => {
+        const r = report([TOKEN_DROPPED]);
+        expect(r.caveats.some(c => c.startsWith('error-stage-is-dead-code'))).toBe(true);
+        expect(r.caveats.some(c => c.includes('fdc'))).toBe(true);
+    });
+
+    it('counts probe errors so partial evidence is never read as "nothing found"', async () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        await runProbes(sel.selected, {
+            retrieval: async () => { throw new Error('down'); },
+        }, { concurrency: 1 });
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'probes', concurrency: 1, perClassCap: 25 });
+        expect(r.probeErrorCount).toBe(1);
+        expect(r.log.some(l => l.includes('probe errors'))).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Markdown
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown', () => {
+    function md(inputs: FunnelRowInput[], perClassCap = 25) {
+        const sel = selectDrops(rows(...inputs), { perClassCap });
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        return renderMarkdown(buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap }));
+    }
+
+    it('renders a truncation section when the cap dropped anything', () => {
+        const many = Array.from({ length: 4 }, (_, i) => ({
+            ...TOKEN_DROPPED, rawLine: `chicken parmesan eta${i}`, normalizedForm: `chicken parmesan eta${i}`,
+        }));
+        const text = md(many, 1);
+        expect(text).toContain('Truncated classes — NOT covered by this run');
+        expect(text).toContain('dropped by cap: **3**');
+    });
+
+    it('omits the truncation section when nothing was dropped', () => {
+        expect(md([TOKEN_DROPPED])).not.toContain('Truncated classes');
+    });
+
+    it('groups confirmed verdicts by action and lists dismissed separately', () => {
+        const text = md([TOKEN_DROPPED, INGEST_GAP, HEALTHY_GATE]);
+        expect(text).toContain('action: `pipeline-fix`');
+        expect(text).toContain('action: `ingest`');
+        expect(text).toContain('## Dismissed');
+        expect(text).toContain('pretzels');
+    });
+
+    it('escapes table-breaking pipes in seeds and notes', () => {
+        const text = md([{ ...TOKEN_DROPPED, rawLine: 'chicken | parmesan pipe', normalizedForm: 'chicken | parmesan pipe' }]);
+        expect(text).toContain('chicken \\| parmesan pipe');
+    });
+
+    it('says out loud that no-probes mode cannot propose targets', () => {
+        expect(md([TOKEN_DROPPED])).toContain('no retrieval calls, so no repoint targets');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Registry wiring
+// ---------------------------------------------------------------------------
+
+describe('coarse-class routing', () => {
+    it('routes EVERY F2 class explicitly (a new class must be routed, not defaulted)', () => {
+        const unrouted = FAILURE_CLASSES.map(c => c.id).filter(id => !(id in COARSE_BY_CLASS_ID));
+        expect(unrouted).toEqual([]);
+    });
+
+    it('does not carry stale ids for classes that no longer exist', () => {
+        const known = new Set(FAILURE_CLASSES.map(c => c.id));
+        expect(Object.keys(COARSE_BY_CLASS_ID).filter(id => !known.has(id))).toEqual([]);
+    });
+
+    it("routes every 'healthy' fixKind class to the healthy coarse bucket", () => {
+        for (const c of FAILURE_CLASSES.filter(c => c.fixKind === 'healthy')) {
+            expect(coarseClassOf(c.id)).toBe('healthy');
+        }
+    });
+
+    it('routes every residual bucket somewhere that cannot be confirmed', () => {
+        for (const c of FAILURE_CLASSES.filter(c => c.residual)) {
+            const v = decideVerdict({
+                dossier: { ...dossierOf(TOKEN_DROPPED), classId: c.id },
+                cls: c,
+                evidence: deriveEvidence(dossierOf(TOKEN_DROPPED), null, 'q'),
+            });
+            expect(v.confirmed).toBe(false);
+        }
+    });
+
+    it('falls back to the frontier for an id it has never seen', () => {
+        expect(coarseClassOf('a-class-invented-tomorrow')).toBe('frontier');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Output paths
+// ---------------------------------------------------------------------------
+
+describe('resolveOutBase', () => {
+    it('defaults to scripts/eval/results/triage-verdicts-<ts>', () => {
+        const base = resolveOutBase(undefined, new Date('2026-07-25T12:34:56.789Z'));
+        expect(base.endsWith(path.join('results', 'triage-verdicts-2026-07-25T12-34-56-789Z'))).toBe(true);
+    });
+
+    it('strips a .json or .md suffix so both siblings share one base', () => {
+        expect(resolveOutBase('/tmp/out.json', new Date())).toBe('/tmp/out');
+        expect(resolveOutBase('/tmp/out.md', new Date())).toBe('/tmp/out');
+        expect(resolveOutBase('/tmp/out', new Date())).toBe('/tmp/out');
+    });
+});

--- a/scripts/eval/__tests__/triage-drops.test.ts
+++ b/scripts/eval/__tests__/triage-drops.test.ts
@@ -21,26 +21,32 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+    APPLY_REPOINTS_TARGET_RE,
     COARSE_BY_CLASS_ID,
     DROP_STAGES,
+    FlagError,
+    applyInputLimit,
     buildReport,
     coarseClassOf,
     decideVerdict,
     deriveEvidence,
+    isApplyRepointsTarget,
     isDropStage,
     parseInputText,
+    parseIntFlag,
     probeQueryFor,
     readInputRows,
     recordToInput,
     renderMarkdown,
     resolveOutBase,
     runProbes,
+    scopeDisclosure,
     selectDrops,
     type DossierProbes,
     type ProbeSet,
     type TriageDossier,
 } from '../triage-drops';
-import { FAILURE_CLASSES, classById, makeFunnelRow, type FunnelRow, type FunnelRowInput } from '../failure-classes';
+import { FAILURE_CLASSES, classById, classStages, makeFunnelRow, type FunnelRow, type FunnelRowInput } from '../failure-classes';
 import type { RetrievalProbe } from '../../debug-retrieval-probe';
 import type { FilterTrace } from '../../filter-trace-probe';
 
@@ -632,6 +638,316 @@ describe('decideVerdict', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 6b. Repoint targets must be in a vocabulary apply-repoints.ts can consume
+// ---------------------------------------------------------------------------
+
+describe('repoint target vocabulary', () => {
+    /** Build a verdict for TOKEN_DROPPED where the probe found exactly this candidate. */
+    function verdictWithCandidate(id: string, name = "Michelangelo's Chicken Parmesan") {
+        const d = dossierOf(TOKEN_DROPPED);
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 2 }),
+            filterTrace: filterTrace({ gathered: 2, survivors: 1, candidates: [{ id, name, kept: true }] }),
+        };
+        const ev = deriveEvidence(d, probes, 'q');
+        expect(ev.betterCandidate?.id).toBe(id);   // the probe really did find it
+        return decideVerdict({ dossier: d, cls: classById(d.classId) ?? null, evidence: ev });
+    }
+
+    it('accepts exactly off_<barcode> and fdc_<digits>', () => {
+        expect(isApplyRepointsTarget('off_0840609112113')).toBe(true);
+        expect(isApplyRepointsTarget('fdc_171705')).toBe(true);
+        // apply-repoints.ts:102 does parseInt(target.slice(4)) for ANY non-off_ target,
+        // so each of these would resolve to an unrelated FdcFood (or NaN) and upsert.
+        for (const bad of ['fs_12345', 'ai_9', 'fdc_abc', 'fdc_', 'off_', 'x', '', 'OFF_123']) {
+            expect(isApplyRepointsTarget(bad)).toBe(false);
+        }
+        expect(isApplyRepointsTarget(null)).toBe(false);
+        expect(isApplyRepointsTarget(undefined)).toBe(false);
+    });
+
+    it('reports an off_ target as the repoint target, as before', () => {
+        const v = verdictWithCandidate('off_right');
+        expect(v).toMatchObject({ action: 'repoint', targetId: 'off_right', withheldTargetId: null });
+    });
+
+    it('WITHHOLDS an fs_ target instead of one apply-repoints.ts would mis-resolve', () => {
+        const v = verdictWithCandidate('fs_12345');
+        expect(v.targetId).toBeNull();
+        expect(v.withheldTargetId).toBe('fs_12345');
+        // the record is not lost — it is named in the note, with the reason
+        expect(v.note).toContain('REPOINT TARGET WITHHELD');
+        expect(v.note).toContain('fs_12345');
+        expect(v.note).toContain("Michelangelo's Chicken Parmesan");
+        expect(v.note).toContain('slice(4)');
+        expect(v.confirmed).toBe(true);
+    });
+
+    it('never emits a targetId outside the accepted vocabulary, for ANY class or candidate shape', () => {
+        const ids = ['off_0840609112113', 'fdc_171705', 'fs_12345', 'ai_estimate_1', 'fdc_x', 'weird'];
+        for (const cls of FAILURE_CLASSES) {
+            for (const id of ids) {
+                const d = { ...dossierOf(TOKEN_DROPPED), classId: cls.id };
+                const probes: DossierProbes = {
+                    retrieval: retrievalProbe({ total: 2 }),
+                    filterTrace: filterTrace({
+                        gathered: 2, survivors: 1,
+                        candidates: [{ id, name: "Michelangelo's Chicken Parmesan", kept: true }],
+                    }),
+                };
+                const v = decideVerdict({ dossier: d, cls, evidence: deriveEvidence(d, probes, 'q') });
+                if (v.targetId !== null) {
+                    expect(v.targetId).toMatch(APPLY_REPOINTS_TARGET_RE);
+                }
+                if (v.action === 'repoint') expect(v.withheldTargetId).toBeNull();
+            }
+        }
+    });
+
+    it('COUNTS withheld targets in the report and the run log', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        const probes: DossierProbes = {
+            retrieval: retrievalProbe({ total: 2 }),
+            filterTrace: filterTrace({
+                gathered: 2, survivors: 1,
+                candidates: [{ id: 'fs_12345', name: "Michelangelo's Chicken Parmesan", kept: true }],
+            }),
+        };
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, probes, 'q');
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'probes', concurrency: 1, perClassCap: 25 });
+        expect(r.withheldTargetCount).toBe(1);
+        const line = r.log.find(l => l.includes('WITHHELD'))!;
+        expect(line).toContain('1 repoint suggestion(s) WITHHELD');
+        expect(line).toContain('fs_');
+        expect(line).toContain('apply-repoints.ts');
+        expect(renderMarkdown(r)).toContain('repoint target(s) withheld');
+    });
+
+    it('reports zero withheld when every target was expressible', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap: 25 });
+        expect(r.withheldTargetCount).toBe(0);
+        expect(r.log.some(l => l.includes('WITHHELD'))).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 6c. Flag validation — a typo must not manufacture a clean-looking empty run
+// ---------------------------------------------------------------------------
+
+describe('parseIntFlag', () => {
+    it('returns the fallback when the flag was not passed', () => {
+        expect(parseIntFlag('--concurrency', undefined, 4, 1)).toBe(4);
+    });
+
+    it('accepts a well-formed integer, with surrounding whitespace', () => {
+        expect(parseIntFlag('--concurrency', '8', 4, 1)).toBe(8);
+        expect(parseIntFlag('--limit', ' 250 ', 0, 1)).toBe(250);
+    });
+
+    it('REFUSES a non-numeric value rather than degrading (--limit abc gave a 0-row report)', () => {
+        expect(() => parseIntFlag('--limit', 'abc', 0, 1)).toThrow(FlagError);
+        expect(() => parseIntFlag('--limit', 'abc', 0, 1)).toThrow(/must be an integer, got "abc"/);
+        expect(() => parseIntFlag('--limit', '', 0, 1)).toThrow(FlagError);
+        expect(() => parseIntFlag('--limit', '1.5', 0, 1)).toThrow(FlagError);
+        expect(() => parseIntFlag('--limit', 'Infinity', 0, 1)).toThrow(FlagError);
+    });
+
+    it('REFUSES concurrency 0 and negatives, and says why zero is dangerous', () => {
+        expect(() => parseIntFlag('--concurrency', '0', 4, 1)).toThrow(/must be >= 1/);
+        expect(() => parseIntFlag('--concurrency', '0', 4, 1)).toThrow(/probes NOTHING/);
+        expect(() => parseIntFlag('--concurrency', '-2', 4, 1)).toThrow(FlagError);
+        expect(() => parseIntFlag('--limit', '0', 0, 1)).toThrow(/must be >= 1/);
+    });
+
+    it('keeps --per-class-cap 0 legal, because 0 is the documented "unlimited"', () => {
+        expect(parseIntFlag('--per-class-cap', '0', 25, 0)).toBe(0);
+        expect(() => parseIntFlag('--per-class-cap', '-1', 25, 0)).toThrow(/must be >= 0/);
+    });
+
+    it('spots the value-is-the-next-flag mistake and says so', () => {
+        expect(() => parseIntFlag('--concurrency', '--no-probes', 4, 1)).toThrow(/looks like the next flag/);
+    });
+});
+
+describe('runProbes concurrency guard', () => {
+    const oneProbe = (calls: string[]): ProbeSet => ({
+        retrieval: async q => { calls.push(q); return retrievalProbe({ total: 1 }); },
+    });
+
+    it('THROWS instead of silently probing nothing (Math.max(1, NaN) built zero workers)', async () => {
+        for (const bad of [Number.NaN, 0, -1, 1.5]) {
+            const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+            const calls: string[] = [];
+            await expect(runProbes(sel.selected, oneProbe(calls), { concurrency: bad }))
+                .rejects.toThrow(/concurrency must be an integer >= 1/);
+            expect(calls).toHaveLength(0);
+            // and the dossier is visibly unprobed rather than looking probed
+            expect(sel.selected[0].probes).toBeNull();
+            expect(sel.selected[0].evidence.probed).toBe(false);
+        }
+    });
+
+    it('probes everything at concurrency 1', async () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED, INGEST_GAP), { perClassCap: 25 });
+        const calls: string[] = [];
+        await runProbes(sel.selected, oneProbe(calls), { concurrency: 1 });
+        expect(calls).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 6d. --limit on the --in path is a REPORTED truncation
+// ---------------------------------------------------------------------------
+
+describe('applyInputLimit', () => {
+    const five = () => rows(...Array.from({ length: 5 }, (_, i) => ({
+        ...TOKEN_DROPPED, rawLine: `chicken parmesan lim${i}`, normalizedForm: `chicken parmesan lim${i}`,
+    })));
+
+    it('is a no-op, and says nothing, when no --limit was passed', () => {
+        const out = applyInputLimit(five(), undefined);
+        expect(out.rows).toHaveLength(5);
+        expect(out.log).toEqual([]);
+    });
+
+    it('REPORTS the truncation with BOTH the file size and the kept size', () => {
+        const out = applyInputLimit(five(), 2);
+        expect(out.rows).toHaveLength(2);
+        expect(out.log).toHaveLength(1);
+        expect(out.log[0]).toContain('--limit 2: TRUNCATED');
+        expect(out.log[0]).toContain('the file had 5 row(s)');
+        expect(out.log[0]).toContain('FIRST 2');
+        expect(out.log[0]).toContain('3 row(s) were discarded');
+        // and it says which numbers now describe the slice, not the file
+        expect(out.log[0]).toContain('KEPT SLICE');
+    });
+
+    it('states positively that nothing was truncated when the file fits', () => {
+        const out = applyInputLimit(five(), 5);
+        expect(out.rows).toHaveLength(5);
+        expect(out.log[0]).toContain('all kept — no truncation');
+    });
+
+    it('the truncation line reaches the report log alongside the other truncations', () => {
+        const limited = applyInputLimit(five(), 1);
+        const sel = selectDrops(limited.rows, { perClassCap: 25 });
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        const r = buildReport(sel, {
+            inputLabel: 'warm.json (--limit 1: 1 of 5 rows)', mode: 'no-probes', concurrency: 1,
+            perClassCap: 25, extraLog: limited.log,
+        });
+        expect(r.log.some(l => l.includes('--limit 1: TRUNCATED'))).toBe(true);
+        // `screened` still describes the slice — but the label now admits it
+        expect(r.screened).toContain('1 rows');
+        expect(r.screened).toContain('1 of 5 rows');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 6e. Scope: what this driver structurally cannot report
+// ---------------------------------------------------------------------------
+
+describe('scope disclosure', () => {
+    const scope = scopeDisclosure();
+
+    it('names the stages it filters out before classifying', () => {
+        expect(scope.dropStages).toEqual(DROP_STAGES);
+        expect([...scope.excludedStages].sort()).toEqual(['cache_hit', 'fast_path', 'saved']);
+    });
+
+    it('lists exactly the classes whose every stage is excluded — derived, not hand-written', () => {
+        expect([...scope.outOfScopeClassIds].sort()).toEqual([
+            'cache-hit-healthy', 'fast-path-water-substring-hijack', 'fast-path-zero-calorie', 'saved-healthy',
+        ]);
+        for (const id of scope.outOfScopeClassIds) {
+            const cls = FAILURE_CLASSES.find(c => c.id === id)!;
+            expect(classStages(cls).some(isDropStage)).toBe(false);
+        }
+        for (const id of scope.partialClassIds) {
+            const cls = FAILURE_CLASSES.find(c => c.id === id)!;
+            expect(classStages(cls).some(isDropStage)).toBe(true);
+            expect(classStages(cls).every(isDropStage)).toBe(false);
+        }
+    });
+
+    it('marks the finding-4 quality classes PARTIAL — they fire on under_gate, which IS a drop stage', () => {
+        // The cached slice (cache_hit/saved) is out of scope, the served-but-uncached
+        // slice is not. Their counts are lower bounds, not zeros.
+        expect(scope.partialClassIds).toContain('degenerate-macros-served');
+        expect(scope.partialClassIds).toContain('corrupt-panel-served');
+        expect(scope.partialClassIds).toContain('serving-flat-100g-fallthrough');
+        expect(scope.outOfScopeClassIds).not.toContain('serving-flat-100g-fallthrough');
+    });
+
+    it('says which coarse byClass buckets are unpopulatable and which are lower bounds', () => {
+        expect(scope.outOfScopeCoarseClasses).toEqual([]);   // every bucket has a reachable class
+        expect(scope.partialCoarseClasses).toContain('serving');
+        expect(scope.partialCoarseClasses).toContain('nutrition');
+        expect(scope.notes.join(' ')).toContain('lower bounds');
+    });
+
+    it('names the actions it can never emit', () => {
+        expect(scope.unreachableActions).toEqual(['evict']);
+    });
+
+    it('states the exclusion in the log AND the markdown, not only in a source comment', () => {
+        const sel = selectDrops(rows(TOKEN_DROPPED), { perClassCap: 25 });
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap: 25 });
+        expect(r.scope).toEqual(scope);
+        expect(r.log.some(l => l.startsWith('SCOPE:'))).toBe(true);
+        expect(r.log.join(' ')).toContain('we looked and found none');
+        expect(r.log.join(' ')).toContain('classify-drops.ts territory');
+        const md = renderMarkdown(r);
+        expect(md).toContain('OUT OF SCOPE for this tool');
+        expect(md).toContain('absent by construction');
+        expect(md).toContain('`cache_hit`');
+        expect(md).toContain('cannot fire here');
+    });
+
+    it('DOES triage a poisoned conversion that was served under the gate (not everything is excluded)', () => {
+        // Evidence for the claim above: an all-zero-macro under_gate row is in scope,
+        // reaches degenerate-macros-served, and yields the mark-corrupt action — so
+        // byAction['mark-corrupt'] is reachable.
+        const sel = selectDrops(rows({
+            rawLine: 'cheesecake factory pasta', normalizedForm: 'cheesecake factory pasta',
+            funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'fatsecret',
+            foodName: 'Pasta Carbonara with Chicken', brandName: 'Cheesecake Factory', grams: 1110,
+            kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.74,
+        }), { perClassCap: 25 });
+        expect(sel.selected[0].classId).toBe('degenerate-macros-served');
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap: 25 });
+        expect(r.byAction['mark-corrupt']).toBe(1);
+        expect(r.byClass.nutrition).toBe(1);
+    });
+
+    it('DOES populate the coarse `serving` bucket, through the under_gate slice', () => {
+        const sel = selectDrops(rows({
+            rawLine: 'ribeye', normalizedForm: 'ribeye', funnelStage: 'under_gate',
+            dropReason: 'under_gate:clear_winner', source: 'openfoodfacts', foodName: 'Ribeye',
+            grams: 100, kcalPer100g: 250, proteinPer100g: 24, carbsPer100g: 0, fatPer100g: 17, confidence: 0.8,
+        }), { perClassCap: 25 });
+        expect(sel.selected[0].classId).toBe('serving-flat-100g-fallthrough');
+        for (const d of sel.selected) d.evidence = deriveEvidence(d, null, 'q');
+        const r = buildReport(sel, { inputLabel: 'fixture', mode: 'no-probes', concurrency: 1, perClassCap: 25 });
+        expect(r.byClass.serving).toBe(1);
+    });
+
+    it('still routes a CACHED poisoned conversion away, and the log says where to', () => {
+        const sel = selectDrops(rows({
+            rawLine: 'brazil nuts', normalizedForm: 'brazil nuts', funnelStage: 'cache_hit',
+            source: 'fatsecret', foodName: 'Brazil Nuts', grams: 100,
+            kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0,
+        }), { perClassCap: 25 });
+        expect(sel.selected).toHaveLength(0);
+        expect(sel.log.some(l => l.includes('classify-drops.ts territory'))).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // 7. Report shaping
 // ---------------------------------------------------------------------------
 
@@ -809,6 +1125,65 @@ describe('coarse-class routing', () => {
 
     it('falls back to the frontier for an id it has never seen', () => {
         expect(coarseClassOf('a-class-invented-tomorrow')).toBe('frontier');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 9b. The read-only guarantee depends on an INVISIBLE import property
+// ---------------------------------------------------------------------------
+
+describe('top-level imports must not reach the FatSecret flag snapshot', () => {
+    /**
+     * loadRealProbes sets FATSECRET_RETRIEVAL_ENABLED=false BEFORE requiring the probe
+     * modules, which is the difference between a SELECT-only run and one that spends
+     * Premier quota and upserts FatSecretFood rows. That only works because
+     * src/lib/mapping/config.ts — which snapshots the flag into a const at module load
+     * — is NOT already resident from a top-level import. Nothing enforced that: adding
+     * one ordinary import to failure-classes.ts would break it with every test green.
+     *
+     * It nearly happened: fixing the cache-key gap wanted deriveMappingCacheKey, whose
+     * module pulls simple-rerank -> ... -> config.ts AND warms the ONNX embedder. Hence
+     * cache-key-core. This walks the real import graph from disk (type-only imports are
+     * erased at runtime, so they are followed for nothing).
+     */
+    const FORBIDDEN = ['mapping/config.ts', 'gather-candidates.ts', 'query-embedding.ts', 'fatsecret-lane.ts'];
+
+    function runtimeGraph(entry: string): string[] {
+        const root = path.resolve(__dirname, '..', '..', '..');
+        const seen = new Set<string>();
+        const walk = (file: string) => {
+            if (seen.has(file)) return;
+            seen.add(file);
+            const src = fs.readFileSync(file, 'utf8');
+            const re = /^\s*import\s+(?:type\s+)?[^;]*?from\s+['"]([^'"]+)['"]|^\s*import\s+['"]([^'"]+)['"]/gm;
+            for (const m of src.matchAll(re)) {
+                if (/^\s*import\s+type\b/.test(m[0])) continue;      // erased at runtime
+                const spec = m[1] ?? m[2];
+                if (!spec.startsWith('.')) continue;                  // node_modules: not our concern
+                const base = path.resolve(path.dirname(file), spec);
+                const resolved = [`${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts')].find(fs.existsSync);
+                if (resolved) walk(resolved);
+            }
+        };
+        walk(path.resolve(root, entry));
+        return Array.from(seen).map(f => path.relative(root, f));
+    }
+
+    it.each(['scripts/eval/triage-drops.ts', 'scripts/eval/failure-classes.ts', 'scripts/eval/classify-drops.ts'])(
+        '%s loads none of the FatSecret/embedder modules at import time',
+        entry => {
+            const graph = runtimeGraph(entry);
+            expect(graph.length).toBeGreaterThan(1);                  // the walker really ran
+            const offenders = graph.filter(f => FORBIDDEN.some(bad => f.endsWith(bad)));
+            expect(offenders).toEqual([]);
+        },
+    );
+
+    it('reaches the cache-key derivation through the leaf module, not the full one', () => {
+        const graph = runtimeGraph('scripts/eval/failure-classes.ts');
+        expect(graph).toContain('src/lib/mapping/cache-key-core.ts');
+        expect(graph).not.toContain('src/lib/mapping/cache-key.ts');
+        expect(graph).not.toContain('src/lib/mapping/simple-rerank.ts');
     });
 });
 

--- a/scripts/eval/classify-drops.ts
+++ b/scripts/eval/classify-drops.ts
@@ -1,0 +1,632 @@
+/**
+ * classify-drops.ts — tag a batch of funnel rows with F2 failure classes and report.
+ *
+ * READ-ONLY. It issues SELECTs against MappingEventLog and FoodMapping and nothing
+ * else; there is no write path in this file. It never calls the API, so it cannot
+ * warm, evict or repoint anything.
+ *
+ * The report deliberately does NOT rank by raw event count. The largest single
+ * dropReason on the live box (save_rejected:cross_source_margin, 404 of 571
+ * save_rejected events) is incumbent protection — correct behaviour — so a
+ * count-ranked list sends the first fix-agent at working code. Instead:
+ *   - 'healthy' classes are reported in a SEPARATE table from real defects;
+ *   - every class shows DISTINCT KEYS alongside events, and is ranked by distinct
+ *     keys (one noisy key repeated 400 times is one problem, not four hundred);
+ *   - every class shows the hadIncumbent split, because a gate that can only fire
+ *     with an incumbent proves itself by having zero cold hits;
+ *   - residual buckets and truly unclassified rows are reported as FRONTIER with
+ *     their raw dropReasons, so new shapes surface instead of hiding in a catch-all.
+ *
+ * Incumbent lookup goes through canonicalizeCacheKey (see failure-classes.ts,
+ * finding 2): MappingEventLog.normalizedForm is PRE-canonicalization, so joining
+ * it straight to FoodMapping.normalizedForm reports "chicken breast", "eggs" and
+ * "pretzels" as uncached and inverts the conclusion. Lookups are batched.
+ *
+ * Run (from repo root):
+ *   # from a warm-cache results file (no DB needed if you pass --no-incumbent)
+ *   npx ts-node -r tsconfig-paths/register --transpile-only --compilerOptions \
+ *     '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/eval/classify-drops.ts --in scripts/eval/results/warm-<ts>.json
+ *
+ *   # from the live event log (read-only)
+ *   ... scripts/eval/classify-drops.ts --from-db --since 2026-07-18 --limit 20000
+ *
+ *   # regenerate the committed doc (no input, no DB)
+ *   ... scripts/eval/classify-drops.ts --emit-doc ../../KindaHealthyMobile/sync-docs/failure-classes.md
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { FunnelStage } from '../../src/lib/mapping/funnel';
+// NOTE: canonicalizeCacheKey is applied inside makeFunnelRow (failure-classes.ts),
+// which is the ONLY place row.cacheKey is produced — so attachIncumbents below is
+// guaranteed to join on the canonical key rather than on the raw logged form.
+import {
+    FAILURE_CLASSES,
+    FUNNEL_CAVEATS,
+    LIVE_DROP_REASONS,
+    LIVE_STAGE_COUNTS,
+    UNCLASSIFIED,
+    classifyRow,
+    classStages,
+    makeFunnelRow,
+    probeLineFor,
+    type FailureClass,
+    type FunnelRow,
+    type FunnelRowInput,
+} from './failure-classes';
+
+// ---------------------------------------------------------------------------
+// Input adapters
+// ---------------------------------------------------------------------------
+
+/** warm-cache.ts WarmResult (or a JSONL line of the same shape). */
+interface WarmResultLike {
+    seed?: string;
+    rawLine?: string;
+    normalizedForm?: string | null;
+    ok?: boolean;
+    foodId?: string;
+    foodName?: string;
+    brandName?: string;
+    source?: string;
+    grams?: number;
+    totalKcal?: number;
+    matchConfidence?: number;
+    confidence?: number;
+    servingTier?: string;
+    per100g?: { kcal?: number; protein?: number; carbs?: number; fat?: number };
+    funnelStage?: string;
+    dropReason?: string;
+    error?: string;
+}
+
+function warmToInput(r: WarmResultLike): FunnelRowInput | null {
+    const rawLine = r.seed ?? r.rawLine;
+    if (!rawLine) return null;
+    const p = r.per100g ?? {};
+    return {
+        rawLine,
+        normalizedForm: r.normalizedForm ?? null,
+        funnelStage: (r.funnelStage ?? null) as FunnelStage | null,
+        dropReason: r.dropReason ?? null,
+        confidence: r.matchConfidence ?? r.confidence ?? null,
+        grams: r.grams ?? null,
+        totalKcal: r.totalKcal ?? null,
+        kcalPer100g: p.kcal ?? null,
+        proteinPer100g: p.protein ?? null,
+        carbsPer100g: p.carbs ?? null,
+        fatPer100g: p.fat ?? null,
+        source: r.source ?? null,
+        foodId: r.foodId ?? null,
+        foodName: r.foodName ?? null,
+        brandName: r.brandName ?? null,
+        servingTier: r.servingTier ?? null,
+    };
+}
+
+/** Accepts warm-cache JSON ({results:[...]}) , a bare JSON array, or JSONL. */
+export function readInputFile(file: string): FunnelRowInput[] {
+    const text = fs.readFileSync(file, 'utf8');
+    const trimmed = text.trim();
+    let records: WarmResultLike[] = [];
+    if (trimmed.startsWith('{') && !trimmed.includes('\n{')) {
+        const parsed = JSON.parse(trimmed) as { results?: WarmResultLike[] };
+        records = parsed.results ?? [];
+    } else if (trimmed.startsWith('[')) {
+        records = JSON.parse(trimmed) as WarmResultLike[];
+    } else if (trimmed.startsWith('{')) {
+        // Could still be pretty-printed JSON with newlines; try whole-file parse first.
+        try {
+            const parsed = JSON.parse(trimmed) as { results?: WarmResultLike[] };
+            records = parsed.results ?? [];
+        } catch {
+            records = trimmed.split('\n').filter(Boolean).map(l => JSON.parse(l) as WarmResultLike);
+        }
+    } else {
+        records = trimmed.split('\n').filter(Boolean).map(l => JSON.parse(l) as WarmResultLike);
+    }
+    const out: FunnelRowInput[] = [];
+    for (const r of records) {
+        const input = warmToInput(r);
+        if (input) out.push(input);
+    }
+    return out;
+}
+
+interface EventLogRow {
+    rawLine: string;
+    normalizedForm: string | null;
+    funnelStage: string | null;
+    dropReason: string | null;
+    confidence: number | null;
+    grams: number | null;
+    totalKcal: number | null;
+    source: string | null;
+    foodId: string | null;
+    foodName: string | null;
+    brandName: string | null;
+    servingTier: string | null;
+}
+
+/** Minimal read-only surface we need from prisma; kept structural so tests never touch a DB. */
+export interface PrismaLike {
+    mappingEventLog: { findMany: (args: unknown) => Promise<EventLogRow[]> };
+    foodMapping: { findMany: (args: unknown) => Promise<{ normalizedForm: string }[]> };
+    $disconnect: () => Promise<void>;
+}
+
+export function openPrisma(): PrismaLike {
+    // Required lazily so --emit-doc and the unit tests never construct a client.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('dotenv/config');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaClient } = require('@prisma/client');
+    return new PrismaClient() as PrismaLike;
+}
+
+export async function readFromDb(
+    prisma: PrismaLike,
+    opts: { since?: Date; limit: number },
+): Promise<FunnelRowInput[]> {
+    const rows = await prisma.mappingEventLog.findMany({
+        where: {
+            funnelStage: { not: null },
+            ...(opts.since ? { createdAt: { gte: opts.since } } : {}),
+        },
+        orderBy: { createdAt: 'desc' },
+        take: opts.limit,
+        select: {
+            rawLine: true, normalizedForm: true, funnelStage: true, dropReason: true,
+            confidence: true, grams: true, totalKcal: true, source: true, foodId: true,
+            foodName: true, brandName: true, servingTier: true,
+        },
+    });
+    return rows.map(r => ({
+        rawLine: r.rawLine,
+        normalizedForm: r.normalizedForm,
+        funnelStage: (r.funnelStage ?? null) as FunnelStage | null,
+        dropReason: r.dropReason,
+        confidence: r.confidence,
+        grams: r.grams,
+        totalKcal: r.totalKcal,
+        // MappingEventLog stores no per-100g panel: degenerate-macro detection falls
+        // back to totalKcal === 0 with grams > 0 (see makeFunnelRow).
+        source: r.source,
+        foodId: r.foodId,
+        foodName: r.foodName,
+        brandName: r.brandName,
+        servingTier: r.servingTier,
+    }));
+}
+
+/**
+ * Populate hadIncumbent for every row, batched. THE CANONICALIZATION IS LOAD-BEARING:
+ * without it "chicken breast" (event log) never finds "breast chicken" (cache).
+ */
+export async function attachIncumbents(prisma: PrismaLike, rows: FunnelRow[], chunkSize = 500): Promise<number> {
+    const keys = Array.from(new Set(rows.map(r => r.cacheKey).filter(k => k.length > 0)));
+    const present = new Set<string>();
+    for (let i = 0; i < keys.length; i += chunkSize) {
+        const chunk = keys.slice(i, i + chunkSize);
+        const found = await prisma.foodMapping.findMany({
+            where: { normalizedForm: { in: chunk } },
+            select: { normalizedForm: true },
+        });
+        for (const f of found) present.add(f.normalizedForm);
+    }
+    for (const r of rows) r.hadIncumbent = r.cacheKey.length > 0 ? present.has(r.cacheKey) : null;
+    return keys.length;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+export interface ClassReport {
+    classId: string;
+    title: string;
+    stage: string;
+    fixKind: string;
+    status: string;
+    residual: boolean;
+    events: number;
+    distinctKeys: number;
+    withIncumbent: number;
+    withoutIncumbent: number;
+    incumbentUnknown: number;
+    /** Raw dropReasons seen under this class — the promotion signal for residuals. */
+    dropReasons: { dropReason: string; events: number }[];
+    examples: { rawLine: string; cacheKey: string; foodName: string | null; brandName: string | null; grams: number | null; totalKcal: number | null; confidence: number | null; dropReason: string | null }[];
+}
+
+export interface ClassifyReport {
+    at: string;
+    inputLabel: string;
+    rowCount: number;
+    stageCounts: Record<string, number>;
+    /** Rows matching a class whose fixKind is not 'healthy' and which is not residual. */
+    defectEvents: number;
+    healthyEvents: number;
+    residualEvents: number;
+    unclassifiedEvents: number;
+    unclassifiedRate: number;
+    defects: ClassReport[];
+    healthy: ClassReport[];
+    frontier: ClassReport[];
+    unclassified: ClassReport | null;
+    /** Live-dropReason coverage audit: any of the 19 measured classes with no owner. */
+    uncoveredLiveDropReasons: string[];
+}
+
+function emptyClassReport(cls: FailureClass | null, classId: string): ClassReport {
+    return {
+        classId,
+        title: cls?.title ?? 'UNCLASSIFIED — a shape the registry has never seen',
+        stage: cls ? classStages(cls).join('|') : '-',
+        fixKind: cls?.fixKind ?? 'unknown',
+        status: cls?.status ?? 'open',
+        residual: cls?.residual ?? false,
+        events: 0,
+        distinctKeys: 0,
+        withIncumbent: 0,
+        withoutIncumbent: 0,
+        incumbentUnknown: 0,
+        dropReasons: [],
+        examples: [],
+    };
+}
+
+export function aggregate(rows: FunnelRow[], opts: { inputLabel: string; examplesPerClass?: number }): ClassifyReport {
+    const perClass = new Map<string, ClassReport>();
+    const perClassKeys = new Map<string, Set<string>>();
+    const perClassReasons = new Map<string, Map<string, number>>();
+    const stageCounts: Record<string, number> = {};
+    const maxExamples = opts.examplesPerClass ?? 5;
+
+    for (const row of rows) {
+        const stageKey = row.funnelStage ?? 'null';
+        stageCounts[stageKey] = (stageCounts[stageKey] ?? 0) + 1;
+
+        const { classId, cls } = classifyRow(row);
+        let report = perClass.get(classId);
+        if (!report) {
+            report = emptyClassReport(cls, classId);
+            perClass.set(classId, report);
+            perClassKeys.set(classId, new Set());
+            perClassReasons.set(classId, new Map());
+        }
+        report.events++;
+        perClassKeys.get(classId)!.add(row.cacheKey || row.rawLine.toLowerCase());
+        if (row.hadIncumbent === true) report.withIncumbent++;
+        else if (row.hadIncumbent === false) report.withoutIncumbent++;
+        else report.incumbentUnknown++;
+
+        const reasonKey = row.dropReason ?? `${stageKey}:<none>`;
+        const reasons = perClassReasons.get(classId)!;
+        reasons.set(reasonKey, (reasons.get(reasonKey) ?? 0) + 1);
+
+        if (report.examples.length < maxExamples) {
+            report.examples.push({
+                rawLine: row.rawLine,
+                cacheKey: row.cacheKey,
+                foodName: row.foodName,
+                brandName: row.brandName,
+                grams: row.grams,
+                totalKcal: row.totalKcal,
+                confidence: row.confidence,
+                dropReason: row.dropReason,
+            });
+        }
+    }
+
+    for (const [classId, report] of perClass) {
+        report.distinctKeys = perClassKeys.get(classId)!.size;
+        report.dropReasons = Array.from(perClassReasons.get(classId)!.entries())
+            .map(([dropReason, events]) => ({ dropReason, events }))
+            .sort((a, b) => b.events - a.events);
+    }
+
+    // RANK: distinct keys first, events only as a tiebreak. See the header comment.
+    const byRank = (a: ClassReport, b: ClassReport) =>
+        b.distinctKeys - a.distinctKeys || b.events - a.events || a.classId.localeCompare(b.classId);
+
+    const all = Array.from(perClass.values());
+    const unclassified = all.find(r => r.classId === UNCLASSIFIED) ?? null;
+    const defects = all.filter(r => r.classId !== UNCLASSIFIED && r.fixKind !== 'healthy' && !r.residual).sort(byRank);
+    const healthy = all.filter(r => r.fixKind === 'healthy').sort(byRank);
+    const frontier = all.filter(r => r.classId !== UNCLASSIFIED && r.residual).sort(byRank);
+
+    const sum = (list: ClassReport[]) => list.reduce((n, r) => n + r.events, 0);
+    const unclassifiedEvents = unclassified?.events ?? 0;
+
+    // Coverage audit against the 19 measured live dropReasons.
+    const uncoveredLiveDropReasons: string[] = [];
+    for (const live of LIVE_DROP_REASONS) {
+        const probe = makeFunnelRow({
+            rawLine: probeLineFor(live),
+            funnelStage: live.stage,
+            dropReason: live.dropReason,
+        });
+        if (classifyRow(probe).cls == null) uncoveredLiveDropReasons.push(live.dropReason);
+    }
+
+    return {
+        at: new Date().toISOString(),
+        inputLabel: opts.inputLabel,
+        rowCount: rows.length,
+        stageCounts,
+        defectEvents: sum(defects),
+        healthyEvents: sum(healthy),
+        residualEvents: sum(frontier),
+        unclassifiedEvents,
+        unclassifiedRate: rows.length > 0 ? unclassifiedEvents / rows.length : 0,
+        defects,
+        healthy,
+        frontier,
+        unclassified,
+        uncoveredLiveDropReasons,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Console rendering
+// ---------------------------------------------------------------------------
+
+function pad(s: string, n: number): string {
+    return s.length >= n ? s.slice(0, n) : s + ' '.repeat(n - s.length);
+}
+function lpad(s: string | number, n: number): string {
+    const t = String(s);
+    return t.length >= n ? t : ' '.repeat(n - t.length) + t;
+}
+
+function printTable(title: string, list: ClassReport[]): void {
+    console.log(`\n${title}`);
+    if (list.length === 0) {
+        console.log('  (none)');
+        return;
+    }
+    console.log(`  ${pad('class', 38)} ${lpad('keys', 5)} ${lpad('events', 7)} ${lpad('inc', 5)} ${lpad('cold', 5)} ${pad('fix', 9)} status`);
+    for (const r of list) {
+        console.log(`  ${pad(r.classId, 38)} ${lpad(r.distinctKeys, 5)} ${lpad(r.events, 7)} ${lpad(r.withIncumbent, 5)} ${lpad(r.withoutIncumbent, 5)} ${pad(r.fixKind, 9)} ${r.status}`);
+    }
+}
+
+function printReport(report: ClassifyReport): void {
+    console.log(`\nF2 drop classification — ${report.inputLabel}`);
+    console.log(`rows=${report.rowCount}  stages=${JSON.stringify(report.stageCounts)}`);
+    console.log(`defect events=${report.defectEvents}  healthy=${report.healthyEvents}  `
+        + `frontier(residual)=${report.residualEvents}  unclassified=${report.unclassifiedEvents} `
+        + `(${(report.unclassifiedRate * 100).toFixed(2)}%)`);
+
+    printTable('DEFECTS (ranked by DISTINCT KEYS, not events)', report.defects);
+    printTable('HEALTHY / BY DESIGN (counted so they stop looking like defects)', report.healthy);
+    printTable('FRONTIER — residual buckets (promote recurring shapes to their own class)', report.frontier);
+
+    for (const r of report.frontier) {
+        if (r.dropReasons.length === 0) continue;
+        console.log(`\n  ${r.classId} raw dropReasons:`);
+        for (const d of r.dropReasons.slice(0, 12)) console.log(`    ${lpad(d.events, 6)}  ${d.dropReason}`);
+        for (const e of r.examples.slice(0, 5)) {
+            console.log(`      e.g. "${e.rawLine}" -> ${e.foodName ?? '(none)'}`
+                + `${e.brandName ? ` [${e.brandName}]` : ''} ${e.grams ?? '?'}g conf=${e.confidence ?? '?'}`);
+        }
+    }
+
+    if (report.unclassified) {
+        console.log(`\nUNCLASSIFIED (${report.unclassified.events} events, ${report.unclassified.distinctKeys} keys) — the true frontier:`);
+        for (const d of report.unclassified.dropReasons.slice(0, 20)) console.log(`  ${lpad(d.events, 6)}  ${d.dropReason}`);
+        for (const e of report.unclassified.examples) {
+            console.log(`    e.g. "${e.rawLine}" (key "${e.cacheKey}") -> ${e.foodName ?? '(none)'} ${e.grams ?? '?'}g`);
+        }
+    } else {
+        console.log('\nUNCLASSIFIED: none.');
+    }
+
+    if (report.uncoveredLiveDropReasons.length > 0) {
+        console.log('\n!! LIVE DROPREASONS WITH NO OWNING CLASS:');
+        for (const d of report.uncoveredLiveDropReasons) console.log(`  ${d}`);
+    } else {
+        console.log(`\nLive-dropReason coverage: all ${LIVE_DROP_REASONS.length} measured classes owned.`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Doc generator (sync-docs/failure-classes.md)
+// ---------------------------------------------------------------------------
+
+export function renderDoc(): string {
+    const L: string[] = [];
+    const byFixKind = new Map<string, FailureClass[]>();
+    for (const c of FAILURE_CLASSES) {
+        const list = byFixKind.get(c.fixKind) ?? [];
+        list.push(c);
+        byFixKind.set(c.fixKind, list);
+    }
+
+    L.push('# Mapping failure classes (F2)');
+    L.push('');
+    L.push('> GENERATED FILE — do not hand-edit.');
+    L.push('> Source of truth: `scripts/eval/failure-classes.ts` in the **backend** repo (`Recipe-App`).');
+    L.push('> Regenerate with `scripts/eval/classify-drops.ts --emit-doc <path-to-this-file>`.');
+    L.push('');
+    L.push('F1 (PR #139) answered *where* lines die. F2 answers *what is broken and who fixes it*: each class');
+    L.push('carries a `fixKind` that routes it (`pipeline` / `data` / `ingest` / `healthy`), a detector that is');
+    L.push('unit-tested against its own exemplars, and golden-case pins so a fix cannot silently regress.');
+    L.push('');
+    L.push('## Why the raw funnel histogram is not a work queue');
+    L.push('');
+    L.push('`save_rejected:cross_source_margin` is 404 of 571 `save_rejected` events on the live box (71%) and every');
+    L.push('one is **incumbent protection** — correct behaviour. The gate is nested inside');
+    L.push('`if (newTargetKey && existingTargetKey && newTargetKey !== existingTargetKey)`');
+    L.push('(`validated-mapping-helpers.ts:724`), so on a cold key `existing` is null and the block never runs: it');
+    L.push('**cannot** fire without an incumbent. Ranking classes by raw count would aim the first and largest');
+    L.push('fix-agent at working code. Hence `fixKind: healthy`, hence the report ranks by **distinct keys** and');
+    L.push('splits every count by whether an incumbent existed.');
+    L.push('');
+    L.push('Three more facts the registry is built around:');
+    L.push('');
+    L.push('- **You cannot join event rows to cache rows on `normalizedForm`.** `MappingEventLog.normalizedForm` is');
+    L.push('  pre-canonicalization; `FoodMapping.normalizedForm` is canonicalized, singularized and token-sorted.');
+    L.push('  `"chicken breast"` -> `"breast chicken"`, `"eggs"` -> `"egg"`, `"pretzels"` -> `"pretzel"`. Always run');
+    L.push('  `canonicalizeCacheKey` first.');
+    L.push("- **`under_gate`'s dropReason is not diagnostic.** It carries the confidence gate's `selectionReason` —");
+    L.push('  which path *selected* the pick, not why confidence was low — and `simple_rerank` / `close_match` /');
+    L.push('  `clear_winner` each split ~50/50 good-vs-bad. Classes under `under_gate` are separated by row');
+    L.push('  heuristics instead.');
+    L.push('- **The funnel measures conversion, not correctness.** 38 rows with all-zero macros counted as `saved`.');
+    L.push('  So every row also carries a quality block (degenerate macros, flat-100g serving, `ai_estimated`');
+    L.push('  source, brand disagreement, uncovered query tokens) and the first classes in the registry fire on');
+    L.push('  *successful* stages.');
+    L.push('');
+
+    L.push('## Class index');
+    L.push('');
+    L.push('Precedence order — `classifyRow` returns the first match.');
+    L.push('');
+    L.push('| # | class | stages | fixKind | status | golden pins | fix PRs |');
+    L.push('| - | ----- | ------ | ------- | ------ | ----------- | ------- |');
+    FAILURE_CLASSES.forEach((c, i) => {
+        L.push(`| ${i + 1} | \`${c.id}\`${c.residual ? ' *(residual)*' : ''} | ${classStages(c).join(', ')} `
+            + `| **${c.fixKind}** | ${c.status} | ${c.goldenCaseIds.length ? c.goldenCaseIds.join(', ') : '—'} `
+            + `| ${c.fixPRs.length ? c.fixPRs.map(n => `#${n}`).join(', ') : '—'} |`);
+    });
+    L.push('');
+    L.push('Counts by fixKind: '
+        + (['pipeline', 'data', 'ingest', 'healthy'] as const)
+            .map(k => `**${k}** ${byFixKind.get(k)?.length ?? 0}`).join(' · ')
+        + ` · total ${FAILURE_CLASSES.length}`);
+    L.push('');
+
+    L.push('## Live-dropReason coverage');
+    L.push('');
+    L.push('The 19 `dropReason` classes actually observed on the live box (2026-07-25, 13,452 `MappingEventLog`');
+    L.push('rows carrying `funnelStage`). Every one must resolve to a class, so the unclassified rate on live data');
+    L.push('starts near zero and only NEW shapes show up as frontier.');
+    L.push('');
+    L.push('| dropReason | events | distinct forms | owning class | fixKind |');
+    L.push('| ---------- | -----: | -------------: | ------------ | ------- |');
+    for (const live of LIVE_DROP_REASONS) {
+        const probe = makeFunnelRow({ rawLine: probeLineFor(live), funnelStage: live.stage, dropReason: live.dropReason });
+        const { classId, cls } = classifyRow(probe);
+        L.push(`| \`${live.dropReason}\` | ${live.events} | ${live.distinctForms} | \`${classId}\` | ${cls?.fixKind ?? '—'} |`);
+    }
+    L.push('');
+    L.push('Stage histogram from the same read: '
+        + Object.entries(LIVE_STAGE_COUNTS).map(([k, v]) => `\`${k}\` ${v}`).join(' · ') + '.');
+    L.push('');
+
+    L.push('## Classes');
+    L.push('');
+    for (const c of FAILURE_CLASSES) {
+        L.push(`### \`${c.id}\``);
+        L.push('');
+        L.push(`**${c.title}**`);
+        L.push('');
+        L.push(`- stages: ${classStages(c).map(s => `\`${s}\``).join(', ')}`);
+        L.push(`- fixKind: **${c.fixKind}**${c.fixKind === 'ingest' ? ' — route to the ingest queue, NEVER a fix-agent' : ''}`);
+        L.push(`- status: ${c.status}${c.residual ? ' · **residual bucket** (hits are frontier, not a diagnosis)' : ''}`);
+        L.push(`- discovered: ${c.discoveredAt}`);
+        if (c.dropClasses?.length) L.push(`- owns dropReason classes: ${c.dropClasses.map(d => `\`${d}\``).join(', ')}`);
+        if (c.goldenCaseIds.length) L.push(`- golden pins: ${c.goldenCaseIds.join(', ')}`);
+        if (c.fixPRs.length) L.push(`- fix PRs: ${c.fixPRs.map(n => `#${n}`).join(', ')}`);
+        L.push('');
+        L.push(c.description);
+        L.push('');
+        L.push('Exemplars: ' + c.exemplars.map(e => `\`${e}\``).join(', '));
+        L.push('');
+    }
+
+    L.push('## Caveats that are facts, not classes');
+    L.push('');
+    L.push('Nothing can detect these from a row, but every consumer of the funnel needs them before drawing a');
+    L.push('conclusion. All verified in code.');
+    L.push('');
+    for (const c of FUNNEL_CAVEATS) {
+        L.push(`- **\`${c.id}\`** — ${c.note}`);
+    }
+    L.push('');
+    return L.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+    const args = process.argv.slice(2);
+    const has = (flag: string) => args.includes(flag);
+    const val = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+
+    const docPath = val('--emit-doc');
+    if (docPath) {
+        const abs = path.isAbsolute(docPath) ? docPath : path.resolve(process.cwd(), docPath);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, renderDoc());
+        console.log(`Wrote ${FAILURE_CLASSES.length} classes to ${abs}`);
+        if (!has('--in') && !has('--from-db')) return;
+    }
+
+    const inFile = val('--in');
+    const fromDb = has('--from-db');
+    if (!inFile && !fromDb) {
+        console.error('Usage: classify-drops.ts (--in <warm.json|.jsonl> | --from-db [--since <date>] [--limit N]) '
+            + '[--no-incumbent] [--json <path>] [--emit-doc <path>] [--examples N]');
+        process.exitCode = 1;
+        return;
+    }
+
+    const wantIncumbent = !has('--no-incumbent');
+    let prisma: PrismaLike | null = null;
+    let inputs: FunnelRowInput[];
+    let label: string;
+
+    if (fromDb) {
+        const sinceRaw = val('--since');
+        const since = sinceRaw ? new Date(sinceRaw) : undefined;
+        if (since && Number.isNaN(since.getTime())) throw new Error(`--since is not a date: ${sinceRaw}`);
+        const limit = Number(val('--limit') ?? 20000);
+        prisma = openPrisma();
+        inputs = await readFromDb(prisma, { since, limit });
+        label = `MappingEventLog (READ ONLY)${sinceRaw ? ` since ${sinceRaw}` : ''} limit ${limit}`;
+    } else {
+        inputs = readInputFile(inFile!);
+        label = path.relative(process.cwd(), inFile!);
+    }
+
+    const rows = inputs.map(makeFunnelRow);
+
+    if (wantIncumbent) {
+        try {
+            prisma = prisma ?? openPrisma();
+            const keys = await attachIncumbents(prisma, rows);
+            console.log(`Resolved hadIncumbent for ${keys} canonical cache keys.`);
+        } catch (err) {
+            console.warn(`hadIncumbent lookup skipped (${(err as Error).message}); counts will show as unknown.`);
+        }
+    }
+
+    const report = aggregate(rows, { inputLabel: label, examplesPerClass: Number(val('--examples') ?? 5) });
+    printReport(report);
+
+    const jsonPath = val('--json');
+    if (jsonPath) {
+        const abs = path.isAbsolute(jsonPath) ? jsonPath : path.resolve(process.cwd(), jsonPath);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, JSON.stringify(report, null, 1));
+        console.log(`\nStructured result written to ${abs}`);
+    }
+
+    if (prisma) await prisma.$disconnect();
+}
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error(err);
+        process.exit(1);
+    });
+}

--- a/scripts/eval/classify-drops.ts
+++ b/scripts/eval/classify-drops.ts
@@ -12,15 +12,22 @@
  *   - 'healthy' classes are reported in a SEPARATE table from real defects;
  *   - every class shows DISTINCT KEYS alongside events, and is ranked by distinct
  *     keys (one noisy key repeated 400 times is one problem, not four hundred);
- *   - every class shows the hadIncumbent split, because a gate that can only fire
- *     with an incumbent proves itself by having zero cold hits;
+ *   - every class shows the hadIncumbent split as CORROBORATION for the claim that a
+ *     gate needs an incumbent — not as proof of it. The split is measured at report
+ *     time and cannot reproduce a brand-prefixed write key, so it is wrong in both
+ *     directions on individual rows; the proof is reading the gate. A large cold
+ *     count on an incumbent-only gate is a prompt to go and re-read it;
  *   - residual buckets and truly unclassified rows are reported as FRONTIER with
- *     their raw dropReasons, so new shapes surface instead of hiding in a catch-all.
+ *     their raw dropReasons, so new shapes surface instead of hiding in a catch-all;
+ *   - `inputFidelity` states what the input SHAPE cannot show — panel-less rows leave
+ *     Atwater-based detector arms dark, so those zeros are not findings.
  *
- * Incumbent lookup goes through canonicalizeCacheKey (see failure-classes.ts,
- * finding 2): MappingEventLog.normalizedForm is PRE-canonicalization, so joining
- * it straight to FoodMapping.normalizedForm reports "chicken breast", "eggs" and
- * "pretzels" as uncached and inverts the conclusion. Lookups are batched.
+ * Incumbent lookup goes through the derived cache key (see failure-classes.ts,
+ * finding 2 and deriveFunnelCacheKey): MappingEventLog.normalizedForm is
+ * PRE-canonicalization, so joining it straight to FoodMapping.normalizedForm reports
+ * "chicken breast", "eggs" and "pretzels" as uncached and inverts the conclusion —
+ * and canonicalizeCacheKey alone still missed the identity discriminators ("3 egg
+ * whites" -> "egg white", not "egg"). Lookups are batched.
  *
  * Run (from repo root):
  *   # from a warm-cache results file (no DB needed if you pass --no-incumbent)
@@ -38,9 +45,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { FunnelStage } from '../../src/lib/mapping/funnel';
-// NOTE: canonicalizeCacheKey is applied inside makeFunnelRow (failure-classes.ts),
-// which is the ONLY place row.cacheKey is produced — so attachIncumbents below is
-// guaranteed to join on the canonical key rather than on the raw logged form.
+// NOTE: the cache key is derived inside makeFunnelRow (failure-classes.ts), which is
+// the ONLY place row.cacheKey is produced — so attachIncumbents below is guaranteed
+// to join on the derived key rather than on the raw logged form. That key is
+// deriveMappingCacheKey minus its brand-prefix step; keyFidelityOf measures how
+// exposed each row is to the difference, and the report prints the total.
 import {
     FAILURE_CLASSES,
     FUNNEL_CAVEATS,
@@ -49,6 +58,8 @@ import {
     UNCLASSIFIED,
     classifyRow,
     classStages,
+    fromDbBlindSpots,
+    keyFidelityOf,
     makeFunnelRow,
     probeLineFor,
     type FailureClass,
@@ -201,8 +212,12 @@ export async function readFromDb(
 }
 
 /**
- * Populate hadIncumbent for every row, batched. THE CANONICALIZATION IS LOAD-BEARING:
- * without it "chicken breast" (event log) never finds "breast chicken" (cache).
+ * Populate hadIncumbent for every row, batched. THE KEY DERIVATION IS LOAD-BEARING:
+ * without it "chicken breast" (event log) never finds "breast chicken" (cache), and
+ * with canonicalizeCacheKey alone "3 egg whites" never finds "egg white". Read the
+ * result as evidence about a CLASS, never as per-row history — see the caveats
+ * incumbent-is-measured-now-not-at-event-time and
+ * cachekey-is-the-read-key-not-always-the-write-key.
  */
 export async function attachIncumbents(prisma: PrismaLike, rows: FunnelRow[], chunkSize = 500): Promise<number> {
     const keys = Array.from(new Set(rows.map(r => r.cacheKey).filter(k => k.length > 0)));
@@ -240,11 +255,33 @@ export interface ClassReport {
     examples: { rawLine: string; cacheKey: string; foodName: string | null; brandName: string | null; grams: number | null; totalKcal: number | null; confidence: number | null; dropReason: string | null }[];
 }
 
+/**
+ * What THIS input shape cannot see. Reported so a zero is never read as a clean
+ * bill of health: a detector arm that cannot fire produces the same 0 as a defect
+ * class that genuinely has no members.
+ */
+export interface InputFidelityReport {
+    /** Rows carrying a per-100g macro panel. 0 means --from-db (or a panel-less warm file). */
+    rowsWithPanel: number;
+    /** Detector arms that cannot fire without a panel, straight from the registry. */
+    inertDetectors: { classId: string; exemplar: string; why: string }[];
+    /** Rows whose derived key needed an identity discriminator or a dup-collapse. */
+    discriminatorAdjustedRows: number;
+    /** Rows naming white/yolk/cooked/whole — where the key hinges on reproducing the parse. */
+    discriminatorTokenRows: number;
+    /** A few of those rows, key included, so the reader can spot-check the join. */
+    discriminatorExamples: { rawLine: string; cacheKey: string; canonicalOnly: string }[];
+    /** Printed verbatim; every entry is a limit of the run, not a finding. */
+    warnings: string[];
+}
+
 export interface ClassifyReport {
     at: string;
     inputLabel: string;
     rowCount: number;
     stageCounts: Record<string, number>;
+    /** Limits of this input shape — panel-less rows, inert detectors, key-fidelity exposure. */
+    inputFidelity: InputFidelityReport;
     /** Rows matching a class whose fixKind is not 'healthy' and which is not residual. */
     defectEvents: number;
     healthyEvents: number;
@@ -274,6 +311,62 @@ function emptyClassReport(cls: FailureClass | null, classId: string): ClassRepor
         incumbentUnknown: 0,
         dropReasons: [],
         examples: [],
+    };
+}
+
+/**
+ * Measure what this batch of rows cannot show, before any class is counted.
+ *
+ * Two independent blind spots, both silent before 2026-07-25:
+ *   1. NO MACRO PANEL. MappingEventLog stores grams + totalKcal and no per-100g
+ *      macros, so Atwater-based arms are dark. corrupt-panel-served's n-mq-27 lemon
+ *      (383 kcal/100g, physically possible, only Atwater catches it) then classifies
+ *      as cache-hit-healthy — a corrupt panel a user was billed from, counted as
+ *      clean. The impossible-kcal arm still works (effectiveKcalPer100g inverts
+ *      grams+totalKcal exactly), so this is a partial loss, and it is enumerated
+ *      from the registry rather than described in prose.
+ *   2. KEY FIDELITY. row.cacheKey is deriveMappingCacheKey minus the brand-prefix
+ *      step. Rows naming white/yolk/cooked/whole are the ones whose key depends on
+ *      reproducing the pipeline's parse, so they are the likeliest false cold reads.
+ */
+export function measureInputFidelity(rows: FunnelRow[]): InputFidelityReport {
+    const rowsWithPanel = rows.filter(r => r.kcalPer100g != null).length;
+    const fid = rows.map(r => ({ row: r, f: keyFidelityOf(r) }));
+    const adjusted = fid.filter(x => x.f.discriminatorApplied);
+    const tokenRows = fid.filter(x => x.f.carriesDiscriminatorToken);
+    const inertDetectors = fromDbBlindSpots().map(s => ({ classId: s.classId, exemplar: s.exemplar, why: s.why }));
+
+    const warnings: string[] = [];
+    if (rows.length > 0 && rowsWithPanel === 0) {
+        warnings.push(`NO PER-100g MACRO PANEL on any of ${rows.length} row(s) — this is the --from-db shape `
+            + '(MappingEventLog stores grams + totalKcal only). kcal/100g is inverted exactly from grams and '
+            + 'totalKcal, so the impossible-kcal arm still fires, but every ATWATER-based arm is DARK here. '
+            + `${inertDetectors.length} declared blind spot(s) below: a 0 in those classes is NOT evidence of `
+            + 'absence. Re-run against a warm JSONL (which carries per100g) to close them.');
+        for (const s of inertDetectors) {
+            warnings.push(`  inert here: ${s.classId} on "${s.exemplar}" — ${s.why}`);
+        }
+    } else if (rows.length > 0 && rowsWithPanel < rows.length) {
+        warnings.push(`${rows.length - rowsWithPanel} of ${rows.length} row(s) carry no per-100g panel; `
+            + 'Atwater-based detector arms cannot fire on those. See inputFidelity.inertDetectors.');
+    }
+    if (tokenRows.length > 0 || adjusted.length > 0) {
+        warnings.push(`KEY FIDELITY: ${adjusted.length} row(s) needed an identity discriminator or a dup-collapse `
+            + `to reach the real FoodMapping key, and ${tokenRows.length} row(s) name white/yolk/cooked/whole. `
+            + 'Those keys are reproduced from parseIngredientLine(rawLine); where the pipeline saw a different '
+            + 'parse (a DB-backed synonym substitution) or prefixed a decisively-named brand, hadIncumbent for '
+            + 'these rows can read false wrongly. Check them before concluding a key was cold.');
+    }
+
+    return {
+        rowsWithPanel,
+        inertDetectors,
+        discriminatorAdjustedRows: adjusted.length,
+        discriminatorTokenRows: tokenRows.length,
+        discriminatorExamples: adjusted.slice(0, 5).map(x => ({
+            rawLine: x.row.rawLine, cacheKey: x.row.cacheKey, canonicalOnly: x.f.canonicalOnly,
+        })),
+        warnings,
     };
 }
 
@@ -356,6 +449,7 @@ export function aggregate(rows: FunnelRow[], opts: { inputLabel: string; example
         inputLabel: opts.inputLabel,
         rowCount: rows.length,
         stageCounts,
+        inputFidelity: measureInputFidelity(rows),
         defectEvents: sum(defects),
         healthyEvents: sum(healthy),
         residualEvents: sum(frontier),
@@ -399,6 +493,14 @@ function printReport(report: ClassifyReport): void {
     console.log(`defect events=${report.defectEvents}  healthy=${report.healthyEvents}  `
         + `frontier(residual)=${report.residualEvents}  unclassified=${report.unclassifiedEvents} `
         + `(${(report.unclassifiedRate * 100).toFixed(2)}%)`);
+
+    if (report.inputFidelity.warnings.length > 0) {
+        console.log('\n!! WHAT THIS INPUT CANNOT SHOW (a 0 below is not proof of absence):');
+        for (const w of report.inputFidelity.warnings) console.log(`  ${w}`);
+        for (const e of report.inputFidelity.discriminatorExamples) {
+            console.log(`     key e.g. "${e.rawLine}" -> "${e.cacheKey}" (canonicalize-only would read "${e.canonicalOnly}")`);
+        }
+    }
 
     printTable('DEFECTS (ranked by DISTINCT KEYS, not events)', report.defects);
     printTable('HEALTHY / BY DESIGN (counted so they stop looking like defects)', report.healthy);
@@ -529,6 +631,9 @@ export function renderDoc(): string {
         L.push(`- status: ${c.status}${c.residual ? ' · **residual bucket** (hits are frontier, not a diagnosis)' : ''}`);
         L.push(`- discovered: ${c.discoveredAt}`);
         if (c.dropClasses?.length) L.push(`- owns dropReason classes: ${c.dropClasses.map(d => `\`${d}\``).join(', ')}`);
+        for (const spot of c.fromDbBlind ?? []) {
+            L.push(`- **\`--from-db\` blind spot** on \`${spot.exemplar}\`: ${spot.why}`);
+        }
         if (c.goldenCaseIds.length) L.push(`- golden pins: ${c.goldenCaseIds.join(', ')}`);
         if (c.fixPRs.length) L.push(`- fix PRs: ${c.fixPRs.map(n => `#${n}`).join(', ')}`);
         L.push('');

--- a/scripts/eval/failure-classes.ts
+++ b/scripts/eval/failure-classes.ts
@@ -18,7 +18,12 @@
  *     the whole block is skipped: it CANNOT fire without an incumbent, and only
  *     ever on off: <-> fs: swaps. Ranking classes by raw count would send the
  *     first and largest fix-agent at working code. Hence `FixKind.healthy`, and
- *     hence classify-drops.ts reports counts split by `hadIncumbent`.
+ *     hence classify-drops.ts reports counts split by `hadIncumbent`. That split
+ *     is CORROBORATION, NOT VERIFICATION: hadIncumbent is measured at report time
+ *     and cannot reproduce a brand-prefixed write key, so it can be wrong in both
+ *     directions (see the two caveats `incumbent-is-measured-now-not-at-event-time`
+ *     and `cachekey-is-the-read-key-not-always-the-write-key`). The claim above is
+ *     established by READING THE GATE, and the split is only a smoke alarm.
  *
  * (2) YOU CANNOT JOIN EVENT ROWS TO CACHE ROWS ON `normalizedForm`.
  *     MappingEventLog.normalizedForm is the PRE-canonicalization AI-normalized
@@ -26,9 +31,20 @@
  *     token-SORTED cache key. "chicken breast" in the log is "breast chicken" in
  *     the cache; "eggs" is "egg"; "pretzels" is "pretzel". A naive join reports
  *     every one of those as uncached and inverts the conclusion. So FunnelRow
- *     carries BOTH: `normalizedForm` (as logged) and `cacheKey`
- *     (canonicalizeCacheKey applied — the real exported function, never a
- *     re-implementation).
+ *     carries BOTH: `normalizedForm` (as logged) and `cacheKey`.
+ *     AND canonicalizeCacheKey ALONE IS NOT THAT KEY EITHER. The save/read path
+ *     uses deriveMappingCacheKey (src/lib/mapping/cache-key.ts:194), which is
+ *     canonicalizeCacheKey PLUS (a) identity discriminators from the parsed line
+ *     (IDENTITY_UNIT_HINTS white/yolk, IDENTITY_QUALIFIERS cooked/whole), (b) a
+ *     brand prefix when the query names a brand with decisive context, and (c) an
+ *     adjacent-duplicate-token collapse. Measured 2026-07-25: canonicalize-only
+ *     read "egg" for "3 egg whites" (real key "egg white"), "oat" for "1 cup
+ *     cooked oats" (real "cooked oat") and "oat rolled rolled" for "rolled rolled
+ *     oats" (real "oat rolled"). So `cacheKey` now runs steps (a) and (c) through
+ *     the pipeline's OWN exported functions (deriveCacheKeyName +
+ *     collapseAdjacentDuplicateTokens, never a re-implementation) over
+ *     parseIngredientLine(rawLine). Step (b) is NOT reproducible from a funnel row
+ *     — see deriveFunnelCacheKey for exactly why and what it costs.
  *
  * (3) under_gate's dropReason IS NOT DIAGNOSTIC. F1 tags under_gate with the
  *     confidence gate's `selectionReason` — which path SELECTED the pick, not
@@ -58,6 +74,15 @@
 
 import { canonicalizeCacheKey } from '../../src/lib/mapping/normalization-rules';
 import { normalizeClassId, type FunnelStage } from '../../src/lib/mapping/funnel';
+// cache-key-CORE, not cache-key: the full module imports simple-rerank, whose graph
+// reaches src/lib/mapping/config.ts (it snapshots FATSECRET_RETRIEVAL_ENABLED into a
+// const at load) and gather-candidates (module-scope ONNX warmup — measured: importing
+// cache-key.ts logs `embedding.model_loaded`). triage-drops.ts sets that flag to false
+// BEFORE requiring its probe modules, so a config.ts already resident from a top-level
+// import here would turn a SELECT-only run into one that spends FatSecret quota and
+// upserts FatSecretFood rows. The core module is the same code, leaf-imported.
+import { deriveCacheKeyName, collapseAdjacentDuplicateTokens } from '../../src/lib/mapping/cache-key-core';
+import { parseIngredientLine, type ParsedIngredient } from '../../src/lib/parse/ingredient-line';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -103,7 +128,12 @@ export interface FunnelRow {
     rawLine: string;
     /** PRE-canonicalization AI-normalized name, exactly as MappingEventLog stores it. */
     normalizedForm: string | null;
-    /** canonicalizeCacheKey(normalizedForm ?? rawLine) — the ONLY key that joins to FoodMapping. */
+    /**
+     * The key this row is joined to FoodMapping on: deriveFunnelCacheKey, i.e. the
+     * pipeline's own deriveCacheKeyName + collapseAdjacentDuplicateTokens. It is
+     * deriveMappingCacheKey MINUS the brand-prefix step, which a funnel row cannot
+     * reproduce — so it is the best available key, not a guaranteed one.
+     */
     cacheKey: string;
     funnelStage: FunnelStage | null;
     /** Namespaced '<stage>:<class>[:<detail>]', as F1 wrote it. */
@@ -175,6 +205,14 @@ export interface FailureClass {
     dropClasses?: string[];
     /** Catch-all bucket: hits are reported as frontier, not as a diagnosed class. */
     residual?: boolean;
+    /**
+     * Exemplars this detector CANNOT match when the input is `--from-db`, because
+     * MappingEventLog carries no per-100g macro panel. Declared rather than
+     * discovered: `failure-classes.test.ts` re-runs every exemplarRow in the db row
+     * shape and fails unless the loss is listed here, so a detector cannot silently
+     * go dark in the mode the docs tell readers to prefer.
+     */
+    fromDbBlind?: { exemplar: string; why: string }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -317,6 +355,26 @@ function atwaterKcal(row: FunnelRow): number | null {
     return 4 * p + 4 * c + 9 * f;
 }
 
+/**
+ * kcal/100g, reconstructed from the billed total when the per-100g panel is absent.
+ *
+ * MappingEventLog stores only `grams` and `totalKcal` (prisma/schema.prisma:717-752),
+ * so every `--from-db` row arrives with kcalPer100g === null. Billing is linear —
+ * totalKcal = kcalPer100g * grams / 100 — so the inverse is EXACT, not an estimate:
+ * the 383 kcal/100g lemon logs 58 g / 222.1 kcal and inverts back to 383. Without
+ * this, `corrupt-panel-served` returned false for every db row and a corrupt panel
+ * that a user was billed from landed in the HEALTHY table (the precise failure
+ * finding 4 exists to prevent).
+ *
+ * NOT a substitute for the panel: the macro-derived arms (Atwater) stay dark from
+ * --from-db and are declared per class in `fromDbBlind`.
+ */
+export function effectiveKcalPer100g(row: FunnelRow): number | null {
+    if (row.kcalPer100g != null) return row.kcalPer100g;
+    if (row.totalKcal == null || row.grams == null || row.grams <= 0) return null;
+    return (row.totalKcal * 100) / row.grams;
+}
+
 /** Strip the stage prefix from a namespaced dropReason and re-normalize it. */
 export function dropClassOf(stage: string | null | undefined, dropReason: string | null | undefined): string {
     if (!dropReason) return '';
@@ -366,6 +424,82 @@ function isPureWaterQuery(rawLine: string): boolean {
 }
 
 /**
+ * THE key a funnel row is joined to FoodMapping on (finding 2).
+ *
+ * Reproduces deriveMappingCacheKey (src/lib/mapping/cache-key.ts:194) with the
+ * pipeline's own exported functions, over the parse of the raw line:
+ *   step 1  deriveCacheKeyName      — canonicalize + identity discriminators   ✅
+ *   step 2  brand prefix            — NOT reproducible (see below)             ❌
+ *   step 3  collapseAdjacentDuplicateTokens                                    ✅
+ *
+ * Verified 2026-07-25 against the real deriveMappingCacheKey over 17 lines: this
+ * equals `deriveMappingCacheKey(name, parseIngredientLine(rawLine), null, rawLine)`
+ * on all 17, and equals the FULL brand-aware key on 15 — the two misses are exactly
+ * the brand-decisive prefixes ("quest protein bar" writes "bar protein quest", this
+ * reads "bar protein"; "dymatize casein" writes "casein dymatize powder protein",
+ * this reads "casein powder protein").
+ *
+ * WHY STEP 2 CANNOT BE DONE HERE, and it is two independent reasons, not one:
+ *   - The INPUT is missing. The brand decision uses the request-stable
+ *     brandDetection = static detector merged with `options.brand` from the API
+ *     request. MappingEventLog records neither the detected brand nor options.brand,
+ *     so even with the detector the merge cannot be reconstructed.
+ *   - The CODE cannot be imported. hasDecisiveBrandContext lives in simple-rerank,
+ *     whose graph loads src/lib/mapping/config.ts (FatSecret flag snapshot) and warms
+ *     the ONNX embedder at module scope. Importing it here would silently break
+ *     triage-drops' read-only default. Re-implementing it is worse (PR #119's lesson).
+ *
+ * Second-order gap: the pipeline parses `preProcessLine`, i.e. rawLine AFTER the
+ * DB-backed synonym substitution (findCanonicalName, map-ingredient-with-fallback.ts
+ * :537) and a spray/squirt cleanup. Where a synonym fired, the parse here differs.
+ *
+ * CONSEQUENCE, stated once so no caller re-derives it: a false hadIncumbent=false is
+ * possible on brand-decisive and synonym-substituted lines. It is NOT symmetric with
+ * the old canonicalize-only key, whose error was the FALSE-POSITIVE direction (every
+ * branded query collapsed onto the generic key the cache is full of, so hadIncumbent
+ * read true for lines whose real key was cold — which is why hadIncumbent could never
+ * have detected this itself).
+ */
+export function deriveFunnelCacheKey(rawLine: string, normalizedForm: string | null): string {
+    const name = normalizedForm ?? rawLine;
+    let parsed: ParsedIngredient | null = null;
+    try {
+        parsed = parseIngredientLine(rawLine);
+    } catch {
+        // A parse failure must degrade to the canonical key, never lose the row.
+        parsed = null;
+    }
+    return collapseAdjacentDuplicateTokens(deriveCacheKeyName(name, parsed));
+}
+
+/**
+ * Tokens that make a row's cache key depend on reproducing the parsed line, i.e.
+ * the population where hadIncumbent is least trustworthy. IDENTITY_UNIT_HINTS
+ * (white/yolk) and IDENTITY_QUALIFIERS (cooked/whole), plus their plurals.
+ */
+export const DISCRIMINATOR_TOKENS = ['white', 'whites', 'yolk', 'yolks', 'cooked', 'whole'];
+
+/** How far this row's key can be trusted as THE FoodMapping key. */
+export interface KeyFidelity {
+    /** What the key was before 2026-07-25: canonicalizeCacheKey and nothing else. */
+    canonicalOnly: string;
+    /** A discriminator or a dup-collapse moved the key off the canonical-only form. */
+    discriminatorApplied: boolean;
+    /** The line names white/yolk/cooked/whole, so its key hinges on the parse. */
+    carriesDiscriminatorToken: boolean;
+}
+
+export function keyFidelityOf(row: FunnelRow): KeyFidelity {
+    const canonicalOnly = canonicalizeCacheKey(row.normalizedForm ?? row.rawLine);
+    const toks = new Set(tokenize(`${row.rawLine} ${row.normalizedForm ?? ''}`));
+    return {
+        canonicalOnly,
+        discriminatorApplied: canonicalOnly !== row.cacheKey,
+        carriesDiscriminatorToken: DISCRIMINATOR_TOKENS.some(t => toks.has(t)),
+    };
+}
+
+/**
  * Build a FunnelRow, deriving the cache key (finding 2) and the quality block
  * (finding 4). Both the CLI and the tests go through here, so a detector can
  * never be green in tests against a shape the CLI would never produce.
@@ -373,7 +507,7 @@ function isPureWaterQuery(rawLine: string): boolean {
 export function makeFunnelRow(input: FunnelRowInput): FunnelRow {
     const stage = (input.funnelStage ?? null) as FunnelStage | null;
     const normalizedForm = input.normalizedForm ?? null;
-    const cacheKey = canonicalizeCacheKey(normalizedForm ?? input.rawLine);
+    const cacheKey = deriveFunnelCacheKey(input.rawLine, normalizedForm);
 
     const grams = input.grams ?? null;
     const kcal100 = input.kcalPer100g ?? null;
@@ -485,11 +619,18 @@ export const FAILURE_CLASSES: FailureClass[] = [
             + 'estimate from its own macros — the kJ-value-in-the-kcal-field family (n-mq-27 lemon: 383 "kcal"/100g '
             + 'vs ~40 real). detect-corrupt-nutrition.ts + mark-corrupt-off.ts already marked 30,788 rows across 8 '
             + 'per-field classes (PRs #116, #119) and the Typesense index dropped 974,044 -> 950,128 accordingly, '
-            + 'so a live hit here means either an unmarked row or a corrupt-exclusion escape. Data fix: mark and purge.',
+            + 'so a live hit here means either an unmarked row or a corrupt-exclusion escape. Data fix: mark and purge. '
+            + 'INPUT-MODE NOTE: the impossible-kcal arm works from --from-db because kcal/100g inverts exactly out of '
+            + 'grams + totalKcal (effectiveKcalPer100g). The 3x-Atwater arm does NOT — MappingEventLog stores no '
+            + 'macro panel — so a scale-slipped-but-not-impossible panel (the n-mq-27 lemon at 383 kcal/100g) is '
+            + 'invisible there and lands in cache-hit-healthy. Declared in fromDbBlind; classify-drops prints it.',
         fixKind: 'data',
         detector: row => {
             if (!atStage(row, SERVED_STAGES)) return false;
-            const kcal = row.kcalPer100g;
+            // Per-100g when we have it, inverted from grams+totalKcal when we do not:
+            // MappingEventLog has no panel, and without this the whole class was dead
+            // in --from-db mode and its rows were counted as HEALTHY.
+            const kcal = effectiveKcalPer100g(row);
             if (kcal == null || kcal <= 0) return false;
             if (kcal > IMPOSSIBLE_KCAL_100G) return true;
             const atwater = atwaterKcal(row);
@@ -511,6 +652,13 @@ export const FAILURE_CLASSES: FailureClass[] = [
         status: 'closed',
         discoveredAt: '2026-07-21',
         dropClasses: [],
+        fromDbBlind: [{
+            exemplar: 'lemon',
+            why: '383 kcal/100g is physically possible, so only the 3x-Atwater arm catches it, and Atwater needs '
+                + 'protein/carbs/fat — which MappingEventLog does not store. From --from-db this row classifies as '
+                + 'cache-hit-healthy. The kJ-as-kcal family is therefore under-counted in that mode; use a warm '
+                + 'JSONL run (which carries per100g) to hunt it, or detect-corrupt-nutrition.ts against the corpus.',
+        }],
     },
     {
         id: 'identity-cooked-vs-dry',
@@ -529,7 +677,10 @@ export const FAILURE_CLASSES: FailureClass[] = [
             if (!atStage(row, SERVED_STAGES)) return false;
             if (!COOKED_RE.test(row.rawLine)) return false;
             if (row.foodName && DRY_RECORD_RE.test(row.foodName)) return true;
-            return (row.kcalPer100g ?? 0) > 250;
+            // effectiveKcalPer100g, not kcalPer100g: from --from-db the panel is null
+            // and this arm went dark, sending "cooked white rice" -> White Rice at
+            // 365 kcal/100g to identity-query-token-dropped instead.
+            return (effectiveKcalPer100g(row) ?? 0) > 250;
         },
         exemplars: ['cooked oats', 'cooked white rice'],
         exemplarRows: [
@@ -791,8 +942,11 @@ export const FAILURE_CLASSES: FailureClass[] = [
             + 'must be meaningfully more confident, not this run\'s rerank winner by a hair. The gate is nested '
             + 'inside `if (newTargetKey && existingTargetKey && newTargetKey !== existingTargetKey)` '
             + '(validated-mapping-helpers.ts:724): on a cold key `existing` is null and the block never runs, so '
-            + 'it CANNOT fire without an incumbent. Verify with the hadIncumbent split — a hit with '
-            + 'hadIncumbent=false would mean the gate or the join is broken, not that a defect was found. '
+            + 'it CANNOT fire without an incumbent — established by READING THE GATE, which is the only proof there '
+            + 'is. The hadIncumbent split CORROBORATES, it does not verify: the lookup is done at report time '
+            + '(evictions since the event read as cold) and cannot reproduce a brand-prefixed write key, so a small '
+            + 'cold count here is a measurement artifact and a LARGE one is a prompt to re-read the gate — never '
+            + 'proof either way on a single row. '
             + 'CAVEAT: newTargetKey/existingTargetKey read only offBarcode then fsId, never fdcId '
             + '(validated-mapping-helpers.ts:720-723), so fdc <-> off and fdc <-> fs displacements bypass this '
             + 'margin AND the serving-downgrade guard entirely. That latent gap is a pipeline defect, not part of '
@@ -823,7 +977,10 @@ export const FAILURE_CLASSES: FailureClass[] = [
             + 'something the cascade was 78% sure of has no business evicting a row a more confident pick earned '
             + '(validated-mapping-helpers.ts:650, funnel fix 4). This is the entire blast-radius bound on '
             + 'conditional admission, and the guarantee the abandoned PR #143 lacked when it repointed the eight '
-            + 'most-used generic keys in the cache. Like cross_source_margin it cannot fire on a cold key.',
+            + 'most-used generic keys in the cache. Like cross_source_margin it cannot fire on a cold key — again a '
+            + 'claim about the CODE. Note the exemplar is the worked example of why hadIncumbent cannot check it: '
+            + '"dymatize casein" is brand-decisive, so its real write key is "casein dymatize powder protein" while '
+            + 'this row derives "casein powder protein" — a live event would read cold and mean nothing.',
         fixKind: 'healthy',
         detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'sub_threshold_no_displace'),
         exemplars: ['dymatize casein'],
@@ -1212,7 +1369,6 @@ export const FAILURE_CLASSES: FailureClass[] = [
     {
         id: 'venue-brand-blackout-tripwire',
         stage: 'all_filtered',
-        alsoStages: ['no_candidates'],
         title: 'TRIPWIRE: a venue-branded query lost its whole candidate pool',
         description:
             'Regression tripwire for the shipped venue-brand blackout (PR #150, 2026-07-25). '
@@ -1222,9 +1378,16 @@ export const FAILURE_CLASSES: FailureClass[] = [
             + 'the cause. Two plausible diagnoses were wrong before running gather+filter with debug:true settled '
             + 'it. This is a QUERY-SIDE proxy (venue word in the query, whole pool filtered), so it should never '
             + 'fire post-#150; a hit means a filter regression, and the diagnosis method is the debug:true trace, '
-            + 'not the reason string.',
+            + 'not the reason string. '
+            + 'STAGE IS all_filtered ONLY. It used to claim no_candidates too, which was wrong on the class\'s own '
+            + 'terms — the blackout was a FILTER bug (UNRELATED_INDICATORS rejected candidates that had been '
+            + 'gathered), and "candidates were gathered then rejected" IS all_filtered. no_candidates means '
+            + 'retrieval returned nothing, which cannot be a filter blackout. Because this class precedes '
+            + 'ingest-gap-no-candidates, the bogus stage claim turned every venue-worded CORPUS GAP '
+            + '("restaurant shrimp scampi" with an empty pool) into a closed pipeline tripwire with fixKind '
+            + 'pipeline — the exact mis-route ingest-gap-no-candidates was written to prevent.',
         fixKind: 'pipeline',
-        detector: row => atStage(row, ['all_filtered', 'no_candidates'])
+        detector: row => row.funnelStage === 'all_filtered'
             && /\b(grill|grille|kitchen|cafe|caf|diner|bistro|restaurant|brewhouse|tavern|creamery)\b/i.test(row.rawLine),
         exemplars: ['restaurant orange chicken', 'restaurant shrimp scampi'],
         exemplarRows: [
@@ -1234,6 +1397,9 @@ export const FAILURE_CLASSES: FailureClass[] = [
         counterRows: [
             { rawLine: 'qdoba steak bowl', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Qdoba Steak Bowl', grams: 100, kcalPer100g: 250 },
             { rawLine: 'restaurant orange chicken', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'openfoodfacts', foodName: "BJ's Restaurant & Brewhouse, Orange Juice", brandName: "BJ's Restaurant & Brewhouse", grams: 100, kcalPer100g: 124 },
+            // A venue word plus an EMPTY pool is a corpus gap, not a filter blackout:
+            // this must reach ingest-gap-no-candidates, never this tripwire.
+            { rawLine: 'restaurant shrimp scampi', normalizedForm: 'shrimp scampi', funnelStage: 'no_candidates', dropReason: 'no_candidates:dataset_gap', source: 'ai_estimated', foodName: 'Shrimp Scampi', grams: 100, kcalPer100g: 220, proteinPer100g: 12, carbsPer100g: 10, fatPer100g: 14, confidence: 0.62 },
         ],
         goldenCaseIds: [],
         fixPRs: [150],
@@ -1467,6 +1633,19 @@ export function classStages(cls: FailureClass): FunnelStage[] {
     return [cls.stage, ...(cls.alsoStages ?? [])];
 }
 
+/**
+ * Every declared `--from-db` blind spot, flattened for the report.
+ *
+ * MappingEventLog stores no per-100g macro panel, so any detector arm that needs
+ * one is inert against that input. classify-drops prints this whenever the rows it
+ * was handed carry no panel, because "0 hits" from a dark detector must not read as
+ * "we looked and found none".
+ */
+export function fromDbBlindSpots(): { classId: string; title: string; exemplar: string; why: string }[] {
+    return FAILURE_CLASSES.flatMap(c =>
+        (c.fromDbBlind ?? []).map(s => ({ classId: c.id, title: c.title, exemplar: s.exemplar, why: s.why })));
+}
+
 // ---------------------------------------------------------------------------
 // Measured ground truth + caveats that are facts, not classes
 // ---------------------------------------------------------------------------
@@ -1572,32 +1751,52 @@ export const FUNNEL_CAVEATS: { id: string; note: string }[] = [
         id: 'event-log-key-is-not-the-cache-key',
         note: 'MappingEventLog.normalizedForm is PRE-canonicalization; FoodMapping.normalizedForm is canonicalized, '
             + 'singularized and token-SORTED. "chicken breast" -> "breast chicken", "eggs" -> "egg", "pretzels" -> '
-            + '"pretzel". Always canonicalizeCacheKey() before joining, or the join reports cached keys as cold and '
-            + 'inverts the conclusion.',
+            + '"pretzel". Always derive the key before joining (deriveFunnelCacheKey — canonicalizeCacheKey is '
+            + 'necessary but NOT sufficient, see cachekey-is-the-read-key-not-always-the-write-key), or the join '
+            + 'reports cached keys as cold and inverts the conclusion.',
     },
     {
         id: 'incumbent-is-measured-now-not-at-event-time',
-        note: 'hadIncumbent is resolved by looking FoodMapping up at report time, not at event time, and it is '
-            + 'wrong in BOTH directions. A key cached after the event reads hadIncumbent=true; a key EVICTED after '
-            + 'the event reads hadIncumbent=false. The second direction is the one that bites: the first real run '
-            + '(2026-07-25, since 07-24) reported 8 "cold" gate-cross-source-margin events, which is impossible — '
-            + 'that gate is nested inside a block requiring an incumbent and cannot fire on a cold key. They were '
-            + 'events whose rows had been evicted hours later by the composite cache refresh. So a small cold count '
-            + 'on a gate that provably needs an incumbent is a timing artifact, NOT a refutation. Read hadIncumbent '
-            + 'as evidence about a class (does this gate ever fire cold?), never as per-row history, and treat a '
-            + 'LARGE cold count on such a gate as the real signal that something is wrong.',
+        note: 'hadIncumbent is resolved by looking FoodMapping up at report time, not at event time, so it is wrong '
+            + 'in both directions: a key cached after the event reads true, a key EVICTED after the event reads '
+            + 'false. Read it as evidence about a class (does this gate ever fire cold?), never as per-row history. '
+            + 'WORKED EXAMPLE, and the lesson is about diagnosis rather than about timing. The first real run '
+            + '(2026-07-25, --from-db since 07-24) reported 8 "cold" gate-cross-source-margin events, which is '
+            + 'impossible — that gate is nested inside a block requiring an incumbent. The obvious explanation was '
+            + 'this timing skew, since a composite cache refresh had evicted rows hours after those events, and that '
+            + 'explanation was WRITTEN DOWN HERE AND WAS WRONG. The real cause was the cacheKey bug in the caveat '
+            + 'below: canonicalizeCacheKey alone missed the identity discriminators, so the lookup asked for a key '
+            + 'nothing held. Fixing the key derivation took the count to 8 -> 0 cold, exactly as reading the gate '
+            + 'predicts. So when a structural claim and the data disagree, suspect the MEASUREMENT before inventing '
+            + 'a story that reconciles them — a plausible reconciliation stops the search at the wrong place.',
     },
     {
         id: 'cachekey-is-the-read-key-not-always-the-write-key',
-        note: 'FunnelRow.cacheKey uses canonicalizeCacheKey, but the SAVE path uses deriveMappingCacheKey, which '
-            + 'brand-PREFIXES when a brand was detected with decisive context. Measured 2026-07-25: for every '
-            + 'branded query tried (oikos greek yogurt, ghost protein cinnamon roll, quest chocolate chip protein '
-            + 'bar, ryse protein cinnamon toast crunch, mcdonalds fries, chipotle/qdoba chicken burrito) the two '
-            + 'agree, because MappingEventLog.normalizedForm is the AI-normalized name and already carries the '
-            + 'brand token. But the event log does NOT record the detected brand or the decisive-context verdict, '
-            + 'so where the save path DID prefix, this lookup cannot reproduce that key and hadIncumbent will read '
-            + 'false. Exposure looks small and is not measurable from the event log alone; if a class shows '
-            + 'implausibly many cold rows on a gate that needs an incumbent, suspect this before believing it. '
+        note: 'FunnelRow.cacheKey reproduces deriveMappingCacheKey in TWO of its three steps and the third is '
+            + 'unreproducible, so hadIncumbent is a lead, never a verification. '
+            + 'CLOSED 2026-07-25 (this was a real defect, not a theoretical gap): the key used to be '
+            + 'canonicalizeCacheKey alone, which omitted the IDENTITY DISCRIMINATORS the save path appends from the '
+            + 'parsed line (IDENTITY_UNIT_HINTS white/yolk, IDENTITY_QUALIFIERS cooked/whole) and the '
+            + 'adjacent-dup-token collapse. Measured divergences: "3 egg whites" read "egg" against a real key of '
+            + '"egg white"; "1 cup cooked oats" read "oat" against "cooked oat"; "rolled rolled oats" read '
+            + '"oat rolled rolled" against "oat rolled". Those rows all read hadIncumbent=false wrongly. '
+            + 'cacheKey now runs deriveCacheKeyName + collapseAdjacentDuplicateTokens (the pipeline\'s own exported '
+            + 'functions, via cache-key-core so the eval tooling does not load config.ts) over '
+            + 'parseIngredientLine(rawLine). '
+            + 'STILL OPEN, in the OPPOSITE direction: the BRAND-PREFIX step. deriveMappingCacheKey prepends the '
+            + 'brand when the query names one with decisive context, and neither input is recoverable — the event '
+            + 'log records neither the detected brand nor the request\'s options.brand, and hasDecisiveBrandContext '
+            + 'cannot be imported into the eval tooling without dragging config.ts + the ONNX warmup in. Measured: '
+            + '"quest protein bar" writes "bar protein quest" while this reads "bar protein"; "dymatize casein" '
+            + 'writes "casein dymatize powder protein" while this reads "casein powder protein". For every branded '
+            + 'query where MappingEventLog.normalizedForm already carries the brand token (oikos greek yogurt, '
+            + 'mcdonalds fries, red bull energy drink, chipotle/qdoba burrito) the two agree, because the '
+            + 'brand-already-present guard skips the prefix — which is why exposure looks small. '
+            + 'ALSO: the pipeline parses rawLine AFTER a DB-backed synonym substitution (findCanonicalName), so a '
+            + 'synonym-rewritten line derives a different key here. '
+            + 'Net: a cold read on a brand-decisive or synonym-substituted line may be an artifact. The OLD error '
+            + 'ran the other way (branded queries collapsing onto the generic key the cache is full of, so cold '
+            + 'rows read as warm) — which is precisely why hadIncumbent could not have detected any of this itself. '
             + 'Related known bug: brand-prefix save-key asymmetry ("oikos" saved "oiko oiko", read "oiko").',
     },
     {

--- a/scripts/eval/failure-classes.ts
+++ b/scripts/eval/failure-classes.ts
@@ -1,0 +1,1596 @@
+/**
+ * failure-classes.ts — F2, the mapping failure-class registry.
+ *
+ * F1 (PR #139) made every ingredient line land in exactly one FunnelStage with
+ * a namespaced dropReason. That answered "where do lines die"; it did NOT answer
+ * "what is broken and who should fix it". This file is the second half: a typed,
+ * committed, testable taxonomy that turns a funnel histogram into a work queue.
+ *
+ * FOUR MEASURED FACTS SHAPE EVERYTHING BELOW. They were established against the
+ * live box on 2026-07-25 (13,452 MappingEventLog rows carrying funnelStage) and
+ * must not be re-derived from the raw counts, because the raw counts lie:
+ *
+ * (1) THE RAW HISTOGRAM IS MISLEADING. `save_rejected:cross_source_margin` is
+ *     404 of the 571 save_rejected events — 71% — and it is INCUMBENT
+ *     PROTECTION, i.e. correct behaviour. The gate is nested inside
+ *     `if (newTargetKey && existingTargetKey && newTargetKey !== existingTargetKey)`
+ *     (validated-mapping-helpers.ts:724), so on a cold key `existing` is null and
+ *     the whole block is skipped: it CANNOT fire without an incumbent, and only
+ *     ever on off: <-> fs: swaps. Ranking classes by raw count would send the
+ *     first and largest fix-agent at working code. Hence `FixKind.healthy`, and
+ *     hence classify-drops.ts reports counts split by `hadIncumbent`.
+ *
+ * (2) YOU CANNOT JOIN EVENT ROWS TO CACHE ROWS ON `normalizedForm`.
+ *     MappingEventLog.normalizedForm is the PRE-canonicalization AI-normalized
+ *     name; FoodMapping.normalizedForm is the canonicalized, singularized,
+ *     token-SORTED cache key. "chicken breast" in the log is "breast chicken" in
+ *     the cache; "eggs" is "egg"; "pretzels" is "pretzel". A naive join reports
+ *     every one of those as uncached and inverts the conclusion. So FunnelRow
+ *     carries BOTH: `normalizedForm` (as logged) and `cacheKey`
+ *     (canonicalizeCacheKey applied — the real exported function, never a
+ *     re-implementation).
+ *
+ * (3) under_gate's dropReason IS NOT DIAGNOSTIC. F1 tags under_gate with the
+ *     confidence gate's `selectionReason` — which path SELECTED the pick, not
+ *     why confidence was low (map-ingredient-with-fallback.ts:2749). The
+ *     2026-07-24 funnel read found simple_rerank / close_match / clear_winner
+ *     each split ~50/50 good-vs-bad. Classes under under_gate are therefore
+ *     distinguished by ROW heuristics (brand agreement, token coverage,
+ *     degenerate macros, composite-dish magnitude), never by the reason string.
+ *
+ * (4) THE FUNNEL MEASURES CONVERSION, NOT CORRECTNESS. 38 rows whose macros were
+ *     all zero counted as `saved` — successes. A stage cannot express "converted,
+ *     but poisoned". So FunnelRow carries a QUALITY block (degenerate macros,
+ *     flat-100g serving, ai_estimated source, brand disagreement, uncovered query
+ *     tokens) and the registry's first classes fire on SUCCESSFUL stages.
+ *
+ * PRECEDENCE. FAILURE_CLASSES is ordered, and classifyRow returns the FIRST
+ * match. Order is by severity of the underlying defect, not by stage:
+ *   degenerate macros > corrupt panel > identity (cooked/prep/composite/brand/
+ *   token) > serving shape > residual buckets > healthy/by-design.
+ *
+ * RESIDUAL BUCKETS. Classes flagged `residual: true` exist so that live data has
+ * an unclassified rate near zero while NEW shapes still surface: classify-drops
+ * reports residual hits as the frontier, with their raw dropReasons, rather than
+ * hiding them inside a named class. Promote a residual's recurring sub-shape to
+ * its own class rather than growing the residual's description.
+ */
+
+import { canonicalizeCacheKey } from '../../src/lib/mapping/normalization-rules';
+import { normalizeClassId, type FunnelStage } from '../../src/lib/mapping/funnel';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Who can fix this class — the routing decision, and the reason a raw histogram
+ * is not a work queue.
+ */
+export type FixKind =
+    /** A gate/filter/rerank/normalizer change fixes the whole class at once. */
+    | 'pipeline'
+    /** A repoint/evict/corrupt-mark on specific rows. Row-by-row, not code. */
+    | 'data'
+    /** No record exists; only new data fixes it. Route to an ingest queue, NEVER a fix-agent. */
+    | 'ingest'
+    /** The drop is correct behaviour. Counted so it stops looking like a defect. */
+    | 'healthy';
+
+/** Quality dimension (finding 4): a line can convert AND still be wrong. */
+export interface FunnelQuality {
+    /**
+     * Every macro we can see reads zero. From warm JSONL this is the per-100g
+     * panel; from MappingEventLog (which stores no per-100g macros) it is
+     * totalKcal === 0 with grams > 0. 38 such rows were cached as 'saved'.
+     */
+    degenerateMacros: boolean;
+    /** kcal is zero (weaker than degenerateMacros — a real 0-kcal food can hit this). */
+    zeroKcal: boolean;
+    /** grams landed on exactly 100 with no resolved serving tier: the flat-100g fallthrough. */
+    flat100gServing: boolean;
+    /** No corpus record answered: an AI 100g estimate did. Ingest signal, not a ranking signal. */
+    aiEstimated: boolean;
+    /** The record carries a brand that shares NO token with the query, and drops query tokens. */
+    brandDisagreement: boolean;
+    /** Distinguishing query tokens absent from the record's name+brand. Identity signal. */
+    uncoveredQueryTokens: string[];
+}
+
+/** One drop (or one poisoned conversion), from warm JSONL or MappingEventLog. */
+export interface FunnelRow {
+    /** The line as the user/warm-seed wrote it. */
+    rawLine: string;
+    /** PRE-canonicalization AI-normalized name, exactly as MappingEventLog stores it. */
+    normalizedForm: string | null;
+    /** canonicalizeCacheKey(normalizedForm ?? rawLine) — the ONLY key that joins to FoodMapping. */
+    cacheKey: string;
+    funnelStage: FunnelStage | null;
+    /** Namespaced '<stage>:<class>[:<detail>]', as F1 wrote it. */
+    dropReason: string | null;
+    /** dropReason with the stage prefix stripped and re-normalized. '' when absent. */
+    dropClass: string;
+    confidence: number | null;
+    grams: number | null;
+    totalKcal: number | null;
+    kcalPer100g: number | null;
+    proteinPer100g: number | null;
+    carbsPer100g: number | null;
+    fatPer100g: number | null;
+    source: string | null;
+    foodId: string | null;
+    foodName: string | null;
+    brandName: string | null;
+    servingTier: string | null;
+    /** Was a FoodMapping row present for cacheKey? null = not looked up. */
+    hadIncumbent: boolean | null;
+    quality: FunnelQuality;
+}
+
+/** Loose input shape; makeFunnelRow derives cacheKey, dropClass and quality. */
+export interface FunnelRowInput {
+    rawLine: string;
+    normalizedForm?: string | null;
+    funnelStage?: FunnelStage | string | null;
+    dropReason?: string | null;
+    confidence?: number | null;
+    grams?: number | null;
+    totalKcal?: number | null;
+    kcalPer100g?: number | null;
+    proteinPer100g?: number | null;
+    carbsPer100g?: number | null;
+    fatPer100g?: number | null;
+    source?: string | null;
+    foodId?: string | null;
+    foodName?: string | null;
+    brandName?: string | null;
+    servingTier?: string | null;
+    hadIncumbent?: boolean | null;
+}
+
+export interface FailureClass {
+    id: string;
+    /** Primary stage. Declarative: the doc groups by it and a meta-test keeps it honest. */
+    stage: FunnelStage;
+    /** Additional stages the detector legitimately fires on (quality classes span stages). */
+    alsoStages?: FunnelStage[];
+    title: string;
+    description: string;
+    fixKind: FixKind;
+    /** Self-contained: it re-checks the stage itself, so calling it alone is safe. */
+    detector: (row: FunnelRow) => boolean;
+    /** Real queries, from measured ground truth unless the class is a tripwire. */
+    exemplars: string[];
+    /** Rows this detector MUST match. rawLine of each must appear in `exemplars`. */
+    exemplarRows: FunnelRowInput[];
+    /** Rows this detector must NOT match. Guards against silent over-matching. */
+    counterRows: FunnelRowInput[];
+    /** Regression pins in scripts/eval/golden-set.json. */
+    goldenCaseIds: string[];
+    fixPRs: number[];
+    status: 'open' | 'fixing' | 'closed' | 'by-design';
+    /** Absolute ISO date the class was first characterized. */
+    discoveredAt: string;
+    /** Live dropReason class-parts this class owns, for the coverage audit. '*' suffix = prefix match. */
+    dropClasses?: string[];
+    /** Catch-all bucket: hits are reported as frontier, not as a diagnosed class. */
+    residual?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Row construction (the single source of truth shared by CLI and tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tokens that carry no identity. The prep/portion group mirrors what
+ * normalizeIngredientName already strips via `prep_phrases` before the cache key
+ * is built — so a real MappingEventLog.normalizedForm would not contain them, and
+ * treating them as identity-bearing when reading a warm file (which carries the
+ * raw seed) manufactured false positives: "pineapple chunks" -> Pineapple and
+ * "stalks celery" -> Celery both looked like dropped-token identity defects.
+ * Nutrition-affecting modifiers are DELIBERATELY absent: cooked, dry, raw, whole,
+ * skim and canned all stay identity-bearing. 'frozen' IS listed — for whole foods
+ * frozen and fresh are nutritionally the same, and it was the single biggest source
+ * of false brand-substitution flags ("frozen broccoli" -> McCain Broccoli).
+ */
+const STOPWORDS = new Set([
+    'and', 'with', 'the', 'of', 'in', 'on', 'a', 'an', 'for', 'from', 'plus', 'style',
+    'flavor', 'flavour', 'my', 'some', 'kinda',
+    // measure words
+    'cup', 'cups', 'ounce', 'ounces', 'gram', 'grams', 'scoop', 'scoops', 'slice', 'slices',
+    'tbsp', 'tsp', 'tablespoon', 'teaspoon', 'can', 'cans', 'bottle', 'bottles',
+    'piece', 'pieces', 'serving', 'servings', 'pack', 'packs', 'container',
+    // portion/shape words
+    'stalk', 'stalks', 'chunk', 'chunks', 'cube', 'cubes', 'wedge', 'wedges', 'half', 'halves',
+    // preparation that does not change nutrition
+    'sliced', 'diced', 'chopped', 'minced', 'grated', 'shredded', 'crushed', 'cubed', 'halved',
+    'peeled', 'trimmed', 'beaten', 'mashed', 'thawed', 'drained', 'rinsed', 'fresh', 'ripe', 'frozen',
+]);
+
+/**
+ * Base ingredients that turn a preceding dish noun into a MODIFIER: "sandwich bread"
+ * and "pizza rolls" are groceries, not assembled meals, and both false-fired the
+ * composite-drift detector on the 2026-07-25 warm run.
+ */
+const DISH_MODIFIER_BASES = new Set([
+    'bread', 'buns', 'bun', 'roll', 'rolls', 'dough', 'crust', 'shell', 'shells', 'mix',
+    'sauce', 'seasoning', 'dressing', 'spread', 'tortilla', 'tortillas', 'kit', 'base',
+]);
+
+/**
+ * Dish nouns that mark a query as an ASSEMBLED item rather than an ingredient.
+ *
+ * 'burger' and 'cheeseburger' are DELIBERATELY EXCLUDED. Measured against the
+ * 2026-07-25 warm run they produced only false positives — "boca veggie burger"
+ * (71g/80 kcal) and "beyond meat burger patty" (71g/160 kcal) are correct picks of
+ * a single patty, which is what a bare burger query usually means in this corpus.
+ * A burger MEAL still qualifies through the conjunction path
+ * ("restaurant burger and fries").
+ */
+const DISH_NOUNS = new Set([
+    'burrito', 'bowl', 'sandwich', 'wrap', 'plate', 'platter', 'casserole', 'parfait',
+    'salad', 'taco', 'pizza', 'soup', 'stew', 'curry',
+    'combo', 'meal', 'sub', 'quesadilla', 'nachos', 'scramble', 'omelette', 'omelet',
+    'lasagna', 'enchilada', 'sushi', 'poke', 'gyro', 'panini', 'melt', 'skillet',
+    'pasta', 'noodles', 'stirfry',
+]);
+
+/** A dish portion below this many grams is suspiciously small for an assembled item. */
+const COMPOSITE_PORTION_FLOOR_G = 200;
+
+/** Preparation words whose disagreement between query and record is an identity defect. */
+const PREP_WORDS = ['baked', 'fried', 'grilled', 'roasted', 'steamed', 'boiled', 'breaded', 'raw', 'smoked', 'poached'];
+
+/** Explicitly-cooked markers: the query asked for the cooked form. */
+const COOKED_RE = /\b(cooked|boiled|steamed|prepared|braised|simmered)\b/i;
+
+/** Record-name markers for the DRY/uncooked form of a grain or legume. */
+const DRY_RECORD_RE = /\b(dry|dried|uncooked|raw|rolled|instant|quick|steel[- ]?cut)\b/i;
+
+/** Serving tiers that mean "no serving shape was resolved". */
+const UNRESOLVED_SERVING_TIERS = new Set(['flat_100g_default', 'fs_per100g_fallback', 'count_unresolved_floor']);
+
+/** kcal/100g above which the panel is physically impossible (pure fat is ~900). */
+export const IMPOSSIBLE_KCAL_100G = 905;
+
+/** Stages where the pick was SERVED to the user (and possibly cached) — quality matters. */
+export const SERVED_STAGES: FunnelStage[] = ['saved', 'cache_hit', 'under_gate'];
+
+export function tokenize(text: string): string[] {
+    return text
+        .toLowerCase()
+        .replace(/['‘’ʼ`´]/g, '')
+        .split(/[^a-z0-9%]+/)
+        .filter(Boolean);
+}
+
+/** Identity-bearing tokens: no stopwords, no bare numbers, length >= 3. */
+export function contentTokens(text: string): string[] {
+    return tokenize(text).filter(t => t.length >= 3 && !STOPWORDS.has(t) && !/^\d+$/.test(t));
+}
+
+/**
+ * Query tokens the record fails to account for. Deliberately generous about
+ * what counts as covered (substring either way, shared 4-char prefix) so that
+ * "guac" is covered by "Guacamole" and "oat" by "Oats" — an uncovered token is
+ * then strong evidence the record is a different thing, not a spelling variant.
+ */
+export function uncoveredTokens(rawLine: string, foodName?: string | null, brandName?: string | null): string[] {
+    const haystack = `${foodName ?? ''} ${brandName ?? ''}`.toLowerCase().replace(/['‘’ʼ`´]/g, '');
+    if (!haystack.trim()) return [];
+    const hayTokens = tokenize(haystack);
+    return contentTokens(rawLine).filter(t => {
+        if (haystack.includes(t)) return false;
+        return !hayTokens.some(h =>
+            h.includes(t) || t.includes(h) ||
+            (t.length >= 4 && h.length >= 4 && h.slice(0, 4) === t.slice(0, 4)));
+    });
+}
+
+/**
+ * Assembled-dish query: names a dish noun, or one of the multi-word dish idioms.
+ *
+ * A "joined by with/and" rule was tried and REMOVED: measured against the
+ * 2026-07-25 warm run it classified flavour pairs as assemblies — "quest cookies
+ * and cream protein bar" (60g/190 kcal, the exactly-right record) and
+ * "quest bar cookies and cream" both false-fired, and no token-count floor
+ * separated them from real two-part dishes. Composite drift is a claim about the
+ * DISH the query names, so only dish vocabulary may make it.
+ */
+export function isCompositeQuery(rawLine: string): boolean {
+    const toks = tokenize(rawLine);
+    const dishIdx = toks.map((t, i) => (DISH_NOUNS.has(t) ? i : -1)).filter(i => i >= 0);
+    // A dish noun immediately followed by a base ingredient is a modifier, not the dish.
+    if (dishIdx.length > 0 && dishIdx.some(i => !DISH_MODIFIER_BASES.has(toks[i + 1] ?? ''))) return true;
+    return /\bstir\s*fry\b|\bmac\s+(and|&|n)\s+cheese\b|\bbeans?\s+and\s+rice\b/i.test(rawLine);
+}
+
+function prepWordIn(text?: string | null): string | null {
+    if (!text) return null;
+    const toks = tokenize(text);
+    return PREP_WORDS.find(p => toks.includes(p)) ?? null;
+}
+
+function atwaterKcal(row: FunnelRow): number | null {
+    const { proteinPer100g: p, carbsPer100g: c, fatPer100g: f } = row;
+    if (p == null || c == null || f == null) return null;
+    return 4 * p + 4 * c + 9 * f;
+}
+
+/** Strip the stage prefix from a namespaced dropReason and re-normalize it. */
+export function dropClassOf(stage: string | null | undefined, dropReason: string | null | undefined): string {
+    if (!dropReason) return '';
+    let rest = dropReason;
+    if (stage && rest.startsWith(`${stage}:`)) rest = rest.slice(stage.length + 1);
+    const normalized = normalizeClassId(rest);
+    return normalized === 'unknown' && !rest ? '' : normalized;
+}
+
+/** Does the row's dropClass match any of the given patterns ('foo' exact, 'foo:*' prefix)? */
+export function hasDropClass(row: FunnelRow, ...patterns: string[]): boolean {
+    if (!row.dropClass) return false;
+    return patterns.some(p => p.endsWith('*')
+        ? row.dropClass.startsWith(p.slice(0, -1))
+        : row.dropClass === p);
+}
+
+export function atStage(row: FunnelRow, stages: readonly FunnelStage[]): boolean {
+    return row.funnelStage != null && stages.includes(row.funnelStage);
+}
+
+/**
+ * Any quality dimension raised (finding 4). The healthy stage classes require the
+ * ABSENCE of this, so "cache_hit / saved with no quality flag" is a claim the
+ * detector actually verifies rather than one precedence quietly makes true. Every
+ * flag below is owned by a class earlier in the registry, so tightening the healthy
+ * classes cannot manufacture unclassified rows:
+ *   degenerateMacros -> degenerate-macros-served
+ *   brandDisagreement -> identity-brand-substituted
+ *   uncoveredQueryTokens -> identity-query-token-dropped
+ *   aiEstimated -> ai-estimated-backfill-served
+ *   flat100gServing -> serving-flat-100g-fallthrough
+ */
+export function hasQualityFlag(row: FunnelRow): boolean {
+    const q = row.quality;
+    return q.degenerateMacros
+        || q.flat100gServing
+        || q.aiEstimated
+        || q.brandDisagreement
+        || q.uncoveredQueryTokens.length > 0;
+}
+
+/** Is this fast_path line actually just water/ice, or a food that merely mentions it? */
+function isPureWaterQuery(rawLine: string): boolean {
+    const WATER_WORDS = ['water', 'ice', 'iced', 'sparkling', 'tap', 'still'];
+    return contentTokens(rawLine).every(t => WATER_WORDS.includes(t));
+}
+
+/**
+ * Build a FunnelRow, deriving the cache key (finding 2) and the quality block
+ * (finding 4). Both the CLI and the tests go through here, so a detector can
+ * never be green in tests against a shape the CLI would never produce.
+ */
+export function makeFunnelRow(input: FunnelRowInput): FunnelRow {
+    const stage = (input.funnelStage ?? null) as FunnelStage | null;
+    const normalizedForm = input.normalizedForm ?? null;
+    const cacheKey = canonicalizeCacheKey(normalizedForm ?? input.rawLine);
+
+    const grams = input.grams ?? null;
+    const kcal100 = input.kcalPer100g ?? null;
+    const protein100 = input.proteinPer100g ?? null;
+    const carbs100 = input.carbsPer100g ?? null;
+    const fat100 = input.fatPer100g ?? null;
+    const totalKcal = input.totalKcal ?? (kcal100 != null && grams != null ? (kcal100 * grams) / 100 : null);
+
+    const macroPanelSeen = kcal100 != null;
+    const panelAllZero = macroPanelSeen
+        && kcal100 === 0 && (protein100 ?? 0) === 0 && (carbs100 ?? 0) === 0 && (fat100 ?? 0) === 0;
+    // MappingEventLog carries no per-100g panel, so fall back to the billed total.
+    const totalAllZero = !macroPanelSeen && totalKcal === 0 && (grams ?? 0) > 0;
+
+    const source = input.source ?? null;
+    const foodId = input.foodId ?? null;
+    const servingTier = input.servingTier ?? null;
+
+    const uncovered = uncoveredTokens(input.rawLine, input.foodName, input.brandName);
+    const brand = (input.brandName ?? '').trim();
+    const brandTokens = brand ? tokenize(brand) : [];
+    const queryTokens = new Set(tokenize(input.rawLine));
+    const brandShares = brandTokens.some(t => queryTokens.has(t));
+
+    const quality: FunnelQuality = {
+        degenerateMacros: panelAllZero || totalAllZero,
+        zeroKcal: kcal100 === 0 || totalKcal === 0,
+        flat100gServing: grams === 100
+            && (servingTier == null || UNRESOLVED_SERVING_TIERS.has(servingTier)),
+        aiEstimated: source === 'ai_estimated' || source === 'ai_generated' || !!foodId?.startsWith('ai_'),
+        brandDisagreement: brand.length > 0 && !brandShares && uncovered.length > 0,
+        uncoveredQueryTokens: uncovered,
+    };
+
+    return {
+        rawLine: input.rawLine,
+        normalizedForm,
+        cacheKey,
+        funnelStage: stage,
+        dropReason: input.dropReason ?? null,
+        dropClass: dropClassOf(stage, input.dropReason),
+        confidence: input.confidence ?? null,
+        grams,
+        totalKcal,
+        kcalPer100g: kcal100,
+        proteinPer100g: protein100,
+        carbsPer100g: carbs100,
+        fatPer100g: fat100,
+        source,
+        foodId,
+        foodName: input.foodName ?? null,
+        brandName: input.brandName ?? null,
+        servingTier,
+        hadIncumbent: input.hadIncumbent ?? null,
+        quality,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// The registry — ORDERED. classifyRow returns the first match.
+// ---------------------------------------------------------------------------
+
+export const FAILURE_CLASSES: FailureClass[] = [
+    // ===================== poisoned conversions (finding 4) =====================
+    {
+        id: 'degenerate-macros-served',
+        stage: 'saved',
+        alsoStages: ['cache_hit', 'under_gate'],
+        title: 'All-zero macros served, and cached as a success',
+        description:
+            'Every macro reads zero, yet the line counted as a conversion. The funnel cannot express '
+            + '"converted but poisoned" (finding 4): 38 such rows were logged as `saved` in the 2026-07-24 read, '
+            + 'and 3,504 FatSecret records (18.8% of the lane) served 0 kcal. The zero-macros save gate exists '
+            + '(validated-mapping-helpers.ts:585) but is SKIPPED entirely when grams is 0, because '
+            + 'nutrientsPer100g is only passed when result.grams > 0 (map-ingredient-with-fallback.ts:2611). '
+            + 'Root cause of the FatSecret 0-kcal family was a PERSIST RACE, not corruption — fixed on the box '
+            + '(master 662d609) — so the pipeline half is done and this stays as (a) a regression tripwire and '
+            + '(b) a data queue: rows already cached at 0 kcal must still be evicted or repointed.',
+        fixKind: 'data',
+        detector: row => atStage(row, SERVED_STAGES) && row.quality.degenerateMacros,
+        exemplars: ['brazil nuts', 'buckwheat', 'cassava', 'chicken salad sandwich', 'cheesecake factory pasta', 'barbecue sauce'],
+        exemplarRows: [
+            { rawLine: 'brazil nuts', funnelStage: 'saved', source: 'fatsecret', foodName: 'Brazil Nuts', grams: 100, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.98 },
+            { rawLine: 'chicken salad sandwich', funnelStage: 'saved', source: 'fatsecret', foodName: 'Chicken Salad Sandwich', brandName: 'Whole Foods Market', grams: 187, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.95 },
+            { rawLine: 'cheesecake factory pasta', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'fatsecret', foodName: 'Pasta Carbonara with Chicken', brandName: 'Cheesecake Factory', grams: 1110, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.74 },
+            // The MappingEventLog shape: no per-100g panel, only a billed total.
+            { rawLine: 'barbecue sauce', funnelStage: 'saved', source: 'fatsecret', foodName: 'Barbecue Sauce', grams: 15.6, totalKcal: 0, confidence: 0.95 },
+        ],
+        counterRows: [
+            // A real zero-calorie food that short-circuits at the fast path: not this class.
+            { rawLine: 'water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+            // A gate BLOCKED this write, so nothing was poisoned.
+            { rawLine: 'boiled potatoes', funnelStage: 'save_rejected', dropReason: 'save_rejected:zero_macros', source: 'fatsecret', foodName: 'Potatoes (Flesh, with Salt, Boiled)', grams: 78, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+            { rawLine: 'clif bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'CLIF BAR', brandName: 'CLIF', grams: 68, kcalPer100g: 367.6, proteinPer100g: 14, carbsPer100g: 66, fatPer100g: 7 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [139],
+        status: 'fixing',
+        discoveredAt: '2026-07-24',
+    },
+    {
+        id: 'corrupt-panel-served',
+        stage: 'cache_hit',
+        alsoStages: ['saved', 'under_gate'],
+        title: 'Per-serving panel (or kJ) served as per-100g',
+        description:
+            'The record hydrates to a physically impossible or scale-slipped panel and the user was billed from it: '
+            + 'kcal/100g above ' + IMPOSSIBLE_KCAL_100G + ' (pure fat is ~900), or kcal more than 3x the Atwater '
+            + 'estimate from its own macros — the kJ-value-in-the-kcal-field family (n-mq-27 lemon: 383 "kcal"/100g '
+            + 'vs ~40 real). detect-corrupt-nutrition.ts + mark-corrupt-off.ts already marked 30,788 rows across 8 '
+            + 'per-field classes (PRs #116, #119) and the Typesense index dropped 974,044 -> 950,128 accordingly, '
+            + 'so a live hit here means either an unmarked row or a corrupt-exclusion escape. Data fix: mark and purge.',
+        fixKind: 'data',
+        detector: row => {
+            if (!atStage(row, SERVED_STAGES)) return false;
+            const kcal = row.kcalPer100g;
+            if (kcal == null || kcal <= 0) return false;
+            if (kcal > IMPOSSIBLE_KCAL_100G) return true;
+            const atwater = atwaterKcal(row);
+            return atwater != null && kcal >= 100 && kcal > 3 * atwater;
+        },
+        exemplars: ['lemon', 'carrot'],
+        exemplarRows: [
+            { rawLine: 'lemon', funnelStage: 'cache_hit', source: 'openfoodfacts', foodId: 'off_0840609112113', foodName: 'Lemon', grams: 58, kcalPer100g: 383, proteinPer100g: 0.4, carbsPer100g: 9.3, fatPer100g: 0.3, confidence: 0.95 },
+            { rawLine: 'carrot', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Carrots', grams: 61, kcalPer100g: 1720, proteinPer100g: 0.9, carbsPer100g: 9.6, fatPer100g: 0.2, confidence: 0.96 },
+        ],
+        counterRows: [
+            // Pure fat: 900 kcal/100g is real, and exactly its own Atwater value.
+            { rawLine: 'olive oil', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Olive oil', grams: 14, kcalPer100g: 900, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 100 },
+            // Alcohol is invisible to Atwater but is not corrupt — and it is rejected by its own gate.
+            { rawLine: 'martini', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:atwater:kcal_exceeds_computed', source: 'fatsecret', foodName: 'Martini', grams: 71, kcalPer100g: 226, proteinPer100g: 0, carbsPer100g: 0.1, fatPer100g: 0 },
+        ],
+        goldenCaseIds: ['n-mq-27'],
+        fixPRs: [116, 119],
+        status: 'closed',
+        discoveredAt: '2026-07-21',
+        dropClasses: [],
+    },
+    {
+        id: 'identity-cooked-vs-dry',
+        stage: 'cache_hit',
+        alsoStages: ['saved', 'under_gate'],
+        title: 'Explicitly-cooked query answered with the dry record',
+        description:
+            'The query says cooked/boiled/prepared and the record is the dry form, so the line bills ~3x the real '
+            + 'calories at cache-worthy confidence. PR #104 shipped a softCooked volume preference that fixed the '
+            + 'rice family ("white rice" -> 158g cooked), but n-cook-06 ("1 cup cooked oats") is CORPUS-BLOCKED: '
+            + 'retrieval returns dry Rolled Oats at 361 kcal/100g because no cooked-oatmeal record exists in any '
+            + 'lane. So the residual is an ingest problem, not a ranking one — do not send a fix-agent at the '
+            + 'reranker for oats/quinoa.',
+        fixKind: 'ingest',
+        detector: row => {
+            if (!atStage(row, SERVED_STAGES)) return false;
+            if (!COOKED_RE.test(row.rawLine)) return false;
+            if (row.foodName && DRY_RECORD_RE.test(row.foodName)) return true;
+            return (row.kcalPer100g ?? 0) > 250;
+        },
+        exemplars: ['cooked oats', 'cooked white rice'],
+        exemplarRows: [
+            { rawLine: 'cooked oats', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Rolled Oats', grams: 40, kcalPer100g: 361, proteinPer100g: 13, carbsPer100g: 60, fatPer100g: 7, confidence: 0.9 },
+            { rawLine: 'cooked white rice', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'White Rice', grams: 45, kcalPer100g: 365, proteinPer100g: 7, carbsPer100g: 80, fatPer100g: 1, confidence: 0.93 },
+        ],
+        counterRows: [
+            // Boiled potato at a plausible cooked density: correct, and not a dry record.
+            { rawLine: 'boiled potatoes', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Potatoes, Boiled', grams: 173, kcalPer100g: 87, proteinPer100g: 2, carbsPer100g: 20, fatPer100g: 0.1 },
+            // No cooked marker in the query: the dry record is what was asked for.
+            { rawLine: 'dry rolled oats', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Rolled Oats', grams: 40, kcalPer100g: 361, proteinPer100g: 13, carbsPer100g: 60, fatPer100g: 7 },
+        ],
+        goldenCaseIds: ['n-cook-06', 'n-cook-05'],
+        fixPRs: [104],
+        status: 'open',
+        discoveredAt: '2026-07-19',
+    },
+    {
+        id: 'identity-preparation-mismatch',
+        stage: 'cache_hit',
+        alsoStages: ['saved', 'under_gate'],
+        title: 'Preparation contradicted by the record (baked query -> Fried record)',
+        description:
+            'Query and record both name a preparation and they disagree. Fat and calories move 30-80% between '
+            + 'baked and fried, so this is a nutrition defect wearing a plausible name — and unlike the '
+            + 'cooked-vs-dry class the tokens are all present, so no gate objects. Fires only when BOTH sides name '
+            + 'a preparation, which keeps unmarked records (the common case) out.',
+        fixKind: 'pipeline',
+        detector: row => {
+            if (!atStage(row, SERVED_STAGES)) return false;
+            const q = prepWordIn(row.rawLine);
+            const r = prepWordIn(row.foodName);
+            return q != null && r != null && q !== r;
+        },
+        exemplars: ['baked chicken tenders'],
+        exemplarRows: [
+            { rawLine: 'baked chicken tenders', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'openfoodfacts', foodName: 'Fried Chicken Tenders', grams: 112, kcalPer100g: 290, proteinPer100g: 18, carbsPer100g: 18, fatPer100g: 16, confidence: 0.76 },
+        ],
+        counterRows: [
+            { rawLine: 'grilled chicken breast', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Grilled Chicken Breast', grams: 112, kcalPer100g: 165, proteinPer100g: 31, carbsPer100g: 0, fatPer100g: 3.6 },
+            { rawLine: 'chicken tenders', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Fried Chicken Tenders', grams: 112, kcalPer100g: 290, proteinPer100g: 18, carbsPer100g: 18, fatPer100g: 16 },
+        ],
+        goldenCaseIds: ['n-mq-21'],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-21',
+    },
+    {
+        id: 'composite-component-drift',
+        stage: 'under_gate',
+        alsoStages: ['saved', 'cache_hit'],
+        title: 'Composite dish answered with one of its components (5-10x undercount)',
+        description:
+            'The largest-magnitude defect class measured so far. An assembled-dish query resolves to a single '
+            + 'component and bills a fraction of the meal while looking authoritative: "chipotle chicken burrito" '
+            + 'measured live at 118g / 166 kcal for a ~1,100 kcal burrito, and "panera green goddess cobb salad" '
+            + 'resolves to the DRESSING. The "half corpus gap" theory was WRONG (corrected 2026-07-25): 3 of the 4 '
+            + 'assembled records are already in Postgres — the root cause is `filtered.slice(0, 10)` truncating the '
+            + 'FatSecret lane before rerank. Fix RETRIEVAL, not a gate: a gate falls through to the AI backfill at '
+            + '100g, which is the same undercount with worse provenance. n-mq-42 ("chipotle chicken burrito bowl", '
+            + 'which resolves correctly at 350g/606 kcal) is the mandatory over-rejection tripwire — adding the '
+            + 'single token "bowl" is the whole difference between 606 and 166 kcal. '
+            + 'DETECTOR CALIBRATION (measured against the 2026-07-25 warm run): dish vocabulary in the query, '
+            + 'PLUS grams < 200, PLUS total < 250 kcal. All three are needed. A "joined by with/and" marker '
+            + 'flagged "quest cookies and cream protein bar" (60g/190 kcal, the exactly-right record) and no '
+            + 'token-count floor separated flavour pairs from real dishes, so it was removed; "burger" as a dish '
+            + 'noun flagged single patties ("boca veggie burger" 71g/80 kcal), so it was removed too. Even so this '
+            + 'is a SUSPICION class: confirm each hit against the real dish before repointing anything.',
+        fixKind: 'pipeline',
+        detector: row => {
+            if (!atStage(row, SERVED_STAGES)) return false;
+            if (!isCompositeQuery(row.rawLine)) return false;
+            // A bare dish word is a category query, not an assembly ("pasta" -> Pasta).
+            if (contentTokens(row.rawLine).length < 2) return false;
+            // Two independent magnitude tests, because either alone has a big false-positive
+            // family: portion (a dish billed under 200 g) AND total energy (under 250 kcal).
+            if (row.grams == null || row.grams >= COMPOSITE_PORTION_FLOOR_G) return false;
+            const kcal = row.totalKcal;
+            return kcal != null && kcal > 0 && kcal < 250;
+        },
+        exemplars: ['chipotle chicken burrito', 'qdoba chicken bowl', 'panera green goddess cobb salad', 'mac and cheese', "stouffer's mac and cheese"],
+        exemplarRows: [
+            { rawLine: 'chipotle chicken burrito', funnelStage: 'saved', source: 'fatsecret', foodName: 'Chicken Burrito Filling', brandName: 'Chipotle', grams: 118, totalKcal: 166, kcalPer100g: 141, proteinPer100g: 12, carbsPer100g: 8, fatPer100g: 7, confidence: 0.95 },
+            { rawLine: "stouffer's mac and cheese", funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'MAC & CHEESE', brandName: "Stouffer's", grams: 28, kcalPer100g: 141.2, proteinPer100g: 5, carbsPer100g: 17, fatPer100g: 6, confidence: 0.95 },
+            { rawLine: 'qdoba chicken bowl', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'openfoodfacts', foodName: 'Qdoba, Chicken Fajita Nachos', brandName: 'Qdoba', grams: 57, kcalPer100g: 25.7, proteinPer100g: 2, carbsPer100g: 3, fatPer100g: 1, confidence: 0.72 },
+            { rawLine: 'panera green goddess cobb salad', funnelStage: 'under_gate', dropReason: 'under_gate:fallback_after_serving_failure', source: 'openfoodfacts', foodName: 'Panera Bread, Green Goddess Dressing, For Half Salads', brandName: 'Panera Bread', grams: 100, kcalPer100g: 57, proteinPer100g: 1, carbsPer100g: 3, fatPer100g: 5, confidence: 0.7 },
+            { rawLine: 'mac and cheese', funnelStage: 'under_gate', dropReason: 'under_gate:single_candidate', source: 'fdc', foodName: 'vegetable enriched dry macaroni', grams: 28, kcalPer100g: 367, proteinPer100g: 13, carbsPer100g: 74, fatPer100g: 2, confidence: 0.66 },
+        ],
+        counterRows: [
+            // n-mq-42: the assembled record wins and the magnitude is right. MUST NOT fire.
+            { rawLine: 'chipotle chicken burrito bowl', funnelStage: 'saved', source: 'fatsecret', foodName: 'Chipotle Chicken Burrito Bowl', brandName: 'Chipotle', grams: 350, totalKcal: 606, kcalPer100g: 173, proteinPer100g: 10, carbsPer100g: 17, fatPer100g: 6, confidence: 0.96 },
+            // A genuinely small two-token item: no dish noun, no conjunction.
+            { rawLine: 'egg roll', funnelStage: 'saved', source: 'fatsecret', foodName: 'Egg Roll', grams: 64, totalKcal: 150, kcalPer100g: 234, proteinPer100g: 7, carbsPer100g: 24, fatPer100g: 6 },
+            // An ingredient query, not a dish.
+            { rawLine: 'spinach', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3, proteinPer100g: 2.9, carbsPer100g: 1.4, fatPer100g: 0.4 },
+            // Measured false positive of the earlier, looser detector: one product whose name
+            // merely contains "and", answered by the exactly-right record.
+            { rawLine: 'quest cookies and cream protein bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Quest Protein Bar Cookies and Cream', brandName: 'Quest', grams: 60, totalKcal: 190, kcalPer100g: 316.7, proteinPer100g: 33, carbsPer100g: 40, fatPer100g: 12 },
+            // Measured false positive of 'burger' as a dish noun: a single patty, billed right.
+            { rawLine: 'boca veggie burger', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Original veggie burgers', brandName: 'Boca', grams: 71, totalKcal: 80, kcalPer100g: 112.7, proteinPer100g: 18, carbsPer100g: 8, fatPer100g: 1.4 },
+            // Measured false positive: the dish noun is a MODIFIER on a grocery item.
+            { rawLine: 'sandwich bread', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Sandwich Bread', brandName: 'My Essentials', grams: 30, totalKcal: 80, kcalPer100g: 267, proteinPer100g: 9, carbsPer100g: 49, fatPer100g: 3 },
+            // Measured false positive: a bare category query, not an assembly.
+            { rawLine: 'pasta', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Pasta', grams: 100, totalKcal: 46, kcalPer100g: 46, proteinPer100g: 2, carbsPer100g: 9, fatPer100g: 0.3 },
+        ],
+        goldenCaseIds: ['n-mq-38', 'n-mq-39', 'n-mq-40', 'n-mq-41', 'n-mq-42'],
+        fixPRs: [147],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+    },
+    {
+        id: 'identity-brand-substituted',
+        stage: 'under_gate',
+        alsoStages: ['saved', 'cache_hit'],
+        title: "Another brand's product answered a brand query",
+        description:
+            'The record carries a brand that shares no token with the query AND drops query tokens: "moes guac" '
+            + '-> Morrisons Guacamole, "just bare chicken breast strips" -> Buckley Farms, '
+            + '"noodles and company japanese pan noodles" -> Origami Catering. The save-time brand-mismatch gate '
+            + '(validated-mapping-helpers.ts:497) stops these from being CACHED when the query names a brand '
+            + 'decisively, but retrieval still SERVES them, which is exactly what n-mq-23 pins. Related shipped '
+            + 'lesson: PR #150 — UNRELATED_INDICATORS read name+brandName, so every chain branded '
+            + 'Grill/Kitchen/Cafe/Diner/Bistro/Restaurant had its entire catalogue rejected pre-rerank '
+            + '(476 FatSecret records, 66-77 brands). Two plausible diagnoses were wrong before that one; only '
+            + 'running gather+filter with debug:true settled it.',
+        fixKind: 'pipeline',
+        detector: row => atStage(row, SERVED_STAGES) && row.quality.brandDisagreement,
+        exemplars: ["moe's guac", 'just bare chicken breast strips', 'noodles and company japanese pan noodles'],
+        exemplarRows: [
+            { rawLine: "moe's guac", funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'openfoodfacts', foodName: 'Guacamole', brandName: 'Morrisons', grams: 50, kcalPer100g: 118, proteinPer100g: 2, carbsPer100g: 3, fatPer100g: 11, confidence: 0.62 },
+            { rawLine: 'just bare chicken breast strips', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'openfoodfacts', foodName: 'Boneless Skinless Chicken Breast Strips', brandName: 'Buckley Farms', grams: 84, kcalPer100g: 145, proteinPer100g: 23, carbsPer100g: 0, fatPer100g: 5, confidence: 0.72 },
+            { rawLine: 'noodles and company japanese pan noodles', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'openfoodfacts', foodName: 'Sweet Potato Noodles And Mushrooms', brandName: 'Origami Catering', grams: 284, kcalPer100g: 113, proteinPer100g: 3, carbsPer100g: 20, fatPer100g: 2, confidence: 0.72 },
+        ],
+        counterRows: [
+            // Post really does make Honey Bunches of Oats: brand shares no token, but nothing is uncovered.
+            { rawLine: 'honey bunches of oats', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'openfoodfacts', foodName: 'Honey Bunches of Oats', brandName: 'Post', grams: 53, kcalPer100g: 433.9, proteinPer100g: 7, carbsPer100g: 85, fatPer100g: 5, confidence: 0.82 },
+            { rawLine: 'clif bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'CLIF BAR', brandName: 'CLIF', grams: 68, kcalPer100g: 367.6, proteinPer100g: 14, carbsPer100g: 66, fatPer100g: 7 },
+        ],
+        goldenCaseIds: ['n-mq-23'],
+        fixPRs: [110, 150],
+        status: 'open',
+        discoveredAt: '2026-07-20',
+    },
+    {
+        id: 'identity-query-token-dropped',
+        stage: 'under_gate',
+        alsoStages: ['saved', 'cache_hit'],
+        title: 'Record is missing a distinguishing query token',
+        description:
+            'A content token of the query appears nowhere in the record name or brand, generously scored '
+            + '(substring either way, shared 4-char prefix), so an uncovered token means a different thing was '
+            + 'served: "michelangelos chicken parmesan" -> a generic Chicken Parmesan, "sweetgreen spicy sabzi" -> '
+            + 'Aloo Sabzi, "moes queso" -> Queso Asadero. This is the heuristic that replaces '
+            + "under_gate's non-diagnostic dropReason (finding 3): simple_rerank / close_match / clear_winner each "
+            + 'split ~50/50 good-vs-bad, and token coverage is what separates the halves. Candidate contributing '
+            + 'cause on the retrieval side: three CRUDER local singularize() copies shadow the exported one '
+            + '(filter-candidates.ts:113, gather-candidates.ts:847, map-ingredient-with-fallback.ts:435) and strip '
+            + 'two chars from ANY -es, generating "oliv", "nood", "sauc", "juic" as query variants. '
+            + 'MEASURED COMPOSITION (391-row warm sample, 2026-07-25): 35 distinct keys splitting into two '
+            + 'sub-shapes that want DIFFERENT fixes. (a) SYNONYM GAPS — "courgette" -> Zucchini, "oatmeal" -> '
+            + 'Rolled Oats, "coke zero" -> Coca-Cola ZERO SUGAR, "all-purpose flour" -> Plain flour: these belong '
+            + 'to the alias/synonym layer, not to the reranker. (b) DROPPED NUTRITION-AFFECTING MODIFIERS — '
+            + '"whole wheat bread" -> Wheat Bread, "whole milk" -> Milk, "ground beef" -> Beef, '
+            + '"ghost vegan protein cinnamon roll" -> Vegan Protein: the record is a less specific product whose '
+            + 'macros genuinely differ. Split the queue before assigning it.',
+        fixKind: 'pipeline',
+        detector: row => atStage(row, SERVED_STAGES) && row.quality.uncoveredQueryTokens.length > 0,
+        exemplars: ["michelangelo's chicken parmesan", 'sweetgreen spicy sabzi', "moe's queso"],
+        exemplarRows: [
+            { rawLine: "michelangelo's chicken parmesan", funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'fatsecret', foodName: 'Chicken Parmesan', grams: 159, kcalPer100g: 160, proteinPer100g: 14, carbsPer100g: 9, fatPer100g: 8, confidence: 0.73 },
+            { rawLine: 'sweetgreen spicy sabzi', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'fatsecret', foodName: 'Aloo Sabzi', grams: 250, kcalPer100g: 96, proteinPer100g: 2, carbsPer100g: 12, fatPer100g: 4, confidence: 0.71 },
+            { rawLine: "moe's queso", funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'fatsecret', foodName: 'Queso Asadero', grams: 28.35, kcalPer100g: 356, proteinPer100g: 23, carbsPer100g: 3, fatPer100g: 28, confidence: 0.74 },
+        ],
+        counterRows: [
+            { rawLine: 'ground beef 90/10', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'openfoodfacts', foodName: 'Ground Beef 85% Lean 15% Fat', brandName: "Rastelli's", grams: 112, kcalPer100g: 232, proteinPer100g: 19, carbsPer100g: 0, fatPer100g: 17, confidence: 0.78 },
+            { rawLine: 'yellow bell pepper', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Yellow Bell Pepper', grams: 164, kcalPer100g: 27, proteinPer100g: 1, carbsPer100g: 6, fatPer100g: 0.2 },
+        ],
+        goldenCaseIds: ['n-mq-22'],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-24',
+    },
+    {
+        id: 'ai-estimated-backfill-served',
+        stage: 'under_gate',
+        alsoStages: ['saved', 'cache_hit'],
+        title: 'No corpus record answered — a fabricated AI estimate was served',
+        description:
+            'The line was billed from an AI-generated nutrition estimate rather than from any record in OFF, FDC '
+            + 'or FatSecret, almost always at exactly 100 g. This is an INGEST signal, not a ranking signal: '
+            + 'sending a rerank fix-agent at it changes nothing because there is nothing to rerank. It is also the '
+            + 'reason a GATE is the wrong tool for composite-component drift — a gate that rejects the component '
+            + 'pick falls through to exactly this path, i.e. the same undercount with worse provenance. Watch for '
+            + 'the fabrication signature: "diet dr pepper" -> "Diet Dr. Black Pepper", "hamburger bun" -> '
+            + '"85% Lean Beef Bun". Confidence sits in the 0.48-0.72 band, so these lines pre-date F1 with a null '
+            + 'funnelStage in older warm files and land in under_gate once staged.',
+        fixKind: 'ingest',
+        detector: row => atStage(row, SERVED_STAGES) && row.quality.aiEstimated,
+        exemplars: ['escarole', 'cherimoya', 'diet dr pepper'],
+        exemplarRows: [
+            { rawLine: 'escarole', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'ai_estimated', foodName: 'Escarole', grams: 100, kcalPer100g: 20, proteinPer100g: 1.6, carbsPer100g: 3.1, fatPer100g: 0.3, confidence: 0.61 },
+            { rawLine: 'cherimoya', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'ai_estimated', foodName: 'Cherimoya', grams: 200, kcalPer100g: 90, proteinPer100g: 1.6, carbsPer100g: 22, fatPer100g: 0.7, confidence: 0.61 },
+            { rawLine: 'diet dr pepper', funnelStage: 'under_gate', dropReason: 'under_gate:clear_winner', source: 'ai_estimated', foodName: 'Diet Dr. Black Pepper', grams: 100, kcalPer100g: 1, proteinPer100g: 0, carbsPer100g: 0.2, fatPer100g: 0, confidence: 0.64 },
+        ],
+        counterRows: [
+            // A real record at 100 g is the serving class, not an ingest gap.
+            { rawLine: 'spinach', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3, proteinPer100g: 2.9, carbsPer100g: 1.4, fatPer100g: 0.4 },
+            // An abstention is no_match, a stage this class does not claim.
+            { rawLine: 'chipotle chicken burrito', funnelStage: 'no_match', dropReason: 'no_match:confidence_too_low', source: 'ai_estimated', foodName: 'chipotle chicken burrito', grams: 0, totalKcal: 0, confidence: 0 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+    },
+    {
+        id: 'serving-flat-100g-fallthrough',
+        stage: 'cache_hit',
+        alsoStages: ['saved', 'under_gate'],
+        title: 'Serving resolution fell through to a flat 100 g',
+        description:
+            'grams landed on exactly 100 with no resolved serving tier — the record was found, its identity is '
+            + 'fine, and then the portion was invented. Chain items are the worst affected because a restaurant '
+            + 'item has no natural 100g portion. PR #145 removed the need for a volume anchor on the FatSecret '
+            + "lane: FatSecret's synthetic `100 g` panel is an invertible WEIGHT ORACLE "
+            + '(100 x serving_nutrient / panel_nutrient, median across nutrients, 98.1% within 5% on 24,579 '
+            + 'known-weight rows). NOTE ON PRECISION: from warm JSONL, servingTier is not recorded, so this fires '
+            + 'on grams === 100 alone and will include records whose label really is 100 g. Run classify-drops '
+            + 'with --from-db to get the exact read from MappingEventLog.servingTier.',
+        fixKind: 'pipeline',
+        detector: row => atStage(row, SERVED_STAGES) && row.quality.flat100gServing,
+        exemplars: ['spinach', 'dry pasta', 'ribeye', 'green beans'],
+        exemplarRows: [
+            { rawLine: 'spinach', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3, proteinPer100g: 2.9, carbsPer100g: 1.4, fatPer100g: 0.4 },
+            { rawLine: 'dry pasta', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Dry Pasta', brandName: 'Rocco', grams: 100, kcalPer100g: 360, proteinPer100g: 12, carbsPer100g: 73, fatPer100g: 1.5 },
+            { rawLine: 'ribeye', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Ribeye', grams: 100, kcalPer100g: 250, proteinPer100g: 24, carbsPer100g: 0, fatPer100g: 17 },
+            { rawLine: 'green beans', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Green beans', grams: 100, kcalPer100g: 20, proteinPer100g: 1.8, carbsPer100g: 3, fatPer100g: 0.1 },
+        ],
+        counterRows: [
+            // The user literally asked for 100 g: the weight tier resolved it.
+            { rawLine: '100g chicken breast', funnelStage: 'cache_hit', servingTier: 'weight_unit', source: 'openfoodfacts', foodName: 'Chicken Breast', grams: 100, kcalPer100g: 116, proteinPer100g: 23, carbsPer100g: 0, fatPer100g: 2 },
+            { rawLine: 'salmon fillet', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Salmon Fillet', brandName: 'Keohane Seafoods', grams: 120, kcalPer100g: 202, proteinPer100g: 20, carbsPer100g: 0, fatPer100g: 13 },
+        ],
+        goldenCaseIds: ['n-serv-35'],
+        fixPRs: [145, 112],
+        status: 'fixing',
+        discoveredAt: '2026-07-21',
+    },
+
+    // ===================== save_rejected: healthy / by-design =====================
+    {
+        id: 'gate-cross-source-margin',
+        stage: 'save_rejected',
+        title: 'Cross-source displacement margin held the incumbent (BY DESIGN)',
+        description:
+            'THE CLASS THAT MAKES THE RAW HISTOGRAM LIE (finding 1). 404 of 571 save_rejected events, 71% — and '
+            + 'every one is correct behaviour. When an overwrite would move a key across source families '
+            + '(off: <-> fs:), the incumbent already passed every save gate at ITS save time, so the challenger '
+            + 'must be meaningfully more confident, not this run\'s rerank winner by a hair. The gate is nested '
+            + 'inside `if (newTargetKey && existingTargetKey && newTargetKey !== existingTargetKey)` '
+            + '(validated-mapping-helpers.ts:724): on a cold key `existing` is null and the block never runs, so '
+            + 'it CANNOT fire without an incumbent. Verify with the hadIncumbent split — a hit with '
+            + 'hadIncumbent=false would mean the gate or the join is broken, not that a defect was found. '
+            + 'CAVEAT: newTargetKey/existingTargetKey read only offBarcode then fsId, never fdcId '
+            + '(validated-mapping-helpers.ts:720-723), so fdc <-> off and fdc <-> fs displacements bypass this '
+            + 'margin AND the serving-downgrade guard entirely. That latent gap is a pipeline defect, not part of '
+            + 'this healthy class.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'cross_source_margin'),
+        exemplars: ['brussels sprouts', 'red bell pepper', 'pretzels', 'frozen brussels sprouts'],
+        exemplarRows: [
+            { rawLine: 'brussels sprouts', normalizedForm: 'brussels sprouts', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', source: 'fatsecret', foodName: 'Brussels Sprouts', grams: 19, kcalPer100g: 43, proteinPer100g: 3, carbsPer100g: 9, fatPer100g: 0.3, confidence: 0.98, hadIncumbent: true },
+            { rawLine: 'pretzels', normalizedForm: 'pretzels', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', source: 'fatsecret', foodName: 'Pretzels', grams: 3, kcalPer100g: 380, proteinPer100g: 10, carbsPer100g: 80, fatPer100g: 3, confidence: 0.98, hadIncumbent: true },
+        ],
+        counterRows: [
+            { rawLine: 'dymatize casein', funnelStage: 'save_rejected', dropReason: 'save_rejected:sub_threshold_no_displace', source: 'openfoodfacts', foodName: 'Elite Casein', brandName: 'Dymatize nutrition', grams: 36, kcalPer100g: 361 },
+            { rawLine: 'brussels sprouts', funnelStage: 'saved', source: 'fatsecret', foodName: 'Brussels Sprouts', grams: 19, kcalPer100g: 43, proteinPer100g: 3, carbsPer100g: 9, fatPer100g: 0.3 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [132],
+        status: 'by-design',
+        discoveredAt: '2026-07-23',
+        dropClasses: ['cross_source_margin'],
+    },
+    {
+        id: 'gate-sub-threshold-no-displace',
+        stage: 'save_rejected',
+        title: 'Sub-threshold pick refused to overwrite an existing row (BY DESIGN)',
+        description:
+            'A pick admitted BELOW the 0.85 confidence gate may seed a NEW key but must never overwrite one: '
+            + 'something the cascade was 78% sure of has no business evicting a row a more confident pick earned '
+            + '(validated-mapping-helpers.ts:650, funnel fix 4). This is the entire blast-radius bound on '
+            + 'conditional admission, and the guarantee the abandoned PR #143 lacked when it repointed the eight '
+            + 'most-used generic keys in the cache. Like cross_source_margin it cannot fire on a cold key.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'sub_threshold_no_displace'),
+        exemplars: ['dymatize casein'],
+        exemplarRows: [
+            { rawLine: 'dymatize casein', normalizedForm: 'dymatize casein', funnelStage: 'save_rejected', dropReason: 'save_rejected:sub_threshold_no_displace', source: 'openfoodfacts', foodName: 'Elite Casein', brandName: 'Dymatize nutrition', grams: 36, kcalPer100g: 361, proteinPer100g: 78, carbsPer100g: 6, fatPer100g: 2, confidence: 0.83, hadIncumbent: true },
+        ],
+        counterRows: [
+            { rawLine: 'pretzels', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', source: 'fatsecret', foodName: 'Pretzels', grams: 3, kcalPer100g: 380 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'by-design',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['sub_threshold_no_displace'],
+    },
+    {
+        id: 'gate-serving-downgrade',
+        stage: 'save_rejected',
+        title: 'Serving-downgrade guard kept the record that has serving shape (BY DESIGN)',
+        description:
+            'A record swap that would replace a row carrying real serving data (Red Bull with its 250ml can label) '
+            + 'with one carrying none is refused, because every later serving-billed request would then fall to '
+            + 'flat_100g_default (validated-mapping-helpers.ts:778, PR #110). A corrupt-marked incumbent forfeits '
+            + 'the guard — otherwise the row zombies: every hit escapes, re-resolves, and lands back here. '
+            + 'SAME CAVEAT AS cross_source_margin: fdc records are invisible to newTargetKey/existingTargetKey, so '
+            + 'fdc displacements bypass this guard.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'serving_downgrade'),
+        exemplars: ['pret a manger chicken caesar wrap'],
+        exemplarRows: [
+            { rawLine: 'pret a manger chicken caesar wrap', normalizedForm: 'pret a manger chicken caesar wrap', funnelStage: 'save_rejected', dropReason: 'save_rejected:serving_downgrade', source: 'fatsecret', foodName: 'Chicken Caesar Wrap', brandName: 'Market Sandwich', grams: 330, kcalPer100g: 200, proteinPer100g: 12, carbsPer100g: 20, fatPer100g: 8, confidence: 0.98, hadIncumbent: true },
+        ],
+        counterRows: [
+            { rawLine: 'red bull', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Red Bull', brandName: 'Red Bull', grams: 250, kcalPer100g: 45 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [110],
+        status: 'by-design',
+        discoveredAt: '2026-07-20',
+        dropClasses: ['serving_downgrade'],
+    },
+    {
+        id: 'gate-bare-category-takeover',
+        stage: 'save_rejected',
+        title: 'Bare-category takeover blocked (BY DESIGN)',
+        description:
+            'A specific branded/multi-token query must not collapse into a bare generic category with no brand — '
+            + '"met rx big 100" saving under the key "protein bar", "special k red berries" -> "Cereal", '
+            + '"restaurant burger and fries" -> "Burger". Two such rows were caught and reverted post-apply in the '
+            + '2026-07-21 big warm batch, which is why the gate exists (validated-mapping-helpers.ts:530). The gate '
+            + 'is correct; the UPSTREAM issue it hints at — telemetry keys that are bare category terms — was '
+            + 'closed separately as a key-granularity question, not a save bug.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'bare_category_takeover'),
+        exemplars: ['restaurant burger and fries'],
+        exemplarRows: [
+            { rawLine: 'restaurant burger and fries', normalizedForm: 'burger and fries', funnelStage: 'save_rejected', dropReason: 'save_rejected:bare_category_takeover', source: 'openfoodfacts', foodName: 'Burger', grams: 100, kcalPer100g: 212, proteinPer100g: 14, carbsPer100g: 18, fatPer100g: 10, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'mcdonalds big mac', funnelStage: 'saved', source: 'fatsecret', foodName: 'Big Mac', brandName: "McDonald's", grams: 219, kcalPer100g: 257 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'by-design',
+        discoveredAt: '2026-07-21',
+        dropClasses: ['bare_category_takeover'],
+    },
+    {
+        id: 'gate-zero-macros',
+        stage: 'save_rejected',
+        title: 'Degenerate-nutrition gate refused to cache an all-zero pick (BY DESIGN)',
+        description:
+            'An all-zero panel passes every bounds check (nothing negative, macro sum 0, Atwater compares 0 to 0), '
+            + 'so before this gate such picks sailed through at confidence 0.95-1.00 and pinned a key to a record '
+            + 'that hydrates to 0 kcal forever (validated-mapping-helpers.ts:585). Declining to CACHE costs only a '
+            + 'repeat lookup — the request is served either way. CAVEAT (latent gap): the gate is skipped entirely '
+            + 'when grams is 0, because nutrientsPer100g is only passed when result.grams > 0 '
+            + '(map-ingredient-with-fallback.ts:2611-2616). Zero live events were observed in the 2026-07-25 read; '
+            + 'the 38 poisoned rows that DID get cached are class `degenerate-macros-served`.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'zero_macros'),
+        exemplars: ['boiled potatoes', 'ben and jerrys cherry garcia'],
+        exemplarRows: [
+            { rawLine: 'boiled potatoes', normalizedForm: 'boiled potatoes', funnelStage: 'save_rejected', dropReason: 'save_rejected:zero_macros', source: 'fatsecret', foodName: 'Potatoes (Flesh, with Salt, Boiled)', grams: 78, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.95 },
+            { rawLine: 'ben and jerrys cherry garcia', normalizedForm: 'ben and jerrys cherry garcia', funnelStage: 'save_rejected', dropReason: 'save_rejected:zero_macros', source: 'fatsecret', foodName: 'Cherry Garcia Ice Cream - Mini Cups', brandName: "Ben & Jerry's", grams: 130, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'brazil nuts', funnelStage: 'saved', source: 'fatsecret', foodName: 'Brazil Nuts', grams: 100, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'by-design',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['zero_macros'],
+    },
+
+    // ===================== save_rejected: real defects behind a correct gate =====================
+    {
+        id: 'gate-human-row-conflated',
+        stage: 'save_rejected',
+        title: "save_rejected:human_row CONFLATES a successful usage-bump with a rejection",
+        description:
+            'INSTRUMENTATION DEFECT, not a mapping defect. markSaveRejected is called OUTSIDE the if/else at '
+            + 'validated-mapping-helpers.ts:684-704, so when a fresh resolution lands on the SAME record as a '
+            + 'human-triage row, the usedCount/lastUsedAt bump succeeds and the line is STILL reported as a '
+            + 'rejection. Only the different-record branch is a real skip. Any conversion-rate computed from this '
+            + 'class is wrong in the pessimistic direction, and the two populations need separate class IDs before '
+            + 'the number means anything. There are 197+ pinned human-triage rows (mayonnaise -> off_9348905001434, '
+            + 'the m&ms and saltine-sleeve pins from the 2026-07-24 revert), so the bump path is well travelled.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'human_row'),
+        exemplars: ['mayonnaise', 'saltine crackers'],
+        exemplarRows: [
+            { rawLine: 'mayonnaise', normalizedForm: 'mayonnaise', funnelStage: 'save_rejected', dropReason: 'save_rejected:human_row', source: 'openfoodfacts', foodId: 'off_9348905001434', foodName: 'Mayonnaise', grams: 15, kcalPer100g: 680, proteinPer100g: 1, carbsPer100g: 2, fatPer100g: 75, confidence: 0.95, hadIncumbent: true },
+            { rawLine: 'saltine crackers', normalizedForm: 'saltine crackers', funnelStage: 'save_rejected', dropReason: 'save_rejected:human_row', source: 'openfoodfacts', foodName: 'Saltine Crackers', grams: 16, kcalPer100g: 421, proteinPer100g: 9, carbsPer100g: 72, fatPer100g: 10, confidence: 0.9, hadIncumbent: true },
+        ],
+        counterRows: [
+            { rawLine: 'mayonnaise', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Mayonnaise', grams: 15, kcalPer100g: 680, proteinPer100g: 1, carbsPer100g: 2, fatPer100g: 75 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['human_row'],
+    },
+    {
+        id: 'gate-brand-mismatch-pick',
+        stage: 'save_rejected',
+        title: 'Brand-mismatch gate fired — a wrong-brand record still SERVED the user',
+        description:
+            'The gate is doing its job (the pick is not cached), but a save_rejected:brand_mismatch event is '
+            + 'positive evidence of a RETRIEVAL defect: the query named a brand decisively and the winning record '
+            + 'carries it in neither its brand field nor its name, and that record was still served for this '
+            + 'request. "cream of wheat" -> First Street "Wheat", "just bare chicken nuggets" -> an unbranded '
+            + 'Chicken Nuggets. Fix belongs in retrieval/rerank; the historical marker is "protein ryse" -> '
+            + '"Protein Rice" (ryse fuzzy-matching rice), whose SAVE path was closed by PR #110 while the '
+            + 'RETRIEVAL gap stayed open as n-mq-23.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'brand_mismatch'),
+        exemplars: ['cream of wheat', 'shredded wheat', 'just bare chicken nuggets', 'real good foods chicken breast strips'],
+        exemplarRows: [
+            { rawLine: 'cream of wheat', normalizedForm: 'cream of wheat', funnelStage: 'save_rejected', dropReason: 'save_rejected:brand_mismatch', source: 'openfoodfacts', foodName: 'Wheat', brandName: 'First Street', grams: 30, kcalPer100g: 250, proteinPer100g: 8, carbsPer100g: 50, fatPer100g: 1, confidence: 0.98 },
+            { rawLine: 'just bare chicken nuggets', normalizedForm: 'just bare chicken nuggets', funnelStage: 'save_rejected', dropReason: 'save_rejected:brand_mismatch', source: 'fatsecret', foodName: 'Chicken Nuggets', grams: 16, kcalPer100g: 297, proteinPer100g: 15, carbsPer100g: 17, fatPer100g: 18, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'nutzo seven nut butter', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'fatsecret', foodName: 'Seven and Seven', grams: 32, kcalPer100g: 89 },
+        ],
+        goldenCaseIds: ['n-mq-23'],
+        fixPRs: [110],
+        status: 'open',
+        discoveredAt: '2026-07-20',
+        dropClasses: ['brand_mismatch'],
+    },
+    {
+        id: 'gate-core-token-mismatch-pick',
+        stage: 'save_rejected',
+        title: 'Core-token gate fired — the winning record is a different food',
+        description:
+            'The gate refuses to cache a pick whose foodName is missing core tokens of the cache key '
+            + '(validated-mapping-helpers.ts:553), with a brand rescue for flavour-spelling cases '
+            + '("cinnamon" vs "Cinnabon"). When it fires unrescued the rerank genuinely picked a different food '
+            + 'and served it: "nutzo seven nut butter" -> "Seven and Seven" (a cocktail), '
+            + '"restaurant orange chicken" -> "BJ\'s Orange Juice", "scrambled eggs with cheese" -> '
+            + '"homemade made with egg cooked pasta". Every one of those left the gate at confidence 0.87-1.00, so '
+            + 'the confidence signal is not the problem — retrieval and rerank are.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'core_token_mismatch'),
+        exemplars: ['nutzo seven nut butter', 'restaurant orange chicken', 'scrambled eggs with cheese'],
+        exemplarRows: [
+            { rawLine: 'nutzo seven nut butter', normalizedForm: 'nutzo seven nut butter', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'fatsecret', foodName: 'Seven and Seven', grams: 32, kcalPer100g: 89, proteinPer100g: 0, carbsPer100g: 8, fatPer100g: 0, confidence: 0.87 },
+            { rawLine: 'restaurant orange chicken', normalizedForm: 'orange chicken', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'openfoodfacts', foodName: "BJ's Restaurant & Brewhouse, Orange Juice", brandName: "BJ's Restaurant & Brewhouse", grams: 100, kcalPer100g: 124, proteinPer100g: 1, carbsPer100g: 30, fatPer100g: 0, confidence: 1 },
+            { rawLine: 'scrambled eggs with cheese', normalizedForm: 'scrambled eggs with cheese', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'fdc', foodName: 'homemade made with egg cooked pasta', grams: 28, kcalPer100g: 130, proteinPer100g: 6, carbsPer100g: 20, fatPer100g: 2, confidence: 1 },
+        ],
+        counterRows: [
+            { rawLine: 'cream of wheat', funnelStage: 'save_rejected', dropReason: 'save_rejected:brand_mismatch', source: 'openfoodfacts', foodName: 'Wheat', brandName: 'First Street', grams: 30, kcalPer100g: 250 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['core_token_mismatch'],
+    },
+    {
+        id: 'gate-produce-classifier-hijack',
+        stage: 'save_rejected',
+        title: 'Plausibility classifier called a manufactured food "fresh produce"',
+        description:
+            'The single largest macro-plausibility class (17 events / 15 distinct keys) and it is a CLASSIFIER bug, '
+            + 'not a bad pick. A produce word anywhere in the query routes the whole item into the fresh-produce '
+            + 'band, so correct branded records get rejected for having branded-food calories: '
+            + '"quaker instant oatmeal APPLE cinnamon" (372 kcal/100g), "grape NUTS" (345), '
+            + '"qdoba cilantro LIME rice" (155). The floor direction has the same bug: '
+            + '"la croix pamplemousse" -> Spindrift Grapefruit Sparkling Water at 4.8 kcal/100g tripped '
+            + 'floor:produce_kcal_below. Both directions belong to one fix: classify on the RECORD\'s identity, '
+            + 'not on the presence of a produce token in the query.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected'
+            && hasDropClass(row, 'implausible_macros:category:fresh_produce_kcal_over', 'implausible_macros:floor:produce_kcal_below'),
+        exemplars: ['quaker instant oatmeal apple cinnamon', 'grape nuts', 'qdoba cilantro lime rice', 'la croix pamplemousse'],
+        exemplarRows: [
+            { rawLine: 'quaker instant oatmeal apple cinnamon', normalizedForm: 'quaker instant oatmeal apple cinnamon', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:fresh_produce_kcal_over', source: 'openfoodfacts', foodName: 'Quaker instant oatmeal apples and cinnamon', brandName: 'Quaker', grams: 2.5, kcalPer100g: 372, proteinPer100g: 9, carbsPer100g: 68, fatPer100g: 7, confidence: 0.95 },
+            { rawLine: 'grape nuts', normalizedForm: 'grape nuts', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:fresh_produce_kcal_over', source: 'openfoodfacts', foodName: 'Grape nuts', brandName: 'Post', grams: 58, kcalPer100g: 344.8, proteinPer100g: 10, carbsPer100g: 76, fatPer100g: 2, confidence: 0.93 },
+            { rawLine: 'la croix pamplemousse', normalizedForm: 'la croix pamplemousse', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:floor:produce_kcal_below', source: 'openfoodfacts', foodName: 'Grapefruit Sparkling Water', brandName: 'Spindrift', grams: 355, kcalPer100g: 4.8, proteinPer100g: 0, carbsPer100g: 1, fatPer100g: 0, confidence: 0.81 },
+        ],
+        counterRows: [
+            { rawLine: 'shrimp scampi', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:lean_cut_protein_below_floor', source: 'openfoodfacts', foodName: 'Shrimp scampi', grams: 85, kcalPer100g: 222.2 },
+            { rawLine: 'banana', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Banana', grams: 118, kcalPer100g: 89, proteinPer100g: 1.1, carbsPer100g: 23, fatPer100g: 0.3 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [109],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['implausible_macros:category:fresh_produce_kcal_over', 'implausible_macros:floor:produce_kcal_below'],
+    },
+    {
+        id: 'gate-lean-protein-floor-on-composite',
+        stage: 'save_rejected',
+        title: 'Lean-cut protein floor applied to a diluted composite dish',
+        description:
+            'Sibling of the produce hijack: naming a lean cut puts the item in the lean-protein band, but the '
+            + 'record is a DISH built from that cut and diluted with pasta, butter or cream, so its protein '
+            + 'legitimately sits below the floor. "shrimp scampi" (both the generic and the Red Lobster record), '
+            + '"shrimp stir fry" and "tuna casserole" are all rejected this way. Fix: the category classifier must '
+            + 'see composite markers (scampi, casserole, stir fry, alfredo) and decline the lean-cut band.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected'
+            && hasDropClass(row, 'implausible_macros:category:lean_cut_protein_below_floor'),
+        exemplars: ['shrimp scampi', 'red lobster shrimp scampi', 'shrimp stir fry', 'tuna casserole'],
+        exemplarRows: [
+            { rawLine: 'shrimp scampi', normalizedForm: 'shrimp scampi', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:lean_cut_protein_below_floor', source: 'openfoodfacts', foodName: 'Shrimp scampi', grams: 85, kcalPer100g: 222.2, proteinPer100g: 11, carbsPer100g: 12, fatPer100g: 14, confidence: 0.98 },
+            { rawLine: 'tuna casserole', normalizedForm: 'tuna casserole', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:lean_cut_protein_below_floor', source: 'fatsecret', foodName: 'Tuna Casserole', brandName: 'NutriSystem', grams: 227, kcalPer100g: 79, proteinPer100g: 6, carbsPer100g: 10, fatPer100g: 2, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'grape nuts', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:category:fresh_produce_kcal_over', source: 'openfoodfacts', foodName: 'Grape nuts', brandName: 'Post', grams: 58, kcalPer100g: 344.8 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [109],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['implausible_macros:category:lean_cut_protein_below_floor'],
+    },
+    {
+        id: 'gate-atwater-no-ethanol',
+        stage: 'save_rejected',
+        title: 'Atwater check has no ethanol term, so cocktails look impossible',
+        description:
+            'Atwater computes 4P + 4C + 9F. Ethanol is 7 kcal/g and appears in none of those, so a spirit-based '
+            + 'record computes to ~0-2 kcal from its macros while its label says 226 kcal/100g, and '
+            + 'atwater:kcal_exceeds_computed rejects a perfectly good pick ("martini"). '
+            + 'detect-corrupt-nutrition.ts already carries an ALCOHOL_PATTERN exemption for exactly this reason; '
+            + 'the save-time gate does not. Small, contained pipeline fix.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected'
+            && hasDropClass(row, 'implausible_macros:atwater:kcal_exceeds_computed', 'implausible_macros:atwater:*'),
+        exemplars: ['martini'],
+        exemplarRows: [
+            { rawLine: 'martini', normalizedForm: 'martini', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:atwater:kcal_exceeds_computed', source: 'fatsecret', foodName: 'Martini', grams: 71, kcalPer100g: 226, proteinPer100g: 0, carbsPer100g: 0.1, fatPer100g: 0, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'beef stew', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:estimate:kcal_vs_expected', source: 'openfoodfacts', foodName: 'Beef stew', brandName: 'The food Life', grams: 350, kcalPer100g: 20 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['implausible_macros:atwater:*'],
+    },
+    {
+        id: 'gate-ai-estimate-disagreement',
+        stage: 'save_rejected',
+        title: "AI expectation disagreed with the record's panel",
+        description:
+            'The save gate compares the record against an AI expected-nutrition estimate and refuses the write '
+            + 'when they diverge. In every observed case the RECORD was the wrong one: "beef stew" at 20 kcal/100g '
+            + 'and "oxtail" (Knorr Oxtail Soup) at 26 kcal/100g are per-serving-diluted or mis-scaled panels, and '
+            + '"mofongo" at 500 kcal/100g with protein over expectation is a corrupt row. So route these to the '
+            + 'corrupt-mark / repoint queue rather than to the gate. Watch the inverse though: an over-tight '
+            + 'expectation would land here too, and simple queries deliberately have NO AI estimate (PR #109 '
+            + 'deterministic floors), so a hit means the estimate really was produced.',
+        fixKind: 'data',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'implausible_macros:estimate:*'),
+        exemplars: ['beef stew', 'oxtail', 'mofongo'],
+        exemplarRows: [
+            { rawLine: 'beef stew', normalizedForm: 'beef stew', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:estimate:kcal_vs_expected', source: 'openfoodfacts', foodName: 'Beef stew', brandName: 'The food Life', grams: 350, kcalPer100g: 20, proteinPer100g: 2, carbsPer100g: 2, fatPer100g: 0.5, confidence: 1 },
+            { rawLine: 'mofongo', normalizedForm: 'mofongo', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:estimate:protein_over_expected', source: 'openfoodfacts', foodName: 'Mofongo', grams: 100, kcalPer100g: 500, proteinPer100g: 30, carbsPer100g: 40, fatPer100g: 25, confidence: 0.98 },
+        ],
+        counterRows: [
+            { rawLine: 'martini', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:atwater:kcal_exceeds_computed', source: 'fatsecret', foodName: 'Martini', grams: 71, kcalPer100g: 226 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [109],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['implausible_macros:estimate:*'],
+    },
+    {
+        id: 'gate-macro-plausibility-residual',
+        stage: 'save_rejected',
+        title: 'RESIDUAL: an unnamed macro-plausibility sub-class fired',
+        description:
+            'Catch-all for save_rejected:implausible_macros:* sub-classes that do not yet have their own entry — '
+            + 'the gate has bound, floor, category and atwater families and interpolates live measurements into '
+            + 'its reason IDs, so new sub-classes appear whenever a band is added. Hits here are FRONTIER: read '
+            + 'the raw dropReason from the classify-drops report and promote any recurring shape to its own class. '
+            + 'Named historical members of this family: "granulated sugar" cached at 16 kcal/100g and "blueberry" '
+            + 'at 8.7 g protein, both from the 2026-07-20 parity sweep, which is why the gate was built (PR #109).',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected' && hasDropClass(row, 'implausible_macros:*'),
+        exemplars: ['granulated sugar', 'blueberry'],
+        exemplarRows: [
+            { rawLine: 'granulated sugar', normalizedForm: 'granulated sugar', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:bound:kcal_below_floor', source: 'openfoodfacts', foodName: 'Granulated Sugar', grams: 4, kcalPer100g: 16, proteinPer100g: 0, carbsPer100g: 4, fatPer100g: 0, confidence: 0.95 },
+            { rawLine: 'blueberry', normalizedForm: 'blueberry', funnelStage: 'save_rejected', dropReason: 'save_rejected:implausible_macros:bound:protein_over_ceiling', source: 'openfoodfacts', foodName: 'Blueberry', grams: 148, kcalPer100g: 57, proteinPer100g: 8.7, carbsPer100g: 14, fatPer100g: 0.3, confidence: 0.95 },
+        ],
+        counterRows: [
+            { rawLine: 'grape nuts', funnelStage: 'save_rejected', dropReason: 'save_rejected:brand_mismatch', source: 'openfoodfacts', foodName: 'Grape nuts', brandName: 'Post', grams: 58, kcalPer100g: 344.8 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [109],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['implausible_macros:*'],
+        residual: true,
+    },
+    {
+        id: 'save-rejected-residual',
+        stage: 'save_rejected',
+        title: 'RESIDUAL: an unrecognised save gate fired',
+        description:
+            'Any save_rejected event whose gate has no class above. Ten markSaveRejected call sites exist today '
+            + '(validated-mapping-helpers.ts:497-806) and all ten are covered, so a hit here means a NEW gate '
+            + 'shipped without a registry entry. Treat it as frontier and add the class in the same PR as the gate.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'save_rejected',
+        exemplars: ['<any query whose save gate has no class yet>'],
+        exemplarRows: [
+            { rawLine: '<any query whose save gate has no class yet>', funnelStage: 'save_rejected', dropReason: 'save_rejected:some_new_gate', source: 'fatsecret', foodName: 'Something', grams: 50, kcalPer100g: 200, proteinPer100g: 5, carbsPer100g: 20, fatPer100g: 5 },
+        ],
+        counterRows: [
+            { rawLine: 'ground turkey', funnelStage: 'under_gate', dropReason: 'under_gate:clear_winner', source: 'openfoodfacts', foodName: '85% lean ground turkey', grams: 112, kcalPer100g: 214 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        residual: true,
+    },
+
+    // ===================== under_gate residual (finding 3) =====================
+    {
+        id: 'under-gate-ranking-residual',
+        stage: 'under_gate',
+        title: 'RESIDUAL: pick served at 0.3-0.85 confidence, never offered to the cache',
+        description:
+            "THE SILENT CLASS, and the population cache-warming exists to convert. Its dropReason is NOT "
+            + 'DIAGNOSTIC (finding 3): F1 tags under_gate with the confidence gate\'s selectionReason — which path '
+            + 'SELECTED the pick, not why confidence was low (map-ingredient-with-fallback.ts:2749) — and the '
+            + '2026-07-24 read found simple_rerank / close_match / clear_winner each split ~50/50 good-vs-bad. '
+            + 'Rows that reach this residual have already failed every dossier heuristic above (degenerate macros, '
+            + 'corrupt panel, cooked/prep/composite/brand/token identity, flat-100g), so what is left is the '
+            + 'genuine near-miss population: plausible picks that the cascade merely was not confident about '
+            + '("ground beef 90/10" -> an 85/15 record, "honey bunches of oats" at 0.82, '
+            + '"panera bacon turkey bravo sandwich" at 0.71 with the right record and 435g). Convert these by '
+            + 'raising retrieval quality or by conditional admission — do NOT relax the 0.85 gate globally.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'under_gate',
+        exemplars: ['ground beef 90/10', 'ground turkey', 'honey bunches of oats', 'panera bacon turkey bravo sandwich'],
+        exemplarRows: [
+            { rawLine: 'ground beef 90/10', normalizedForm: 'ground beef 90/10', funnelStage: 'under_gate', dropReason: 'under_gate:simple_rerank', source: 'openfoodfacts', foodName: 'Ground Beef 85% Lean 15% Fat', brandName: "Rastelli's", grams: 112, kcalPer100g: 232, proteinPer100g: 19, carbsPer100g: 0, fatPer100g: 17, confidence: 0.78 },
+            { rawLine: 'ground turkey', normalizedForm: 'ground turkey', funnelStage: 'under_gate', dropReason: 'under_gate:clear_winner', source: 'openfoodfacts', foodName: '85% lean ground turkey', grams: 112, kcalPer100g: 214, proteinPer100g: 17, carbsPer100g: 0, fatPer100g: 15, confidence: 0.83 },
+            { rawLine: 'honey bunches of oats', normalizedForm: 'honey bunches of oats', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'openfoodfacts', foodName: 'Honey Bunches of Oats', brandName: 'Post', grams: 53, kcalPer100g: 433.9, proteinPer100g: 7, carbsPer100g: 85, fatPer100g: 5, confidence: 0.82 },
+            { rawLine: 'panera bacon turkey bravo sandwich', normalizedForm: 'panera bacon turkey bravo sandwich', funnelStage: 'under_gate', dropReason: 'under_gate:close_match', source: 'fatsecret', foodName: 'Bacon Turkey Bravo Sandwich on Tomato Basil - Whole', brandName: 'Panera Bread', grams: 435, kcalPer100g: 200, proteinPer100g: 12, carbsPer100g: 20, fatPer100g: 8, confidence: 0.71 },
+        ],
+        counterRows: [
+            { rawLine: 'clif bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'CLIF BAR', brandName: 'CLIF', grams: 68, kcalPer100g: 367.6, proteinPer100g: 14, carbsPer100g: 66, fatPer100g: 7 },
+            { rawLine: 'pretzels', funnelStage: 'save_rejected', dropReason: 'save_rejected:cross_source_margin', source: 'fatsecret', foodName: 'Pretzels', grams: 3, kcalPer100g: 380 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [139],
+        status: 'open',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['close_match', 'clear_winner', 'simple_rerank', 'fallback_after_serving_failure', 'single_candidate'],
+        residual: true,
+    },
+
+    // ===================== retrieval / corpus stages =====================
+    {
+        id: 'venue-brand-blackout-tripwire',
+        stage: 'all_filtered',
+        alsoStages: ['no_candidates'],
+        title: 'TRIPWIRE: a venue-branded query lost its whole candidate pool',
+        description:
+            'Regression tripwire for the shipped venue-brand blackout (PR #150, 2026-07-25). '
+            + 'UNRELATED_INDICATORS was tested against name + brandName, so every chain branded Grill / Kitchen / '
+            + 'Cafe / Diner / Bistro / Restaurant had its ENTIRE catalogue rejected pre-rerank: 476 FatSecret '
+            + 'records across 66-77 brands, invisible because FilterResult.reason is a blanket label rather than '
+            + 'the cause. Two plausible diagnoses were wrong before running gather+filter with debug:true settled '
+            + 'it. This is a QUERY-SIDE proxy (venue word in the query, whole pool filtered), so it should never '
+            + 'fire post-#150; a hit means a filter regression, and the diagnosis method is the debug:true trace, '
+            + 'not the reason string.',
+        fixKind: 'pipeline',
+        detector: row => atStage(row, ['all_filtered', 'no_candidates'])
+            && /\b(grill|grille|kitchen|cafe|caf|diner|bistro|restaurant|brewhouse|tavern|creamery)\b/i.test(row.rawLine),
+        exemplars: ['restaurant orange chicken', 'restaurant shrimp scampi'],
+        exemplarRows: [
+            { rawLine: 'restaurant orange chicken', normalizedForm: 'orange chicken', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Orange Chicken', grams: 100, kcalPer100g: 250, proteinPer100g: 12, carbsPer100g: 30, fatPer100g: 9, confidence: 0.6 },
+            { rawLine: 'restaurant shrimp scampi', normalizedForm: 'shrimp scampi', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Shrimp Scampi', grams: 100, kcalPer100g: 220, proteinPer100g: 12, carbsPer100g: 10, fatPer100g: 14, confidence: 0.62 },
+        ],
+        counterRows: [
+            { rawLine: 'qdoba steak bowl', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Qdoba Steak Bowl', grams: 100, kcalPer100g: 250 },
+            { rawLine: 'restaurant orange chicken', funnelStage: 'save_rejected', dropReason: 'save_rejected:core_token_mismatch', source: 'openfoodfacts', foodName: "BJ's Restaurant & Brewhouse, Orange Juice", brandName: "BJ's Restaurant & Brewhouse", grams: 100, kcalPer100g: 124 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [150],
+        status: 'closed',
+        discoveredAt: '2026-07-25',
+    },
+    {
+        id: 'all-filtered-over-rejection',
+        stage: 'all_filtered',
+        title: 'RESIDUAL: candidates existed and every one was filtered out',
+        description:
+            'Retrieval found records and the filter stage killed them all, so an AI 100g estimate answered instead '
+            + '("qdoba steak bowl"). Only 7 live events / 5 distinct keys, but this stage is where OVER-REJECTION '
+            + 'shows up and over-rejection has been the expensive class twice: the venue-brand blackout (PR #150) '
+            + 'and the FatSecret lane truncation behind composite drift. Standing suspect on the variant-generation '
+            + 'side: three CRUDER local singularize() copies shadow the exported one (filter-candidates.ts:113, '
+            + 'gather-candidates.ts:847, map-ingredient-with-fallback.ts:435), stripping two chars from ANY -es and '
+            + 'producing "oliv", "nood", "sauc", "juic". Diagnose by running gather+filter with debug:true and '
+            + 'reading the per-candidate trace — FilterResult.reason is a blanket label, not the cause.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'all_filtered',
+        exemplars: ['qdoba steak bowl'],
+        exemplarRows: [
+            { rawLine: 'qdoba steak bowl', normalizedForm: 'steak bowl', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Qdoba Steak Bowl', grams: 100, kcalPer100g: 250, proteinPer100g: 12, carbsPer100g: 25, fatPer100g: 10, confidence: 0.64 },
+        ],
+        counterRows: [
+            { rawLine: 'lemon', funnelStage: 'no_candidates', dropReason: 'no_candidates:dataset_gap', source: 'ai_estimated', foodName: 'Lemon', grams: 100, kcalPer100g: 29 },
+        ],
+        goldenCaseIds: ['n-mq-42'],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['no_candidate_survived_filters'],
+        residual: true,
+    },
+    {
+        id: 'ingest-gap-no-candidates',
+        stage: 'no_candidates',
+        title: 'No record exists in any lane — INGEST, never a fix-agent',
+        description:
+            'Retrieval returned nothing at all: a dataset gap, not a ranking gap. Sending a pipeline fix-agent at '
+            + 'this class burns a session and changes nothing. Confirmed members: n-cook-06 "cooked oats" (the '
+            + 'corpus has no cooked-oatmeal record; the 2026-07-21 deploy probe on n-mq-27 "lemon" returned '
+            + 'lemon-pepper turkey, danish pastry, Fanta Lemon and Ritz Lemon crackers as the top hits), plus '
+            + 'cooked quinoa. Route to the ingest queue and re-run the eval after the next ingest, not before. '
+            + 'Zero live events in the 2026-07-25 read, which is itself informative: today the corpus almost '
+            + 'always returns SOMETHING, so gaps surface as all_filtered or as an ai_estimated backfill rather '
+            + 'than as an honest empty result.',
+        fixKind: 'ingest',
+        detector: row => row.funnelStage === 'no_candidates',
+        exemplars: ['cooked oats', 'cooked quinoa'],
+        exemplarRows: [
+            { rawLine: 'cooked oats', normalizedForm: 'cooked oats', funnelStage: 'no_candidates', dropReason: 'no_candidates:dataset_gap', source: 'ai_estimated', foodName: 'Cooked Oats', grams: 100, kcalPer100g: 71, proteinPer100g: 2.5, carbsPer100g: 12, fatPer100g: 1.4, confidence: 0.5 },
+            { rawLine: 'cooked quinoa', normalizedForm: 'cooked quinoa', funnelStage: 'no_candidates', dropReason: 'no_candidates:dataset_gap', source: 'ai_estimated', foodName: 'Cooked Quinoa', grams: 100, kcalPer100g: 120, proteinPer100g: 4.4, carbsPer100g: 21, fatPer100g: 1.9, confidence: 0.5 },
+        ],
+        counterRows: [
+            { rawLine: 'qdoba steak bowl', funnelStage: 'all_filtered', dropReason: 'all_filtered:no_candidate_survived_filters', source: 'ai_estimated', foodName: 'Qdoba Steak Bowl', grams: 100, kcalPer100g: 250 },
+        ],
+        goldenCaseIds: ['n-cook-06', 'n-mq-27'],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-21',
+        dropClasses: ['dataset_gap'],
+    },
+    {
+        id: 'no-match-total-abstention',
+        stage: 'no_match',
+        title: 'Mapper abstained: best pick below MIN_ACCEPTABLE_CONFIDENCE',
+        description:
+            'The no-pick branch echoes the query back as foodName with foodId undefined and confidence 0.0, and '
+            + 'run-eval scored that as a PASS on 47 of 238 nlp cases until commit 6beba93 — a positive name '
+            + 'assertion matched trivially against the echoed query. Treat any regression here as scoring-critical. '
+            + 'For composite dishes an abstention is NOT evidence of a corpus gap: 3 of the 4 assembled records '
+            + 'behind n-mq-38..41 are already in Postgres, and the cause is `filtered.slice(0, 10)` truncating the '
+            + 'FatSecret lane before rerank.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'no_match',
+        exemplars: ['chipotle chicken burrito'],
+        exemplarRows: [
+            { rawLine: 'chipotle chicken burrito', normalizedForm: 'chipotle chicken burrito', funnelStage: 'no_match', dropReason: 'no_match:confidence_too_low', source: 'ai_estimated', foodName: 'chipotle chicken burrito', grams: 0, totalKcal: 0, confidence: 0 },
+        ],
+        counterRows: [
+            { rawLine: 'chipotle chicken burrito', funnelStage: 'saved', source: 'fatsecret', foodName: 'Chicken Burrito Filling', brandName: 'Chipotle', grams: 118, totalKcal: 166, kcalPer100g: 141, proteinPer100g: 12, carbsPer100g: 8, fatPer100g: 7 },
+        ],
+        goldenCaseIds: ['n-mq-38'],
+        fixPRs: [],
+        status: 'open',
+        discoveredAt: '2026-07-25',
+        dropClasses: ['confidence_too_low', 'no_winner_selected'],
+    },
+
+    // ===================== fast path =====================
+    {
+        id: 'fast-path-water-substring-hijack',
+        stage: 'fast_path',
+        title: 'TRIPWIRE: a food that merely CONTAINS water took the zero-calorie fast path',
+        description:
+            'Regression tripwire. "canned tuna in water" short-circuited to Water and billed 0 kcal (map:565, '
+            + 'logged HIGH severity), and "vitamin water" is ~30 kcal, not 0. Fixed in the cache-first sprint '
+            + '(PR #120) by requiring the query to BE water/ice rather than to mention it. Fires when a fast_path '
+            + 'line carries content tokens beyond water/ice, so it should never fire post-#120. Note fast_path '
+            + 'rows log normalizedForm as null (47 live events, 0 distinct forms), so only rawLine is available '
+            + 'here.',
+        fixKind: 'pipeline',
+        detector: row => row.funnelStage === 'fast_path' && !isPureWaterQuery(row.rawLine),
+        exemplars: ['canned tuna in water', 'vitamin water'],
+        exemplarRows: [
+            { rawLine: 'canned tuna in water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 1 },
+            { rawLine: 'vitamin water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 1 },
+        ],
+        counterRows: [
+            { rawLine: '2 cups water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 474, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+            { rawLine: 'water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [120],
+        status: 'closed',
+        discoveredAt: '2026-07-21',
+    },
+    {
+        id: 'fast-path-zero-calorie',
+        stage: 'fast_path',
+        title: 'Zero-calorie fast path (BY DESIGN)',
+        description:
+            'Water and ice short-circuit before the corpus is consulted, so they never reach a save and never '
+            + 'reach the degenerate-nutrition gate. 47 live events. Counted only so the stage stops looking like a '
+            + 'drop: nothing failed here. The detector requires the line to BE water/ice, so a substring hijack '
+            + 'cannot hide in this class.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'fast_path' && isPureWaterQuery(row.rawLine),
+        exemplars: ['water', '2 cups water', 'ice'],
+        exemplarRows: [
+            { rawLine: 'water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 1 },
+            { rawLine: '2 cups water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 474, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 1 },
+            { rawLine: 'ice', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Ice', grams: 100, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0, confidence: 1 },
+        ],
+        counterRows: [
+            { rawLine: 'canned tuna in water', funnelStage: 'fast_path', dropReason: 'fast_path:zero_calorie', source: 'fatsecret', foodName: 'Water', grams: 237, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [120],
+        status: 'by-design',
+        discoveredAt: '2026-07-24',
+        dropClasses: ['zero_calorie'],
+    },
+
+    // ===================== healthy conversions =====================
+    {
+        id: 'cache-hit-healthy',
+        stage: 'cache_hit',
+        title: 'Served from the validated cache with no quality flag (BY DESIGN)',
+        description:
+            'The dominant stage — 11,144 of 13,452 live events — and by far the cheapest path (nlp p50 18ms on '
+            + 'the box). Counted explicitly so the registry can state an unclassified rate honestly instead of '
+            + 'leaving 83% of live rows uncategorised. A cache_hit that carries ANY quality flag is excluded by the '
+            + 'detector itself, not merely by precedence — so this class is a positive claim of cleanliness, which '
+            + 'is the whole point of finding 4.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'cache_hit' && !hasQualityFlag(row),
+        exemplars: ['yellow bell pepper', 'chicken thigh', 'salmon fillet', 'egg white'],
+        exemplarRows: [
+            { rawLine: 'yellow bell pepper', normalizedForm: 'yellow bell pepper', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Yellow Bell Pepper', grams: 164, kcalPer100g: 27, proteinPer100g: 1, carbsPer100g: 6, fatPer100g: 0.2, confidence: 0.95, hadIncumbent: true },
+            { rawLine: 'chicken thigh', normalizedForm: 'chicken thigh', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Chicken Thigh', brandName: 'One Fine Chicken', grams: 113, kcalPer100g: 115, proteinPer100g: 19, carbsPer100g: 0, fatPer100g: 4, confidence: 0.95, hadIncumbent: true },
+            { rawLine: 'salmon fillet', normalizedForm: 'salmon fillet', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Salmon Fillet', brandName: 'Keohane Seafoods', grams: 120, kcalPer100g: 202, proteinPer100g: 20, carbsPer100g: 0, fatPer100g: 13, confidence: 0.95, hadIncumbent: true },
+            { rawLine: 'egg white', normalizedForm: 'egg white', funnelStage: 'cache_hit', source: 'fdc', foodName: 'Eggs, Grade A, Large, egg white', grams: 33, kcalPer100g: 55, proteinPer100g: 11, carbsPer100g: 0.7, fatPer100g: 0.2, confidence: 0.95, hadIncumbent: true },
+        ],
+        counterRows: [
+            { rawLine: 'spinach', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Spinach', grams: 100, kcalPer100g: 16.3, proteinPer100g: 2.9, carbsPer100g: 1.4, fatPer100g: 0.4 },
+            { rawLine: 'clif bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'CLIF BAR', brandName: 'CLIF', grams: 68, kcalPer100g: 367.6, proteinPer100g: 14, carbsPer100g: 66, fatPer100g: 7 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'by-design',
+        discoveredAt: '2026-07-24',
+    },
+    {
+        id: 'saved-healthy',
+        stage: 'saved',
+        title: 'Fresh pick cleared the 0.85 gate and was cached with no quality flag (BY DESIGN)',
+        description:
+            'A real conversion: 1,386 live events. This is the number cache-warming is trying to grow (coverage '
+            + '28.8% -> 33.6% after the fast-casual pilot warm, ~73% conversion on 93 added keys, tracked nightly '
+            + 'by flywheel-sweep step 4c). The detector requires an empty quality block, so "saved" in this summary '
+            + 'means clean-saved — NOT saved-including-the-38-all-zero-rows, which is how the funnel alone reads it.',
+        fixKind: 'healthy',
+        detector: row => row.funnelStage === 'saved' && !hasQualityFlag(row),
+        exemplars: ['clif bar', 'goldfish crackers', 'fairlife core power', 'pop tarts'],
+        exemplarRows: [
+            { rawLine: 'clif bar', normalizedForm: 'clif bar', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'CLIF BAR', brandName: 'CLIF', grams: 68, kcalPer100g: 367.6, proteinPer100g: 14, carbsPer100g: 66, fatPer100g: 7, confidence: 0.95 },
+            { rawLine: 'goldfish crackers', normalizedForm: 'goldfish crackers', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Goldfish crackers', brandName: 'Goldfish', grams: 30, kcalPer100g: 466.7, proteinPer100g: 10, carbsPer100g: 66, fatPer100g: 17, confidence: 0.96 },
+            { rawLine: 'fairlife core power', normalizedForm: 'fairlife core power', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Fairlife core power elite', brandName: 'Fairlife', grams: 250, kcalPer100g: 230, proteinPer100g: 12, carbsPer100g: 8, fatPer100g: 5, confidence: 0.97 },
+            { rawLine: 'pop tarts', normalizedForm: 'pop tarts', funnelStage: 'saved', source: 'openfoodfacts', foodName: 'Pop Tarts', brandName: "Kellogg's", grams: 96, kcalPer100g: 395.8, proteinPer100g: 4, carbsPer100g: 72, fatPer100g: 9, confidence: 0.96 },
+        ],
+        counterRows: [
+            { rawLine: 'brazil nuts', funnelStage: 'saved', source: 'fatsecret', foodName: 'Brazil Nuts', grams: 100, kcalPer100g: 0, proteinPer100g: 0, carbsPer100g: 0, fatPer100g: 0 },
+            { rawLine: 'yellow bell pepper', funnelStage: 'cache_hit', source: 'openfoodfacts', foodName: 'Yellow Bell Pepper', grams: 164, kcalPer100g: 27, proteinPer100g: 1, carbsPer100g: 6, fatPer100g: 0.2 },
+        ],
+        goldenCaseIds: [],
+        fixPRs: [],
+        status: 'by-design',
+        discoveredAt: '2026-07-24',
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+export const UNCLASSIFIED = 'unclassified';
+
+/** Tag a row with the FIRST matching class (registry order is precedence order). */
+export function classifyRow(row: FunnelRow): { classId: string; cls: FailureClass | null } {
+    for (const cls of FAILURE_CLASSES) {
+        let matched = false;
+        try {
+            matched = cls.detector(row);
+        } catch {
+            matched = false;
+        }
+        if (matched) return { classId: cls.id, cls };
+    }
+    return { classId: UNCLASSIFIED, cls: null };
+}
+
+export function classById(id: string): FailureClass | undefined {
+    return FAILURE_CLASSES.find(c => c.id === id);
+}
+
+/** Every stage a class declares it can fire on. */
+export function classStages(cls: FailureClass): FunnelStage[] {
+    return [cls.stage, ...(cls.alsoStages ?? [])];
+}
+
+// ---------------------------------------------------------------------------
+// Measured ground truth + caveats that are facts, not classes
+// ---------------------------------------------------------------------------
+
+/**
+ * The 19 dropReason classes actually observed on the live box, 2026-07-25
+ * (13,452 MappingEventLog rows carrying funnelStage). Used by the coverage test
+ * and by the generated doc: every one of these MUST classify to something, even
+ * if that something is fixKind 'healthy'.
+ */
+export interface LiveDropReason {
+    dropReason: string;
+    stage: FunnelStage;
+    events: number;
+    distinctForms: number;
+    /**
+     * rawLine to use when probing coverage for this dropReason. Only needed where a
+     * class is decided by the LINE and not by the reason: fast_path has two classes
+     * separated by whether the query IS water, so a placeholder probe would land on
+     * the substring-hijack tripwire and misreport the owner.
+     */
+    probeRawLine?: string;
+}
+
+/** Default rawLine for a coverage probe. */
+export const COVERAGE_PROBE_LINE = 'coverage probe';
+
+/** The rawLine to classify when auditing coverage for a live dropReason. */
+export function probeLineFor(live: LiveDropReason): string {
+    return live.probeRawLine ?? COVERAGE_PROBE_LINE;
+}
+
+export const LIVE_DROP_REASONS: LiveDropReason[] = [
+    { dropReason: 'save_rejected:cross_source_margin', stage: 'save_rejected', events: 404, distinctForms: 21 },
+    { dropReason: 'under_gate:close_match', stage: 'under_gate', events: 133, distinctForms: 46 },
+    { dropReason: 'under_gate:clear_winner', stage: 'under_gate', events: 102, distinctForms: 25 },
+    { dropReason: 'save_rejected:sub_threshold_no_displace', stage: 'save_rejected', events: 61, distinctForms: 3 },
+    { dropReason: 'save_rejected:brand_mismatch', stage: 'save_rejected', events: 50, distinctForms: 10 },
+    { dropReason: 'under_gate:simple_rerank', stage: 'under_gate', events: 48, distinctForms: 45 },
+    { dropReason: 'fast_path:zero_calorie', stage: 'fast_path', events: 47, distinctForms: 0, probeRawLine: 'water' },
+    { dropReason: 'save_rejected:core_token_mismatch', stage: 'save_rejected', events: 23, distinctForms: 4 },
+    { dropReason: 'save_rejected:implausible_macros:category:fresh_produce_kcal_over', stage: 'save_rejected', events: 17, distinctForms: 15 },
+    { dropReason: 'under_gate:fallback_after_serving_failure', stage: 'under_gate', events: 13, distinctForms: 13 },
+    { dropReason: 'all_filtered:no_candidate_survived_filters', stage: 'all_filtered', events: 7, distinctForms: 5 },
+    { dropReason: 'save_rejected:implausible_macros:category:lean_cut_protein_below_floor', stage: 'save_rejected', events: 5, distinctForms: 4 },
+    { dropReason: 'save_rejected:serving_downgrade', stage: 'save_rejected', events: 4, distinctForms: 4 },
+    { dropReason: 'save_rejected:implausible_macros:estimate:kcal_vs_expected', stage: 'save_rejected', events: 3, distinctForms: 2 },
+    { dropReason: 'save_rejected:implausible_macros:floor:produce_kcal_below', stage: 'save_rejected', events: 1, distinctForms: 1 },
+    { dropReason: 'save_rejected:implausible_macros:estimate:protein_over_expected', stage: 'save_rejected', events: 1, distinctForms: 1 },
+    { dropReason: 'save_rejected:implausible_macros:atwater:kcal_exceeds_computed', stage: 'save_rejected', events: 1, distinctForms: 1 },
+    { dropReason: 'save_rejected:bare_category_takeover', stage: 'save_rejected', events: 1, distinctForms: 1 },
+    { dropReason: 'under_gate:single_candidate', stage: 'under_gate', events: 1, distinctForms: 1 },
+];
+
+/** Live stage histogram, same read. */
+export const LIVE_STAGE_COUNTS: Record<string, number> = {
+    cache_hit: 11144,
+    saved: 1386,
+    save_rejected: 571,
+    under_gate: 297,
+    fast_path: 47,
+    all_filtered: 7,
+};
+
+/**
+ * Verified-in-code facts that are NOT classes — nothing can detect them from a
+ * row, but every consumer of the funnel needs to know them before drawing a
+ * conclusion. Rendered into the generated doc.
+ */
+export const FUNNEL_CAVEATS: { id: string; note: string }[] = [
+    {
+        id: 'error-stage-is-dead-code',
+        note: "funnelStage 'error' is UNREACHABLE. mapIngredientWithFallback uses try/finally with no catch, so a "
+            + 'throw 500s the request and writes ZERO MappingEventLog rows. An errored line is INVISIBLE to the '
+            + "funnel, not tagged 'error' — never read a 0 in the error bucket as 'nothing threw'.",
+    },
+    {
+        id: 'fdc-bypasses-two-save-guards',
+        note: 'fdc <-> off and fdc <-> fs displacements bypass BOTH the serving-downgrade guard AND the '
+            + 'cross-source displacement margin, because newTargetKey/existingTargetKey read only offBarcode then '
+            + 'fsId — fdcId is never considered (validated-mapping-helpers.ts:720-723). Latent gap: an fdc row can '
+            + 'be silently displaced by a lower-confidence pick with no serving shape.',
+    },
+    {
+        id: 'zero-macros-gate-skipped-at-zero-grams',
+        note: 'The degenerate-nutrition gate is skipped entirely when grams is 0, because nutrientsPer100g is only '
+            + 'passed when result.grams > 0 (map-ingredient-with-fallback.ts:2611-2616).',
+    },
+    {
+        id: 'human-row-reason-conflates-two-outcomes',
+        note: "save_rejected:human_row means EITHER a successful usage-bump on the same record OR a genuine skip on "
+            + 'a different one: markSaveRejected sits outside the if/else at validated-mapping-helpers.ts:684-704. '
+            + 'Tracked as class gate-human-row-conflated.',
+    },
+    {
+        id: 'three-shadowing-singularize-copies',
+        note: 'Three cruder local singularize() copies shadow the exported one on the filter/retrieval path '
+            + '(filter-candidates.ts:113, gather-candidates.ts:847, map-ingredient-with-fallback.ts:435). They '
+            + 'strip two chars from ANY -es, producing "oliv", "nood", "sauc", "juic" — a candidate cause of '
+            + 'filter misses in all-filtered-over-rejection.',
+    },
+    {
+        id: 'event-log-key-is-not-the-cache-key',
+        note: 'MappingEventLog.normalizedForm is PRE-canonicalization; FoodMapping.normalizedForm is canonicalized, '
+            + 'singularized and token-SORTED. "chicken breast" -> "breast chicken", "eggs" -> "egg", "pretzels" -> '
+            + '"pretzel". Always canonicalizeCacheKey() before joining, or the join reports cached keys as cold and '
+            + 'inverts the conclusion.',
+    },
+    {
+        id: 'incumbent-is-measured-now-not-at-event-time',
+        note: 'hadIncumbent is resolved by looking FoodMapping up at report time, not at event time, and it is '
+            + 'wrong in BOTH directions. A key cached after the event reads hadIncumbent=true; a key EVICTED after '
+            + 'the event reads hadIncumbent=false. The second direction is the one that bites: the first real run '
+            + '(2026-07-25, since 07-24) reported 8 "cold" gate-cross-source-margin events, which is impossible — '
+            + 'that gate is nested inside a block requiring an incumbent and cannot fire on a cold key. They were '
+            + 'events whose rows had been evicted hours later by the composite cache refresh. So a small cold count '
+            + 'on a gate that provably needs an incumbent is a timing artifact, NOT a refutation. Read hadIncumbent '
+            + 'as evidence about a class (does this gate ever fire cold?), never as per-row history, and treat a '
+            + 'LARGE cold count on such a gate as the real signal that something is wrong.',
+    },
+    {
+        id: 'dropreason-vocabularies-interpolate-measurements',
+        note: 'Macro-plausibility reasons embed live numbers (atwater:kcal_412_exceeds_computed_388.5) and '
+            + 'selectionReason can carry free-form AI rationale. ALWAYS normalize via normalizeClassId before '
+            + 'grouping; stored raw, dropReason is near-unique per row.',
+    },
+];

--- a/scripts/eval/failure-classes.ts
+++ b/scripts/eval/failure-classes.ts
@@ -1588,6 +1588,19 @@ export const FUNNEL_CAVEATS: { id: string; note: string }[] = [
             + 'LARGE cold count on such a gate as the real signal that something is wrong.',
     },
     {
+        id: 'cachekey-is-the-read-key-not-always-the-write-key',
+        note: 'FunnelRow.cacheKey uses canonicalizeCacheKey, but the SAVE path uses deriveMappingCacheKey, which '
+            + 'brand-PREFIXES when a brand was detected with decisive context. Measured 2026-07-25: for every '
+            + 'branded query tried (oikos greek yogurt, ghost protein cinnamon roll, quest chocolate chip protein '
+            + 'bar, ryse protein cinnamon toast crunch, mcdonalds fries, chipotle/qdoba chicken burrito) the two '
+            + 'agree, because MappingEventLog.normalizedForm is the AI-normalized name and already carries the '
+            + 'brand token. But the event log does NOT record the detected brand or the decisive-context verdict, '
+            + 'so where the save path DID prefix, this lookup cannot reproduce that key and hadIncumbent will read '
+            + 'false. Exposure looks small and is not measurable from the event log alone; if a class shows '
+            + 'implausibly many cold rows on a gate that needs an incumbent, suspect this before believing it. '
+            + 'Related known bug: brand-prefix save-key asymmetry ("oikos" saved "oiko oiko", read "oiko").',
+    },
+    {
         id: 'dropreason-vocabularies-interpolate-measurements',
         note: 'Macro-plausibility reasons embed live numbers (atwater:kcal_412_exceeds_computed_388.5) and '
             + 'selectionReason can carry free-form AI rationale. ALWAYS normalize via normalizeClassId before '

--- a/scripts/eval/triage-drops.ts
+++ b/scripts/eval/triage-drops.ts
@@ -1,0 +1,1249 @@
+/**
+ * triage-drops.ts — F3: the warm-and-triage driver.
+ *
+ * warm JSONL (or MappingEventLog) -> keep only the DROP stages -> probe each
+ * distinct query -> merge into ONE dossier -> classify with F2 -> emit
+ * `scripts/eval/results/triage-verdicts-<ts>.json` + a sibling `.md`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IT WRITES
+ * ---------------------------------------------------------------------------
+ * Its own two report files, and nothing else. It NEVER calls
+ * mapIngredientWithFallback, so it cannot warm, overwrite, evict or repoint a
+ * FoodMapping row, and it writes no MappingEventLog rows. The two probes it runs
+ * (retrieval + filter trace) are search + pure token logic.
+ *
+ * Two side-effect edges, both closed by default:
+ *   - The FatSecret lane background-upserts FatSecretFood/FatSecretServing and
+ *     spends FS API quota. `FATSECRET_RETRIEVAL_ENABLED=false` is therefore forced
+ *     BEFORE the probe modules load unless you pass `--fatsecret`.
+ *   - full-pipeline-probe.ts / golden-diff-eval.ts / warm-names.ts DO write and DO
+ *     cost LLM tokens. This driver never calls them; they are separate CLIs.
+ * No probe here makes an LLM call, so cost scales as search QPS, not tokens.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE OUTPUT LOOKS LIKE THE 2026-07-21 FILE
+ * ---------------------------------------------------------------------------
+ * `screened` / `suspectCount` / `confirmedCount` / `byClass` / `confirmed` /
+ * `dismissed` are kept byte-compatible in meaning with
+ * scripts/eval/results/triage-verdicts-2026-07-21.json (the 296-defect multi-agent
+ * run), including the COARSE `cls` vocabulary (identity / serving / nutrition /
+ * ingest-gap / ranking-gap) so existing readers keep working. Everything new is
+ * additive: `classId` + `fixKind` carry the precise F2 class, and `dossier` carries
+ * the evidence.
+ *
+ * ---------------------------------------------------------------------------
+ * TRUNCATION IS ALWAYS REPORTED
+ * ---------------------------------------------------------------------------
+ * A per-class cap (`--per-class-cap`, default 25) stops one loud class from eating
+ * the whole run. Every dossier the cap drops, every duplicate event collapsed and
+ * every non-drop-stage row skipped is counted into `log[]` and printed. Silent
+ * truncation reads as "covered everything" when it did not.
+ *
+ * Run (from repo root):
+ *   # cheap mode: classify only, no retrieval at all
+ *   npx ts-node -r tsconfig-paths/register --transpile-only --compilerOptions \
+ *     '{"module":"commonjs","moduleResolution":"node"}' \
+ *     scripts/eval/triage-drops.ts --in scripts/eval/results/warm-<ts>.json --no-probes
+ *
+ *   # full triage with probes
+ *   ... scripts/eval/triage-drops.ts --in <warm.json> --concurrency 4
+ *
+ *   # from the live event log (SELECTs only)
+ *   ... scripts/eval/triage-drops.ts --from-db --since 2026-07-18 --limit 5000
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { FunnelStage } from '../../src/lib/mapping/funnel';
+import {
+    FAILURE_CLASSES,
+    FUNNEL_CAVEATS,
+    UNCLASSIFIED,
+    classifyRow,
+    makeFunnelRow,
+    uncoveredTokens,
+    type FailureClass,
+    type FixKind,
+    type FunnelQuality,
+    type FunnelRow,
+    type FunnelRowInput,
+} from './failure-classes';
+import { attachIncumbents, openPrisma, readFromDb, type PrismaLike } from './classify-drops';
+import type { ProbeCandidate, RetrievalProbe } from '../debug-retrieval-probe';
+import type { FilterTrace } from '../filter-trace-probe';
+
+// ---------------------------------------------------------------------------
+// Drop stages
+// ---------------------------------------------------------------------------
+
+/**
+ * The stages this driver triages. `cache_hit` / `saved` / `fast_path` are NOT
+ * drops — F2 can still flag them as poisoned conversions (finding 4), which is
+ * `classify-drops.ts`'s job; this driver is about lines that did not land.
+ */
+export const DROP_STAGES: FunnelStage[] = ['no_match', 'under_gate', 'save_rejected', 'all_filtered', 'no_candidates'];
+
+const DROP_STAGE_SET = new Set<string>(DROP_STAGES);
+
+export function isDropStage(stage: string | null | undefined): boolean {
+    return stage != null && DROP_STAGE_SET.has(stage);
+}
+
+// ---------------------------------------------------------------------------
+// Coarse class vocabulary (legacy `cls` / `byClass`)
+// ---------------------------------------------------------------------------
+
+/**
+ * The 2026-07-21 triage vocabulary (identity 149 / serving 82 / nutrition 50 /
+ * ingest-gap 13 / ranking-gap 2), plus three buckets that run had no name for:
+ * `telemetry` (a reporting defect, not a mapping defect), `healthy` (finding 1 —
+ * a by-design drop is not a defect) and `frontier` (residual / unclassified).
+ */
+export type CoarseClass =
+    | 'identity' | 'serving' | 'nutrition' | 'ingest-gap' | 'ranking-gap'
+    | 'telemetry' | 'healthy' | 'frontier';
+
+/**
+ * F2 class id -> coarse class. Explicit rather than derived from the id string:
+ * a meta-test asserts every registry class appears here, so adding an F2 class
+ * fails the suite until it is routed instead of silently landing in a default.
+ */
+export const COARSE_BY_CLASS_ID: Record<string, CoarseClass> = {
+    // poisoned conversions
+    'degenerate-macros-served': 'nutrition',
+    'corrupt-panel-served': 'nutrition',
+    'identity-cooked-vs-dry': 'identity',
+    'identity-preparation-mismatch': 'identity',
+    'composite-component-drift': 'identity',
+    'identity-brand-substituted': 'identity',
+    'identity-query-token-dropped': 'identity',
+    'ai-estimated-backfill-served': 'ingest-gap',
+    'serving-flat-100g-fallthrough': 'serving',
+    // save gates that are working as designed
+    'gate-cross-source-margin': 'healthy',
+    'gate-sub-threshold-no-displace': 'healthy',
+    'gate-serving-downgrade': 'healthy',
+    'gate-bare-category-takeover': 'healthy',
+    'gate-zero-macros': 'healthy',
+    'fast-path-zero-calorie': 'healthy',
+    'cache-hit-healthy': 'healthy',
+    'saved-healthy': 'healthy',
+    // save gates whose firing exposes a defect upstream of them
+    'gate-human-row-conflated': 'telemetry',
+    'gate-brand-mismatch-pick': 'identity',
+    'gate-core-token-mismatch-pick': 'identity',
+    'gate-produce-classifier-hijack': 'nutrition',
+    'gate-lean-protein-floor-on-composite': 'nutrition',
+    'gate-atwater-no-ethanol': 'nutrition',
+    'gate-ai-estimate-disagreement': 'nutrition',
+    // retrieval / ranking / corpus
+    'venue-brand-blackout-tripwire': 'identity',
+    'fast-path-water-substring-hijack': 'identity',
+    'ingest-gap-no-candidates': 'ingest-gap',
+    'no-match-total-abstention': 'ranking-gap',
+    'under-gate-ranking-residual': 'ranking-gap',
+    'all-filtered-over-rejection': 'ranking-gap',
+    // residual buckets with no diagnosis yet
+    'gate-macro-plausibility-residual': 'frontier',
+    'save-rejected-residual': 'frontier',
+};
+
+export function coarseClassOf(classId: string): CoarseClass {
+    return COARSE_BY_CLASS_ID[classId] ?? 'frontier';
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * `repoint` / `evict` / `mark-corrupt` are row-level data ops (apply-repoints.ts
+ * consumes `{seed, target}` in the `off_<barcode>` / `fdc_<id>` vocabulary, which
+ * is exactly the candidate `id` this driver reports). `pipeline-fix` routes to a
+ * code change. `ingest` routes to the ingest queue and NEVER to a fix-agent.
+ * `triage` means the evidence does not support any action yet.
+ */
+export type TriageAction = 'repoint' | 'evict' | 'mark-corrupt' | 'ingest' | 'pipeline-fix' | 'triage' | 'none';
+
+/** Per-class default action where fixKind alone is too coarse. */
+const ACTION_BY_CLASS_ID: Record<string, TriageAction> = {
+    'degenerate-macros-served': 'mark-corrupt',
+    'corrupt-panel-served': 'mark-corrupt',
+    // The AI expectation disagreeing with a panel split good/bad in the 07-21 run,
+    // so it is a human read, not an automatic data op.
+    'gate-ai-estimate-disagreement': 'triage',
+};
+
+function defaultActionFor(cls: FailureClass): TriageAction {
+    const explicit = ACTION_BY_CLASS_ID[cls.id];
+    if (explicit) return explicit;
+    switch (cls.fixKind) {
+        case 'ingest': return 'ingest';
+        case 'data': return 'repoint';
+        case 'pipeline': return 'pipeline-fix';
+        case 'healthy': return 'none';
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dossier
+// ---------------------------------------------------------------------------
+
+/** The two read-only probes, as they land in the dossier. */
+export interface DossierProbes {
+    retrieval: RetrievalProbe | { error: string } | null;
+    filterTrace: FilterTrace | { error: string } | null;
+}
+
+/** A candidate the probe says would have covered the query better than the pick. */
+export interface BetterCandidate extends ProbeCandidate {
+    /** Query tokens the served record dropped and this candidate carries. */
+    coversUncovered: string[];
+    /** Did it survive the pipeline's own filters, or only appear in gather? */
+    survivedFilters: boolean;
+}
+
+/** What the probes established. Every field is `null` when `--no-probes`. */
+export interface DossierEvidence {
+    probed: boolean;
+    /** The string the probes searched with — `normalizedForm ?? seed`, never the raw quantity line. */
+    probeQuery: string | null;
+    candidateCount: number | null;
+    bySource: Record<string, number> | null;
+    fatsecretCount: number | null;
+    mustHaveTokens: string[] | null;
+    survivors: number | null;
+    removedByTokenFilter: number | null;
+    droppedByCoreToken: number | null;
+    /** Nothing exists in any lane -> dataset gap, not a ranking gap. */
+    corpusGap: boolean;
+    /** Candidates existed and every one was filtered out -> filter over-rejection. */
+    filterWipeout: boolean;
+    betterCandidate: BetterCandidate | null;
+    probeErrors: string[];
+    notes: string[];
+}
+
+export interface TriageVerdict {
+    confirmed: boolean;
+    cls: CoarseClass;
+    action: TriageAction;
+    /** `off_<barcode>` | `fdc_<id>` | `fs_<fsId>`, or null when no target was found. */
+    targetId: string | null;
+    note: string;
+    /** Secondary actions the evidence also supports (e.g. mark-corrupt alongside a repoint). */
+    extraActions: TriageAction[];
+    /** True when probe evidence overrode the row-only class (e.g. pipeline -> ingest). */
+    reclassifiedByProbe: boolean;
+}
+
+export interface TriageDossier {
+    seed: string;
+    /** canonicalizeCacheKey(normalizedForm ?? seed) — the ONLY key that joins to FoodMapping. */
+    cacheKey: string;
+    normalizedForm: string | null;
+    /** Distinct raw lines collapsed into this dossier by cache key. */
+    variants: string[];
+    /** Events collapsed into this dossier — the frequency signal the cap must not hide. */
+    occurrences: number;
+    funnelStage: FunnelStage | null;
+    dropReason: string | null;
+    dropClass: string;
+    hadIncumbent: boolean | null;
+    /** The pick that was rejected/served under the gate. */
+    served: {
+        foodId: string | null;
+        foodName: string | null;
+        brandName: string | null;
+        source: string | null;
+        grams: number | null;
+        totalKcal: number | null;
+        kcalPer100g: number | null;
+        confidence: number | null;
+        servingTier: string | null;
+    };
+    quality: FunnelQuality;
+    classId: string;
+    classTitle: string;
+    fixKind: FixKind | 'unknown';
+    residual: boolean;
+    probes: DossierProbes | null;
+    evidence: DossierEvidence;
+    verdict: TriageVerdict;
+}
+
+// ---------------------------------------------------------------------------
+// Input parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Any of the warm shapes we produce: warm-cache.ts (`seed`), warm-names.ts
+ * (`query`), MappingEventLog exports (`rawLine`). Getting `query` wrong is not
+ * cosmetic — a warm-names JSONL keyed only on `query` parses to ZERO rows if the
+ * reader looks for `seed`/`rawLine` alone.
+ */
+export interface WarmRecordLike {
+    seed?: string;
+    rawLine?: string;
+    query?: string;
+    normalizedForm?: string | null;
+    funnelStage?: string | null;
+    dropReason?: string | null;
+    matchConfidence?: number | null;
+    confidence?: number | null;
+    grams?: number | null;
+    totalKcal?: number | null;
+    per100g?: { kcal?: number; protein?: number; carbs?: number; fat?: number } | null;
+    source?: string | null;
+    foodId?: string | null;
+    foodName?: string | null;
+    brandName?: string | null;
+    servingTier?: string | null;
+}
+
+export function recordToInput(r: WarmRecordLike): FunnelRowInput | null {
+    const rawLine = r.seed ?? r.rawLine ?? r.query;
+    if (!rawLine) return null;
+    const p = r.per100g ?? {};
+    return {
+        rawLine,
+        normalizedForm: r.normalizedForm ?? null,
+        funnelStage: (r.funnelStage ?? null) as FunnelStage | null,
+        dropReason: r.dropReason ?? null,
+        confidence: r.matchConfidence ?? r.confidence ?? null,
+        grams: r.grams ?? null,
+        totalKcal: r.totalKcal ?? null,
+        kcalPer100g: p.kcal ?? null,
+        proteinPer100g: p.protein ?? null,
+        carbsPer100g: p.carbs ?? null,
+        fatPer100g: p.fat ?? null,
+        source: r.source ?? null,
+        foodId: r.foodId ?? null,
+        foodName: r.foodName ?? null,
+        brandName: r.brandName ?? null,
+        servingTier: r.servingTier ?? null,
+    };
+}
+
+/** Parse `{results:[...]}`, a bare JSON array, or JSONL — pretty-printed or not. */
+export function parseInputText(text: string): WarmRecordLike[] {
+    const trimmed = text.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith('[')) return JSON.parse(trimmed) as WarmRecordLike[];
+    if (trimmed.startsWith('{')) {
+        try {
+            const parsed = JSON.parse(trimmed) as { results?: WarmRecordLike[] } | WarmRecordLike;
+            const results = (parsed as { results?: WarmRecordLike[] }).results;
+            if (Array.isArray(results)) return results;
+            return [parsed as WarmRecordLike];
+        } catch {
+            // Not a single JSON document: fall through to JSONL.
+        }
+    }
+    const out: WarmRecordLike[] = [];
+    trimmed.split('\n').forEach((line, i) => {
+        const l = line.trim();
+        if (!l) return;
+        try {
+            out.push(JSON.parse(l) as WarmRecordLike);
+        } catch (e) {
+            throw new Error(`line ${i + 1} is not JSON: ${(e as Error).message}`);
+        }
+    });
+    return out;
+}
+
+export function readInputRows(file: string): FunnelRow[] {
+    const records = parseInputText(fs.readFileSync(file, 'utf8'));
+    const rows: FunnelRow[] = [];
+    for (const r of records) {
+        const input = recordToInput(r);
+        if (input) rows.push(makeFunnelRow(input));
+    }
+    return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Selection: drop stages -> dedupe -> per-class cap
+// ---------------------------------------------------------------------------
+
+export interface CapTruncation {
+    classId: string;
+    seen: number;
+    kept: number;
+    dropped: number;
+}
+
+export interface SelectionResult {
+    /** One entry per distinct cache key, already capped. */
+    selected: TriageDossier[];
+    /** Every stage seen in the input (drops and non-drops). */
+    stageCounts: Record<string, number>;
+    /** Stage histogram of the drop rows only. */
+    dropStageCounts: Record<string, number>;
+    rowCount: number;
+    dropRowCount: number;
+    /** Distinct cache keys among the drop rows, before the cap. */
+    distinctKeyCount: number;
+    duplicateEventsCollapsed: number;
+    truncation: CapTruncation[];
+    droppedByCap: number;
+    log: string[];
+}
+
+function servedOf(row: FunnelRow): TriageDossier['served'] {
+    return {
+        foodId: row.foodId,
+        foodName: row.foodName,
+        brandName: row.brandName,
+        source: row.source,
+        grams: row.grams,
+        totalKcal: row.totalKcal,
+        kcalPer100g: row.kcalPer100g,
+        confidence: row.confidence,
+        servingTier: row.servingTier,
+    };
+}
+
+function emptyEvidence(): DossierEvidence {
+    return {
+        probed: false,
+        probeQuery: null,
+        candidateCount: null,
+        bySource: null,
+        fatsecretCount: null,
+        mustHaveTokens: null,
+        survivors: null,
+        removedByTokenFilter: null,
+        droppedByCoreToken: null,
+        corpusGap: false,
+        filterWipeout: false,
+        betterCandidate: null,
+        probeErrors: [],
+        notes: [],
+    };
+}
+
+/** The string the probes should search with: the mapper's own query, not the quantity line. */
+export function probeQueryFor(row: FunnelRow): string {
+    const nf = (row.normalizedForm ?? '').trim();
+    return nf.length > 0 ? nf : row.rawLine;
+}
+
+/**
+ * Filter to drop stages, collapse duplicate cache keys, then cap per F2 class.
+ *
+ * Order matters: dedupe BEFORE the cap so the cap counts distinct problems (one
+ * key logged 400 times is one problem — the same reason classify-drops ranks by
+ * distinct keys), and classify BEFORE the cap so the cap is per class rather than
+ * "the first N of whatever came back".
+ */
+export function selectDrops(rows: FunnelRow[], opts: { perClassCap: number }): SelectionResult {
+    const stageCounts: Record<string, number> = {};
+    const dropStageCounts: Record<string, number> = {};
+    const skippedByStage: Record<string, number> = {};
+    const log: string[] = [];
+
+    const drops: FunnelRow[] = [];
+    for (const row of rows) {
+        const stage = row.funnelStage ?? 'null';
+        stageCounts[stage] = (stageCounts[stage] ?? 0) + 1;
+        if (isDropStage(row.funnelStage)) {
+            dropStageCounts[stage] = (dropStageCounts[stage] ?? 0) + 1;
+            drops.push(row);
+        } else {
+            skippedByStage[stage] = (skippedByStage[stage] ?? 0) + 1;
+        }
+    }
+
+    log.push(`input: ${rows.length} rows`);
+    const skippedTotal = rows.length - drops.length;
+    log.push(`stage filter: kept ${drops.length} drop-stage rows (${DROP_STAGES.join('|')}); `
+        + `skipped ${skippedTotal}`
+        + (skippedTotal > 0 ? ` (${fmtCounts(skippedByStage)})` : '')
+        + ' — non-drop stages are classify-drops.ts territory, not triage.');
+    if ((skippedByStage.null ?? 0) > 0) {
+        log.push(`NOTE: ${skippedByStage.null} row(s) carried NO funnelStage (pre-F1 warm output or a `
+            + "row the mapper never tagged) and were skipped. They are invisible here, not 'clean'.");
+    }
+
+    // --- dedupe by cache key ---
+    const byKey = new Map<string, { row: FunnelRow; variants: string[]; occurrences: number }>();
+    for (const row of drops) {
+        const key = row.cacheKey || row.rawLine.toLowerCase();
+        const hit = byKey.get(key);
+        if (!hit) {
+            byKey.set(key, { row, variants: [row.rawLine], occurrences: 1 });
+            continue;
+        }
+        hit.occurrences++;
+        if (!hit.variants.includes(row.rawLine)) hit.variants.push(row.rawLine);
+    }
+    const duplicateEventsCollapsed = drops.length - byKey.size;
+    if (duplicateEventsCollapsed > 0) {
+        log.push(`dedupe: ${drops.length} drop events collapsed to ${byKey.size} distinct canonical cache keys `
+            + `(${duplicateEventsCollapsed} duplicate events not probed again; the count is kept as `
+            + '`occurrences` on each dossier).');
+    }
+
+    // --- classify, then cap per class ---
+    const perClassSeen = new Map<string, number>();
+    const perClassKept = new Map<string, number>();
+    const selected: TriageDossier[] = [];
+    for (const { row, variants, occurrences } of byKey.values()) {
+        const { classId, cls } = classifyRow(row);
+        perClassSeen.set(classId, (perClassSeen.get(classId) ?? 0) + 1);
+        const kept = perClassKept.get(classId) ?? 0;
+        if (opts.perClassCap > 0 && kept >= opts.perClassCap) continue;
+        perClassKept.set(classId, kept + 1);
+        selected.push({
+            seed: row.rawLine,
+            cacheKey: row.cacheKey,
+            normalizedForm: row.normalizedForm,
+            variants,
+            occurrences,
+            funnelStage: row.funnelStage,
+            dropReason: row.dropReason,
+            dropClass: row.dropClass,
+            hadIncumbent: row.hadIncumbent,
+            served: servedOf(row),
+            quality: row.quality,
+            classId,
+            classTitle: cls?.title ?? 'UNCLASSIFIED — a shape the registry has never seen',
+            fixKind: cls?.fixKind ?? 'unknown',
+            residual: cls?.residual ?? false,
+            probes: null,
+            evidence: emptyEvidence(),
+            // Placeholder; decideVerdict runs after the probes so evidence can override.
+            verdict: { confirmed: false, cls: 'frontier', action: 'triage', targetId: null, note: 'not yet decided', extraActions: [], reclassifiedByProbe: false },
+        });
+    }
+
+    const truncation: CapTruncation[] = [];
+    for (const [classId, seen] of perClassSeen) {
+        const kept = perClassKept.get(classId) ?? 0;
+        if (seen > kept) truncation.push({ classId, seen, kept, dropped: seen - kept });
+    }
+    truncation.sort((a, b) => b.dropped - a.dropped || a.classId.localeCompare(b.classId));
+    const droppedByCap = truncation.reduce((n, t) => n + t.dropped, 0);
+    if (droppedByCap > 0) {
+        log.push(`PER-CLASS CAP ${opts.perClassCap}: DROPPED ${droppedByCap} dossier(s) — `
+            + truncation.map(t => `${t.classId} kept ${t.kept}/${t.seen}`).join(', ')
+            + '. This run does NOT cover those; raise --per-class-cap to see them.');
+    } else {
+        log.push(`per-class cap ${opts.perClassCap > 0 ? opts.perClassCap : '(none)'}: nothing dropped — `
+            + 'every distinct key is in this report.');
+    }
+
+    return {
+        selected,
+        stageCounts,
+        dropStageCounts,
+        rowCount: rows.length,
+        dropRowCount: drops.length,
+        distinctKeyCount: byKey.size,
+        duplicateEventsCollapsed,
+        truncation,
+        droppedByCap,
+        log,
+    };
+}
+
+function fmtCounts(counts: Record<string, number>): string {
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k} ${v}`).join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// Probes
+// ---------------------------------------------------------------------------
+
+/** Injected so tests never touch a network or a DB. */
+export interface ProbeSet {
+    retrieval?: (query: string) => Promise<RetrievalProbe>;
+    filterTrace?: (query: string) => Promise<FilterTrace>;
+}
+
+/**
+ * Load the real probes. Deliberately `require`d late: importing
+ * debug-retrieval-probe pulls in gather-candidates, which constructs a Prisma
+ * client and warms the ONNX embedder at module load.
+ */
+export function loadRealProbes(opts: { fatsecret: boolean }): ProbeSet {
+    if (!opts.fatsecret) {
+        // Read BEFORE the lane module loads (config.ts snapshots it into a const),
+        // so this is the difference between a read-only run and one that upserts
+        // FatSecretFood rows.
+        process.env.FATSECRET_RETRIEVAL_ENABLED = 'false';
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const retrievalMod = require('../debug-retrieval-probe') as typeof import('../debug-retrieval-probe');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const filterMod = require('../filter-trace-probe') as typeof import('../filter-trace-probe');
+    return {
+        retrieval: (q: string) => retrievalMod.probeRetrieval(q, { skipFatSecretLaneCall: !opts.fatsecret }),
+        filterTrace: (q: string) => filterMod.traceFilters(q),
+    };
+}
+
+/** Run the probes over the selected dossiers with a fixed-size worker pool. */
+export async function runProbes(
+    dossiers: TriageDossier[],
+    probes: ProbeSet,
+    opts: { concurrency: number; onProgress?: (done: number, total: number) => void },
+): Promise<void> {
+    let idx = 0;
+    let done = 0;
+    const workers = Array.from({ length: Math.max(1, opts.concurrency) }, async () => {
+        while (idx < dossiers.length) {
+            const d = dossiers[idx++];
+            const query = probeQueryFor({
+                rawLine: d.seed,
+                normalizedForm: d.normalizedForm,
+            } as FunnelRow);
+            const result: DossierProbes = { retrieval: null, filterTrace: null };
+            if (probes.retrieval) {
+                try {
+                    result.retrieval = await probes.retrieval(query);
+                } catch (e) {
+                    result.retrieval = { error: (e as Error)?.message ?? String(e) };
+                }
+            }
+            if (probes.filterTrace) {
+                try {
+                    result.filterTrace = await probes.filterTrace(query);
+                } catch (e) {
+                    result.filterTrace = { error: (e as Error)?.message ?? String(e) };
+                }
+            }
+            d.probes = result;
+            d.evidence = deriveEvidence(d, result, query);
+            done++;
+            opts.onProgress?.(done, dossiers.length);
+        }
+    });
+    await Promise.all(workers);
+}
+
+// ---------------------------------------------------------------------------
+// Evidence + verdict (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Union of everything the two probes saw, filter-trace candidates first so their
+ * `survivedFilters` flag is preserved and gather-only duplicates are not re-added.
+ */
+function candidatePool(probes: DossierProbes): (ProbeCandidate & { survivedFilters: boolean })[] {
+    const out: (ProbeCandidate & { survivedFilters: boolean })[] = [];
+    const trace = probes.filterTrace;
+    if (trace && !('error' in trace) && Array.isArray(trace.candidates)) {
+        for (const c of trace.candidates) {
+            out.push({ id: c.id, source: c.source, name: c.name, brand: c.brand, score: c.score, survivedFilters: c.fate === 'KEPT' });
+        }
+    }
+    const ret = probes.retrieval;
+    if (ret && !('error' in ret)) {
+        const seen = new Set(out.map(c => c.id));
+        const push = (c: ProbeCandidate) => {
+            if (c.id && seen.has(c.id)) return;
+            if (c.id) seen.add(c.id);
+            out.push({ ...c, survivedFilters: false });
+        };
+        if (ret.gather && !('error' in ret.gather)) ret.gather.top.forEach(push);
+        if (ret.fatsecret && !('error' in ret.fatsecret)) ret.fatsecret.top.forEach(push);
+    }
+    return out;
+}
+
+/**
+ * Turn raw probe output into the handful of facts a verdict needs.
+ *
+ * `betterCandidate` is only claimed when the served record actually DROPPED query
+ * tokens and some candidate carries all of them — the same `uncoveredTokens`
+ * function F2's identity detectors use, so the two cannot disagree.
+ */
+export function deriveEvidence(
+    dossier: Pick<TriageDossier, 'seed' | 'quality' | 'served'>,
+    probes: DossierProbes | null,
+    probeQuery: string,
+): DossierEvidence {
+    const ev = emptyEvidence();
+    if (!probes) {
+        ev.notes.push('probes disabled (--no-probes): the class is row-only, no repoint target can be proposed.');
+        return ev;
+    }
+    ev.probed = true;
+    ev.probeQuery = probeQuery;
+
+    const ret = probes.retrieval;
+    if (ret && 'error' in ret) ev.probeErrors.push(`retrieval: ${ret.error}`);
+    else if (ret) {
+        if ('error' in ret.gather) ev.probeErrors.push(`gather: ${ret.gather.error}`);
+        else {
+            ev.candidateCount = ret.gather.total;
+            ev.bySource = ret.gather.bySource;
+        }
+        if (ret.fatsecret && 'error' in ret.fatsecret) ev.probeErrors.push(`fatsecret: ${ret.fatsecret.error}`);
+        else if (ret.fatsecret) ev.fatsecretCount = ret.fatsecret.count;
+    }
+
+    const trace = probes.filterTrace;
+    if (trace && 'error' in trace) ev.probeErrors.push(`filterTrace: ${trace.error}`);
+    else if (trace) {
+        if (trace.error) ev.probeErrors.push(`filterTrace: ${trace.error}`);
+        ev.mustHaveTokens = trace.mustHaveTokens;
+        ev.survivors = trace.survivors;
+        ev.removedByTokenFilter = trace.removedByTokenFilter;
+        ev.droppedByCoreToken = trace.droppedByCoreToken;
+        if (ev.candidateCount == null) ev.candidateCount = trace.gathered;
+    }
+
+    ev.corpusGap = ev.candidateCount === 0 && (ev.fatsecretCount ?? 0) === 0;
+    ev.filterWipeout = (ev.candidateCount ?? 0) > 0 && ev.survivors === 0;
+
+    const uncovered = dossier.quality.uncoveredQueryTokens;
+    if (uncovered.length > 0 && (ev.candidateCount ?? 0) > 0) {
+        const covering = candidatePool(probes)
+            .filter(c => c.id != null && c.id !== dossier.served.foodId)
+            .filter(c => uncoveredTokens(dossier.seed, c.name, c.brand).length === 0);
+        // Prefer a candidate the pipeline's own filters kept; then the best score.
+        covering.sort((a, b) =>
+            Number(b.survivedFilters) - Number(a.survivedFilters) || (b.score ?? 0) - (a.score ?? 0));
+        const best = covering[0];
+        if (best) {
+            ev.betterCandidate = { ...best, coversUncovered: uncovered };
+        } else {
+            ev.notes.push(`no candidate in the probed pool covers the dropped token(s) [${uncovered.join(', ')}] `
+                + '— the better record is deeper in the pool or absent from the corpus.');
+        }
+    }
+    return ev;
+}
+
+/**
+ * Decide the actionable verdict. PURE — same dossier facts always give the same
+ * verdict, which is what makes the report reviewable.
+ *
+ * `confirmed` means "the diagnosis is supported by the evidence in this dossier",
+ * NOT "a human verified the fix". A `repoint` target is a PROPOSAL: it says a
+ * record covering the dropped tokens exists and survived the filters. The 07-21
+ * lesson stands — the durable fix for a `pipeline` class is the code change; the
+ * repoint only fixes today's cache row.
+ */
+export function decideVerdict(args: {
+    dossier: Pick<TriageDossier, 'seed' | 'classId' | 'dropReason' | 'hadIncumbent' | 'quality' | 'served' | 'occurrences'>;
+    cls: FailureClass | null;
+    evidence: DossierEvidence;
+}): TriageVerdict {
+    const { dossier, cls, evidence } = args;
+    const extraActions: TriageAction[] = [];
+
+    if (!cls) {
+        return {
+            confirmed: false, cls: 'frontier', action: 'triage', targetId: null, extraActions,
+            reclassifiedByProbe: false,
+            note: `No registry class matched (dropReason ${dossier.dropReason ?? 'none'}). This is the true `
+                + 'frontier: characterize it and add an F2 class before acting.',
+        };
+    }
+
+    if (cls.fixKind === 'healthy') {
+        return {
+            confirmed: false, cls: 'healthy', action: 'none', targetId: null, extraActions,
+            reclassifiedByProbe: false,
+            note: `${cls.title} — by design, not a defect. incumbent=${String(dossier.hadIncumbent)}. `
+                + 'Counted so it stops looking like work.',
+        };
+    }
+
+    if (cls.residual) {
+        return {
+            confirmed: false, cls: coarseClassOf(cls.id), action: 'triage', targetId: null, extraActions,
+            reclassifiedByProbe: false,
+            note: `${cls.title} (residual bucket, dropReason ${dossier.dropReason ?? 'none'}). No diagnosis yet `
+                + '— promote a class from the recurring shapes before sending a fix-agent.',
+        };
+    }
+
+    // --- probe evidence can override the row-only class ---
+    if (evidence.probed && evidence.corpusGap && cls.fixKind !== 'ingest') {
+        return {
+            confirmed: true, cls: 'ingest-gap', action: 'ingest', targetId: null, extraActions,
+            reclassifiedByProbe: true,
+            note: `Row facts said ${cls.id}, but retrieval returned ZERO candidates in every lane for `
+                + `"${evidence.probeQuery}" — this is a dataset gap, not a ranking gap. Route to the ingest `
+                + 'queue, NEVER a fix-agent.',
+        };
+    }
+
+    if (evidence.probed && evidence.filterWipeout) {
+        return {
+            confirmed: true, cls: 'ranking-gap', action: 'pipeline-fix', targetId: null, extraActions,
+            reclassifiedByProbe: cls.id !== 'all-filtered-over-rejection',
+            note: `${evidence.candidateCount} candidate(s) gathered and NONE survived the filters `
+                + `(${evidence.removedByTokenFilter ?? '?'} removed by the token filter, `
+                + `${evidence.droppedByCoreToken ?? '?'} by core-token mismatch; mustHave=`
+                + `[${(evidence.mustHaveTokens ?? []).join(', ')}]). Filter over-rejection — fix the filter, `
+                + `not the row. Row class was ${cls.id}.`,
+        };
+    }
+
+    const baseAction = defaultActionFor(cls);
+    const better = evidence.betterCandidate;
+    if (better?.id) {
+        if (baseAction === 'mark-corrupt') extraActions.push('mark-corrupt');
+        if (cls.fixKind === 'pipeline') extraActions.push('pipeline-fix');
+        return {
+            confirmed: true, cls: coarseClassOf(cls.id), action: 'repoint', targetId: better.id, extraActions,
+            reclassifiedByProbe: false,
+            note: `${cls.title}. Probe found ${better.id} ("${better.name}"${better.brand ? ` [${better.brand}]` : ''}, `
+                + `${better.source}, score ${better.score ?? '?'}${better.survivedFilters ? ', survived the filters' : ', gather-only'}) `
+                + `covering the dropped token(s) [${better.coversUncovered.join(', ')}] that the served pick `
+                + `("${dossier.served.foodName ?? 'none'}") misses. Repoint fixes today's cache row; the durable `
+                + `fix for ${cls.fixKind === 'pipeline' ? 'this pipeline class is the ranking/filter change' : 'the class is the data op'}.`,
+        };
+    }
+
+    let evidenceNote = evidence.probed
+        ? `Probe: ${evidence.candidateCount ?? '?'} candidate(s), ${evidence.survivors ?? '?'} survivor(s)`
+            + (evidence.notes.length ? `; ${evidence.notes.join(' ')}` : '.')
+        : 'No probes were run (--no-probes), so this verdict rests on row facts alone.';
+
+    // An ingest class claims "no record exists". When the probe found survivors that
+    // claim is only true of the specific FORM asked for (n-cook-06: the corpus has
+    // oats, just not COOKED oats). Say so rather than letting the class title stand
+    // unchallenged next to contradicting evidence.
+    if (cls.fixKind === 'ingest' && evidence.probed && (evidence.survivors ?? 0) > 0) {
+        evidenceNote += ` CAUTION: the lane is NOT empty — ${evidence.survivors} candidate(s) survived the `
+            + 'filters, so what is missing is the specific form/variant, not the food. Confirm that before '
+            + 'queueing an ingest.';
+    }
+
+    return {
+        confirmed: true,
+        cls: coarseClassOf(cls.id),
+        action: baseAction,
+        targetId: null,
+        extraActions,
+        reclassifiedByProbe: false,
+        note: `${cls.title}. ${describeRowEvidence(dossier)} ${evidenceNote}`,
+    };
+}
+
+/** The row facts that made the class fire, so a reader can check the call. */
+function describeRowEvidence(d: Pick<TriageDossier, 'quality' | 'served' | 'occurrences'>): string {
+    const bits: string[] = [];
+    if (d.quality.degenerateMacros) bits.push('all-zero macros');
+    if (d.quality.flat100gServing) bits.push('flat 100 g serving');
+    if (d.quality.aiEstimated) bits.push('ai_estimated source');
+    if (d.quality.brandDisagreement) bits.push('brand shares no token with the query');
+    if (d.quality.uncoveredQueryTokens.length) bits.push(`dropped token(s) [${d.quality.uncoveredQueryTokens.join(', ')}]`);
+    const served = `served "${d.served.foodName ?? 'none'}"${d.served.brandName ? ` [${d.served.brandName}]` : ''} `
+        + `${d.served.grams ?? '?'}g conf=${d.served.confidence ?? '?'}`;
+    return `${served}${bits.length ? `; row flags: ${bits.join(', ')}` : ''}. `
+        + (d.occurrences > 1 ? `Seen ${d.occurrences}x. ` : '');
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+/** Legacy row shape from triage-verdicts-2026-07-21.json, extended with the dossier. */
+export interface VerdictRow {
+    seed: string;
+    confirmed: boolean;
+    cls: CoarseClass;
+    action: TriageAction;
+    targetId: string | null;
+    note: string;
+    // --- extensions ---
+    classId: string;
+    fixKind: FixKind | 'unknown';
+    dossier: TriageDossier;
+}
+
+export interface TriageReport {
+    // ---- keys the 2026-07-21 readers expect, same meaning ----
+    screened: string;
+    suspectCount: number;
+    confirmedCount: number;
+    byClass: Record<string, number>;
+    confirmed: VerdictRow[];
+    dismissed: VerdictRow[];
+    // ---- extensions ----
+    at: string;
+    inputLabel: string;
+    mode: 'probes' | 'no-probes';
+    concurrency: number;
+    perClassCap: number;
+    rowCount: number;
+    dropRowCount: number;
+    distinctKeyCount: number;
+    dossierCount: number;
+    stageCounts: Record<string, number>;
+    dropStageCounts: Record<string, number>;
+    byFailureClass: Record<string, number>;
+    byFixKind: Record<string, number>;
+    byAction: Record<string, number>;
+    truncation: CapTruncation[];
+    droppedByCap: number;
+    reclassifiedByProbe: number;
+    probeErrorCount: number;
+    log: string[];
+    caveats: string[];
+}
+
+const CLASS_BY_ID = new Map(FAILURE_CLASSES.map(c => [c.id, c]));
+
+/**
+ * Decide every verdict and shape the report.
+ *
+ * `suspectCount` = dossiers whose class is not `healthy` (i.e. candidate defects).
+ * `confirmedCount` = those whose verdict the evidence supports. Residual and
+ * unclassified dossiers stay UNCONFIRMED on purpose: a catch-all bucket is not a
+ * diagnosis, and counting it as one is how a frontier disappears.
+ */
+export function buildReport(
+    selection: SelectionResult,
+    opts: { inputLabel: string; mode: 'probes' | 'no-probes'; concurrency: number; perClassCap: number; extraLog?: string[] },
+): TriageReport {
+    const confirmed: VerdictRow[] = [];
+    const dismissed: VerdictRow[] = [];
+    const byClass: Record<string, number> = {};
+    const byFailureClass: Record<string, number> = {};
+    const byFixKind: Record<string, number> = {};
+    const byAction: Record<string, number> = {};
+    let suspectCount = 0;
+    let reclassified = 0;
+    let probeErrorCount = 0;
+
+    for (const d of selection.selected) {
+        const cls = d.classId === UNCLASSIFIED ? null : CLASS_BY_ID.get(d.classId) ?? null;
+        d.verdict = decideVerdict({ dossier: d, cls, evidence: d.evidence });
+        if (d.verdict.reclassifiedByProbe) reclassified++;
+        probeErrorCount += d.evidence.probeErrors.length;
+
+        byFailureClass[d.classId] = (byFailureClass[d.classId] ?? 0) + 1;
+        byFixKind[d.fixKind] = (byFixKind[d.fixKind] ?? 0) + 1;
+        byAction[d.verdict.action] = (byAction[d.verdict.action] ?? 0) + 1;
+
+        const row: VerdictRow = {
+            seed: d.seed,
+            confirmed: d.verdict.confirmed,
+            cls: d.verdict.cls,
+            action: d.verdict.action,
+            targetId: d.verdict.targetId,
+            note: d.verdict.note,
+            classId: d.classId,
+            fixKind: d.fixKind,
+            dossier: d,
+        };
+        if (d.fixKind !== 'healthy') suspectCount++;
+        if (d.verdict.confirmed) {
+            confirmed.push(row);
+            byClass[d.verdict.cls] = (byClass[d.verdict.cls] ?? 0) + 1;
+        } else {
+            dismissed.push(row);
+        }
+    }
+
+    // Most-frequent first inside `confirmed`, so a reader starts at the loudest key.
+    confirmed.sort((a, b) => b.dossier.occurrences - a.dossier.occurrences || a.seed.localeCompare(b.seed));
+
+    const log = [...selection.log, ...(opts.extraLog ?? [])];
+    log.push(`verdicts: ${confirmed.length} confirmed / ${dismissed.length} dismissed `
+        + `(${suspectCount} suspect = non-healthy class). `
+        + `${reclassified} reclassified by probe evidence.`);
+    if (probeErrorCount > 0) log.push(`probe errors: ${probeErrorCount} lane failure(s) recorded — `
+        + 'those dossiers have partial evidence, do NOT read them as "nothing found".');
+
+    return {
+        screened: `${selection.rowCount} rows (${selection.dropRowCount} drop-stage, `
+            + `${selection.distinctKeyCount} distinct keys, ${selection.selected.length} triaged) — ${opts.inputLabel}`,
+        suspectCount,
+        confirmedCount: confirmed.length,
+        byClass,
+        confirmed,
+        dismissed,
+        at: new Date().toISOString(),
+        inputLabel: opts.inputLabel,
+        mode: opts.mode,
+        concurrency: opts.concurrency,
+        perClassCap: opts.perClassCap,
+        rowCount: selection.rowCount,
+        dropRowCount: selection.dropRowCount,
+        distinctKeyCount: selection.distinctKeyCount,
+        dossierCount: selection.selected.length,
+        stageCounts: selection.stageCounts,
+        dropStageCounts: selection.dropStageCounts,
+        byFailureClass,
+        byFixKind,
+        byAction,
+        truncation: selection.truncation,
+        droppedByCap: selection.droppedByCap,
+        reclassifiedByProbe: reclassified,
+        probeErrorCount,
+        log,
+        caveats: FUNNEL_CAVEATS.map(c => `${c.id}: ${c.note}`),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+function mdEscape(s: string): string {
+    return s.replace(/\|/g, '\\|');
+}
+
+export function renderMarkdown(report: TriageReport): string {
+    const L: string[] = [];
+    L.push(`# Drop triage — ${report.at}`);
+    L.push('');
+    L.push('> GENERATED by `scripts/eval/triage-drops.ts` (F3). Read-only run: the only files it wrote are');
+    L.push('> this report and its `.json` sibling.');
+    L.push('');
+    L.push(`- input: \`${report.inputLabel}\``);
+    L.push(`- mode: **${report.mode}**${report.mode === 'no-probes' ? ' — no retrieval calls, so no repoint targets' : ` (concurrency ${report.concurrency})`}`);
+    L.push(`- screened: ${report.screened}`);
+    L.push(`- suspects: **${report.suspectCount}** · confirmed: **${report.confirmedCount}** · dismissed: ${report.dismissed.length}`);
+    L.push(`- per-class cap: ${report.perClassCap} · dropped by cap: **${report.droppedByCap}**`);
+    L.push('');
+
+    L.push('## Run log (everything this run dropped)');
+    L.push('');
+    for (const line of report.log) L.push(`- ${line}`);
+    L.push('');
+
+    if (report.truncation.length > 0) {
+        L.push('### Truncated classes — NOT covered by this run');
+        L.push('');
+        L.push('| class | distinct keys seen | triaged | dropped |');
+        L.push('| ----- | -----------------: | ------: | ------: |');
+        for (const t of report.truncation) L.push(`| \`${t.classId}\` | ${t.seen} | ${t.kept} | ${t.dropped} |`);
+        L.push('');
+    }
+
+    L.push('## Stages');
+    L.push('');
+    L.push(`- all rows: ${fmtCounts(report.stageCounts) || '(none)'}`);
+    L.push(`- drop rows only: ${fmtCounts(report.dropStageCounts) || '(none)'}`);
+    L.push('');
+
+    L.push('## Confirmed, by coarse class (the 2026-07-21 vocabulary)');
+    L.push('');
+    L.push('| coarse class | confirmed |');
+    L.push('| ------------ | --------: |');
+    for (const [k, v] of Object.entries(report.byClass).sort((a, b) => b[1] - a[1])) L.push(`| ${k} | ${v} |`);
+    L.push('');
+
+    L.push('## All triaged dossiers, by F2 class');
+    L.push('');
+    L.push('| F2 class | fixKind | dossiers |');
+    L.push('| -------- | ------- | -------: |');
+    for (const [k, v] of Object.entries(report.byFailureClass).sort((a, b) => b[1] - a[1])) {
+        L.push(`| \`${k}\` | ${CLASS_BY_ID.get(k)?.fixKind ?? 'unknown'} | ${v} |`);
+    }
+    L.push('');
+    L.push(`Actions: ${fmtCounts(report.byAction) || '(none)'}. `
+        + `Reclassified by probe evidence: ${report.reclassifiedByProbe}.`);
+    L.push('');
+
+    const byAction = new Map<TriageAction, VerdictRow[]>();
+    for (const row of report.confirmed) {
+        const list = byAction.get(row.action) ?? [];
+        list.push(row);
+        byAction.set(row.action, list);
+    }
+    L.push('## Confirmed verdicts');
+    L.push('');
+    if (report.confirmed.length === 0) L.push('_(none)_');
+    for (const action of ['repoint', 'mark-corrupt', 'evict', 'ingest', 'pipeline-fix', 'triage', 'none'] as TriageAction[]) {
+        const rows = byAction.get(action);
+        if (!rows?.length) continue;
+        L.push(`### action: \`${action}\` (${rows.length})`);
+        L.push('');
+        L.push('| seed | key | class | target | served | note |');
+        L.push('| ---- | --- | ----- | ------ | ------ | ---- |');
+        for (const r of rows) {
+            const d = r.dossier;
+            L.push(`| \`${mdEscape(r.seed)}\`${d.occurrences > 1 ? ` ×${d.occurrences}` : ''} `
+                + `| \`${mdEscape(d.cacheKey)}\` | \`${r.classId}\` | ${r.targetId ? `\`${r.targetId}\`` : '—'} `
+                + `| ${mdEscape(d.served.foodName ?? '—')} ${d.served.grams ?? '?'}g | ${mdEscape(r.note)} |`);
+        }
+        L.push('');
+    }
+
+    L.push('## Dismissed');
+    L.push('');
+    if (report.dismissed.length === 0) {
+        L.push('_(none)_');
+    } else {
+        L.push('| seed | class | why not actionable |');
+        L.push('| ---- | ----- | ------------------ |');
+        for (const r of report.dismissed) {
+            L.push(`| \`${mdEscape(r.seed)}\` | \`${r.classId}\` | ${mdEscape(r.note)} |`);
+        }
+    }
+    L.push('');
+
+    L.push('## Caveats that are facts, not classes');
+    L.push('');
+    for (const c of report.caveats) L.push(`- ${c}`);
+    L.push('');
+    return L.join('\n') + '\n';
+}
+
+export function renderConsole(report: TriageReport): void {
+    console.log(`\nF3 drop triage — ${report.inputLabel}`);
+    console.log(report.screened);
+    console.log(`mode=${report.mode} concurrency=${report.concurrency} perClassCap=${report.perClassCap}`);
+    for (const line of report.log) console.log(`  · ${line}`);
+    console.log(`\nsuspects=${report.suspectCount} confirmed=${report.confirmedCount} dismissed=${report.dismissed.length}`);
+    console.log(`byClass (coarse, confirmed only): ${JSON.stringify(report.byClass)}`);
+    console.log(`byAction: ${JSON.stringify(report.byAction)}`);
+    console.log('\nTop F2 classes among triaged dossiers:');
+    for (const [k, v] of Object.entries(report.byFailureClass).sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+        console.log(`  ${String(v).padStart(5)}  ${k} (${CLASS_BY_ID.get(k)?.fixKind ?? 'unknown'})`);
+    }
+    if (report.truncation.length > 0) {
+        console.log('\n!! TRUNCATED — not covered by this run:');
+        for (const t of report.truncation) console.log(`  ${t.classId}: triaged ${t.kept}/${t.seen} (dropped ${t.dropped})`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export function resolveOutBase(out: string | undefined, at: Date): string {
+    if (out) return out.replace(/\.(json|md)$/i, '');
+    const ts = at.toISOString().replace(/[:.]/g, '-');
+    return path.join(__dirname, 'results', `triage-verdicts-${ts}`);
+}
+
+async function main(): Promise<void> {
+    const args = process.argv.slice(2);
+    const has = (flag: string) => args.includes(flag);
+    const val = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+
+    const inFile = val('--in');
+    const fromDb = has('--from-db');
+    if (!inFile && !fromDb) {
+        console.error('Usage: triage-drops.ts (--in <warm.json|.jsonl> | --from-db [--since <date>] [--limit N])');
+        console.error('  [--concurrency 4] [--per-class-cap 25] [--out <path>] [--no-probes] [--no-incumbent]');
+        console.error('  [--fatsecret] [--dry]');
+        console.error('');
+        console.error('  --no-probes   classify only, zero retrieval calls (cheap mode)');
+        console.error('  --dry         run everything, write nothing');
+        console.error('  --fatsecret   include the FatSecret lane: spends FS API quota AND background-upserts');
+        console.error('                FatSecretFood/FatSecretServing rows. OFF by default so a run is read-only.');
+        process.exitCode = 1;
+        return;
+    }
+
+    const concurrency = Number(val('--concurrency') ?? 4);
+    const perClassCap = Number(val('--per-class-cap') ?? 25);
+    const noProbes = has('--no-probes');
+    const dry = has('--dry');
+    const wantIncumbent = !has('--no-incumbent');
+    const fatsecret = has('--fatsecret');
+    const extraLog: string[] = [];
+
+    let prisma: PrismaLike | null = null;
+    let rows: FunnelRow[];
+    let inputLabel: string;
+
+    if (fromDb) {
+        const sinceRaw = val('--since');
+        const since = sinceRaw ? new Date(sinceRaw) : undefined;
+        if (since && Number.isNaN(since.getTime())) throw new Error(`--since is not a date: ${sinceRaw}`);
+        const limit = Number(val('--limit') ?? 20000);
+        prisma = openPrisma();
+        const inputs = await readFromDb(prisma, { since, limit });
+        rows = inputs.map(makeFunnelRow);
+        inputLabel = `MappingEventLog (SELECT only)${sinceRaw ? ` since ${sinceRaw}` : ''} limit ${limit}`;
+    } else {
+        rows = readInputRows(inFile!);
+        const limit = val('--limit');
+        if (limit) rows = rows.slice(0, Number(limit));
+        const rel = path.relative(process.cwd(), inFile!);
+        inputLabel = rel.startsWith('..') ? inFile! : rel;
+        // The approximate read. warm JSONL records no servingTier, so F2's
+        // flat100gServing quality flag falls back to grams === 100 and counts
+        // records whose label genuinely IS 100 g. --from-db has the real tier.
+        extraLog.push('input is a warm file: servingTier is NOT recorded there, so the flat-100g signal falls '
+            + 'back to grams === 100 and OVER-COUNTS serving-flat-100g-fallthrough. Use --from-db for the '
+            + 'precise read.');
+    }
+
+    if (wantIncumbent) {
+        try {
+            prisma = prisma ?? openPrisma();
+            const keys = await attachIncumbents(prisma, rows);
+            extraLog.push(`hadIncumbent resolved for ${keys} canonical cache keys (canonicalizeCacheKey applied — `
+                + 'a raw normalizedForm join would report cached keys as cold).');
+        } catch (err) {
+            extraLog.push(`hadIncumbent lookup SKIPPED (${(err as Error).message}); incumbent counts read as unknown.`);
+        }
+    } else {
+        extraLog.push('hadIncumbent lookup skipped (--no-incumbent); incumbent counts read as unknown.');
+    }
+
+    const selection = selectDrops(rows, { perClassCap });
+
+    if (noProbes) {
+        extraLog.push('probes: DISABLED (--no-probes). Verdicts rest on row facts only; no corpus-gap vs '
+            + 'ranking-gap split and no repoint targets.');
+        for (const d of selection.selected) d.evidence = deriveEvidence(d, null, probeQueryFor({ rawLine: d.seed, normalizedForm: d.normalizedForm } as FunnelRow));
+    } else {
+        extraLog.push(`probes: retrieval + filter-trace over ${selection.selected.length} distinct queries, `
+            + `concurrency ${concurrency}. NO LLM calls (search + pure token logic only).`);
+        extraLog.push(fatsecret
+            ? 'FatSecret lane ON (--fatsecret): FS API quota is spent and FatSecretFood/FatSecretServing rows '
+                + 'are background-upserted. This run is NOT strictly read-only.'
+            : 'FatSecret lane OFF (default): FATSECRET_RETRIEVAL_ENABLED=false forced before the probe modules '
+                + 'load, so no FS API calls and no FatSecretFood upserts. The candidate pool therefore excludes '
+                + 'the fs lane — pass --fatsecret when triaging fs-related drops.');
+        const probes = loadRealProbes({ fatsecret });
+        await runProbes(selection.selected, probes, {
+            concurrency,
+            onProgress: (done, total) => {
+                if (done % 25 === 0 || done === total) console.log(`  probed ${done}/${total}`);
+            },
+        });
+    }
+
+    const report = buildReport(selection, {
+        inputLabel,
+        mode: noProbes ? 'no-probes' : 'probes',
+        concurrency,
+        perClassCap,
+        extraLog,
+    });
+    renderConsole(report);
+
+    const base = resolveOutBase(val('--out'), new Date());
+    const jsonPath = `${base}.json`;
+    const mdPath = `${base}.md`;
+    if (dry) {
+        console.log(`\n--dry: nothing written. Would have written:\n  ${jsonPath}\n  ${mdPath}`);
+    } else {
+        fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+        fs.writeFileSync(jsonPath, JSON.stringify(report, null, 1));
+        fs.writeFileSync(mdPath, renderMarkdown(report));
+        console.log(`\nWrote:\n  ${jsonPath}\n  ${mdPath}`);
+    }
+
+    if (prisma) await prisma.$disconnect();
+}
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error(err);
+        process.exit(1);
+    });
+}

--- a/scripts/eval/triage-drops.ts
+++ b/scripts/eval/triage-drops.ts
@@ -36,9 +36,17 @@
  * TRUNCATION IS ALWAYS REPORTED
  * ---------------------------------------------------------------------------
  * A per-class cap (`--per-class-cap`, default 25) stops one loud class from eating
- * the whole run. Every dossier the cap drops, every duplicate event collapsed and
- * every non-drop-stage row skipped is counted into `log[]` and printed. Silent
- * truncation reads as "covered everything" when it did not.
+ * the whole run. Every dossier the cap drops, every duplicate event collapsed, every
+ * non-drop-stage row skipped and every row `--limit` cut off is counted into `log[]`
+ * and printed. Silent truncation reads as "covered everything" when it did not.
+ *
+ * The same rule applies to what the tool CANNOT see: `scope` states which F2 classes,
+ * which coarse `byClass` buckets and which actions are unreachable here, because a
+ * bucket that is empty by construction otherwise reads as "we looked and found none".
+ *
+ * And numeric flags are VALIDATED, not coerced (`parseIntFlag`): `--concurrency 0`
+ * used to build zero probe workers and `--limit abc` an empty row set, each producing
+ * a clean-looking report of a run that never happened.
  *
  * Run (from repo root):
  *   # cheap mode: classify only, no retrieval at all
@@ -60,6 +68,7 @@ import {
     FAILURE_CLASSES,
     FUNNEL_CAVEATS,
     UNCLASSIFIED,
+    classStages,
     classifyRow,
     makeFunnelRow,
     uncoveredTokens,
@@ -81,6 +90,12 @@ import type { FilterTrace } from '../filter-trace-probe';
  * The stages this driver triages. `cache_hit` / `saved` / `fast_path` are NOT
  * drops — F2 can still flag them as poisoned conversions (finding 4), which is
  * `classify-drops.ts`'s job; this driver is about lines that did not land.
+ *
+ * The exclusion has a cost, and `scopeDisclosure()` states it in the report rather
+ * than leaving it in this comment: the finding-4 quality classes span served stages,
+ * so this run sees only their `under_gate` slice (served to the user, never cached)
+ * and never their `cache_hit`/`saved` slice (already cached — the poisoned
+ * conversion). Four classes are excluded outright.
  */
 export const DROP_STAGES: FunnelStage[] = ['no_match', 'under_gate', 'save_rejected', 'all_filtered', 'no_candidates'];
 
@@ -158,13 +173,43 @@ export function coarseClassOf(classId: string): CoarseClass {
 // ---------------------------------------------------------------------------
 
 /**
- * `repoint` / `evict` / `mark-corrupt` are row-level data ops (apply-repoints.ts
- * consumes `{seed, target}` in the `off_<barcode>` / `fdc_<id>` vocabulary, which
- * is exactly the candidate `id` this driver reports). `pipeline-fix` routes to a
- * code change. `ingest` routes to the ingest queue and NEVER to a fix-agent.
+ * `repoint` / `evict` / `mark-corrupt` are row-level data ops. `pipeline-fix` routes
+ * to a code change. `ingest` routes to the ingest queue and NEVER to a fix-agent.
  * `triage` means the evidence does not support any action yet.
+ *
+ * A `repoint` hands `{seed, targetId}` to apply-repoints.ts, which WRITES FoodMapping
+ * under validatedBy 'human-triage'. Its target vocabulary is NOT the candidate-id
+ * vocabulary — see APPLY_REPOINTS_TARGET_RE, which is what `targetId` is constrained
+ * to. Getting that wrong pins a wrong record against future warm waves.
  */
 export type TriageAction = 'repoint' | 'evict' | 'mark-corrupt' | 'ingest' | 'pipeline-fix' | 'triage' | 'none';
+
+/**
+ * EXACTLY what apply-repoints.ts can consume as `target`, read off its own code
+ * (scripts/eval/apply-repoints.ts:83-104):
+ *
+ *   if (r.target.startsWith('off_')) { barcode = target.slice(4); ...OffFood... }
+ *   const fdcId = parseInt(r.target.slice(4), 10);   // EVERYTHING ELSE
+ *
+ * There is no third branch and no validation. `fs_12345` therefore does not error —
+ * `'fs_12345'.slice(4)` is `'2345'`, so it looks up FdcFood 2345, an unrelated
+ * record, and if that row has nutrition it UPSERTS the cache key onto it. That is a
+ * silent wrong-record cache poisoning applied under validatedBy 'human-triage', i.e.
+ * pinned against future warm waves — the same shape as the 2026-07-24 clobber
+ * incident that had to be surgically reverted.
+ *
+ * So the vocabulary is off_<barcode> and fdc_<digits>, and NOTHING else. Candidate
+ * ids from the probes span a wider space (`off_` / `fdc_` / `fs_`, and the served
+ * `foodId` can also be `ai_`), so an fs_ candidate — reachable whenever `--fatsecret`
+ * is passed — must be WITHHELD rather than reported as a target. Extend this regex
+ * only together with a branch in apply-repoints.ts, never before it.
+ */
+export const APPLY_REPOINTS_TARGET_RE = /^(off_[A-Za-z0-9._-]+|fdc_\d+)$/;
+
+/** Can apply-repoints.ts resolve this candidate id to the record it names? */
+export function isApplyRepointsTarget(id: string | null | undefined): boolean {
+    return typeof id === 'string' && APPLY_REPOINTS_TARGET_RE.test(id);
+}
 
 /** Per-class default action where fixKind alone is too coarse. */
 const ACTION_BY_CLASS_ID: Record<string, TriageAction> = {
@@ -184,6 +229,98 @@ function defaultActionFor(cls: FailureClass): TriageAction {
         case 'pipeline': return 'pipeline-fix';
         case 'healthy': return 'none';
     }
+}
+
+// ---------------------------------------------------------------------------
+// Scope: what this tool structurally cannot report
+// ---------------------------------------------------------------------------
+
+/**
+ * Which parts of the advertised 2026-07-21 vocabulary this driver cannot fill.
+ *
+ * The report prints the full `byClass` vocabulary, so a bucket that is *unreachable
+ * by construction* would read as "we looked and found none". This is computed from
+ * DROP_STAGES x the registry, never hand-listed, so it cannot drift.
+ */
+export interface ScopeDisclosure {
+    dropStages: FunnelStage[];
+    /** Stages present in the registry that selectDrops filters out before classifying. */
+    excludedStages: FunnelStage[];
+    /** Classes that can NEVER fire here: every stage they declare is excluded. */
+    outOfScopeClassIds: string[];
+    /** Classes only PARTLY visible: some declared stages are excluded, some are not. */
+    partialClassIds: string[];
+    /** Coarse buckets with no reachable class at all — unpopulatable by construction. */
+    outOfScopeCoarseClasses: CoarseClass[];
+    /** Coarse buckets whose count is real but INCOMPLETE (a member class is partly/fully excluded). */
+    partialCoarseClasses: CoarseClass[];
+    /** Actions this driver can never emit, whatever the input. */
+    unreachableActions: TriageAction[];
+    /** Rendered into log[] and into the md, so the exclusion travels with the numbers. */
+    notes: string[];
+}
+
+const ALL_ACTIONS: TriageAction[] = ['repoint', 'evict', 'mark-corrupt', 'ingest', 'pipeline-fix', 'triage', 'none'];
+
+export function scopeDisclosure(): ScopeDisclosure {
+    const inScope = (cls: FailureClass) => classStages(cls).some(s => isDropStage(s));
+    const fullyVisible = (cls: FailureClass) => classStages(cls).every(s => isDropStage(s));
+
+    const excludedStages = Array.from(new Set(
+        FAILURE_CLASSES.flatMap(classStages).filter(s => !isDropStage(s)))).sort();
+    const outOfScope = FAILURE_CLASSES.filter(c => !inScope(c));
+    const partial = FAILURE_CLASSES.filter(c => inScope(c) && !fullyVisible(c));
+
+    const coarseOf = (ids: string[]) => Array.from(new Set(ids.map(coarseClassOf)));
+    const reachableCoarse = new Set(FAILURE_CLASSES.filter(inScope).map(c => coarseClassOf(c.id)));
+    const outOfScopeCoarseClasses = coarseOf(outOfScope.map(c => c.id)).filter(c => !reachableCoarse.has(c)).sort();
+    const partialCoarseClasses = coarseOf([...outOfScope, ...partial].map(c => c.id))
+        .filter(c => !outOfScopeCoarseClasses.includes(c)).sort();
+
+    // Actions the code can still emit for an in-scope class, plus the ones the
+    // probe-override / healthy / residual / unclassified paths hard-code.
+    const reachableActions = new Set<TriageAction>([
+        ...FAILURE_CLASSES.filter(inScope).map(defaultActionFor),
+        'repoint', 'ingest', 'pipeline-fix', 'triage', 'none',
+    ]);
+    const unreachableActions = ALL_ACTIONS.filter(a => !reachableActions.has(a));
+
+    const notes: string[] = [];
+    notes.push(`SCOPE: this driver triages ${DROP_STAGES.join('|')} ONLY. Rows at `
+        + `${excludedStages.join('|')} are filtered out BEFORE classification, so anything below is absent `
+        + 'BY CONSTRUCTION and must not be read as "we looked and found none". Poisoned conversions that were '
+        + 'actually CACHED (finding 4) are classify-drops.ts territory — run that, not this.');
+    if (outOfScope.length > 0) {
+        notes.push(`SCOPE: ${outOfScope.length} F2 class(es) can NEVER fire here — `
+            + outOfScope.map(c => `${c.id} (${classStages(c).join('|')})`).join(', ') + '.');
+    }
+    if (partial.length > 0) {
+        notes.push(`SCOPE: ${partial.length} class(es) are only PARTLY visible — `
+            + partial.map(c => `${c.id} (sees ${classStages(c).filter(isDropStage).join('|')}, `
+                + `blind to ${classStages(c).filter(s => !isDropStage(s)).join('|')})`).join('; ')
+            + '. Their counts are real but LOWER BOUNDS: the quality classes span served stages, so this run '
+            + 'sees the under_gate slice (served, never cached) and never the cache_hit/saved slice (cached, '
+            + 'i.e. the poisoned conversion).');
+    }
+    notes.push(outOfScopeCoarseClasses.length > 0
+        ? `SCOPE: coarse byClass bucket(s) ${outOfScopeCoarseClasses.join(', ')} are UNPOPULATABLE here.`
+        : 'SCOPE: every coarse byClass bucket has at least one reachable class, but '
+            + `${partialCoarseClasses.join(', ')} draw on partly-excluded classes, so their counts are lower bounds.`);
+    if (unreachableActions.length > 0) {
+        notes.push(`SCOPE: action(s) ${unreachableActions.join(', ')} are never emitted by this driver `
+            + '(no in-scope class defaults to them and no code path proposes them), so a 0 there says nothing '
+            + 'about the underlying work.');
+    }
+    return {
+        dropStages: [...DROP_STAGES],
+        excludedStages,
+        outOfScopeClassIds: outOfScope.map(c => c.id),
+        partialClassIds: partial.map(c => c.id),
+        outOfScopeCoarseClasses,
+        partialCoarseClasses,
+        unreachableActions,
+        notes,
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -229,13 +366,24 @@ export interface TriageVerdict {
     confirmed: boolean;
     cls: CoarseClass;
     action: TriageAction;
-    /** `off_<barcode>` | `fdc_<id>` | `fs_<fsId>`, or null when no target was found. */
+    /**
+     * `off_<barcode>` or `fdc_<id>` — ALWAYS a value apply-repoints.ts can resolve
+     * (APPLY_REPOINTS_TARGET_RE) — or null when no target was found OR the record the
+     * probe found cannot be expressed in that vocabulary. Never an `fs_` id.
+     */
     targetId: string | null;
     note: string;
     /** Secondary actions the evidence also supports (e.g. mark-corrupt alongside a repoint). */
     extraActions: TriageAction[];
     /** True when probe evidence overrode the row-only class (e.g. pipeline -> ingest). */
     reclassifiedByProbe: boolean;
+    /**
+     * The candidate id the probe DID find but which apply-repoints.ts cannot consume,
+     * so `targetId` is null and the record is named in `note` instead. Counted in the
+     * run log — a withheld target is a finding a human can still act on, and it must
+     * not read as "the probe found nothing".
+     */
+    withheldTargetId: string | null;
 }
 
 export interface TriageDossier {
@@ -516,7 +664,7 @@ export function selectDrops(rows: FunnelRow[], opts: { perClassCap: number }): S
             probes: null,
             evidence: emptyEvidence(),
             // Placeholder; decideVerdict runs after the probes so evidence can override.
-            verdict: { confirmed: false, cls: 'frontier', action: 'triage', targetId: null, note: 'not yet decided', extraActions: [], reclassifiedByProbe: false },
+            verdict: { confirmed: false, cls: 'frontier', action: 'triage', targetId: null, note: 'not yet decided', extraActions: [], reclassifiedByProbe: false, withheldTargetId: null },
         });
     }
 
@@ -586,15 +734,28 @@ export function loadRealProbes(opts: { fatsecret: boolean }): ProbeSet {
     };
 }
 
-/** Run the probes over the selected dossiers with a fixed-size worker pool. */
+/**
+ * Run the probes over the selected dossiers with a fixed-size worker pool.
+ *
+ * THROWS on an invalid concurrency rather than degrading. `Math.max(1, NaN)` is NaN,
+ * so `Array.from({length: NaN})` built an EMPTY worker array: runProbes resolved
+ * immediately, every dossier kept `probes: null`, and the report still said
+ * mode='probes' with each note claiming '--no-probes'. A run that reads as fully
+ * probed but proposed nothing is indistinguishable from "the corpus had nothing" —
+ * so this is a hard failure, at entry, before any probe is called.
+ */
 export async function runProbes(
     dossiers: TriageDossier[],
     probes: ProbeSet,
     opts: { concurrency: number; onProgress?: (done: number, total: number) => void },
 ): Promise<void> {
+    if (!Number.isInteger(opts.concurrency) || opts.concurrency < 1) {
+        throw new Error(`runProbes: concurrency must be an integer >= 1, got ${JSON.stringify(opts.concurrency)}. `
+            + 'A non-positive or NaN value builds zero workers and silently probes NOTHING.');
+    }
     let idx = 0;
     let done = 0;
-    const workers = Array.from({ length: Math.max(1, opts.concurrency) }, async () => {
+    const workers = Array.from({ length: opts.concurrency }, async () => {
         while (idx < dossiers.length) {
             const d = dossiers[idx++];
             const query = probeQueryFor({
@@ -741,7 +902,7 @@ export function decideVerdict(args: {
     if (!cls) {
         return {
             confirmed: false, cls: 'frontier', action: 'triage', targetId: null, extraActions,
-            reclassifiedByProbe: false,
+            reclassifiedByProbe: false, withheldTargetId: null,
             note: `No registry class matched (dropReason ${dossier.dropReason ?? 'none'}). This is the true `
                 + 'frontier: characterize it and add an F2 class before acting.',
         };
@@ -750,7 +911,7 @@ export function decideVerdict(args: {
     if (cls.fixKind === 'healthy') {
         return {
             confirmed: false, cls: 'healthy', action: 'none', targetId: null, extraActions,
-            reclassifiedByProbe: false,
+            reclassifiedByProbe: false, withheldTargetId: null,
             note: `${cls.title} — by design, not a defect. incumbent=${String(dossier.hadIncumbent)}. `
                 + 'Counted so it stops looking like work.',
         };
@@ -759,7 +920,7 @@ export function decideVerdict(args: {
     if (cls.residual) {
         return {
             confirmed: false, cls: coarseClassOf(cls.id), action: 'triage', targetId: null, extraActions,
-            reclassifiedByProbe: false,
+            reclassifiedByProbe: false, withheldTargetId: null,
             note: `${cls.title} (residual bucket, dropReason ${dossier.dropReason ?? 'none'}). No diagnosis yet `
                 + '— promote a class from the recurring shapes before sending a fix-agent.',
         };
@@ -769,7 +930,7 @@ export function decideVerdict(args: {
     if (evidence.probed && evidence.corpusGap && cls.fixKind !== 'ingest') {
         return {
             confirmed: true, cls: 'ingest-gap', action: 'ingest', targetId: null, extraActions,
-            reclassifiedByProbe: true,
+            reclassifiedByProbe: true, withheldTargetId: null,
             note: `Row facts said ${cls.id}, but retrieval returned ZERO candidates in every lane for `
                 + `"${evidence.probeQuery}" — this is a dataset gap, not a ranking gap. Route to the ingest `
                 + 'queue, NEVER a fix-agent.',
@@ -779,7 +940,7 @@ export function decideVerdict(args: {
     if (evidence.probed && evidence.filterWipeout) {
         return {
             confirmed: true, cls: 'ranking-gap', action: 'pipeline-fix', targetId: null, extraActions,
-            reclassifiedByProbe: cls.id !== 'all-filtered-over-rejection',
+            reclassifiedByProbe: cls.id !== 'all-filtered-over-rejection', withheldTargetId: null,
             note: `${evidence.candidateCount} candidate(s) gathered and NONE survived the filters `
                 + `(${evidence.removedByTokenFilter ?? '?'} removed by the token filter, `
                 + `${evidence.droppedByCoreToken ?? '?'} by core-token mismatch; mustHave=`
@@ -790,14 +951,21 @@ export function decideVerdict(args: {
 
     const baseAction = defaultActionFor(cls);
     const better = evidence.betterCandidate;
-    if (better?.id) {
+    // A candidate id apply-repoints.ts cannot resolve must never be reported as a
+    // target: it would not error there, it would silently resolve to an unrelated
+    // FdcFood and pin the key onto it. Withhold it, name it in the note, count it.
+    const withheldTargetId = better?.id && !isApplyRepointsTarget(better.id) ? better.id : null;
+    const describeCandidate = (c: BetterCandidate) =>
+        `${c.id} ("${c.name}"${c.brand ? ` [${c.brand}]` : ''}, ${c.source}, score ${c.score ?? '?'}`
+        + `${c.survivedFilters ? ', survived the filters' : ', gather-only'})`;
+
+    if (better?.id && withheldTargetId == null) {
         if (baseAction === 'mark-corrupt') extraActions.push('mark-corrupt');
         if (cls.fixKind === 'pipeline') extraActions.push('pipeline-fix');
         return {
             confirmed: true, cls: coarseClassOf(cls.id), action: 'repoint', targetId: better.id, extraActions,
-            reclassifiedByProbe: false,
-            note: `${cls.title}. Probe found ${better.id} ("${better.name}"${better.brand ? ` [${better.brand}]` : ''}, `
-                + `${better.source}, score ${better.score ?? '?'}${better.survivedFilters ? ', survived the filters' : ', gather-only'}) `
+            reclassifiedByProbe: false, withheldTargetId: null,
+            note: `${cls.title}. Probe found ${describeCandidate(better)} `
                 + `covering the dropped token(s) [${better.coversUncovered.join(', ')}] that the served pick `
                 + `("${dossier.served.foodName ?? 'none'}") misses. Repoint fixes today's cache row; the durable `
                 + `fix for ${cls.fixKind === 'pipeline' ? 'this pipeline class is the ranking/filter change' : 'the class is the data op'}.`,
@@ -808,6 +976,14 @@ export function decideVerdict(args: {
         ? `Probe: ${evidence.candidateCount ?? '?'} candidate(s), ${evidence.survivors ?? '?'} survivor(s)`
             + (evidence.notes.length ? `; ${evidence.notes.join(' ')}` : '.')
         : 'No probes were run (--no-probes), so this verdict rests on row facts alone.';
+
+    if (better && withheldTargetId != null) {
+        evidenceNote += ` REPOINT TARGET WITHHELD: the probe DID find ${describeCandidate(better)} covering the `
+            + `dropped token(s) [${better.coversUncovered.join(', ')}], but apply-repoints.ts can only consume `
+            + 'off_<barcode> / fdc_<id> targets — it parses anything else as an fdcId via target.slice(4), so '
+            + `reporting "${withheldTargetId}" would silently repoint this key onto an unrelated FdcFood under `
+            + 'validatedBy=human-triage. Act on this by hand, or add the branch to apply-repoints.ts first.';
+    }
 
     // An ingest class claims "no record exists". When the probe found survivors that
     // claim is only true of the specific FORM asked for (n-cook-06: the corpus has
@@ -826,6 +1002,7 @@ export function decideVerdict(args: {
         targetId: null,
         extraActions,
         reclassifiedByProbe: false,
+        withheldTargetId,
         note: `${cls.title}. ${describeRowEvidence(dossier)} ${evidenceNote}`,
     };
 }
@@ -889,6 +1066,10 @@ export interface TriageReport {
     droppedByCap: number;
     reclassifiedByProbe: number;
     probeErrorCount: number;
+    /** Repoint proposals suppressed because apply-repoints.ts cannot consume the target. */
+    withheldTargetCount: number;
+    /** What this tool structurally cannot report — so an empty bucket is not read as a clean one. */
+    scope: ScopeDisclosure;
     log: string[];
     caveats: string[];
 }
@@ -916,11 +1097,13 @@ export function buildReport(
     let suspectCount = 0;
     let reclassified = 0;
     let probeErrorCount = 0;
+    const withheldTargets: string[] = [];
 
     for (const d of selection.selected) {
         const cls = d.classId === UNCLASSIFIED ? null : CLASS_BY_ID.get(d.classId) ?? null;
         d.verdict = decideVerdict({ dossier: d, cls, evidence: d.evidence });
         if (d.verdict.reclassifiedByProbe) reclassified++;
+        if (d.verdict.withheldTargetId) withheldTargets.push(d.verdict.withheldTargetId);
         probeErrorCount += d.evidence.probeErrors.length;
 
         byFailureClass[d.classId] = (byFailureClass[d.classId] ?? 0) + 1;
@@ -950,12 +1133,22 @@ export function buildReport(
     // Most-frequent first inside `confirmed`, so a reader starts at the loudest key.
     confirmed.sort((a, b) => b.dossier.occurrences - a.dossier.occurrences || a.seed.localeCompare(b.seed));
 
+    const scope = scopeDisclosure();
     const log = [...selection.log, ...(opts.extraLog ?? [])];
     log.push(`verdicts: ${confirmed.length} confirmed / ${dismissed.length} dismissed `
         + `(${suspectCount} suspect = non-healthy class). `
         + `${reclassified} reclassified by probe evidence.`);
     if (probeErrorCount > 0) log.push(`probe errors: ${probeErrorCount} lane failure(s) recorded — `
         + 'those dossiers have partial evidence, do NOT read them as "nothing found".');
+    if (withheldTargets.length > 0) {
+        const prefixes = Array.from(new Set(withheldTargets.map(t => `${t.split('_')[0]}_`))).sort();
+        log.push(`${withheldTargets.length} repoint suggestion(s) WITHHELD: ${prefixes.join('/')} targets are not `
+            + 'expressible to apply-repoints.ts (it resolves anything non-off_ as an fdcId via slice(4), so the id '
+            + 'would silently repoint the key onto an unrelated FdcFood). The record is named in the verdict note '
+            + `for each — ${withheldTargets.join(', ')} — so this is a finding to act on by hand, NOT "no `
+            + 'candidate found".');
+    }
+    for (const note of scope.notes) log.push(note);
 
     return {
         screened: `${selection.rowCount} rows (${selection.dropRowCount} drop-stage, `
@@ -983,6 +1176,8 @@ export function buildReport(
         droppedByCap: selection.droppedByCap,
         reclassifiedByProbe: reclassified,
         probeErrorCount,
+        withheldTargetCount: withheldTargets.length,
+        scope,
         log,
         caveats: FUNNEL_CAVEATS.map(c => `${c.id}: ${c.note}`),
     };
@@ -1030,12 +1225,35 @@ export function renderMarkdown(report: TriageReport): string {
     L.push(`- drop rows only: ${fmtCounts(report.dropStageCounts) || '(none)'}`);
     L.push('');
 
+    L.push('## OUT OF SCOPE for this tool — absent by construction, NOT "looked and found none"');
+    L.push('');
+    for (const note of report.scope.notes) L.push(`- ${note}`);
+    L.push('');
+    L.push(`- drop stages triaged: ${report.scope.dropStages.map(s => `\`${s}\``).join(', ')}`);
+    L.push(`- stages excluded before classification: ${report.scope.excludedStages.map(s => `\`${s}\``).join(', ') || '(none)'}`);
+    L.push(`- classes that cannot fire here: ${report.scope.outOfScopeClassIds.map(c => `\`${c}\``).join(', ') || '(none)'}`);
+    L.push(`- classes only partly visible: ${report.scope.partialClassIds.map(c => `\`${c}\``).join(', ') || '(none)'}`);
+    L.push(`- coarse buckets unpopulatable: ${report.scope.outOfScopeCoarseClasses.join(', ') || '(none)'}`);
+    L.push(`- coarse buckets that are LOWER BOUNDS: ${report.scope.partialCoarseClasses.join(', ') || '(none)'}`);
+    L.push(`- actions never emitted: ${report.scope.unreachableActions.join(', ') || '(none)'}`);
+    L.push('');
+
     L.push('## Confirmed, by coarse class (the 2026-07-21 vocabulary)');
+    L.push('');
+    L.push(`> Read with the scope section above: ${report.scope.outOfScopeCoarseClasses.length > 0
+        ? `${report.scope.outOfScopeCoarseClasses.join(', ')} cannot appear at all, and `
+        : ''}${report.scope.partialCoarseClasses.join(', ') || 'no bucket'} draw on partly-excluded classes.`);
     L.push('');
     L.push('| coarse class | confirmed |');
     L.push('| ------------ | --------: |');
     for (const [k, v] of Object.entries(report.byClass).sort((a, b) => b[1] - a[1])) L.push(`| ${k} | ${v} |`);
     L.push('');
+    if (report.withheldTargetCount > 0) {
+        L.push(`**${report.withheldTargetCount} repoint target(s) withheld** — the probe found a covering record `
+            + 'whose id apply-repoints.ts cannot resolve, so `targetId` is null and the record is named in the '
+            + 'note. Act on those by hand.');
+        L.push('');
+    }
 
     L.push('## All triaged dossiers, by F2 class');
     L.push('');
@@ -1110,6 +1328,12 @@ export function renderConsole(report: TriageReport): void {
         console.log('\n!! TRUNCATED — not covered by this run:');
         for (const t of report.truncation) console.log(`  ${t.classId}: triaged ${t.kept}/${t.seen} (dropped ${t.dropped})`);
     }
+    if (report.withheldTargetCount > 0) {
+        console.log(`\n!! ${report.withheldTargetCount} repoint target(s) WITHHELD (not expressible to `
+            + 'apply-repoints.ts) — see the notes, act by hand.');
+    }
+    console.log('\n!! OUT OF SCOPE — absent by construction, not "looked and found none":');
+    for (const note of report.scope.notes) console.log(`  ${note}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -1120,6 +1344,57 @@ export function resolveOutBase(out: string | undefined, at: Date): string {
     if (out) return out.replace(/\.(json|md)$/i, '');
     const ts = at.toISOString().replace(/[:.]/g, '-');
     return path.join(__dirname, 'results', `triage-verdicts-${ts}`);
+}
+
+/** Thrown for a bad flag value; main() prints the message and exits non-zero. */
+export class FlagError extends Error { }
+
+/**
+ * Parse an integer flag, or REFUSE the run.
+ *
+ * Every numeric flag here used to be `Number(val(flag) ?? default)`, unvalidated,
+ * and each failed silently in its own way: `--concurrency 0` / `--concurrency abc`
+ * built zero probe workers (a report that reads as fully probed while nothing was
+ * probed), and `--limit abc` made `slice(0, NaN)` = [] — a fully-formed 0-row report
+ * saying "nothing dropped — every distinct key is in this report". A typo must not
+ * be able to manufacture a clean-looking empty run.
+ */
+export function parseIntFlag(flag: string, raw: string | undefined, fallback: number, min: number): number {
+    if (raw === undefined) return fallback;
+    const trimmed = raw.trim();
+    const n = Number(trimmed);
+    if (trimmed.length === 0 || !Number.isFinite(n) || !Number.isInteger(n)) {
+        throw new FlagError(`${flag} must be an integer, got "${raw}". `
+            + (trimmed.startsWith('--')
+                ? `That looks like the next flag — ${flag} takes a value.`
+                : 'A non-numeric value would silently degrade this run, so it is refused.'));
+    }
+    if (n < min) {
+        throw new FlagError(`${flag} must be >= ${min}, got ${n}.`
+            + (flag === '--concurrency' ? ' A concurrency below 1 builds zero workers and probes NOTHING.' : ''));
+    }
+    return n;
+}
+
+/**
+ * Apply `--limit` to the `--in` rows and SAY SO. The old `rows.slice(0, limit)`
+ * pushed nothing into log[], so every downstream count (rowCount, screened,
+ * stageCounts, dropStageCounts) described the slice while reading as the file —
+ * exactly the "covered everything" failure the header's TRUNCATION IS ALWAYS
+ * REPORTED section exists to prevent. Both sizes are reported, always.
+ */
+export function applyInputLimit(rows: FunnelRow[], limit: number | undefined): { rows: FunnelRow[]; log: string[] } {
+    if (limit === undefined) return { rows, log: [] };
+    if (rows.length <= limit) {
+        return { rows, log: [`--limit ${limit}: the input file had ${rows.length} row(s), all kept — no truncation.`] };
+    }
+    return {
+        rows: rows.slice(0, limit),
+        log: [`--limit ${limit}: TRUNCATED the input — the file had ${rows.length} row(s) and this run covers only `
+            + `the FIRST ${limit}. ${rows.length - limit} row(s) were discarded before any stage filtering, so `
+            + 'rowCount / screened / stageCounts below describe the KEPT SLICE, not the file. Raise or drop '
+            + '--limit to cover the rest.'],
+    };
 }
 
 async function main(): Promise<void> {
@@ -1133,10 +1408,14 @@ async function main(): Promise<void> {
     const inFile = val('--in');
     const fromDb = has('--from-db');
     if (!inFile && !fromDb) {
-        console.error('Usage: triage-drops.ts (--in <warm.json|.jsonl> | --from-db [--since <date>] [--limit N])');
+        console.error('Usage: triage-drops.ts (--in <warm.json|.jsonl> | --from-db) [--since <date>] [--limit N]');
         console.error('  [--concurrency 4] [--per-class-cap 25] [--out <path>] [--no-probes] [--no-incumbent]');
         console.error('  [--fatsecret] [--dry]');
         console.error('');
+        console.error('  --limit N     integer >= 1. Caps the DB read with --from-db; with --in it truncates the');
+        console.error('                file to the first N rows, and the truncation is reported in the run log.');
+        console.error('  --concurrency N        integer >= 1 (probe worker pool).');
+        console.error('  --per-class-cap N      integer >= 0; 0 means UNLIMITED.');
         console.error('  --no-probes   classify only, zero retrieval calls (cheap mode)');
         console.error('  --dry         run everything, write nothing');
         console.error('  --fatsecret   include the FatSecret lane: spends FS API quota AND background-upserts');
@@ -1145,8 +1424,12 @@ async function main(): Promise<void> {
         return;
     }
 
-    const concurrency = Number(val('--concurrency') ?? 4);
-    const perClassCap = Number(val('--per-class-cap') ?? 25);
+    // Validated, not coerced: see parseIntFlag. `--per-class-cap 0` is the documented
+    // "unlimited", so its floor is 0; a probe pool of 0 is meaningless, so that floor is 1.
+    const concurrency = parseIntFlag('--concurrency', val('--concurrency'), 4, 1);
+    const perClassCap = parseIntFlag('--per-class-cap', val('--per-class-cap'), 25, 0);
+    const limitRaw = val('--limit');
+    const limit = limitRaw === undefined ? undefined : parseIntFlag('--limit', limitRaw, 0, 1);
     const noProbes = has('--no-probes');
     const dry = has('--dry');
     const wantIncumbent = !has('--no-incumbent');
@@ -1160,18 +1443,26 @@ async function main(): Promise<void> {
     if (fromDb) {
         const sinceRaw = val('--since');
         const since = sinceRaw ? new Date(sinceRaw) : undefined;
-        if (since && Number.isNaN(since.getTime())) throw new Error(`--since is not a date: ${sinceRaw}`);
-        const limit = Number(val('--limit') ?? 20000);
+        if (since && Number.isNaN(since.getTime())) throw new FlagError(`--since is not a date: ${sinceRaw}`);
+        const dbLimit = limit ?? 20000;
         prisma = openPrisma();
-        const inputs = await readFromDb(prisma, { since, limit });
+        const inputs = await readFromDb(prisma, { since, limit: dbLimit });
         rows = inputs.map(makeFunnelRow);
-        inputLabel = `MappingEventLog (SELECT only)${sinceRaw ? ` since ${sinceRaw}` : ''} limit ${limit}`;
+        inputLabel = `MappingEventLog (SELECT only)${sinceRaw ? ` since ${sinceRaw}` : ''} limit ${dbLimit}`;
+        if (inputs.length === dbLimit) {
+            extraLog.push(`--limit ${dbLimit} was REACHED exactly (${inputs.length} rows read): the event log almost `
+                + 'certainly holds older matching rows this run never saw. Raise --limit or narrow --since.');
+        }
     } else {
-        rows = readInputRows(inFile!);
-        const limit = val('--limit');
-        if (limit) rows = rows.slice(0, Number(limit));
+        const fileRows = readInputRows(inFile!);
+        const limited = applyInputLimit(fileRows, limit);
+        rows = limited.rows;
+        extraLog.push(...limited.log);
         const rel = path.relative(process.cwd(), inFile!);
         inputLabel = rel.startsWith('..') ? inFile! : rel;
+        if (rows.length !== fileRows.length) {
+            inputLabel += ` (--limit ${limit}: ${rows.length} of ${fileRows.length} rows)`;
+        }
         // The approximate read. warm JSONL records no servingTier, so F2's
         // flat100gServing quality flag falls back to grams === 100 and counts
         // records whose label genuinely IS 100 g. --from-db has the real tier.
@@ -1243,6 +1534,11 @@ async function main(): Promise<void> {
 
 if (require.main === module) {
     main().catch(err => {
+        // A bad flag is a user error, not a crash: print the message, not a stack.
+        if (err instanceof FlagError) {
+            console.error(`\n${err.message}\nRun with no arguments for usage. Nothing was written.`);
+            process.exit(2);
+        }
         console.error(err);
         process.exit(1);
     });

--- a/scripts/filter-trace-probe.ts
+++ b/scripts/filter-trace-probe.ts
@@ -1,0 +1,165 @@
+/**
+ * filter-trace-probe.ts — gather candidates, then run each candidate through the
+ * SAME filter functions the pipeline uses, and report which filter (if any)
+ * dropped it. Pinpoints the exact rejection cause behind an `all_filtered` or a
+ * "the right record existed and we lost it" drop.
+ *
+ * Recorded lesson (venue-brand blackout, PR #150): `FilterResult.reason` is a
+ * blanket label, not the cause. Two plausible diagnoses were wrong and only
+ * running gather+filter with debug logs settled it — which is what this does.
+ *
+ * ---------------------------------------------------------------------------
+ * COST + SIDE EFFECTS
+ * ---------------------------------------------------------------------------
+ * - NO LLM CALLS. `filterCandidatesByTokens` / `hasCoreTokenMismatch` /
+ *   `deriveMustHaveTokens` are pure deterministic token logic.
+ * - Same caveat as debug-retrieval-probe for the gather step: FatSecret lane
+ *   hits are background-upserted into FatSecretFood/FatSecretServing and FS API
+ *   quota is consumed. Set FATSECRET_RETRIEVAL_ENABLED=false before load for a
+ *   strictly read-only run.
+ *
+ * Usage (unchanged):
+ *   ts-node ... scripts/filter-trace-probe.ts '<query1>' '<query2>' ...
+ */
+import { gatherCandidates, type UnifiedCandidate } from '../src/lib/mapping/gather-candidates';
+import {
+    filterCandidatesByTokens,
+    hasCoreTokenMismatch,
+    deriveMustHaveTokens,
+} from '../src/lib/mapping/filter-candidates';
+
+/** Where a candidate died (or that it survived both filters). */
+export type CandidateFate = 'KEPT' | 'DROPPED@filterCandidatesByTokens' | 'DROPPED@coreTokenMismatch';
+
+export interface TracedCandidate {
+    /** `off_<barcode>` | `fdc_<id>` | `fs_<fsId>`. */
+    id: string | null;
+    source: string | null;
+    name: string | null;
+    brand: string | null;
+    score: number | null;
+    fate: CandidateFate;
+}
+
+export interface FilterTrace {
+    query: string;
+    gathered: number;
+    mustHaveTokens: string[];
+    keptAfterTokenFilter: number;
+    removedByTokenFilter: number;
+    /** FilterResult.reason — a blanket label, NOT the per-candidate cause. */
+    tokenFilterReason: string | null;
+    droppedByCoreToken: number;
+    survivors: number;
+    /** Every gathered candidate with its fate (capped by `topN`, default all). */
+    candidates: TracedCandidate[];
+    error?: string;
+}
+
+export interface FilterTraceOptions {
+    maxPerSource?: number;
+    /** Cap on candidates reported (default: all gathered). */
+    topN?: number;
+}
+
+function flatten(c: UnifiedCandidate, fate: CandidateFate): TracedCandidate {
+    return {
+        id: c.id ?? null,
+        source: c.source ?? null,
+        name: c.name ?? null,
+        brand: c.brandName ?? null,
+        score: typeof c.score === 'number' ? +c.score.toFixed(3) : null,
+        fate,
+    };
+}
+
+/**
+ * Trace one query through gather -> filterCandidatesByTokens -> hasCoreTokenMismatch.
+ *
+ * Fates are keyed on candidate `id`, not on `name|brand` as the original ad-hoc
+ * probe did: two OFF SKUs routinely share a name+brand pair (near-dups across
+ * barcodes), which made the name-keyed version report the survivor's fate for
+ * the dropped twin.
+ */
+export async function traceFilters(query: string, opts: FilterTraceOptions = {}): Promise<FilterTrace> {
+    const maxPerSource = opts.maxPerSource ?? 8;
+    const trace: FilterTrace = {
+        query,
+        gathered: 0,
+        mustHaveTokens: [],
+        keptAfterTokenFilter: 0,
+        removedByTokenFilter: 0,
+        tokenFilterReason: null,
+        droppedByCoreToken: 0,
+        survivors: 0,
+        candidates: [],
+    };
+
+    let cands: UnifiedCandidate[];
+    try {
+        cands = await gatherCandidates(query, null, query, { isBrandedQuery: true, maxPerSource });
+    } catch (e) {
+        trace.error = (e as Error)?.message ?? String(e);
+        return trace;
+    }
+
+    trace.gathered = cands.length;
+    try {
+        trace.mustHaveTokens = deriveMustHaveTokens(query);
+        const fr = filterCandidatesByTokens(cands, query, { debug: false, rawLine: query });
+        trace.keptAfterTokenFilter = fr.filtered.length;
+        trace.removedByTokenFilter = fr.removedCount;
+        trace.tokenFilterReason = fr.reason ?? null;
+
+        const survivedTokenFilter = new Set(fr.filtered.map(c => c.id));
+        for (const c of fr.filtered) {
+            if (hasCoreTokenMismatch(query, c.name, c.brandName)) trace.droppedByCoreToken++;
+        }
+        trace.survivors = trace.keptAfterTokenFilter - trace.droppedByCoreToken;
+
+        const reported = opts.topN != null ? cands.slice(0, opts.topN) : cands;
+        for (const c of reported) {
+            let fate: CandidateFate;
+            if (!survivedTokenFilter.has(c.id)) fate = 'DROPPED@filterCandidatesByTokens';
+            else if (hasCoreTokenMismatch(query, c.name, c.brandName)) fate = 'DROPPED@coreTokenMismatch';
+            else fate = 'KEPT';
+            trace.candidates.push(flatten(c, fate));
+        }
+    } catch (e) {
+        trace.error = (e as Error)?.message ?? String(e);
+    }
+    return trace;
+}
+
+/** Candidates that survived BOTH filters. */
+export function survivingCandidates(trace: FilterTrace): TracedCandidate[] {
+    return trace.candidates.filter(c => c.fate === 'KEPT');
+}
+
+/** The original CLI rendering, preserved. */
+export function printFilterTrace(trace: FilterTrace): void {
+    console.log('\n================ ' + trace.query + ' ================');
+    if (trace.error) console.log('ERROR:', trace.error);
+    console.log('gathered:', trace.gathered, ' mustHave=', JSON.stringify(trace.mustHaveTokens));
+    console.log(`filterCandidatesByTokens: kept ${trace.keptAfterTokenFilter}/${trace.gathered} `
+        + `(removed ${trace.removedByTokenFilter})`);
+    console.log(`hasCoreTokenMismatch: dropped ${trace.droppedByCoreToken}, final survivors ${trace.survivors}`);
+    for (const c of trace.candidates.slice(0, 8)) {
+        console.log(`   [${c.source}] ${JSON.stringify(c.name)} brand=${c.brand ?? '-'} `
+            + `score=${c.score ?? '?'} => ${c.fate}`);
+    }
+}
+
+async function main(): Promise<void> {
+    for (const q of process.argv.slice(2).filter(a => !a.startsWith('--'))) {
+        printFilterTrace(await traceFilters(q));
+    }
+    process.exit(0);
+}
+
+if (require.main === module) {
+    main().catch(e => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/scripts/full-pipeline-probe.ts
+++ b/scripts/full-pipeline-probe.ts
@@ -1,0 +1,120 @@
+/**
+ * full-pipeline-probe.ts — run mapIngredientWithFallback exactly like warm-names
+ * and dump the ENTIRE telemetry object + result, so you can see WHY it returned
+ * null (or a bad pick) even when retrieval had good candidates.
+ *
+ * ===========================================================================
+ * !! THIS PROBE MUTATES THE DATABASE AND COSTS LLM TOKENS. NOT READ-ONLY. !!
+ * ===========================================================================
+ * `mapIngredientWithFallback(..., { allowLiveFallback: true })`:
+ *   - calls `saveValidatedMapping` (map-ingredient-with-fallback.ts:2685, :2723),
+ *     which UPSERTS FoodMapping rows — i.e. it warms/overwrites the shared cache;
+ *   - upserts FdcServing rows (:1830) and can create AiGeneratedFood rows;
+ *   - writes MappingEventLog rows (the funnel), so it pollutes the very telemetry
+ *     a later `--from-db` read screens;
+ *   - makes PAID LLM calls: AI normalize/segment, rerank, AI validation and
+ *     serving estimation (OpenRouter gpt-4o-mini per the routing memory).
+ *
+ * Consequence for F3: `triage-drops.ts` NEVER runs this by default. It is exposed
+ * so that a human, or a deliberate `--allow-write-probes` run against a scratch
+ * DATABASE_URL, can use it — and so the write surface is documented in git rather
+ * than in an uncommitted scratch file.
+ *
+ * Usage (unchanged):
+ *   ts-node ... scripts/full-pipeline-probe.ts '<query>' ...
+ *   ts-node ... scripts/full-pipeline-probe.ts --file <queries.txt>
+ *   PROBE_DEBUG=1 ... (verbose mapper logging)
+ */
+import * as nodeFs from 'fs';
+import { mapIngredientWithFallback } from '../src/lib/mapping/map-ingredient-with-fallback';
+
+export interface FullPipelineProbe {
+    query: string;
+    error?: string;
+    status?: string;
+    source?: string;
+    foodName?: string;
+    brandName?: string | null;
+    confidence?: number;
+    grams?: number;
+    aiValidation?: unknown;
+    reason?: string;
+    per100g?: unknown;
+    /** MappingTelemetry as the mapper filled it — normalizedForm, gate decisions, funnelStage. */
+    telemetry: Record<string, unknown>;
+}
+
+export interface FullPipelineProbeOptions {
+    debug?: boolean;
+    /**
+     * Explicit acknowledgement that this call WRITES to the database and spends
+     * LLM tokens. Omit it and the call throws instead of silently mutating.
+     */
+    iUnderstandThisWrites: boolean;
+}
+
+export async function probeFullPipeline(
+    query: string,
+    opts: FullPipelineProbeOptions,
+): Promise<FullPipelineProbe> {
+    if (!opts?.iUnderstandThisWrites) {
+        throw new Error(
+            'probeFullPipeline WRITES FoodMapping/MappingEventLog and spends LLM tokens; '
+            + 'pass { iUnderstandThisWrites: true } to proceed.',
+        );
+    }
+    const telemetry: Record<string, unknown> = {};
+    const summary: FullPipelineProbe = { query, telemetry };
+    let result: unknown;
+    try {
+        result = await mapIngredientWithFallback(query, {
+            allowLiveFallback: true,
+            skipOnLock: true,
+            debug: opts.debug ?? process.env.PROBE_DEBUG === '1',
+            telemetry: telemetry as never,
+        } as never);
+    } catch (e) {
+        summary.error = (e as Error)?.message ?? String(e);
+        return summary;
+    }
+
+    if (result === null) {
+        summary.status = 'no_match(null)';
+    } else if (result && typeof result === 'object') {
+        const r = result as Record<string, unknown> & { aiValidation?: { reason?: string } };
+        summary.status = (r.status as string) ?? 'mapped';
+        summary.source = r.source as string;
+        summary.foodName = r.foodName as string;
+        summary.brandName = r.brandName as string | null;
+        summary.confidence = r.confidence as number;
+        summary.grams = r.grams as number;
+        summary.aiValidation = r.aiValidation;
+        summary.reason = (r.reason as string) ?? r.aiValidation?.reason;
+        summary.per100g = r.nutritionPer100g ?? r.per100g
+            ?? (r.nutrition as { per100g?: unknown } | undefined)?.per100g ?? null;
+    }
+    return summary;
+}
+
+function readQueriesFromArgv(argv: string[]): string[] {
+    const fileIdx = argv.indexOf('--file');
+    if (fileIdx >= 0) {
+        return nodeFs.readFileSync(argv[fileIdx + 1], 'utf8').split('\n').map(s => s.trim()).filter(Boolean);
+    }
+    return argv.filter(a => !a.startsWith('--'));
+}
+
+async function main(): Promise<void> {
+    for (const query of readQueriesFromArgv(process.argv.slice(2))) {
+        const summary = await probeFullPipeline(query, { iUnderstandThisWrites: true });
+        console.log('PROBE ' + JSON.stringify(summary));
+    }
+    process.exit(0);
+}
+
+if (require.main === module) {
+    main().catch(e => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/scripts/golden-diff-eval.ts
+++ b/scripts/golden-diff-eval.ts
@@ -1,0 +1,123 @@
+/**
+ * golden-diff-eval.ts — run every golden nlp case through mapIngredientWithFallback
+ * directly (current source, no HTTP) and emit a compact result line per case.
+ *
+ * Run once with a patch applied and once without, then diff the two outputs: any
+ * case whose (foodName|grams|source) changed is the blast radius of the change.
+ * This is the cheap pre-flight for a filter/rerank edit — `run-eval.ts` is the
+ * authoritative gate, this just shows what MOVED.
+ *
+ * ===========================================================================
+ * !! WRITES + COSTS LLM TOKENS. Same surface as full-pipeline-probe:          !!
+ * !! allowLiveFallback:true -> saveValidatedMapping upserts FoodMapping and    !!
+ * !! MappingEventLog rows, and the AI normalize/rerank/validate calls are paid.!!
+ * ===========================================================================
+ * Run it against a scratch DATABASE_URL, or accept that it warms the shared cache.
+ * `triage-drops.ts` never calls it.
+ *
+ * Usage (unchanged):
+ *   ts-node ... scripts/golden-diff-eval.ts            # all nlp cases
+ *   ts-node ... scripts/golden-diff-eval.ts --limit 20 # first N
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { mapIngredientWithFallback } from '../src/lib/mapping/map-ingredient-with-fallback';
+
+export interface GoldenDiffRecord {
+    id: string;
+    cat?: string;
+    query: string;
+    status: 'mapped' | 'null' | 'pending' | 'error';
+    foodName?: string;
+    source?: string;
+    grams?: number;
+    conf?: number;
+    error?: string;
+}
+
+interface GoldenCase {
+    id: string;
+    category?: string;
+    item?: { rawText?: string; name?: string };
+    text?: string;
+}
+
+export function readGoldenNlpCases(goldenPath?: string): GoldenCase[] {
+    const p = goldenPath ?? path.join(__dirname, 'eval', 'golden-set.json');
+    const golden = JSON.parse(fs.readFileSync(p, 'utf8')) as { nlp: GoldenCase[] };
+    return golden.nlp;
+}
+
+export function goldenCaseQuery(c: GoldenCase): string {
+    return c.item?.rawText ?? c.item?.name ?? c.text ?? '';
+}
+
+export interface GoldenDiffOptions {
+    goldenPath?: string;
+    limit?: number;
+    /** Explicit acknowledgement of the write + token cost (see the header). */
+    iUnderstandThisWrites: boolean;
+    onRecord?: (rec: GoldenDiffRecord) => void;
+}
+
+export async function runGoldenDiffEval(opts: GoldenDiffOptions): Promise<GoldenDiffRecord[]> {
+    if (!opts?.iUnderstandThisWrites) {
+        throw new Error(
+            'runGoldenDiffEval WRITES FoodMapping/MappingEventLog and spends LLM tokens; '
+            + 'pass { iUnderstandThisWrites: true } to proceed.',
+        );
+    }
+    let cases = readGoldenNlpCases(opts.goldenPath);
+    if (opts.limit) cases = cases.slice(0, opts.limit);
+
+    const out: GoldenDiffRecord[] = [];
+    for (const c of cases) {
+        const query = goldenCaseQuery(c);
+        const rec: GoldenDiffRecord = { id: c.id, cat: c.category, query, status: 'null' };
+        try {
+            const telemetry: Record<string, unknown> = {};
+            const r = await mapIngredientWithFallback(query, {
+                allowLiveFallback: true,
+                skipOnLock: true,
+                telemetry: telemetry as never,
+            });
+            if (r === null) {
+                rec.status = 'null';
+            } else if (r && typeof r === 'object' && (r as { status?: string }).status === 'pending') {
+                rec.status = 'pending';
+            } else if (r) {
+                const m = r as { foodName?: string; source?: string; grams?: number; confidence?: number };
+                rec.status = 'mapped';
+                rec.foodName = m.foodName;
+                rec.source = m.source;
+                rec.grams = m.grams;
+                rec.conf = typeof m.confidence === 'number' ? +m.confidence.toFixed(3) : m.confidence;
+            }
+        } catch (e) {
+            rec.status = 'error';
+            rec.error = (e as Error)?.message ?? String(e);
+        }
+        out.push(rec);
+        opts.onRecord?.(rec);
+    }
+    return out;
+}
+
+async function main(): Promise<void> {
+    const args = process.argv.slice(2);
+    const i = args.indexOf('--limit');
+    const limit = i >= 0 && args[i + 1] ? Number(args[i + 1]) : undefined;
+    await runGoldenDiffEval({
+        limit,
+        iUnderstandThisWrites: true,
+        onRecord: rec => console.log('GD ' + JSON.stringify(rec)),
+    });
+    process.exit(0);
+}
+
+if (require.main === module) {
+    main().catch(e => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/scripts/warm-names.ts
+++ b/scripts/warm-names.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env ts-node
+/**
+ * warm-names.ts — Warm the FoodMapping cache from a flat list of query strings.
+ *
+ * Unlike pilot-batch-import (recipe-ingredient driven) this takes an arbitrary
+ * seed list — e.g. the output of the fs-strong seed-gen grow workflow — and runs
+ * each query through the SAME gated save path (mapIngredientWithFallback →
+ * saveValidatedMapping: deterministic gates + gpt-4o-mini AI-validation). No new
+ * trust surface; it just feeds names in.
+ *
+ * ===========================================================================
+ * !! WRITER. NOT A PROBE. Every query mutates the shared cache and costs LLM  !!
+ * ===========================================================================
+ * It exists in F3's file set because it is the tool that PRODUCES the warm JSONL
+ * that `triage-drops.ts --in` reads. The driver never calls it; a human runs it,
+ * then points the driver at its `--out` file.
+ *
+ * Usage (unchanged):
+ *   ts-node scripts/warm-names.ts --file data/seeds/fs-strong.json \
+ *       [--out logs/warm-fs-strong.jsonl] [--concurrency 4] [--limit N]
+ *
+ * Input file: JSON array of strings, or { "queries": [...] }.
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mapIngredientWithFallback } from '../src/lib/mapping/map-ingredient-with-fallback';
+import { refreshNormalizationRules } from '../src/lib/mapping/normalization-rules';
+
+export type WarmResult = {
+    query: string;
+    status: 'mapped' | 'pending' | 'no_match' | 'rejected' | 'error' | 'skipped';
+    source?: string;
+    foodName?: string;
+    brandName?: string | null;
+    confidence?: number;
+    normalizedForm?: string;
+    approved?: boolean;
+    reason?: string;
+    error?: string;
+    /** Funnel stage the mapper recorded, when telemetry carried one (F1, PR #139). */
+    funnelStage?: string;
+    dropReason?: string;
+};
+
+export type WarmStats = Record<'mapped' | 'pending' | 'no_match' | 'rejected' | 'error' | 'skipped', number>;
+
+// Backstop against generic-key-takeover: seed-gen is instructed to emit specific
+// branded queries, but reject bare category words if any slip through so they
+// can't clobber a generic cache key. (See flywheel memory: 'met rx big 100' →
+// key 'protein bar' takeover class.)
+const BARE_CATEGORY_BLOCKLIST = new Set([
+    'protein bar', 'protein bars', 'protein shake', 'protein powder', 'protein drink',
+    'energy drink', 'energy bar', 'granola bar', 'candy bar', 'cereal', 'chips',
+    'crackers', 'cookies', 'soda', 'yogurt', 'ice cream', 'pizza', 'burger',
+    'sandwich', 'salad', 'smoothie', 'coffee', 'tea', 'water', 'juice', 'snack',
+    'supplement', 'pre workout', 'preworkout', 'creatine', 'bcaa',
+]);
+
+export function isTooGeneric(q: string): boolean {
+    const norm = q.toLowerCase().trim().replace(/\s+/g, ' ');
+    if (BARE_CATEGORY_BLOCKLIST.has(norm)) return true;
+    // single-token generic (no brand/specificity) — one word only
+    if (!norm.includes(' ') && norm.length <= 12) return true;
+    return false;
+}
+
+/** Load + de-dupe a seed list from a JSON array or { queries: [...] } file. */
+export function readSeedFile(file: string, limit?: number): string[] {
+    const raw = JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+    let queries: string[] = Array.isArray(raw) ? raw : raw.queries;
+    queries = queries.map(q => String(q).trim()).filter(Boolean);
+    const seen = new Set<string>();
+    queries = queries.filter(q => {
+        const k = q.toLowerCase();
+        if (seen.has(k)) return false;
+        seen.add(k);
+        return true;
+    });
+    return limit ? queries.slice(0, limit) : queries;
+}
+
+export interface WarmNamesOptions {
+    /** Seed list. Either `queries` directly or `file` to read one. */
+    queries?: string[];
+    file?: string;
+    /** JSONL sink, appended. This is the file `triage-drops.ts --in` consumes. */
+    out?: string;
+    concurrency?: number;
+    limit?: number;
+    /** Progress callback; the CLI prints a line every 25 completions. */
+    onProgress?: (done: number, total: number, stats: WarmStats) => void;
+}
+
+/**
+ * Warm every query through the gated save path. WRITES. Returns the per-query
+ * results alongside the stats histogram.
+ */
+export async function warmNames(opts: WarmNamesOptions): Promise<{ results: WarmResult[]; stats: WarmStats }> {
+    let queries = opts.queries ? [...opts.queries] : opts.file ? readSeedFile(opts.file) : [];
+    if (!opts.file && opts.queries) {
+        const seen = new Set<string>();
+        queries = queries.map(q => String(q).trim()).filter(Boolean).filter(q => {
+            const k = q.toLowerCase();
+            if (seen.has(k)) return false;
+            seen.add(k);
+            return true;
+        });
+    }
+    if (opts.limit) queries = queries.slice(0, opts.limit);
+
+    await refreshNormalizationRules();
+
+    const outStream = opts.out ? fs.createWriteStream(path.resolve(opts.out), { flags: 'a' }) : null;
+    const results: WarmResult[] = [];
+    const record = (r: WarmResult) => {
+        results.push(r);
+        outStream?.write(JSON.stringify(r) + '\n');
+    };
+
+    const stats: WarmStats = { mapped: 0, pending: 0, no_match: 0, rejected: 0, error: 0, skipped: 0 };
+    let done = 0;
+
+    async function warmOne(query: string): Promise<void> {
+        if (isTooGeneric(query)) {
+            stats.skipped++;
+            record({ query, status: 'skipped', reason: 'too_generic' });
+            return;
+        }
+        const telemetry: Record<string, unknown> = {};
+        try {
+            const result = await mapIngredientWithFallback(query, {
+                allowLiveFallback: true,
+                skipOnLock: true,
+                telemetry: telemetry as never,
+            });
+            const funnel = {
+                funnelStage: telemetry.funnelStage as string | undefined,
+                dropReason: telemetry.dropReason as string | undefined,
+            };
+            if (result === null) {
+                stats.no_match++;
+                record({ query, status: 'no_match', normalizedForm: telemetry.normalizedForm as string, ...funnel });
+                return;
+            }
+            if ('status' in result && (result as { status?: string }).status === 'pending') {
+                stats.pending++;
+                record({ query, status: 'pending', ...funnel });
+                return;
+            }
+            const r = result as {
+                source: string; foodName: string; brandName?: string | null;
+                confidence: number; aiValidation?: { approved: boolean; reason: string };
+            };
+            const approved = r.aiValidation?.approved ?? true;
+            stats.mapped++;
+            record({
+                query,
+                status: approved ? 'mapped' : 'rejected',
+                source: r.source,
+                foodName: r.foodName,
+                brandName: r.brandName,
+                confidence: r.confidence,
+                normalizedForm: telemetry.normalizedForm as string,
+                approved,
+                reason: r.aiValidation?.reason,
+                ...funnel,
+            });
+        } catch (e) {
+            stats.error++;
+            record({ query, status: 'error', error: (e as Error).message });
+        } finally {
+            done++;
+            opts.onProgress?.(done, queries.length, stats);
+        }
+    }
+
+    // simple fixed-size worker pool
+    let idx = 0;
+    const workers = Array.from({ length: Math.max(1, opts.concurrency ?? 4) }, async () => {
+        while (idx < queries.length) {
+            const my = idx++;
+            await warmOne(queries[my]);
+            await new Promise(res => setTimeout(res, 80)); // gentle rate limit
+        }
+    });
+    await Promise.all(workers);
+
+    await new Promise<void>(res => {
+        if (!outStream) return res();
+        outStream.end(() => res());
+    });
+    return { results, stats };
+}
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const get = (flag: string, dflt?: string) => {
+        const i = args.indexOf(flag);
+        return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+    };
+    return {
+        file: get('--file'),
+        out: get('--out'),
+        concurrency: parseInt(get('--concurrency', '4')!, 10),
+        limit: get('--limit') ? parseInt(get('--limit')!, 10) : undefined,
+    };
+}
+
+async function main(): Promise<void> {
+    const { file, out, concurrency, limit } = parseArgs();
+    if (!file) {
+        console.error('ERROR: --file <path> is required');
+        process.exit(1);
+    }
+    const seeds = readSeedFile(file, limit);
+    console.log(`🌱 warm-names: ${seeds.length} unique queries, concurrency=${concurrency}`);
+    const { stats } = await warmNames({
+        queries: seeds,
+        out,
+        concurrency,
+        onProgress: (done, total, s) => {
+            if (done % 25 === 0 || done === total) {
+                console.log(`  [${done}/${total}] mapped=${s.mapped} skip=${s.skipped} `
+                    + `nomatch=${s.no_match} err=${s.error}`);
+            }
+        },
+    });
+    console.log('\n📈 warm-names done:', JSON.stringify(stats));
+    process.exit(0);
+}
+
+if (require.main === module) {
+    main().catch(e => {
+        console.error('warm-names fatal:', e);
+        process.exit(1);
+    });
+}

--- a/src/lib/mapping/cache-key-core.ts
+++ b/src/lib/mapping/cache-key-core.ts
@@ -1,0 +1,116 @@
+/**
+ * cache-key-core.ts — the LEAF half of the cache-key derivation.
+ *
+ * Split out of cache-key.ts (2026-07-25) with ZERO behaviour change: the
+ * functions below are moved verbatim and re-exported from cache-key.ts, so every
+ * existing importer is unaffected.
+ *
+ * WHY THE SPLIT EXISTS. cache-key.ts needs `hasDecisiveBrandContext` for the
+ * brand-prefix step, and that lives in simple-rerank — whose import graph reaches
+ * `src/lib/mapping/config.ts` (which SNAPSHOTS `FATSECRET_RETRIEVAL_ENABLED` into
+ * a const at module load) and `gather-candidates` (module-scope embedder warmup).
+ * The read-only eval tooling (scripts/eval/failure-classes.ts and its consumers
+ * classify-drops.ts / triage-drops.ts) must derive the SAME key as the pipeline,
+ * but it MUST NOT load config.ts: triage-drops sets
+ * `FATSECRET_RETRIEVAL_ENABLED=false` before it requires the probe modules, and a
+ * config.ts already resident from a top-level import would defeat that — turning a
+ * SELECT-only run into one that spends FatSecret quota and upserts FatSecretFood
+ * rows. So the two steps a funnel row CAN reproduce (identity discriminators and
+ * the adjacent-dup collapse) live here, where the graph is
+ * normalization-rules + parse/qualifiers and nothing else.
+ *
+ * Anything needing the brand-prefix step must import from ./cache-key.
+ */
+
+import { canonicalizeCacheKey } from './normalization-rules';
+import { IDENTITY_QUALIFIERS } from '../parse/qualifiers';
+import type { ParsedIngredient } from '../parse/ingredient-line';
+
+// Unit hints that name a distinct food part (egg white vs yolk vs whole egg).
+// Piece-like hints (leaf, clove, slice, ...) are serving concerns, not identity.
+export const IDENTITY_UNIT_HINTS = new Set(['white', 'yolk']);
+
+/**
+ * Derive the ValidatedMapping cache key for a normalized ingredient name,
+ * appending whitelisted identity discriminators from the parsed line.
+ *
+ * Pure function — no I/O, no side effects.
+ *
+ * Dedupe note (verified required): canonicalizeCacheKey lowercases,
+ * singularizes, and sorts but does NOT dedupe tokens, so "whole milk" with a
+ * re-attached "whole" qualifier would become "milk whole whole" without the
+ * set-dedupe here. Dedupe compares in canonical (singularized) space so
+ * "egg whites" + hint "white" also collapses correctly.
+ */
+export function deriveCacheKeyName(
+  normalizedName: string,
+  parsed: ParsedIngredient | null | undefined
+): string {
+  if (process.env.CACHE_KEY_DISCRIMINATORS === '0') {
+    return canonicalizeCacheKey(normalizedName);
+  }
+
+  if (!parsed) {
+    return canonicalizeCacheKey(normalizedName);
+  }
+
+  const discriminators: string[] = [];
+
+  if (parsed.unitHint && IDENTITY_UNIT_HINTS.has(parsed.unitHint.toLowerCase())) {
+    discriminators.push(parsed.unitHint.toLowerCase());
+  }
+
+  for (const qualifier of parsed.qualifiers ?? []) {
+    const lower = qualifier.toLowerCase();
+    if (IDENTITY_QUALIFIERS.has(lower)) {
+      discriminators.push(lower);
+    }
+  }
+
+  if (discriminators.length === 0) {
+    return canonicalizeCacheKey(normalizedName);
+  }
+
+  // Set-dedupe BEFORE the final canonicalize call, comparing tokens in
+  // canonical form so plural/singular variants ("whites" vs "white") and
+  // already-present qualifiers ("whole milk" + "whole") don't duplicate.
+  const seen = new Set(
+    normalizedName
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(t => t.length > 0)
+      .map(t => canonicalizeCacheKey(t))
+  );
+
+  const appended: string[] = [];
+  for (const discriminator of discriminators) {
+    const canonical = canonicalizeCacheKey(discriminator);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    appended.push(discriminator);
+  }
+
+  if (appended.length === 0) {
+    return canonicalizeCacheKey(normalizedName);
+  }
+
+  return canonicalizeCacheKey(`${normalizedName} ${appended.join(' ')}`);
+}
+
+/**
+ * Collapse adjacent duplicate tokens in a key ("oiko oiko" → "oiko").
+ *
+ * canonicalizeCacheKey sorts tokens, so in canonical space ALL duplicate
+ * tokens are adjacent — collapsing adjacent runs is a full dedupe. Exported
+ * for the malformed-key cleanup script (scripts/fix-malformed-cache-keys.ts),
+ * which uses collapsed !== original as its malformation predicate.
+ */
+export function collapseAdjacentDuplicateTokens(key: string): string {
+  const out: string[] = [];
+  for (const token of key.split(/\s+/)) {
+    if (token.length === 0) continue;
+    if (out.length > 0 && out[out.length - 1] === token) continue;
+    out.push(token);
+  }
+  return out.join(' ');
+}

--- a/src/lib/mapping/cache-key.ts
+++ b/src/lib/mapping/cache-key.ts
@@ -33,79 +33,18 @@
 
 import { canonicalizeCacheKey } from './normalization-rules';
 import { hasDecisiveBrandContext } from './simple-rerank';
-import { IDENTITY_QUALIFIERS } from '../parse/qualifiers';
+import { deriveCacheKeyName, collapseAdjacentDuplicateTokens } from './cache-key-core';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 
-// Unit hints that name a distinct food part (egg white vs yolk vs whole egg).
-// Piece-like hints (leaf, clove, slice, ...) are serving concerns, not identity.
-const IDENTITY_UNIT_HINTS = new Set(['white', 'yolk']);
-
 /**
- * Derive the ValidatedMapping cache key for a normalized ingredient name,
- * appending whitelisted identity discriminators from the parsed line.
- *
- * Pure function — no I/O, no side effects.
- *
- * Dedupe note (verified required): canonicalizeCacheKey lowercases,
- * singularizes, and sorts but does NOT dedupe tokens, so "whole milk" with a
- * re-attached "whole" qualifier would become "milk whole whole" without the
- * set-dedupe here. Dedupe compares in canonical (singularized) space so
- * "egg whites" + hint "white" also collapses correctly.
+ * Step 1 (identity discriminators) and step 3's dup-collapse live in
+ * ./cache-key-core, which is import-leaf on purpose: the read-only eval tooling
+ * (scripts/eval/failure-classes.ts) must derive the same key WITHOUT loading
+ * simple-rerank -> ... -> src/lib/mapping/config.ts, which snapshots
+ * FATSECRET_RETRIEVAL_ENABLED at module load. Re-exported here so this module
+ * stays the one public surface for cache keys.
  */
-export function deriveCacheKeyName(
-  normalizedName: string,
-  parsed: ParsedIngredient | null | undefined
-): string {
-  if (process.env.CACHE_KEY_DISCRIMINATORS === '0') {
-    return canonicalizeCacheKey(normalizedName);
-  }
-
-  if (!parsed) {
-    return canonicalizeCacheKey(normalizedName);
-  }
-
-  const discriminators: string[] = [];
-
-  if (parsed.unitHint && IDENTITY_UNIT_HINTS.has(parsed.unitHint.toLowerCase())) {
-    discriminators.push(parsed.unitHint.toLowerCase());
-  }
-
-  for (const qualifier of parsed.qualifiers ?? []) {
-    const lower = qualifier.toLowerCase();
-    if (IDENTITY_QUALIFIERS.has(lower)) {
-      discriminators.push(lower);
-    }
-  }
-
-  if (discriminators.length === 0) {
-    return canonicalizeCacheKey(normalizedName);
-  }
-
-  // Set-dedupe BEFORE the final canonicalize call, comparing tokens in
-  // canonical form so plural/singular variants ("whites" vs "white") and
-  // already-present qualifiers ("whole milk" + "whole") don't duplicate.
-  const seen = new Set(
-    normalizedName
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(t => t.length > 0)
-      .map(t => canonicalizeCacheKey(t))
-  );
-
-  const appended: string[] = [];
-  for (const discriminator of discriminators) {
-    const canonical = canonicalizeCacheKey(discriminator);
-    if (!canonical || seen.has(canonical)) continue;
-    seen.add(canonical);
-    appended.push(discriminator);
-  }
-
-  if (appended.length === 0) {
-    return canonicalizeCacheKey(normalizedName);
-  }
-
-  return canonicalizeCacheKey(`${normalizedName} ${appended.join(' ')}`);
-}
+export { deriveCacheKeyName, collapseAdjacentDuplicateTokens, IDENTITY_UNIT_HINTS } from './cache-key-core';
 
 /**
  * Brand-detection shape consumed by deriveMappingCacheKey. Matches the
@@ -115,24 +54,6 @@ export function deriveCacheKeyName(
 export interface BrandKeyInput {
   isBranded: boolean;
   matchedBrand?: string | null;
-}
-
-/**
- * Collapse adjacent duplicate tokens in a key ("oiko oiko" → "oiko").
- *
- * canonicalizeCacheKey sorts tokens, so in canonical space ALL duplicate
- * tokens are adjacent — collapsing adjacent runs is a full dedupe. Exported
- * for the malformed-key cleanup script (scripts/fix-malformed-cache-keys.ts),
- * which uses collapsed !== original as its malformation predicate.
- */
-export function collapseAdjacentDuplicateTokens(key: string): string {
-  const out: string[] = [];
-  for (const token of key.split(/\s+/)) {
-    if (token.length === 0) continue;
-    if (out.length > 0 && out[out.length - 1] === token) continue;
-    out.push(token);
-  }
-  return out.join(' ');
 }
 
 /**


### PR DESCRIPTION
## F2 — the registry

`scripts/eval/failure-classes.ts`: **32 typed classes — 18 pipeline / 8 healthy / 3 data / 3 ingest** — seeded from the 19 `dropReason` classes actually observed on the box, the 13 cold classes from the 2026-07-24 funnel read, and the 296-defect 2026-07-21 triage vocabulary. Plus `classify-drops.ts` (warm JSONL **or** `MappingEventLog`, read-only) and a generated `sync-docs/failure-classes.md`.

### Four measured findings shaped it, and each would have produced a wrong registry

**1. The raw histogram lies.** `save_rejected:cross_source_margin` is 404 of 571 `save_rejected` events — **71%** — and it is **incumbent protection**, not a defect. The gate sits inside `if (newTargetKey && existingTargetKey && ...)` (`validated-mapping-helpers.ts:724`), so on a cold key `existing` is null and the block is skipped: **it cannot fire without an incumbent.** A registry ranked by raw count sends its first and largest fix-agent at correct code. Hence `fixKind: 'healthy'`, `status: 'by-design'`, and counts split incumbent-vs-cold.

**2. You cannot join event rows to cache rows on `normalizedForm`.** `MappingEventLog.normalizedForm` is *pre*-canonicalization; `FoodMapping`'s is canonicalized, singularized and token-**sorted**. `chicken breast` → `breast chicken`, `eggs` → `egg`, `pretzels` → `pretzel`. A naive join reports cached keys as cold and **inverts the conclusion** — it did exactly that during scoping. `canonicalizeCacheKey` is imported from the real module and applied at a single chokepoint.

**3. `under_gate`'s dropReason is not diagnostic.** F1 tags it with the confidence gate's `selectionReason` — which path *selected* the pick — and `simple_rerank` / `close_match` / `clear_winner` each split ~50/50 good-vs-bad. Classes under `under_gate` are distinguished by row heuristics, never by that string.

**4. The funnel measures conversion, not correctness.** 38 all-zero-macro rows counted as `saved` — successes. A quality dimension sits alongside the stage so "converted, but poisoned" is expressible.

### `fixKind` is the load-bearing addition

Only `'pipeline'` classes may ever be handed to a fix-agent. `'ingest'` means no record exists in any lane and **no code change produces the right number**. `'data'` means a repoint batch. `'healthy'` is counted so it stops reading as a defect.

Detectors carry both `exemplarRows` **and `counterRows`** — rows they must *not* match — so a passing test cannot be tautological.

### Verified against the live box (read-only, 2,000 rows since 2026-07-24)

```
rows=2000  defect events=561  healthy=1439  unclassified=0 (0.00%)

DEFECTS (ranked by DISTINCT KEYS, not events)
  identity-query-token-dropped     38 keys  323 events  pipeline
  identity-brand-substituted        9        100        pipeline
  composite-component-drift         8         66        pipeline
  serving-flat-100g-fallthrough     6         49        pipeline  fixing
HEALTHY / BY DESIGN
  gate-cross-source-margin          8         57        by-design
  gate-sub-threshold-no-displace     3         21        by-design

Live-dropReason coverage: all 19 measured classes owned.
```

## F3 — the driver

`scripts/eval/triage-drops.ts` wires drops through the probes into one dossier per key, classifies via F2, and emits `triage-verdicts-<ts>.json` + `.md` **keeping every key of the 2026-07-21 report shape** (`screened` / `suspectCount` / `confirmedCount` / `byClass` / `confirmed` / `dismissed`, and `seed` / `confirmed` / `cls` / `action` / `targetId` / `note` per row) so existing readers still work.

**The sprint spec called F3 "pure wiring of scaffolding that already exists". That was false.** `debug-retrieval-probe.ts`, `filter-trace-probe.ts`, `full-pipeline-probe.ts`, `warm-names.ts` and `golden-diff-eval.ts` existed only in the Syncthing tree and were **never committed**. They are now in the repo and importable as functions while keeping their CLI behaviour.

**Nothing is silently truncated.** The run logs its stage filter, its dedupe, its per-class cap and whether the cap dropped anything, and states plainly that `--no-probes` verdicts rest on row facts alone.

## Two limits named, both found by running it rather than reading it

- **`hadIncumbent` is wrong in *both* directions.** Resolved at report time, so a key cached after the event reads true *and* a key evicted after reads false. The first run reported 8 "cold" `cross_source_margin` events — impossible for that gate. They were rows the composite cache refresh had evicted hours later. A small cold count there is a timing artifact; a large one is a real signal.
- **`cacheKey` is the READ key, not always the WRITE key.** `deriveMappingCacheKey` brand-prefixes under decisive brand context. Measured: for every branded query tried the two agree, because the event log's `normalizedForm` already carries the brand token — but the log records neither the detected brand nor the decisive-context verdict, so where the save path did prefix, this lookup cannot reproduce that key.

## Gate

- **1,733 tests across 94 suites**, `tsc` clean, `lint:ci` **0 errors**
- `classify-drops` and `triage-drops` both exercised against the live event log, read-only, no DB writes

## Next

F4 — the per-class fix workflow — is written and parked at `sync-docs/warm-plan-2026-07-25/f4/` in the mobile repo, pending this merge. Diego's standing decision holds: report-only nightly, fix-agents on manual trigger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx