### PR TITLE
fix(mapping): apostrophe-insensitive brand matching

### DIFF
--- a/src/lib/mapping/__tests__/possessive-brand-match.test.ts
+++ b/src/lib/mapping/__tests__/possessive-brand-match.test.ts
@@ -1,0 +1,78 @@
+import { candidateMatchesTargetBrand, simpleRerank, type RerankCandidate } from '../simple-rerank';
+
+/**
+ * Possessive brands defeat the whole-token brand matcher (found by warm batch 01,
+ * Jul 2026).
+ *
+ * `candidateMatchesTargetBrand` tokenizes on `[\s,()[\]{}]+`, which does not
+ * include the apostrophe, so a record branded "Member's Mark" yields the token
+ * `member's` while the lexicon's detected form yields `members`. They never
+ * matched. Because the function is consulted by the rerank decisive-brand boost,
+ * same-brand variant precision, sub-threshold admission and the save gate, a
+ * possessive-first brand lost its *ranking* boost as well as its save — the
+ * larger of the two effects.
+ *
+ * Measured exposure at the time of the fix: 27 multi-word lexicon brands against
+ * 6,122 corpus records — Nature's Promise (2587), Member's Mark (1202),
+ * President's Choice (1104), Boar's Head (397).
+ *
+ * Same root cause as the PR #149 cache-key fix, on a different path: #149 was
+ * apostrophes in the key, this is apostrophes in the brand comparison.
+ */
+
+function cand(partial: Partial<RerankCandidate> & { id: string; name: string }): RerankCandidate {
+    return { score: 0.5, source: 'openfoodfacts', ...partial };
+}
+
+describe('candidateMatchesTargetBrand — apostrophe folding', () => {
+    it('matches an apostrophe-free lexicon brand against a possessive record brand', () => {
+        // The batch-01 defect verbatim: `members mark trail mix` was rejected
+        // against a record whose brand is literally "Member's Mark".
+        expect(candidateMatchesTargetBrand('Member\'s Mark', 'Trail Mix', 'members mark')).toBe(true);
+        expect(candidateMatchesTargetBrand('Boar\'s Head', 'Ovengold Turkey Breast', 'boars head')).toBe(true);
+        expect(candidateMatchesTargetBrand('Nature\'s Promise', 'Organic Baby Spinach', 'natures promise')).toBe(true);
+    });
+
+    it('matches in the reverse direction: possessive lexicon form, bare record brand', () => {
+        expect(candidateMatchesTargetBrand('Members Mark', 'Trail Mix', 'member\'s mark')).toBe(true);
+        expect(candidateMatchesTargetBrand('Boars Head', 'Ovengold Turkey Breast', 'boar\'s head')).toBe(true);
+    });
+
+    it('folds the typographic apostrophe too — OFF carries both forms', () => {
+        expect(candidateMatchesTargetBrand('Member’s Mark', 'Trail Mix', 'members mark')).toBe(true);
+        expect(candidateMatchesTargetBrand('Members Mark', 'Trail Mix', 'member’s mark')).toBe(true);
+    });
+
+    it('still finds the brand when it is embedded in the name and the brand field is empty', () => {
+        // The reason the matcher reads name + brand in the first place.
+        expect(candidateMatchesTargetBrand(undefined, 'Boar\'s Head Ovengold Turkey', 'boars head')).toBe(true);
+    });
+
+    it('does not admit an unrelated brand — folding must not become substring matching', () => {
+        expect(candidateMatchesTargetBrand('Udi\'s', 'Granola Bars', 'great value')).toBe(false);
+        expect(candidateMatchesTargetBrand('Bear Naked', 'Pumpkin Spice Granola', 'trader joes')).toBe(false);
+        // "one" must not match "Toblerone" — the substring hazard the whole-token
+        // rule exists to prevent, unchanged by folding.
+        expect(candidateMatchesTargetBrand('Toblerone', 'Milk Chocolate', 'one')).toBe(false);
+    });
+
+    it('rejects a degenerate all-apostrophe target instead of matching everything', () => {
+        expect(candidateMatchesTargetBrand('Member\'s Mark', 'Trail Mix', '\'')).toBe(false);
+    });
+});
+
+describe('possessive brand — end-to-end rerank', () => {
+    it('gives the possessive-brand record the decisive boost over a cross-brand competitor', () => {
+        const hijacker = cand({
+            id: 'off_other', name: 'Trail Mix', brandName: 'Second Nature', score: 0.9,
+        });
+        const membersMark = cand({
+            id: 'off_mm', name: 'Sweet & Salty Trail Mix', brandName: 'Member\'s Mark', score: 0.6,
+        });
+        const result = simpleRerank(
+            'members mark trail mix', [hijacker, membersMark], undefined,
+            'members mark trail mix', true, 'members mark',
+        );
+        expect(result.winner?.id).toBe('off_mm');
+    });
+});

--- a/src/lib/mapping/simple-rerank.ts
+++ b/src/lib/mapping/simple-rerank.ts
@@ -1387,19 +1387,39 @@ export function hasDecisiveBrandContext(text: string, targetBrand: string): bool
 }
 
 /**
+ * The tokenizer splits on whitespace and brackets, so an apostrophe stays glued
+ * inside its token: "Member's Mark" yields "member's". The brand lexicon's
+ * detected form is routinely apostrophe-free ("members mark"), so the two sides
+ * never met and possessive-first brands failed a match against their own
+ * records. Folding `'` / `’` / `` ` `` out of both sides fixes that; it is an
+ * admit-only relaxation, because dropping characters can only merge token forms
+ * and therefore can only turn a false match into a true one.
+ */
+function foldApostrophes(token: string): string {
+    return token.replace(/['’`]/g, '');
+}
+
+/**
  * Whole-token brand match: the candidate must carry the detected brand's first
  * token as a full word — in its brand field OR its name, because OFF records
  * often embed the brand in the name with an empty brand field ("Ghost Whey
  * Protein (Cinnabon)", brand ""). Substring matching is unsafe ("one" would
  * match "Toblerone"); requiring every detected token is too strict because
  * lexicon entries can be brand+form ("one bar" vs brand "ONE Brands").
+ *
+ * Comparison is apostrophe-insensitive on both sides (see foldApostrophes) so
+ * "Member's Mark" / "members mark" / "Members Mark" are one brand, not three.
  */
 export function candidateMatchesTargetBrand(brandName: string | undefined, candidateName: string, targetBrand: string): boolean {
     const brandTokens = targetBrand.toLowerCase().trim().split(/\s+/).filter(Boolean);
     if (brandTokens.length === 0) return false;
+    const target = foldApostrophes(brandTokens[0]);
+    if (target.length === 0) return false;
     const candTokens = `${candidateName} ${brandName ?? ''}`.toLowerCase()
-        .split(/[\s,()[\]{}]+/).filter(Boolean);
-    return candTokens.includes(brandTokens[0]);
+        .split(/[\s,()[\]{}]+/)
+        .map(foldApostrophes)
+        .filter(Boolean);
+    return candTokens.includes(target);
 }
 
 /**


### PR DESCRIPTION
## What

`candidateMatchesTargetBrand` tokenizes on `[\s,()[\]{}]+` — **the apostrophe is not a delimiter** — then asks `candTokens.includes(brandTokens[0])`. A record branded `Member's Mark` yields the token `member's`; the brand lexicon's detected form yields `members`. They never matched.

Found by **warm batch 01** of the seed-corpus campaign: `members mark trail mix` was rejected by the save gate against a record whose brand *is* Member's Mark.

## Why it matters more than the save gate

The save gate is the smaller half. The same function has **five call sites**, and the other three are ranking:

| site | effect when it wrongly returns false |
|---|---|
| `simple-rerank.ts:1672` | loses the **decisive-brand boost** |
| `simple-rerank.ts:1859` | loses same-brand variant precision |
| `sub-threshold-admission.ts:126` | candidate not admitted |
| `validated-mapping-helpers.ts:489,514` | save rejected → `winner = null` → AI backfill at 100 g |

So an affected brand was losing its *ranking* anchor, not just a save.

## Fix

Fold `'` / `’` / `` ` `` out of **both** sides before the whole-token comparison.

This is an **admit-only relaxation** — dropping characters can only merge token forms, so it can only turn a failed match into a successful one. Every one of the five consumers therefore becomes more permissive, never stricter. Top of the preference order in `sync-docs/mapping_investigation_playbook.md`.

**No migration needed** — the function is computed at request time and never persisted.

Deliberately *not* fixed here: loosening the save gate itself. A hard reject there sets `winner = null` and falls through to AI backfill at 100 g, which is worse than the drop.

## Measured scope

Live probe through the real `detectBrandInQuery` → `hasDecisiveBrandContext` → `candidateMatchesTargetBrand` chain — **not** a static join:

| | tokens | corpus records exposed |
|---|---:|---:|
| multi-word lexicon brand vs possessive-first record | **27** | **6,122** |

Nature's Promise 2587 · Member's Mark 1202 · President's Choice 1104 · Boar's Head 397 · Farmer's Union 163 · Baker's Life 153 · Lowe's Foods 76 · Wegman's 65 · Bird's Eye 15.

Two corrections worth recording:

- An earlier **static lexicon × corpus join predicted ~17,200 records and was overstated ~3×.** Single-token possessives (`hersheys`, `campbells`, `lays`, `mcdonalds`, `reeses`, `welchs`, `smuckers`) are detected but score `decisive=false`, so the gate never fires and they are admitted normally. Only multi-word brands, where `hasDecisiveBrandContext` short-circuits true, are bitten.
- **6,122 is the exposed record population, not the defect count.** The gate only fires when such a record is the winner for a decisive-brand query.

Probe-confirmed rejections: `boars head turkey breast`, `members mark trail mix`, `bobs red mill oats`. Controls `great value` / `kirkland signature` admit correctly both before and after.

## Relationship to #149

Same root cause, different path. #149 fixed apostrophes in the **cache key**; this fixes apostrophes in the **brand comparison**.

A third, separate class remains open and is **not** in this PR: where the lexicon carries *only* the possessive form, an apostrophe-free query (`chilis chicken crispers`, `applebees riblets`) returns `matchedBrand: null` from `detectBrandInQuery`. That is a lexicon **data** fix (add apostrophe-free aliases) and is being sized separately.

## Verification

- New `possessive-brand-match.test.ts`: **5 of 7 fail** against the unfixed function, **7 of 7 pass** with it. The two negative controls — unrelated brand (`Udi's` vs `great value`), and the substring hazard (`one` must not match `Toblerone`) — pass in *both* directions, so folding has not silently become substring matching. A degenerate all-apostrophe target is rejected rather than matching everything.
- Full `src/lib/mapping` suite: **774 pass**. One pre-existing failure, `does NOT fast-path "canned tuna in water"`, **also fails on clean master** and is unrelated (CI's `build` job does not run jest).
- `lint:ci` 0 errors · `typecheck` clean.
- Box eval gate to be run against this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx