### PR TITLE
fix(mapping): close the FatSecret FK persist race, insert-bound

### DIFF
--- a/src/lib/mapping/__tests__/fatsecret-fk-persist-race.test.ts
+++ b/src/lib/mapping/__tests__/fatsecret-fk-persist-race.test.ts
@@ -1,0 +1,265 @@
+/**
+ * FatSecret FK persist race (Jul 2026).
+ *
+ * FoodMapping.fsId is a FOREIGN KEY to FatSecretFood.fsId, but the lane writes
+ * those parent rows fire-and-forget. On a food's first-ever sighting the child
+ * write can beat its parent, the FK rejects it, and saveValidatedMapping
+ * swallows the error — so the funnel reports `saved` for a row that was never
+ * written. Warm batch 01 reported 92 saves and wrote 81 rows.
+ *
+ * The DB mock below ENFORCES the foreign key (foodMapping.upsert throws P2003
+ * while the parent is absent) and the parent write is deliberately slow, so
+ * these tests exercise the real ordering rather than asserting on a spy.
+ *
+ * The bound matters as much as the fix: 8 of the 67 measured FK failures were
+ * `update` branches against hot validatedBy='ai' incumbents (`cooked rice`,
+ * `cooked pasta`, the bare key `chicken`). The wait is therefore insert-bound —
+ * see the second describe block.
+ */
+
+import type { FatSecretFoodSummary } from '../client';
+
+const PARENT_WRITE_DELAY_MS = 25;
+
+// Simulated database ------------------------------------------------------
+/** fsId values whose FatSecretFood parent row has actually landed. */
+const fsParentRows = new Set<string>();
+/** normalizedForm → stored FoodMapping row. */
+const foodMappingRows = new Map<string, Record<string, unknown>>();
+
+function foreignKeyError(): Error {
+    const err = new Error(
+        'Foreign key constraint violated on the constraint: `FoodMapping_fsId_fkey`'
+    );
+    (err as Error & { code?: string }).code = 'P2003';
+    return err;
+}
+
+const mockFlags = { retrievalEnabled: true };
+
+jest.mock('../config', () => {
+    const actual = jest.requireActual('../config');
+    return {
+        ...actual,
+        get FATSECRET_RETRIEVAL_ENABLED() {
+            return mockFlags.retrievalEnabled;
+        },
+        FATSECRET_LANE_TIMEOUT_MS: 800,
+        FATSECRET_LANE_MAX_RESULTS: 8,
+        // Force "no credentials" so the singleton path never builds a real
+        // client; every test injects its own.
+        FATSECRET_CLIENT_ID: '',
+        FATSECRET_CLIENT_SECRET: '',
+    };
+});
+
+jest.mock('../../db', () => ({
+    prisma: {
+        // Parent write: slow on purpose — this IS the race window.
+        fatSecretFood: {
+            upsert: jest.fn(async (args: { where: { fsId: string } }) => {
+                await new Promise(resolve => setTimeout(resolve, PARENT_WRITE_DELAY_MS));
+                fsParentRows.add(args.where.fsId);
+                return {};
+            }),
+        },
+        fatSecretServing: {
+            upsert: jest.fn(async () => ({})),
+            findFirst: jest.fn(async () => null),
+        },
+        offFood: {
+            findUnique: jest.fn(async () => null),
+        },
+        foodMapping: {
+            findUnique: jest.fn(async (args: { where: { normalizedForm: string } }) =>
+                foodMappingRows.get(args.where.normalizedForm) ?? null
+            ),
+            // Child write: enforces the foreign key the real schema declares.
+            upsert: jest.fn(async (args: {
+                where: { normalizedForm: string };
+                create: Record<string, unknown>;
+                update: Record<string, unknown>;
+            }) => {
+                const existing = foodMappingRows.get(args.where.normalizedForm);
+                const data = existing ? { ...existing, ...args.update } : args.create;
+                const fsId = data.fsId as string | null | undefined;
+                if (fsId && !fsParentRows.has(fsId)) throw foreignKeyError();
+                foodMappingRows.set(args.where.normalizedForm, data);
+                return data;
+            }),
+            update: jest.fn(async () => ({})),
+        },
+    },
+}));
+
+jest.mock('../../logger', () => ({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { saveValidatedMapping } from '../validated-mapping-helpers';
+import {
+    searchFatSecretLane,
+    __setFatSecretLaneClientForTests,
+    __resetPendingFatSecretPersistForTests,
+} from '../fatsecret-lane';
+import { drainPendingBackgroundTasks } from '../deferred-hydration';
+import { canonicalizeCacheKey } from '../normalization-rules';
+import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+import type { AIValidationResult } from '../ai-validation';
+
+const FS_ID = '4482913';
+
+function hit(): FatSecretFoodSummary {
+    return {
+        id: FS_ID,
+        name: 'Kohlrabi Fritters',
+        brandName: null,
+        foodType: 'Generic',
+        servings: [
+            {
+                id: 's1',
+                description: '100 g',
+                measurementDescription: 'g',
+                metricServingAmount: 100,
+                metricServingUnit: 'g',
+                numberOfUnits: 1,
+                calories: 118,
+                protein: 3.4,
+                carbohydrate: 12,
+                fat: 6.2,
+            },
+        ],
+    } as FatSecretFoodSummary;
+}
+
+function makeMapping(over: Partial<FatsecretMappedIngredient>): FatsecretMappedIngredient {
+    return {
+        foodId: `fs_${FS_ID}`,
+        foodName: 'Kohlrabi Fritters',
+        brandName: undefined,
+        grams: 100,
+        kcal: 118,
+        protein: 3.4,
+        carbs: 12,
+        fat: 6.2,
+        ...over,
+    } as FatsecretMappedIngredient;
+}
+
+const validation = { confidence: 0.95 } as AIValidationResult;
+
+/** Client that answers instantly; only the PERSIST is slow. */
+function makeClient(hits: FatSecretFoodSummary[]) {
+    return { searchFoodsV4: jest.fn(async () => hits) };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    fsParentRows.clear();
+    foodMappingRows.clear();
+    mockFlags.retrievalEnabled = true;
+    __setFatSecretLaneClientForTests(undefined);
+    __resetPendingFatSecretPersistForTests();
+});
+
+afterEach(async () => {
+    // Let the slow background persist finish so it cannot leak into the next
+    // test (or keep an open handle).
+    await drainPendingBackgroundTasks();
+});
+
+describe('FoodMapping save vs. the fire-and-forget FatSecret persist', () => {
+    it('writes the row on a first-ever sighting, while the parent persist is still in flight', async () => {
+        const candidates = await searchFatSecretLane('kohlrabi fritters', 8, makeClient([hit()]));
+        expect(candidates).toHaveLength(1);
+        // The race window: the child write is about to happen and the parent
+        // row does NOT exist yet.
+        expect(fsParentRows.has(FS_ID)).toBe(false);
+
+        await saveValidatedMapping('kohlrabi fritters', makeMapping({}), validation, {
+            canonicalBase: 'kohlrabi fritters',
+        });
+
+        const key = canonicalizeCacheKey('kohlrabi fritters');
+        expect(foodMappingRows.get(key)).toMatchObject({
+            normalizedForm: key,
+            fsId: FS_ID,
+            source: 'fatsecret',
+        });
+    });
+
+    it('still saves normally once the persist has drained (no behavior change off the race path)', async () => {
+        await searchFatSecretLane('kohlrabi fritters', 8, makeClient([hit()]));
+        await drainPendingBackgroundTasks();
+        expect(fsParentRows.has(FS_ID)).toBe(true);
+
+        await saveValidatedMapping('kohlrabi fritters', makeMapping({}), validation, {
+            canonicalBase: 'kohlrabi fritters',
+        });
+
+        expect(foodMappingRows.get(canonicalizeCacheKey('kohlrabi fritters'))).toBeDefined();
+    });
+});
+
+describe('the wait is insert-bound', () => {
+    // An UNBOUNDED version of this fix — waiting for the parent on every
+    // fatsecret save — would let these 8 measured update-branch failures land,
+    // displacing hot 'ai' incumbents. `cooked rice` is exactly the row golden
+    // case n-cook-01 locks.
+    const COOKED_RICE_KEY = canonicalizeCacheKey('cooked rice');
+
+    function seedIncumbent() {
+        foodMappingRows.set(COOKED_RICE_KEY, {
+            normalizedForm: COOKED_RICE_KEY,
+            foodName: 'Brown Parboiled Cooked Uncle Bens Rice',
+            offBarcode: '0054800020058',
+            fdcId: null,
+            fsId: null,
+            source: 'openfoodfacts',
+            validatedBy: 'ai',
+            aiConfidence: 0.5, // low enough that the cross-source margin passes
+        });
+    }
+
+    it('does NOT wait for the parent when a row already exists, so the incumbent survives', async () => {
+        seedIncumbent();
+        await searchFatSecretLane('cooked rice', 8, makeClient([
+            { ...hit(), name: 'Cooked Rice' } as FatSecretFoodSummary,
+        ]));
+        expect(fsParentRows.has(FS_ID)).toBe(false);
+
+        await saveValidatedMapping('cooked rice', makeMapping({ foodName: 'Cooked Rice' }), validation, {
+            canonicalBase: 'cooked rice',
+        });
+
+        // Proof it did not wait: the slow parent write is still pending.
+        expect(fsParentRows.has(FS_ID)).toBe(false);
+        // Proof it did not displace: the incumbent row is byte-identical.
+        expect(foodMappingRows.get(COOKED_RICE_KEY)).toMatchObject({
+            foodName: 'Brown Parboiled Cooked Uncle Bens Rice',
+            offBarcode: '0054800020058',
+            fsId: null,
+        });
+    });
+
+    it('leaves an existing row alone even after the parent lands (the FK was never the guard)', async () => {
+        seedIncumbent();
+        await searchFatSecretLane('cooked rice', 8, makeClient([
+            { ...hit(), name: 'Cooked Rice' } as FatSecretFoodSummary,
+        ]));
+        await drainPendingBackgroundTasks();
+
+        // With the parent present the FK no longer blocks anything, so this
+        // asserts what actually protects the incumbent: the cross-source
+        // displacement margin / downgrade guards, not the persist race.
+        await saveValidatedMapping('cooked rice', makeMapping({ foodName: 'Cooked Rice' }), {
+            confidence: 0.5,
+        } as AIValidationResult, {
+            canonicalBase: 'cooked rice',
+        });
+
+        expect(foodMappingRows.get(COOKED_RICE_KEY)).toMatchObject({
+            foodName: 'Brown Parboiled Cooked Uncle Bens Rice',
+        });
+    });
+});

--- a/src/lib/mapping/__tests__/fatsecret-lane.test.ts
+++ b/src/lib/mapping/__tests__/fatsecret-lane.test.ts
@@ -594,6 +594,48 @@ describe('persistFatSecretHits', () => {
         expect(mockPrisma.fatSecretServing.upsert).not.toHaveBeenCalled();
     });
 
+    // FoodMapping.fsId is an FK to FatSecretFood.fsId, so a save that lands
+    // before this background write does gets rejected by the database. The
+    // per-fsId registry lets exactly that save wait for exactly that write.
+    describe('in-flight persist registry (FK persist race)', () => {
+        it('returns immediately for an fsId with no persist in flight', async () => {
+            lane.__resetPendingFatSecretPersistForTests();
+            // Would hang (or hit the 3s cap) if it awaited anything.
+            await expect(lane.awaitPendingFatSecretPersist('12345')).resolves.toBeUndefined();
+        });
+
+        it('resolves only once the in-flight parent write has landed', async () => {
+            let resolveUpsert!: (v: unknown) => void;
+            let parentWritten = false;
+            mockPrisma.fatSecretFood.upsert.mockImplementation(
+                () => new Promise(resolve => {
+                    resolveUpsert = (v: unknown) => { parentWritten = true; resolve(v); };
+                })
+            );
+
+            await lane.searchFatSecretLane('protein bar', 8, makeClient([summary({ servings: [] })]));
+            expect(parentWritten).toBe(false);
+
+            let waited = false;
+            const wait = lane.awaitPendingFatSecretPersist('12345').then(() => { waited = true; });
+            await Promise.resolve();
+            expect(waited).toBe(false); // still blocked on the persist
+
+            resolveUpsert({});
+            await wait;
+            expect(parentWritten).toBe(true);
+        });
+
+        it('drops the entry once the persist settles, so later saves never wait', async () => {
+            await lane.searchFatSecretLane('protein bar', 8, makeClient([summary({ servings: [] })]));
+            await deferred.drainPendingBackgroundTasks();
+
+            // Nothing left to await: a hung mock here would prove otherwise.
+            mockPrisma.fatSecretFood.upsert.mockImplementation(() => new Promise(() => { }));
+            await expect(lane.awaitPendingFatSecretPersist('12345')).resolves.toBeUndefined();
+        });
+    });
+
     it('lane registers the persist with the background drain (drainPendingBackgroundTasks awaits it)', async () => {
         // Make the upsert async-slow enough that it cannot have completed inline
         let resolveUpsert!: (v: unknown) => void;

--- a/src/lib/mapping/fatsecret-lane.ts
+++ b/src/lib/mapping/fatsecret-lane.ts
@@ -305,6 +305,85 @@ function rawServingNutrients(s: FatSecretApiServing): Record<string, number> | n
     return Object.keys(out).length > 0 ? out : null;
 }
 
+// ============================================================
+// In-flight persist registry (FK persist race)
+// ============================================================
+
+/**
+ * fsId → the in-flight `persistFatSecretHits` promise that will write that
+ * food's FatSecretFood parent row.
+ *
+ * FoodMapping.fsId is a FOREIGN KEY to FatSecretFood.fsId, but the lane
+ * persists its hits fire-and-forget, so on a food's first-ever sighting the
+ * child write can reach the database before its parent. The FK then rejects
+ * the save, `saveValidatedMapping` swallows the error, and the mapping is
+ * silently never cached (11 of warm batch 01's 92 reported saves; 67 such
+ * events since 2026-07-23).
+ *
+ * Entries live only while a persist is actually in flight — the `.finally`
+ * below removes them — so the registry is bounded by concurrent lane
+ * searches, and a lookup after the persist drained is a Map miss (free).
+ */
+const pendingPersistByFsId = new Map<string, Promise<void>>();
+
+/**
+ * Cap on how long a save may wait for an in-flight persist. The measured
+ * window is under 2s for every observed failure; the cap exists so a stalled
+ * background write can never hold a request open — on timeout the caller
+ * proceeds and the write behaves exactly as it does today.
+ */
+const PERSIST_WAIT_TIMEOUT_MS = 3000;
+
+function trackPendingPersist(hits: FatSecretFoodSummary[], task: Promise<void>): void {
+    const ids = hits.map(h => h.id).filter((id): id is string => !!id);
+    if (ids.length === 0) return;
+    for (const id of ids) pendingPersistByFsId.set(id, task);
+    void task.finally(() => {
+        for (const id of ids) {
+            // Only clear entries this task owns — a later search for the same
+            // food may already have replaced them.
+            if (pendingPersistByFsId.get(id) === task) pendingPersistByFsId.delete(id);
+        }
+    });
+}
+
+/**
+ * Wait for the background persist that owns `fsId`, if one is still running.
+ *
+ * Returns immediately (a Map lookup) when nothing is in flight — the common
+ * case, since a persist started at retrieval time has normally drained long
+ * before rerank + AI validation finish. Callers writing a row that references
+ * FatSecretFood.fsId should await this first; see the insert-bound call in
+ * `saveValidatedMapping`.
+ *
+ * Never throws: the registered task already carries its own `.catch`, and a
+ * failed persist simply leaves the parent absent, which is today's behavior.
+ */
+export async function awaitPendingFatSecretPersist(fsId: string): Promise<void> {
+    const task = pendingPersistByFsId.get(fsId);
+    if (!task) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race([
+            task,
+            new Promise<void>(resolve => {
+                timer = setTimeout(() => {
+                    logger.warn('fatsecret_lane.persist_wait_timeout', { fsId });
+                    resolve();
+                }, PERSIST_WAIT_TIMEOUT_MS);
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+/** Test seam: drop every registry entry (tests only). */
+export function __resetPendingFatSecretPersistForTests(): void {
+    pendingPersistByFsId.clear();
+}
+
 /**
  * Upsert search hits into FatSecretFood/FatSecretServing. Called
  * fire-and-forget from the lane (registered with the deferred-hydration
@@ -411,6 +490,9 @@ export async function searchFatSecretLane(
             });
         });
         registerBackgroundTask(task);
+        // ...and indexed by fsId, so a save that needs one of these FK parents
+        // can wait for exactly that write instead of the whole drain.
+        trackPendingPersist(hits, task);
 
         return hits.map((hit, index) => toUnifiedCandidate(hit, index, trimmed));
     } catch (err) {

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -22,6 +22,7 @@ import { markSaveRejected, normalizeClassId, type FunnelSink } from './funnel';
 import { hasDecisiveBrandContext, candidateMatchesTargetBrand } from './simple-rerank';
 import { parseIngredientLine } from '../parse/ingredient-line';
 import { normalizeIngredientName, canonicalizeCacheKey } from './normalization-rules';
+import { awaitPendingFatSecretPersist } from './fatsecret-lane';
 
 // Cross-source displacement margin (fs displacement hardening, Jul 2026):
 // how much MORE confident a challenger from a different source family
@@ -807,6 +808,34 @@ export async function saveValidatedMapping(
                     return;
                 }
             }
+        }
+
+        // FatSecret FK persist race (Jul 2026). FoodMapping.fsId is a foreign
+        // key to FatSecretFood.fsId, and the lane writes those parent rows
+        // fire-and-forget (fatsecret-lane.ts persistFatSecretHits, registered
+        // as a background task). On a food's FIRST-EVER sighting this child
+        // write can beat its parent: the upsert then fails the FK, the catch
+        // below logs save_error, and the mapping is silently never cached even
+        // though the funnel already marked the line 'saved'. Warm batch 01
+        // reported 92 saves and wrote 81 rows — 31.4% of its fatsecret saves
+        // wrote nothing.
+        //
+        // Waiting on the ONE in-flight persist that owns this fsId is free
+        // when it already drained (a Map lookup, the normal case — the persist
+        // starts at retrieval time and rerank + AI validation run after it)
+        // and capped when it hasn't.
+        //
+        // INSERT-BOUND on `existing`: only a save that would CREATE a row
+        // waits. When a row is already there the parent is left to the
+        // background task exactly as today, so this can never turn a
+        // currently-failing overwrite into a successful one. That bound is not
+        // cosmetic — 8 of the 67 measured FK failures were update branches
+        // against hot validatedBy='ai' incumbents, including the `cooked rice`
+        // and `cooked pasta` rows golden cases n-cook-01/n-cook-02 exist to
+        // lock and the bare generic key `chicken`. An unbounded version of
+        // this fix displaces them.
+        if (fsId && !existing) {
+            await awaitPendingFatSecretPersist(fsId);
         }
 
         await prisma.foodMapping.upsert({


### PR DESCRIPTION
## The race

`getFatSecretCandidates` fires `persistFatSecretHits(hits)` as a **fire-and-forget** background task. When the mapper then writes a `FoodMapping` row carrying `fsId`, the `FatSecretFood` parent may not exist yet, so the write fails the FK at `prisma/schema.prisma:490`. `saveValidatedMapping` catches it and returns — the row is simply never written.

**Measured:** warm batch 01 reported 92 saves, wrote 81 rows, and had exactly 11 FK failures. 31.4% of its FatSecret saves wrote nothing. #158 makes that visible; this PR makes the write succeed.

## The shape, and why not the alternatives

A per-`fsId` registry of in-flight persists (`fatsecret-lane.ts`), indexing the *same* promise already handed to `registerBackgroundTask`. Immediately before the upsert:

```ts
if (fsId && !existing) {
    await awaitPendingFatSecretPersist(fsId);
}
```

| alternative | why not |
|---|---|
| await the persist inside the lane | adds latency to **every** request with fs hits, on the hot path before rerank — precisely why it was backgrounded |
| upsert the parent from the save path | creates a **second writer** of `FatSecretFood` holding only `foodName`/`brandName` — no servings, no per-100g panel. Given this project's history with zero-kcal FatSecret rows, manufacturing a half-populated parent to satisfy an FK is the wrong trade |
| retry after drain | needs to know the save failed (couples to #158), and `drainPendingBackgroundTasks()` awaits *everything* — hydration, produce backfill — far more than this needs |

No new writes, no new read queries, no new persistence path. In the normal case the persist has already drained (it starts at retrieval; rerank and AI validation run after it), so the cost is one `Map.get` miss. Capped at 3 s via `Promise.race` + `clearTimeout`, so a stalled background write can never hold a request open — on timeout the caller proceeds and behaves exactly as today. The waiting save holds no Prisma connection, so there is no pool deadlock.

## The insert bound is mandatory, not decorative

Of the 67 measured FK failures, **8 were `update` branches against rows that already existed** — all `validatedBy='ai'` incumbents that predate the failure, including `cooked rice` → *brown parboiled cooked uncle bens rice* and `cooked pasta` → *fresh-refrigerated spinach cooked pasta*, which are the exact rows golden **n-cook-01** and **n-cook-02** exist to lock, plus the bare generic key `chicken`. Unbounded, this fix displaces them.

The bound reads `existing` — the **already-hoisted** `findUnique` that the pre-existing `insertOnly` guard, the human-row guard and the downgrade guard all read. No new query, and **no re-derivation of `normalizedForm`** (a re-derived key that is wrong fails *open*, toward displacement).

**Proof it cannot overwrite:** when `existing` is non-null the wait does not happen, so the code reaching `upsert` is byte-identical to master. The fix can only convert `FK-error → no row` into `insert → new row`.

`insertOnly: true` was deliberately *not* passed: that would block fs saves from legitimately updating existing rows (usedCount bumps, same-record refreshes) — a far larger blast radius than the defect. This uses the same *predicate* at the same *place*, applied to the wait rather than the write.

## Verification

The test does **not** assert on a spy. The prisma mock **enforces the foreign key** — `foodMapping.upsert` throws `P2003` while the parent is absent — and the parent write is deliberately slow, so a real `searchFatSecretLane()` followed by a real `saveValidatedMapping()` reproduces the defect in-repo.

- **Without the fix: 1 failed, 3 passed.** The failure is the right one — `foodMappingRows.get(key)` is `undefined`, the row was silently never written.
- **With the fix: 4 passed.**
- The two insert-bound tests pass either way *by design*: they fail if someone makes the wait unconditional.

`typecheck` clean · `lint:ci` 0 errors · `next build` succeeds · combined with #158: 786 pass in `src/lib/mapping` (1 pre-existing failure).

## Residual risk, stated rather than smoothed over

- **The 12% recovery figure is not verified in production.** The test proves the mechanism; only a warm batch proves the number.
- **A persist that *failed* is not helped** — the parent still doesn't exist and the FK still rejects. That degrades to today's behaviour, and #158 is what makes it visible. Same for an fs pick whose persist failed in an earlier request.
- **Pre-existing concurrency window, shared with `insertOnly`:** `existing` is read before the upsert, so a row created by a concurrent save in that window would be updated rather than inserted. Closing it means `create()` + unique-violation handling, a bigger change than the defect warrants.
- **The 3 s cap is a judgement call.** If a persist routinely exceeds it under warm-batch load the fix quietly stops working, visible only as `fatsecret_lane.persist_wait_timeout` warnings, which nothing currently alerts on.
- The registry is per-process in memory. Lane search and save always occur in the same request, so this holds today — but if a future change moves the save to another process the guard becomes a silent no-op rather than failing loudly.