### PR TITLE
fix(eval): n-mq-47 asserts the right brand instead of forbidding wrong ones

### DIFF
--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -6262,12 +6262,8 @@
       "text": "trader joes chicken breast",
       "expectName": [
         [
-          "chicken breast"
-        ]
-      ],
-      "forbidName": [
-        [
-          "mary's"
+          "chicken breast",
+          "trader joe"
         ]
       ],
       "grams": [
@@ -6281,7 +6277,7 @@
         ]
       },
       "knownIssue": true,
-      "notes": "OVER-ADMISSION TRIPWIRE for n-mq-43..46, and a separately-found defect. Measured 2026-07-25 on the deployed corpus by resolving the seed COLD (skipCache) in two isolated, write-guarded trees that differed only in the PR #160 patch. This seed is UNCHANGED by #160 — off_0208065711897 'Skinless Chicken Breast' [Mary's Chicken] 112 g / 130 kcal, pool 10 both before and after — which is the point: opening the Trader Joe's pool must not reorder a query that already had one. It is marked knownIssue because the answer is WRONG IN A DIFFERENT WAY: the brand is Mary's Chicken, not Trader Joe's, even though off_0274038708522 (\"Trader Joe's Boneless Skinless Chicken Breast\") exists and was the record hijacking 'trader joes gone bananas' before #160. Same food, wrong brand, right macros — so the numeric bands pass and only the brand is wrong, which is why this class survived every gate. Do not 'fix' this by tightening the brand requirement without measuring n-mq-43..46 again; the two pull in opposite directions. ASSERTION CORRECTED after the first eval run reported this case as 'known issue NOW PASSING'. It passed because expectName ['chicken breast'] and both numeric bands are satisfied by the WRONG-BRAND record — which is precisely the defect. A wrong answer that passes is worse than no case at all, so forbidName [\"mary's\"] now makes the defect expressible. The forbid is safe in the sense n-mq-40 warns about: \"mary's\" is not a substring of the correct answer (\"Trader Joe's Boneless Skinless Chicken Breast\"), so the case becomes passable the moment the brand is right, rather than unpassable forever."
+      "notes": "OVER-ADMISSION TRIPWIRE for n-mq-43..46, and a separately-found defect. Measured 2026-07-25 on the deployed corpus by resolving the seed COLD (skipCache) in two isolated, write-guarded trees that differed only in the PR #160 patch. This seed is UNCHANGED by #160 — off_0208065711897 'Skinless Chicken Breast' [Mary's Chicken] 112 g / 130 kcal, pool 10 both before and after — which is the point: opening the Trader Joe's pool must not reorder a query that already had one. It is marked knownIssue because the answer is WRONG IN A DIFFERENT WAY: the brand is Mary's Chicken, not Trader Joe's, even though off_0274038708522 (\"Trader Joe's Boneless Skinless Chicken Breast\") exists and was the record hijacking 'trader joes gone bananas' before #160. Same food, wrong brand, right macros — so the numeric bands pass and only the brand is wrong, which is why this class survived every gate. Do not 'fix' this by tightening the brand requirement without measuring n-mq-43..46 again; the two pull in opposite directions. ASSERTION CORRECTED TWICE, and the second correction is the instructive one. Round 1 added forbidName [\"mary's\"] after the case reported 'NOW PASSING' on the wrong-brand record. Round 2 (2026-07-26, post-#160 deploy) it reported 'NOW PASSING' AGAIN — because the winner had moved to a THIRD brand, off 'Skinless Chicken Breast' [Great Value] 112 g / 140 kcal. Neither Mary's nor Trader Joe's. Enumerating forbidden brands is the wrong SHAPE of assertion: it can only ever exclude the wrong answers you have already seen, and a retrieval change just walks to the next one. Replaced with a POSITIVE brand requirement — expectName [[\"chicken breast\",\"trader joe\"]], inner-AND against name+brand — which is satisfied by exactly one thing, the correct record, and is robust to every wrong brand including ones not yet observed. Still knownIssue: off_0274038708522 (\"Trader Joe's Boneless Skinless Chicken Breast\") exists and is not being retrieved. This tightening changes NO pipeline behaviour and therefore cannot affect n-mq-43..46 — the warning above about the two pulling in opposite directions applies to changing the brand requirement in the MAPPER, not in this assertion."
     }
   ]
 }


### PR DESCRIPTION
## What

`n-mq-47` reported **"known issue NOW PASSING — promote to hard assertion"** on the post-#160 eval. Promoting it would have locked in a wrong answer.

## Why it falsely passed

`trader joes chicken breast` currently resolves to:

```
Skinless Chicken Breast | brand=Great Value | 112g | 140 kcal | openfoodfacts
```

Great Value is Walmart's store brand. Not Trader Joe's — and not Mary's Chicken, which is the brand the case was originally written against.

The old assertion was:

```json
"expectName": [["chicken breast"]],
"forbidName": [["mary's"]]
```

`expectName` and both numeric bands are satisfied by *any* chicken-breast record, and the forbid-list excluded only the single wrong brand that had been observed when the case was written. The winner moved to a third brand and the case went green while still being wrong.

**This is the second false pass on this case for the same reason.** A forbid-list can only exclude wrong answers already seen; a retrieval change walks to the next one.

## The fix

```json
"expectName": [["chicken breast", "trader joe"]]
```

Inner-AND against `name + ' ' + brand`, so it is satisfied by exactly one thing — the correct record — and is robust to every wrong brand, including ones not yet observed. `forbidName` is now redundant and removed.

Stays `knownIssue: true`: `off_0274038708522` ("Trader Joe's Boneless Skinless Chicken Breast") exists in the corpus and is not being retrieved. The case becomes passable the moment retrieval is fixed, rather than unpassable forever.

## Blast radius

Assertion-only. No pipeline code touched, so it cannot affect `n-mq-43..46`. The note's existing warning about brand-tightening pulling against those cases applies to the **mapper**, not to this assertion.

## Verification

Deployed state at time of measurement: box on `f503856` (#160 + #161 + #162), eval **0 real failures / 15 known issues**. Under this change n-mq-47 fails `expectName` and is reported as a 🟡 known issue rather than a false green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx