### PR TITLE
fix(funnel): a save that throws is no longer reported as a conversion

### DIFF
--- a/src/lib/mapping/__tests__/save-persist-failure-telemetry.test.ts
+++ b/src/lib/mapping/__tests__/save-persist-failure-telemetry.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A failed save must not be reported as a conversion.
+ *
+ * The funnel marks a line 'saved' optimistically, before `saveValidatedMapping`
+ * writes. The catch block used to log `validated_mapping.save_error` and return
+ * quietly, so a write that threw still read as `funnelStage: 'saved'`.
+ *
+ * That is not hypothetical. Warm batch 01 of the seed-corpus campaign reported
+ * **92 saves and wrote 81 rows**; the 11-row gap was exactly 11 foreign-key
+ * failures, and 31.4% of that batch's FatSecret saves (11 of 35) wrote nothing
+ * while telemetry called them conversions. The campaign then graded itself —
+ * conversion, coverage lift, its own stop rules — on that number.
+ *
+ * The FK case is split out because the two failure modes need different fixes:
+ * P2003 is the FatSecret lane's background `persistFatSecretHits` not having
+ * written the `FatSecretFood` parent yet, which is a race; anything else is not.
+ */
+
+const mockFoodMappingFindUnique = jest.fn();
+const mockFoodMappingUpsert = jest.fn();
+const mockFoodMappingUpdate = jest.fn();
+const mockOffFoodFindUnique = jest.fn();
+const mockFatSecretServingFindFirst = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        foodMapping: {
+            findUnique: (...args: unknown[]) => mockFoodMappingFindUnique(...args),
+            upsert: (...args: unknown[]) => mockFoodMappingUpsert(...args),
+            update: (...args: unknown[]) => mockFoodMappingUpdate(...args),
+        },
+        offFood: { findUnique: (...args: unknown[]) => mockOffFoodFindUnique(...args) },
+        fatSecretServing: { findFirst: (...args: unknown[]) => mockFatSecretServingFindFirst(...args) },
+    },
+}));
+
+import { saveValidatedMapping } from '../validated-mapping-helpers';
+import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+import type { AIValidationResult } from '../ai-validation';
+import type { FunnelSink } from '../funnel';
+
+const validation = { confidence: 0.95 } as AIValidationResult;
+
+function makeMapping(overrides: Partial<FatsecretMappedIngredient> = {}): FatsecretMappedIngredient {
+    return {
+        source: 'fatsecret',
+        foodId: 'fs_122756',
+        foodName: 'Trail Mix',
+        brandName: 'Nuts Co',
+        grams: 30,
+        kcal: 150,
+        protein: 5,
+        carbs: 12,
+        fat: 9,
+        confidence: 0.95,
+        quality: 'high',
+        rawLine: 'trail mix',
+        ...overrides,
+    } as FatsecretMappedIngredient;
+}
+
+/** Prisma surfaces a foreign-key violation as code P2003. */
+function foreignKeyError(): Error {
+    const e = new Error('Foreign key constraint failed on the field: `fsId`') as Error & { code: string };
+    e.code = 'P2003';
+    return e;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFoodMappingFindUnique.mockResolvedValue(null);
+    mockOffFoodFindUnique.mockResolvedValue(null);
+    mockFatSecretServingFindFirst.mockResolvedValue(null);
+    mockFoodMappingUpdate.mockResolvedValue({});
+});
+
+describe('a save that throws is not a conversion', () => {
+    it('downgrades the funnel to save_rejected when the write hits an FK violation', async () => {
+        mockFoodMappingUpsert.mockRejectedValue(foreignKeyError());
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+
+        await saveValidatedMapping('trail mix', makeMapping(), validation, { telemetry });
+
+        expect(telemetry.funnelStage).toBe('save_rejected');
+        expect(telemetry.dropReason).toBe('save_rejected:persist_failed_fk');
+    });
+
+    it('downgrades the funnel on any other write failure, with a distinct class', async () => {
+        mockFoodMappingUpsert.mockRejectedValue(new Error('connection terminated'));
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+
+        await saveValidatedMapping('trail mix', makeMapping(), validation, { telemetry });
+
+        expect(telemetry.funnelStage).toBe('save_rejected');
+        expect(telemetry.dropReason).toBe('save_rejected:persist_failed');
+    });
+
+    it('still swallows the error — a failed cache write must never break the request', async () => {
+        mockFoodMappingUpsert.mockRejectedValue(foreignKeyError());
+        await expect(
+            saveValidatedMapping('trail mix', makeMapping(), validation, { telemetry: { funnelStage: 'saved' } }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('leaves the funnel alone when the write succeeds', async () => {
+        mockFoodMappingUpsert.mockResolvedValue({});
+        const telemetry: FunnelSink = { funnelStage: 'saved' };
+
+        await saveValidatedMapping('trail mix', makeMapping(), validation, { telemetry });
+
+        expect(telemetry.funnelStage).toBe('saved');
+        expect(telemetry.dropReason).toBeUndefined();
+    });
+
+    it('does not throw when no telemetry sink is supplied', async () => {
+        mockFoodMappingUpsert.mockRejectedValue(foreignKeyError());
+        await expect(saveValidatedMapping('trail mix', makeMapping(), validation)).resolves.toBeUndefined();
+    });
+});

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -861,10 +861,29 @@ export async function saveValidatedMapping(
             aiConfidence: clampedConfidence,
         });
     } catch (error) {
+        // The funnel optimistically marks a line 'saved' before this write. If the
+        // write throws and we return quietly, telemetry reports a conversion for a
+        // row that does not exist — which is exactly what happened to warm batch 01:
+        // it reported 92 saves, wrote 81 rows, and the 11-row gap was 11 FK failures
+        // that no metric could see. Every downstream number (conversion, coverage
+        // lift, the campaign's own gate) inherits that lie, so the failure has to be
+        // reported here or the information is destroyed at write time.
+        //
+        // P2003 is Prisma's foreign-key violation. The FatSecret lane persists its
+        // FatSecretFood parents in a background task, so a first-sighting fs winner
+        // can reach this write before its parent row exists — the dominant cause by
+        // a wide margin (31.4% of batch 01's FatSecret saves). It is split out from
+        // other save errors because the two need completely different fixes.
+        const isForeignKeyViolation = (error as { code?: string }).code === 'P2003';
+        markSaveRejected(options?.telemetry, isForeignKeyViolation ? 'persist_failed_fk' : 'persist_failed');
         logger.error('validated_mapping.save_error', {
             error: (error as Error).message,
+            code: (error as { code?: string }).code,
+            foreignKeyViolation: isForeignKeyViolation,
             rawIngredient,
             normalizedForm,
+            source: mapping.source,
+            foodId: mapping.foodId,
         });
     }
 }


### PR DESCRIPTION
## The defect

The funnel marks a line `saved` **optimistically, before** `saveValidatedMapping` writes. Its catch block logged `validated_mapping.save_error` and returned quietly — so a write that threw still read as `funnelStage: 'saved'`.

## Measured cost

Warm batch 01 of the seed-corpus campaign reported **92 saves and wrote 81 rows**. The 11-row gap is *exactly* 11 foreign-key failures in the warm window.

| | |
|---|---|
| FatSecret saves that wrote nothing | **11 of 35 (31.4%)** |
| FK `save_error` events since 2026-07-23 | **67** |
| of the 11 keys, checked against live `FoodMapping` 3 days later | **0 rows returned** — still absent |
| displacements among them | 0 — they were inserts |

Everything downstream inherited the error:

- The campaign's headline **83.6% conversion overstates written rows by 12 percentage points.**
- The batch gate's `lift_ratio` (added/saved) read **88%** — comfortably above its 55% flag — while 12% of the batch was being dropped on the floor. **The instrument could not detect its own largest loss.**
- The campaign plan attributed this entire gap to "key-form drift" and called fixing it *"the single highest-value fix in this campaign."* For batch 01, none of it is key form.

The information is destroyed at write time and survives only in a `next-start.log` that is already 395 MB, so it cannot be recovered after the fact. That is why this cannot be deferred.

## The change

One `markSaveRejected` call in the catch, plus log fields. **Telemetry only — it cannot change a pick, a row, or a response.** The error is still swallowed: a failed cache write must never break the request.

`P2003` (Prisma's FK violation) gets its own class because it has a specific cause needing a specific fix — the FatSecret lane persists `FatSecretFood` parents in an unawaited background task, so a first-sighting FatSecret winner reaches this write before its parent exists. That race is closed separately in #159; this PR only stops it lying.

## Verification

Regression test **fails 2/5 without the change, passes 5/5 with it.** The three that pass in both directions are deliberate controls — the error is still swallowed, a successful save is untouched, a missing telemetry sink does not throw.

`typecheck` clean · `lint:ci` 0 errors · full `src/lib/mapping` suite 786 pass (1 pre-existing failure, `does NOT fast-path "canned tuna in water"`, which also fails on clean master; CI's `build` job does not run jest).

## Deliberately not in this PR

A `scripts/eval/failure-classes.ts` registry entry for the two new class IDs. They land in the registry's `UNCLASSIFIED` bucket — which is a safe fallthrough and still shows their distinct `dropReason` to a funnel read — and the entry lands with the persist-race work, where the exemplar rows will be real rather than invented.