### PR TITLE
fix(dedupe): near-dup election must not elect a corrupt-marked row

### DIFF
--- a/scripts/__tests__/dedupe-election-corrupt-guard.test.ts
+++ b/scripts/__tests__/dedupe-election-corrupt-guard.test.ts
@@ -1,0 +1,135 @@
+import { isBetterRepresentative, completenessScore } from '../dedupe-off-mark';
+import type { Row } from '../dedupe-off-mark';
+
+/**
+ * Near-dup election must never elect a corrupt-marked row over a clean one.
+ *
+ * The hazard is not that marks get lost — they are sticky. It is that
+ * `dedupe-off-mark --clear` resets every `duplicateOfBarcode` and re-elects
+ * from scratch, and before this change the election could not see
+ * `corruptReason` at all: the field was absent from both the `Row` type and the
+ * Prisma `select`. So the guard had no input, silently.
+ *
+ * Why completeness cannot be trusted to break the tie in our favour: the
+ * corrupt row is usually the MORE complete of the pair. The defect in this
+ * corpus is a whole-container panel stored as per-100g, which means every macro
+ * is populated (just at the wrong scale) and `servingGrams` is set — a perfect
+ * 5/5 on `completenessScore`. Its clean twin routinely scores lower. That is
+ * why the corrupt check has to come FIRST, and it is what the tests below pin.
+ *
+ * Real pair this was found on: `7500024202430` / `7500024202434`, Factor
+ * "Sun dried tomato chicken", byte-identical inflated panels (312 g, 670 kcal,
+ * macro sum 102 g/100g — arithmetically impossible).
+ */
+
+function row(over: Partial<Row> & Pick<Row, 'barcode' | 'name'>): Row {
+    return {
+        brandName: null,
+        nutrientsPer100g: null,
+        servingGrams: null,
+        servingSize: null,
+        corruptReason: null,
+        ...over,
+    };
+}
+
+/** The shape the defect actually takes: every macro filled, serving set. */
+const FULL_PANEL = { calories: 670, protein: 39, carbs: 14, fat: 49 };
+
+describe('a clean row always beats a corrupt one', () => {
+    it('prefers the clean row even when the corrupt row is strictly MORE complete', () => {
+        // This is the non-obvious case and the whole reason for the ordering.
+        const corrupt = row({
+            barcode: '7500024202430',
+            name: 'Sun dried tomato chicken',
+            nutrientsPer100g: FULL_PANEL,
+            servingGrams: 312,
+            corruptReason: 'macro-sum-impossible:direct',
+        });
+        const clean = row({
+            barcode: '7500024202434',
+            name: 'Sun dried tomato chicken',
+            nutrientsPer100g: { calories: 140 }, // sparse but honest
+        });
+
+        // Guard against the test being vacuous: the corrupt row really is the
+        // more complete one, so completeness alone would elect it.
+        expect(completenessScore(corrupt)).toBeGreaterThan(completenessScore(clean));
+
+        expect(isBetterRepresentative(clean, corrupt)).toBe(true);
+        expect(isBetterRepresentative(corrupt, clean)).toBe(false);
+    });
+
+    it('prefers the clean row even when the corrupt row has the shorter name', () => {
+        // Name length is the second tiebreak and would otherwise pick `corrupt`.
+        const corrupt = row({ barcode: '111', name: 'Cola', corruptReason: 'panel-inflated:foodtype-sibling' });
+        const clean = row({ barcode: '222', name: 'Cola Classic 12oz' });
+
+        expect(clean.name.length).toBeGreaterThan(corrupt.name.length);
+        expect(isBetterRepresentative(clean, corrupt)).toBe(true);
+        expect(isBetterRepresentative(corrupt, clean)).toBe(false);
+    });
+
+    it('prefers the clean row even when the corrupt row has the lower barcode', () => {
+        // Barcode is the final deterministic tiebreak and would pick `corrupt`.
+        const corrupt = row({ barcode: '000111', name: 'Soup', corruptReason: 'kcal-impossible:direct' });
+        const clean = row({ barcode: '999888', name: 'Soup' });
+
+        expect(corrupt.barcode < clean.barcode).toBe(true);
+        expect(isBetterRepresentative(clean, corrupt)).toBe(true);
+        expect(isBetterRepresentative(corrupt, clean)).toBe(false);
+    });
+});
+
+describe('the guard changes nothing when corruptness is equal', () => {
+    // These pin that the pre-existing ordering is untouched. If any of these
+    // break, the guard has overreached beyond the corrupt/clean distinction.
+    it('falls through to completeness when neither is corrupt', () => {
+        const richer = row({ barcode: '222', name: 'Yogurt', nutrientsPer100g: FULL_PANEL, servingGrams: 150 });
+        const sparser = row({ barcode: '111', name: 'Yogurt' });
+        expect(isBetterRepresentative(richer, sparser)).toBe(true);
+    });
+
+    it('falls through to completeness when BOTH are corrupt', () => {
+        const richer = row({
+            barcode: '222', name: 'Yogurt', nutrientsPer100g: FULL_PANEL, servingGrams: 150,
+            corruptReason: 'kcal-impossible:direct',
+        });
+        const sparser = row({ barcode: '111', name: 'Yogurt', corruptReason: 'kcal-impossible:direct' });
+        expect(isBetterRepresentative(richer, sparser)).toBe(true);
+    });
+
+    it('falls through to name length, then barcode, on equal completeness', () => {
+        expect(isBetterRepresentative(
+            row({ barcode: '999', name: 'Cola' }),
+            row({ barcode: '111', name: 'Cola Classic' }),
+        )).toBe(true);
+
+        expect(isBetterRepresentative(
+            row({ barcode: '111', name: 'Cola' }),
+            row({ barcode: '222', name: 'Cola' }),
+        )).toBe(true);
+    });
+
+    it('is antisymmetric and deterministic across argument order', () => {
+        // Re-runs must elect the same representative; a comparator that returns
+        // true both ways would make election order-dependent.
+        const pairs: Array<[Row, Row]> = [
+            [row({ barcode: '111', name: 'A', corruptReason: 'x' }), row({ barcode: '222', name: 'A' })],
+            [row({ barcode: '111', name: 'A' }), row({ barcode: '222', name: 'A' })],
+            [row({ barcode: '111', name: 'A', corruptReason: 'x' }), row({ barcode: '222', name: 'A', corruptReason: 'y' })],
+        ];
+        for (const [a, b] of pairs) {
+            expect(isBetterRepresentative(a, b)).toBe(!isBetterRepresentative(b, a));
+        }
+    });
+});
+
+describe('importing this script does not run it', () => {
+    it('is import-safe, which is what makes the above testable at all', () => {
+        // Before the require.main guard, importing dedupe-off-mark.ts executed
+        // main() and connected to the production database. If that regresses,
+        // this whole file becomes a data-op rather than a test.
+        expect(typeof isBetterRepresentative).toBe('function');
+    });
+});

--- a/scripts/dedupe-off-mark.ts
+++ b/scripts/dedupe-off-mark.ts
@@ -41,6 +41,7 @@ interface Row {
     nutrientsPer100g: { calories?: number; protein?: number; carbs?: number; fat?: number } | null;
     servingGrams: number | null;
     servingSize: string | null;
+    corruptReason: string | null;
 }
 
 /** Same completeness idea as dedupe-candidates.ts isBetterRepresentative,
@@ -58,8 +59,26 @@ function completenessScore(r: Row): number {
 }
 
 /** True when a should survive over b. Ties broken deterministically so
- *  re-runs pick the same representative. */
+ *  re-runs pick the same representative.
+ *
+ *  A clean row ALWAYS beats a corrupt-marked one, ahead of completeness. That
+ *  ordering is load-bearing, not a preference: the corrupt row is usually the
+ *  MORE "complete" of the pair, because the defect in this corpus is a
+ *  whole-container panel stored as per-100g — every macro populated (at the
+ *  wrong scale) and servingGrams set, a perfect 5/5 below. Ranking by
+ *  completeness first therefore actively prefers the corrupt row.
+ *
+ *  Why it matters even though marks look sticky: --clear resets every
+ *  duplicateOfBarcode and re-elects from scratch, and before this change the
+ *  election could not see corruptReason at all — it was not even selected. If a
+ *  corrupt representative is ever hard-deleted rather than marked, the next run
+ *  elects its clean-LOOKING clone and re-introduces the identical bad panel into
+ *  search, since sync-typesense.ts only excludes duplicateOfBarcode IS NOT NULL
+ *  and corruptReason IS NOT NULL — and the clone is neither. */
 function isBetterRepresentative(a: Row, b: Row): boolean {
+    const aCorrupt = a.corruptReason != null;
+    const bCorrupt = b.corruptReason != null;
+    if (aCorrupt !== bCorrupt) return bCorrupt;
     const ac = completenessScore(a);
     const bc = completenessScore(b);
     if (ac !== bc) return ac > bc;
@@ -110,6 +129,9 @@ async function main() {
                 nutrientsPer100g: true,
                 servingGrams: true,
                 servingSize: true,
+                // Required by isBetterRepresentative. Omitting it silently made
+                // election blind to corrupt marks rather than failing loudly.
+                corruptReason: true,
             },
             orderBy: { barcode: 'asc' },
             take: READ_BATCH,
@@ -199,11 +221,19 @@ async function main() {
     console.log('so the rebuilt off_foods index drops them.');
 }
 
-main()
-    .catch(err => {
-        console.error('❌ Crashed:', err);
-        process.exit(1);
-    })
-    .finally(async () => {
-        await prisma.$disconnect();
-    });
+// Guarded so the election logic above can be unit-tested without this script
+// connecting to the production database on import. Same pattern as
+// scripts/eval/correctness-screen.ts:982.
+if (require.main === module) {
+    main()
+        .catch(err => {
+            console.error('❌ Crashed:', err);
+            process.exit(1);
+        })
+        .finally(async () => {
+            await prisma.$disconnect();
+        });
+}
+
+export { isBetterRepresentative, completenessScore, groupKey };
+export type { Row };


### PR DESCRIPTION
## The bug

`isBetterRepresentative` in `scripts/dedupe-off-mark.ts` **could not see `corruptReason`** — the field was absent from both the `Row` interface and the Prisma `select`. The guard had no input at all; election was blind, silently.

## Why the corrupt check goes FIRST, ahead of completeness

Because **the corrupt row is usually the *more* complete of the pair.** The dominant defect in this corpus is a whole-container panel stored as per-100g, which means every macro is populated (at the wrong scale) and `servingGrams` is set — a perfect 5/5 on `completenessScore`, while the honest twin is often sparse.

So ranking by completeness first doesn't merely fail to help, it **actively prefers the corrupt row**. The test asserts this rather than assuming it:

```ts
expect(completenessScore(corrupt)).toBeGreaterThan(completenessScore(clean));
```

## Why it matters even though marks look sticky

`--clear` resets every `duplicateOfBarcode` and re-elects from scratch.

Today the affected pair is a deterministic no-op: `7500024202430` / `7500024202434`, Factor "Sun dried tomato chicken", byte-identical panels (312 g, 670 kcal, macro sum **102 g per 100 g** — arithmetically impossible). Both score 5, equal name length, so the lower barcode wins and it happens to be the marked one.

**The hazard is a corrupt representative being hard-DELETED rather than marked.** The next run then elects its clean-looking clone and re-introduces the identical inflated panel into search, because `sync-typesense.ts:137` only excludes `duplicateOfBarcode IS NOT NULL` and `corruptReason IS NOT NULL` — and the clone is neither.

## Measured scope

- 92,625 rows carry `duplicateOfBarcode` with `corruptReason` NULL
- 2 match the impossible-macro signature; both currently sit under corrupt representatives
- 3,773 dup rows sit under a now-corrupt representative. Of the 3,598 where both have kcal, **3,592 are within 10% of their rep** — same bad data, nothing lost. The materially-recoverable set is **6 rows**, not thousands.

## Also: the script is now testable

Added `if (require.main === module)` (same pattern as `scripts/eval/correctness-screen.ts:982`) and exported the pure election helpers. Before this, importing the module **executed `main()` and connected to the production database**, so none of this logic could be unit-tested at all — the gap PR #152 flagged for `scripts/`.

## Verification

8 tests. Red/green proved by substituting `origin/master`'s function body: the **3** corrupt-precedence cases fail without the guard, all **8** pass with it. The **5** fall-through cases pin that the pre-existing ordering (completeness → name length → barcode) is untouched, including when *both* rows are corrupt, plus an antisymmetry check so election stays deterministic across argument order.

`npx tsc --noEmit` clean, `lint:ci` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx