### PR TITLE
fix(mapping): iOS Smart Punctuation split every possessive brand in two

### DIFF
--- a/src/lib/mapping/__tests__/smart-punctuation-key.test.ts
+++ b/src/lib/mapping/__tests__/smart-punctuation-key.test.ts
@@ -1,0 +1,86 @@
+import { canonicalizeCacheKey, normalizeIngredientName } from '../normalization-rules';
+
+/** normalizeIngredientName returns {cleaned, nounOnly, stripped}; the key is built from `cleaned`. */
+const norm = (s: string): string => normalizeIngredientName(s).cleaned;
+
+/**
+ * iOS Smart Punctuation split every possessive brand into two cache spaces.
+ *
+ * `collapseSpaces` preserved only the STRAIGHT apostrophe: its strip is
+ * `[^\w\s'%\-]`, so `’ ‘ ʼ ´` all became a SPACE. That ran upstream of
+ * `canonicalizeCacheKey`, whose `['‘’ʼ`´]` fold exists precisely to collapse
+ * possessives — by the time it ran the apostrophe was already gone and an
+ * orphan `s` token was in its place.
+ *
+ * This is not a theoretical spelling. `ChunkyInput` is a bare React Native
+ * `TextInput` with no `autoCorrect={false}`, and iOS Smart Punctuation is on by
+ * default, so `’` is the DEFAULT spelling arriving from the mobile client. A
+ * user typing "McDonald's fries" on an iPhone and a user typing it on a desktop
+ * keyboard were reaching different cache rows.
+ *
+ * Measured live before the fix (write-guarded probe, stable across two runs):
+ *   "amy's lentil soup"  -> fs_46343    Organic Lentil Soup        81.60 kcal
+ *   "amy’s lentil soup"  -> off_00422…  Amy's Organic Lentil Soup  52.55 kcal
+ * A different food and a 55% difference in what the user is billed, decided by
+ * which keyboard they used.
+ *
+ * Same root cause as PR #149 (apostrophes splitting the key space), one layer
+ * upstream of the fix that closed it.
+ */
+
+const SPELLINGS: Array<[string, string]> = [
+    ['straight', "mcdonald's fries"],
+    ['curly (iOS default)', 'mcdonald’s fries'],
+    ['bare', 'mcdonalds fries'],
+    ['modifier letter', 'mcdonaldʼs fries'],
+    ['acute accent', 'mcdonald´s fries'],
+    ['left single quote', 'mcdonald‘s fries'],
+];
+
+describe('every apostrophe glyph reaches one cache key', () => {
+    it.each(SPELLINGS)('%s spelling agrees with the straight one', (_label, text) => {
+        expect(canonicalizeCacheKey(norm(text)))
+            .toBe(canonicalizeCacheKey(norm("mcdonald's fries")));
+    });
+
+    it('leaves no orphan "s" token in the key', () => {
+        // The specific corruption: "mcdonald’s" -> "mcdonald s" -> key token "s".
+        // Before the fix the curly spelling produced "fry mcdonald s".
+        for (const [, text] of SPELLINGS) {
+            const key = canonicalizeCacheKey(norm(text));
+            expect(key.split(' ')).not.toContain('s');
+        }
+    });
+
+    it('agrees for other possessive brands too', () => {
+        for (const brand of ['arby', 'wendy', 'amy', 'trader joe']) {
+            const straight = canonicalizeCacheKey(norm(`${brand}'s curly fries`));
+            const curly = canonicalizeCacheKey(norm(`${brand}’s curly fries`));
+            expect(curly).toBe(straight);
+        }
+    });
+});
+
+describe('the characters collapseSpaces was written to protect are untouched', () => {
+    it('keeps the percent sign — "2% milk" is nutritionally distinct from "2 milk"', () => {
+        expect(norm('2% milk')).toContain('%');
+    });
+
+    it('keeps hyphens in compound words', () => {
+        expect(norm('all-purpose flour')).toContain('-');
+    });
+
+    it('still strips punctuation that is not an apostrophe', () => {
+        // The fold must not turn into "preserve everything".
+        expect(norm('chicken (boneless), diced')).not.toMatch(/[(),]/);
+    });
+
+    it('does not merge two words that were separated by real punctuation', () => {
+        // "&" must still become a separator, not vanish into a merged token.
+        // (A synonym rule also expands this to "salt black pepper" — the point
+        // here is only that the two words did not fuse.)
+        const n = norm('salt&pepper');
+        expect(n).not.toContain('salt&pepper');
+        expect(n.split(/\s+/)).toEqual(expect.arrayContaining(['salt', 'pepper']));
+    });
+});

--- a/src/lib/mapping/normalization-rules.ts
+++ b/src/lib/mapping/normalization-rules.ts
@@ -569,11 +569,32 @@ export function normalizeIngredientName(raw: string): NormalizationResult {
   };
 }
 
+/**
+ * Every apostrophe glyph a keyboard can produce.
+ *
+ * Deliberately the SAME set `canonicalizeCacheKey` folds. iOS Smart Punctuation
+ * is on by default and rewrites `'` to `’` as the user types, so the curly form
+ * is not an edge case — it is what the mobile client actually sends.
+ */
+const APOSTROPHES = /['‘’ʼ`´]/g;
+
 function collapseSpaces(value: string): string {
   // Preserve hyphens (important for compound words like "all-purpose flour")
   // apostrophes (important for contractions and possessives)
   // and percent signs (important for "2% milk", nutritionally significant)
-  return value.replace(/\s+/g, ' ').replace(/[^\w\s'%\-]/g, ' ').replace(/\s+/g, ' ').trim();
+  //
+  // The apostrophe normalisation on the first line is load-bearing and was
+  // missing: the strip below preserves only the STRAIGHT apostrophe, so every
+  // other glyph became a space here — upstream of `canonicalizeCacheKey`, whose
+  // whole job is to fold them. By the time it ran, `mcdonald’s` had already
+  // become `mcdonald s` and the apostrophe it was written to collapse was gone,
+  // leaving an orphan `s` token in the key and a brand the detector cannot see.
+  return value
+    .replace(APOSTROPHES, "'")
+    .replace(/\s+/g, ' ')
+    .replace(/[^\w\s'%\-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function escapeRegex(value: string): string {


### PR DESCRIPTION
**This one reaches real users on their phones today.** Found while auditing for a fourth apostrophe fork after #149, #157 and #160.

## The defect

`collapseSpaces` (`normalization-rules.ts:576`) preserves only the **straight** apostrophe — its strip is `[^\w\s'%\-]`, so `’ ‘ ʼ ´` each become a **space**. It runs *upstream* of `canonicalizeCacheKey`, whose `['‘’ʼ`´]` fold exists precisely to collapse possessives. By the time that fold runs, the apostrophe is gone and an orphan `s` token stands in its place.

Real `deriveMappingCacheKey` output — **6 of 6 brands tested land in two key spaces**:

```
"mcdonald's fries" -> "mcdonald's fries" -> KEY "fry mcdonald"    brand="mcdonald's"
"mcdonald’s fries" -> "mcdonald s fries" -> KEY "fry mcdonald s"  brand=null
"mcdonalds fries"  -> "mcdonalds fries"  -> KEY "fry mcdonald"    brand="mcdonalds"
```

The function's own comment says it preserves *"apostrophes (important for contractions and possessives)"*. It preserved one of the six glyphs.

## Why this is not an edge case

`ChunkyInput` (`src/components/ui/ChunkyInput.tsx:54` in the mobile repo) is a bare React Native `TextInput` that spreads `{...props}` with **no `autoCorrect={false}`**. iOS Smart Punctuation is on by default and rewrites `'` → `’` as the user types. **`’` is the default spelling arriving from an iPhone.** Only two `autoCapitalize` props exist anywhere in the app and neither is on this input.

So a user typing "McDonald's fries" on their phone and the same user typing it on a desktop keyboard reach different cache rows.

Measured live through the real mapper with writes blocked, stable across two runs:

```
"amy's lentil soup"  -> fs_46343           Organic Lentil Soup        81.60 kcal
"amy’s lentil soup"  -> off_0042234005833  Amy's Organic Lentil Soup  52.55 kcal
```

A **different food** and **55% more calories**, decided by which keyboard was used. And the save path was writing the orphan key for real:

```json
{"rawIngredient":"1 serving arby’s curly fries","normalizedForm":"arby curly fry s"}
```

`brand=null` on the curly spelling is a second-order effect worth noting: the brand detector never fires, so brand-targeted retrieval, the decisive-brand gate, the save gate and the cache-key brand prefix all lose their input at once.

## No migration — measured, not assumed

```
FoodMapping      rows with a bare `s` token:  0 of 3,245
AiNormalizeCache rows with a bare `s` token:  0 of 2,497
```

Nothing currently occupies the orphan key space. This is the one way it differs from #149, which needed 108 rows moved — same root cause, one layer upstream of the code that fixed it.

I checked the thing that actually matters here rather than the convenient one: the playbook records an earlier investigation that asked "do stored keys move?", got zero, and wrongly called a bug inert. The right question is whether the key a **lookup computes** changes — and it does, for every curly-spelled query. The zero above is only about whether a migration is needed.

## The fix

Normalise every apostrophe glyph to the straight form **before** the strip, using the same character class `canonicalizeCacheKey` already folds — so the two agree by construction rather than by coincidence.

## Tests

`src/lib/mapping/__tests__/smart-punctuation-key.test.ts` — 12 tests, **6 fail without the fix**.

The 6 that pass either way are deliberate controls: the straight and bare spellings (which already agreed), and the three things `collapseSpaces` exists to protect — `%` in "2% milk", the hyphen in "all-purpose flour", and real punctuation still becoming a separator rather than fusing two words.

`npm run typecheck` clean · `npm run lint:ci` 0 errors · `npx jest src/lib/mapping` 799/799.

One note on that last number: the failure I described on #160 as "pre-existing on clean master" (`does NOT fast-path "canned tuna in water"`) **passes here**. It is environment-dependent, not a code defect — that test makes live database and AI calls, so it fails whenever `DATABASE_URL` does not point at a real database. A unit test reaching the network is worth fixing on its own, but it is not this PR.

## Not fixed here

The audit that found this also found a **mirror of #160**: `deriveMustHaveTokens` (`filter-candidates.ts:2944`) is unfolded on the *query* side, so an apostrophe-bearing query still cannot match a bare candidate (`amy's` vs `Amys`) — 65,160 OFF records carry the bare spelling of a brand that also appears possessively. And `foldApostrophes` in #160 covers 3 of the 6 glyphs, missing `‘ ʼ ´`, which the corpus does carry (`trader joe‘s`, `hershey‘s`, `kellogg´s`). Both are admit-only and both are follow-ups, kept out of here so this change stays independently reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx