### PR TITLE
feat(corrupt): sibling-free panel-inflated-serving detector (detection only)

### DIFF
--- a/scripts/eval/__tests__/panel-inflated-serving.test.ts
+++ b/scripts/eval/__tests__/panel-inflated-serving.test.ts
@@ -1,0 +1,390 @@
+/**
+ * panel-inflated-serving.test.ts — the sibling-free per-serving-panel rule,
+ * tested against real corpus rows on both sides.
+ *
+ * Same hard requirement as failure-classes.test.ts: a detector that no longer
+ * fires on the rows that motivated it is worse than no detector, because the
+ * report then reads "class closed". So every exemplar below is a REAL row
+ * (barcode + measured panel, read from the live corpus on 2026-07-26), and every
+ * negative control is a real row too — a legitimately large serving that this
+ * rule must refuse. The negatives are chosen so that each one clears every
+ * condition except the one named in its expectation: a control that failed at
+ * the first gate would execute none of the rule and prove nothing.
+ *
+ * The rule permanently removes records from the index once the (separate,
+ * human-gated) marking op runs, so its refusals matter as much as its hits.
+ */
+
+import {
+    MAX_MACRO_SUM_100G,
+    MIN_DRY_MACRO_SUM_100G,
+    MIN_IMPLIED_SERVING_KCAL,
+    SERVING_WINDOW_MAX_G,
+    SERVING_WINDOW_MIN_G,
+    atwaterKcal,
+    decideMark,
+    impliedServingKcal,
+    rejectPanelInflatedServing,
+    type CorruptScanFlag,
+    type ServingScalePanel,
+} from '../../../src/lib/mapping/corrupt-mark';
+
+interface Exemplar {
+    barcode: string;
+    label: string;
+    panel: ServingScalePanel;
+    /** What the reviewer concluded the row really is. */
+    note: string;
+}
+
+// ---------------------------------------------------------------------------
+// Positive exemplars — measured members of the class
+// ---------------------------------------------------------------------------
+
+const MEMBERS: Exemplar[] = [
+    {
+        barcode: '7500618202346',
+        label: 'Factor "Pork chili Mac"',
+        panel: { kcal100: 560, servingGrams: 357, protein: 29, carbs: 46, fat: 29 },
+        note: '560 kcal is the TRAY, not 100 g of it. Believed per-100g it bills 1,999 kcal.',
+    },
+    {
+        barcode: '00040420',
+        label: 'Raymond et Roquelaure "Cassoulet canard"',
+        panel: { kcal100: 597, servingGrams: 420, protein: 44, carbs: 30, fat: 30 },
+        note: 'A 420 g tin of cassoulet cannot be 597 kcal per 100 g; 2,507 kcal implied.',
+    },
+    {
+        barcode: '7500021202235',
+        label: 'Factor "Grilled chicken a la vodka"',
+        panel: { kcal100: 630, servingGrams: 366, protein: 42, carbs: 10, fat: 50 },
+        note: '2,306 kcal implied for one meal tray.',
+    },
+    {
+        barcode: '2062759005994',
+        label: 'Market Basket "Whole Steak Cheese Sub"',
+        panel: { kcal100: 570, servingGrams: 269, protein: 30, carbs: 41, fat: 32 },
+        note: 'Deli singleton — no same-name siblings, so the median rule cannot see it.',
+    },
+    {
+        barcode: '0088332030056',
+        label: 'Sodebo "Salade et compagnie"',
+        panel: { kcal100: 575, servingGrams: 320, protein: 26, carbs: 51, fat: 28 },
+        note: 'Macro sum lands on exactly 105 — the top edge of the rounding slack.',
+    },
+    {
+        barcode: '0990739144666',
+        label: 'KFC chocolate shake',
+        panel: { kcal100: 522.7999877929688, servingGrams: 310, protein: 9, carbs: 74, fat: 20 },
+        note: 'Restaurant singleton: 522.8 kcal is the cup. Believed per-100g it bills 1,621.',
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Negative controls — real rows that are NOT this class
+// ---------------------------------------------------------------------------
+
+const CONTROLS: Array<Exemplar & { expected: string }> = [
+    {
+        barcode: '8413080019282',
+        label: 'Gourmet refined sunflower oil, 1 L bottle',
+        panel: { kcal100: 826, servingGrams: 1000, protein: 0, carbs: 9, fat: 91.8 },
+        note:
+            'The single largest implied per-serving energy in the whole corpus (8,260 kcal) ' +
+            'and a perfectly correct panel: 826 kcal/100g IS refined oil. servingGrams is the ' +
+            'bottle. It clears the dry band, the Atwater test and the energy threshold — only ' +
+            'the serving window saves it, which is exactly what that window is for.',
+        expected: 'serving_outside_single_serving_window',
+    },
+    {
+        barcode: '8964001506133',
+        label: 'Hemani coconut oil, 700 g jar',
+        panel: { kcal100: 900, servingGrams: 700, protein: 0, carbs: 0, fat: 100 },
+        note: 'Pure fat, panel exactly right, 6,300 kcal implied from a jar-sized "serving".',
+        expected: 'serving_outside_single_serving_window',
+    },
+    {
+        barcode: '0850000628168',
+        label: 'Naked Mass weight-gainer, 315 g scoop',
+        panel: { kcal100: 390, servingGrams: 315, protein: 15.9, carbs: 78.7, fat: 1.27 },
+        note:
+            'A genuinely ~1,229 kcal SINGLE serving: the scoop really is 315 g and the powder ' +
+            'really is 390 kcal/100g. Clears the dry band, Atwater and the serving window; the ' +
+            'energy threshold is the only thing between this rule and deleting mass gainers.',
+        expected: 'implied_serving_kcal_below_threshold',
+    },
+    {
+        barcode: '0810056840174',
+        label: 'Keto Brick, 141 g bar',
+        panel: { kcal100: 709, servingGrams: 141, protein: 21.3, carbs: 8.51, fat: 65.2 },
+        note:
+            'The largest legitimate single-serve item measured in the corpus: 999.7 kcal in one ' +
+            'bar, correct 709 kcal/100g density. It is the row the 1,500 threshold has to clear.',
+        expected: 'implied_serving_kcal_below_threshold',
+    },
+    {
+        barcode: '00524803',
+        label: "Sainsbury's hickory smoked BBQ beef brisket, 1.2 kg family tray",
+        panel: { kcal100: 188, servingGrams: 1200, protein: 25.6, carbs: 4.2, fat: 7.4 },
+        note:
+            'A family tray whose implied energy IS absurd (2,256 kcal) but whose panel is an ' +
+            'ordinary wet food. The dry band rejects it before the energy test is even reached.',
+        expected: 'macro_sum_outside_dry_band',
+    },
+    {
+        barcode: '9310645215297',
+        label: 'Coles "Triple Chicken" (servingGrams === calories)',
+        panel: { kcal100: 543, servingGrams: 543, protein: 20.6, carbs: 61, fat: 23.3 },
+        note:
+            'Almost certainly a per-serving panel, but servingGrams carries the CALORIES value — ' +
+            'a measured ingest artifact. The serving mass is unusable, so the 2,948 kcal it ' +
+            'implies is evidence about that field, not about the panel. Refuse and leave it to ' +
+            'human triage.',
+        expected: 'serving_grams_mirrors_calories',
+    },
+    {
+        barcode: '209752824208588986029219',
+        label: "Wendy's Spicy Chicken Sandwich (validatedBy = human-triage)",
+        panel: { kcal100: 513, servingGrams: 100, protein: 30, carbs: 51, fat: 21 },
+        note:
+            'The adjacent-band row a human already validated. Macro sum 102 (inside the dry ' +
+            'band) and Atwater-exact, so it reaches the serving window and is refused there: ' +
+            'at a 100 g serving the two readings of the panel are identical, which is why the ' +
+            'window floor sits above it. Human-validated rows must never be auto-marked.',
+        expected: 'serving_outside_single_serving_window',
+    },
+    {
+        barcode: '0681603525666',
+        label: 'Shrimp tacos (already marked panel-inflated:foodtype-sibling)',
+        panel: { kcal100: 600, servingGrams: 475, protein: 28, carbs: 19, fat: 37 },
+        note:
+            'A known member of the broader per-serving-panel family that this rule does NOT ' +
+            'reach: its macros sum to 84 g/100g, below the dry band. Pinned so the miss is a ' +
+            'recorded property of the rule rather than a surprise. The sibling-median rule ' +
+            'already caught it.',
+        expected: 'macro_sum_outside_dry_band',
+    },
+];
+
+function flagFor(panel: ServingScalePanel, overrides: Partial<CorruptScanFlag> = {}): CorruptScanFlag {
+    return {
+        barcode: '0000000000000',
+        name: 'Test Food',
+        brandName: null,
+        kcal100: panel.kcal100,
+        servingGrams: panel.servingGrams,
+        tier: 'direct',
+        direction: 'panel-inflated-serving',
+        rescaled: Math.round((panel.kcal100 * 100) / panel.servingGrams),
+        siblingMedian: 0,
+        groupSize: 0,
+        triageConfirmed: false,
+        value: impliedServingKcal(panel),
+        panel,
+        check: { field: 'calories', value: panel.kcal100 },
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('rejectPanelInflatedServing — measured members', () => {
+    for (const m of MEMBERS) {
+        it(`flags ${m.label} (off_${m.barcode})`, () => {
+            expect(rejectPanelInflatedServing(m.panel)).toBeNull();
+        });
+    }
+
+    it('every member is internally coherent — which is why no per-field rule sees them', () => {
+        for (const m of MEMBERS) {
+            const atwater = atwaterKcal(m.panel);
+            expect(Math.abs(m.panel.kcal100 - atwater)).toBeLessThanOrEqual(0.1 * m.panel.kcal100);
+        }
+    });
+
+    it('every member sits INSIDE the existing macro-sum slack, so macro-sum-impossible cannot claim it', () => {
+        for (const m of MEMBERS) {
+            const macroSum = m.panel.protein + m.panel.fat + m.panel.carbs;
+            expect(macroSum).toBeLessThanOrEqual(MAX_MACRO_SUM_100G);
+            expect(macroSum).toBeGreaterThanOrEqual(MIN_DRY_MACRO_SUM_100G);
+        }
+    });
+
+    it('every member bills an absurd single serving if the per-100g field is believed', () => {
+        for (const m of MEMBERS) {
+            expect(impliedServingKcal(m.panel)).toBeGreaterThan(MIN_IMPLIED_SERVING_KCAL);
+        }
+    });
+});
+
+describe('rejectPanelInflatedServing — negative controls', () => {
+    for (const c of CONTROLS) {
+        it(`refuses ${c.label} with ${c.expected}`, () => {
+            expect(rejectPanelInflatedServing(c.panel)).toBe(c.expected);
+        });
+    }
+
+    it('the large-legitimate-serving controls are non-vacuous — each clears every earlier condition', () => {
+        // Oil, coconut oil and the gainer all reach the condition that rejects
+        // them. If a future edit reordered or broke an earlier condition these
+        // would start failing at the wrong gate, and this assertion is what
+        // notices. (The brisket and shrimp-taco controls stop at the dry band by
+        // design, and the Wendy's row is asserted separately below.)
+        const oil = CONTROLS.find(c => c.barcode === '8413080019282')!.panel;
+        const gainer = CONTROLS.find(c => c.barcode === '0850000628168')!.panel;
+        for (const p of [oil, gainer]) {
+            const macroSum = p.protein + p.fat + p.carbs;
+            expect(macroSum).toBeGreaterThanOrEqual(MIN_DRY_MACRO_SUM_100G);
+            expect(macroSum).toBeLessThanOrEqual(MAX_MACRO_SUM_100G);
+            expect(Math.abs(p.kcal100 - atwaterKcal(p))).toBeLessThanOrEqual(0.1 * p.kcal100);
+        }
+        // Oil is stopped only by the window; the gainer only by the threshold.
+        expect(oil.servingGrams).toBeGreaterThan(SERVING_WINDOW_MAX_G);
+        expect(impliedServingKcal(oil)).toBeGreaterThan(MIN_IMPLIED_SERVING_KCAL);
+        expect(gainer.servingGrams).toBeGreaterThan(SERVING_WINDOW_MIN_G);
+        expect(gainer.servingGrams).toBeLessThanOrEqual(SERVING_WINDOW_MAX_G);
+        expect(impliedServingKcal(gainer)).toBeLessThanOrEqual(MIN_IMPLIED_SERVING_KCAL);
+    });
+
+    it("the human-triage Wendy's row is Atwater-exact and inside the dry band, and still refused", () => {
+        const wendys = CONTROLS.find(c => c.barcode === '209752824208588986029219')!.panel;
+        expect(atwaterKcal(wendys)).toBe(wendys.kcal100);
+        expect(wendys.protein + wendys.fat + wendys.carbs).toBeGreaterThanOrEqual(MIN_DRY_MACRO_SUM_100G);
+        expect(rejectPanelInflatedServing(wendys)).toBe('serving_outside_single_serving_window');
+        expect(decideMark(flagFor(wendys)).mark).toBe(false);
+    });
+
+    it('refuses a missing or unusable panel instead of assuming', () => {
+        expect(rejectPanelInflatedServing(undefined)).toBe('serving_scale_panel_missing');
+        expect(rejectPanelInflatedServing(null)).toBe('serving_scale_panel_missing');
+        expect(rejectPanelInflatedServing({ kcal100: 0, servingGrams: 400, protein: 30, carbs: 40, fat: 30 }))
+            .toBe('serving_scale_panel_missing');
+        expect(rejectPanelInflatedServing({ kcal100: 560, servingGrams: 0, protein: 30, carbs: 40, fat: 30 }))
+            .toBe('serving_scale_panel_missing');
+        expect(rejectPanelInflatedServing({ kcal100: 560, servingGrams: 357, protein: NaN, carbs: 46, fat: 29 }))
+            .toBe('serving_scale_panel_missing');
+    });
+});
+
+describe('rejectPanelInflatedServing — boundaries', () => {
+    /** Pork chili Mac, with one dimension moved to the edge under test. */
+    const at = (o: Partial<ServingScalePanel>): ServingScalePanel =>
+        ({ kcal100: 560, servingGrams: 357, protein: 29, carbs: 46, fat: 29, ...o });
+
+    it('accepts a macro sum at exactly MAX_MACRO_SUM_100G and rejects just above it', () => {
+        // 105 stays a member: above it the row belongs to macro-sum-impossible.
+        expect(rejectPanelInflatedServing(at({ protein: 30, carbs: 46, fat: 29 }))).toBeNull();
+        expect(rejectPanelInflatedServing(at({ protein: 31, carbs: 46, fat: 29 })))
+            .toBe('macro_sum_outside_dry_band');
+    });
+
+    it('rejects a macro sum just under the dry-band floor', () => {
+        // 94.9 g/100g: a food with >5% water is not a plausible per-100g panel
+        // for this class, and the wet-food population is far too large to touch.
+        expect(rejectPanelInflatedServing(at({ protein: 24, carbs: 42, fat: 28.9 })))
+            .toBe('macro_sum_outside_dry_band');
+    });
+
+    it('rejects an incoherent panel — one bad field is a different class', () => {
+        expect(rejectPanelInflatedServing(at({ kcal100: 900 }))).toBe('panel_not_atwater_consistent');
+    });
+
+    it('rejects at the serving-window edges and accepts strictly inside', () => {
+        expect(rejectPanelInflatedServing(at({ servingGrams: SERVING_WINDOW_MIN_G })))
+            .toBe('serving_outside_single_serving_window');
+        expect(rejectPanelInflatedServing(at({ servingGrams: SERVING_WINDOW_MAX_G + 0.1 })))
+            .toBe('serving_outside_single_serving_window');
+        expect(rejectPanelInflatedServing(at({ servingGrams: SERVING_WINDOW_MAX_G }))).toBeNull();
+    });
+
+    it('rejects at exactly MIN_IMPLIED_SERVING_KCAL and accepts strictly above', () => {
+        const grams = (MIN_IMPLIED_SERVING_KCAL * 100) / 560;
+        expect(impliedServingKcal(at({ servingGrams: grams }))).toBeCloseTo(MIN_IMPLIED_SERVING_KCAL, 6);
+        expect(rejectPanelInflatedServing(at({ servingGrams: grams })))
+            .toBe('implied_serving_kcal_below_threshold');
+        expect(rejectPanelInflatedServing(at({ servingGrams: grams + 1 }))).toBeNull();
+    });
+});
+
+describe('decideMark — panel-inflated-serving', () => {
+    it('marks a measured member with the family reason string', () => {
+        const d = decideMark(flagFor(MEMBERS[0].panel));
+        expect(d).toEqual({ mark: true, reason: 'panel-inflated-serving:direct' });
+    });
+
+    it('re-runs the WHOLE rule from the raw panel, so an inflated `value` cannot mark a clean row', () => {
+        // The self-verification guard every other direction has: a hand-edited or
+        // stale scan file must not be able to mark a row the rule would refuse
+        // today. Here the panel is the Keto Brick (999.7 kcal, legitimate) while
+        // `value` claims 9,999 — decideMark must believe the measurements.
+        const brick = CONTROLS.find(c => c.barcode === '0810056840174')!.panel;
+        const d = decideMark(flagFor(brick, { value: 9999 }));
+        expect(d).toEqual({ mark: false, skip: 'implied_serving_kcal_below_threshold' });
+    });
+
+    it('refuses every negative control, naming the condition that refused it', () => {
+        for (const c of CONTROLS) {
+            expect(decideMark(flagFor(c.panel))).toEqual({ mark: false, skip: c.expected });
+        }
+    });
+
+    it('refuses a flag that carries no panel at all', () => {
+        const d = decideMark(flagFor(MEMBERS[0].panel, { panel: undefined, value: 99999 }));
+        expect(d).toEqual({ mark: false, skip: 'serving_scale_panel_missing' });
+    });
+
+    it('does not borrow the sibling trust floors — the rule is sibling-free', () => {
+        // groupSize 0 / siblingMedian 0 is the normal shape for this direction
+        // (name-space singletons). If it ever started sharing panel-inflated's
+        // MIN_INFLATED_GROUP_SIZE floor, nothing would ever mark.
+        const d = decideMark(flagFor(MEMBERS[0].panel, { groupSize: 0, siblingMedian: 0 }));
+        expect(d.mark).toBe(true);
+    });
+});
+
+describe('the existing classes are untouched', () => {
+    it('keeps MAX_MACRO_SUM_100G at 105 — the deliberate label-rounding slack', () => {
+        expect(MAX_MACRO_SUM_100G).toBe(105);
+    });
+
+    it('leaves macro-sum-impossible deciding purely on its own value', () => {
+        const base = {
+            barcode: '0000000000000', name: 'x', brandName: null, kcal100: 500,
+            servingGrams: 400, tier: 'direct' as const, rescaled: 0,
+            siblingMedian: 0, groupSize: 0, triageConfirmed: false,
+        };
+        expect(decideMark({ ...base, direction: 'macro-sum-impossible', value: 106 }))
+            .toEqual({ mark: true, reason: 'macro-sum-impossible:direct' });
+        expect(decideMark({ ...base, direction: 'macro-sum-impossible', value: 105 }))
+            .toEqual({ mark: false, skip: 'value_below_threshold' });
+        // A panel that would satisfy the NEW rule must not change that verdict.
+        expect(decideMark({
+            ...base, direction: 'macro-sum-impossible', value: 105,
+            panel: MEMBERS[0].panel,
+        })).toEqual({ mark: false, skip: 'value_below_threshold' });
+    });
+
+    it('leaves the sibling-based panel directions on their group-size and median floors', () => {
+        const base = {
+            barcode: '0000000000000', name: 'x', brandName: null, kcal100: 900,
+            servingGrams: 30, tier: 'direct' as const, rescaled: 270,
+            siblingMedian: 265, groupSize: 8, triageConfirmed: false,
+        };
+        expect(decideMark({ ...base, direction: 'panel-inflated' }))
+            .toEqual({ mark: true, reason: 'panel-inflated:direct' });
+        expect(decideMark({ ...base, direction: 'panel-inflated', groupSize: 7 }))
+            .toEqual({ mark: false, skip: 'inflated_group_too_small' });
+        expect(decideMark({ ...base, direction: 'panel-low', kcal100: 160, siblingMedian: 540 }))
+            .toEqual({ mark: true, reason: 'panel-low:direct' });
+    });
+
+    it('gives the new class its own reason string, distinct from panel-inflated', () => {
+        const neu = decideMark(flagFor(MEMBERS[0].panel));
+        expect(neu).toEqual({ mark: true, reason: 'panel-inflated-serving:direct' });
+        // Same family prefix on purpose (mark-corrupt-off.ts --clear-prefix
+        // "panel-inflated" clears both generations), but distinguishable:
+        // "panel-inflated:" selects only the sibling-median generation.
+        expect('panel-inflated-serving:direct'.startsWith('panel-inflated')).toBe(true);
+        expect('panel-inflated-serving:direct'.startsWith('panel-inflated:')).toBe(false);
+    });
+});

--- a/scripts/eval/detect-corrupt-nutrition.ts
+++ b/scripts/eval/detect-corrupt-nutrition.ts
@@ -25,6 +25,19 @@
  *                          kJ-value-in-the-kcal-field family (n-mq-27 lemon:
  *                          383 "kcal"/100g vs ~40 real). Alcohol names are
  *                          exempt (7 kcal/g invisible to Atwater).
+ *   panel-inflated-serving a per-SERVING panel stored in the per-100g fields —
+ *                          the same corruption detect-corrupt-panel.ts catches
+ *                          via same-name sibling medians, but caught SIBLING-FREE
+ *                          from the row alone. Needed because the class lives in
+ *                          meal-kit / restaurant / deli items, which are name-space
+ *                          singletons: 45 of a 65-row sample had no siblings, so the
+ *                          median approach is structurally blind there. Two absolute
+ *                          measurements replace the median: an internally coherent
+ *                          panel (calories within 10% of Atwater) whose macros sum
+ *                          into the near-anhydrous [95, 105] g/100g band, and an
+ *                          implied per-serving energy above 1,500 kcal from a serving
+ *                          mass inside the single-eating-occasion window. See the
+ *                          threshold block in corrupt-mark.ts for the calibration.
  *   sodium-sibling-outlier sodium >= max(2 g, 6x the same-name sibling
  *                          median) with >= --min-group siblings whose median
  *                          is itself sane — the mayo class, where the value
@@ -63,6 +76,10 @@ import {
     MIN_SODIUM_OUTLIER_GROUP,
     MIN_SODIUM_OUTLIER_RATIO,
     MIN_SODIUM_OUTLIER_G,
+    MIN_IMPLIED_SERVING_KCAL,
+    impliedServingKcal,
+    rejectPanelInflatedServing,
+    ServingScalePanel,
 } from '../../src/lib/mapping/corrupt-mark';
 
 const prisma = new PrismaClient();
@@ -221,6 +238,26 @@ async function main() {
                 }
             }
             if (na != null && na > 4) sauceBand++;
+            // Sibling-free per-serving-panel rule. Sits AFTER every absolute
+            // per-field rule (a row that is individually impossible is better
+            // described by that class) and after the sauceBand tally so the
+            // existing diagnostic counters are unaffected. The macro-sum upper
+            // bound is enforced inside the rule too, so it stays correct if the
+            // precedence chain is ever reordered.
+            if (protein != null && fat != null && carbs != null && kcal != null && r.servingGrams != null) {
+                const panel: ServingScalePanel = {
+                    kcal100: kcal, servingGrams: r.servingGrams, protein, fat, carbs,
+                };
+                if (rejectPanelInflatedServing(panel) == null) {
+                    const implied = impliedServingKcal(panel);
+                    flagged.push({
+                        ...base, direction: 'panel-inflated-serving', value: implied,
+                        rescaled: Math.round((kcal * 100) / r.servingGrams),
+                        panel, check: { field: 'calories', value: kcal },
+                    });
+                    continue;
+                }
+            }
             if (na != null && na >= MIN_SODIUM_OUTLIER_G) {
                 const m = sodiumMedians.get(normalizeNameKey(r.name));
                 if (m && m.med > 0 && m.med <= MAX_OUTLIER_SANE_MEDIAN && na >= MIN_SODIUM_OUTLIER_RATIO * m.med) {
@@ -272,6 +309,22 @@ async function main() {
         console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''} (${f.direction}): ${f.value}${extra}`);
     }
     if (flagged.length > PRINT) console.log(`  ... ${flagged.length - PRINT} more in the report file`);
+
+    // panel-inflated-serving reads differently from the per-field classes (the
+    // value is an implied SERVING energy, not a per-100g field), so it gets its
+    // own block instead of competing in the shared severity list.
+    const servingScale = flagged.filter(f => f.direction === 'panel-inflated-serving');
+    if (servingScale.length) {
+        console.log(`\npanel-inflated-serving (${servingScale.length} rows, implied serving kcal > ${MIN_IMPLIED_SERVING_KCAL}):`);
+        for (const f of servingScale.sort((a, b) => (b.value ?? 0) - (a.value ?? 0)).slice(0, PRINT)) {
+            const p = f.panel!;
+            console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''}: ` +
+                `${p.kcal100} kcal/100g x ${p.servingGrams}g = ${Math.round(f.value ?? 0)} kcal/serving ` +
+                `(macro sum ${(p.protein + p.fat + p.carbs).toFixed(1)} g/100g, ` +
+                `panel-as-serving reads ${f.rescaled} kcal/100g)`);
+        }
+        if (servingScale.length > PRINT) console.log(`  ... ${servingScale.length - PRINT} more in the report file`);
+    }
     console.log(`\nReport written to ${path.relative(process.cwd(), outPath)}`);
     console.log('Next: scripts/mark-corrupt-off.ts --file <report> (dry-run first, then --apply after approval).');
 }

--- a/scripts/mark-corrupt-off.ts
+++ b/scripts/mark-corrupt-off.ts
@@ -8,7 +8,9 @@
  *   - panel-low flags whose sibling median exceeds the physical ceiling are
  *     skipped (the SIBLING group is the corrupt one — kJ-as-kcal family);
  *   - panel-inflated flags from groups smaller than 8 are skipped;
- *   - nutrition-scale flags are re-verified against their own thresholds.
+ *   - nutrition-scale flags are re-verified against their own thresholds;
+ *   - panel-inflated-serving flags have the ENTIRE rule re-run from the raw
+ *     panel they carry, and re-check servingGrams against the live row.
  * Surviving flags are re-checked against the live row (barcode still exists,
  * stored value of the flag's check field still matches the scan within 0.5 —
  * the corpus may have changed since the scan) and then written as
@@ -129,7 +131,7 @@ async function main(): Promise<void> {
         const chunk = barcodes.slice(i, i + FETCH_CHUNK);
         const rows = await prisma.offFood.findMany({
             where: { barcode: { in: chunk } },
-            select: { barcode: true, nutrientsPer100g: true, corruptReason: true },
+            select: { barcode: true, nutrientsPer100g: true, corruptReason: true, servingGrams: true },
         });
         const byBarcode = new Map(rows.map(r => [r.barcode, r]));
         for (const barcode of chunk) {
@@ -141,6 +143,16 @@ async function main(): Promise<void> {
                 entry.flag.check ?? { field: 'calories', value: entry.flag.kcal100 };
             const live = checkValueOf(row.nutrientsPer100g, check.field);
             if (live == null || Math.abs(live - check.value) > 0.5) {
+                stale++;
+                continue;
+            }
+            // panel-inflated-serving is the one rule whose verdict depends on
+            // servingGrams as well as the panel, so its flags re-check it too —
+            // otherwise a serving-mass edit between scan and mark would slip
+            // past a check that only ever looked at the nutrient field.
+            if (entry.flag.panel &&
+                (row.servingGrams == null ||
+                 Math.abs(row.servingGrams - entry.flag.panel.servingGrams) > 0.5)) {
                 stale++;
                 continue;
             }

--- a/src/lib/mapping/corrupt-mark.ts
+++ b/src/lib/mapping/corrupt-mark.ts
@@ -6,7 +6,9 @@
  *     panel is really a per-serving panel (rescaling by 100/servingGrams
  *     lands on the same-name sibling median);
  *   - scripts/eval/detect-corrupt-nutrition.ts — per-field impossibilities
- *     and scale slips: kcal above the physical ceiling, macro sums over
+ *     and scale slips, plus the sibling-FREE panel-inflated-serving rule (the
+ *     same per-serving-panel corruption as above, caught from the row alone for
+ *     the name-space singletons the sibling median cannot reach): kcal above the physical ceiling, macro sums over
  *     100 g/100g, sodium above pure salt (the mg-entered-as-g family),
  *     kJ-values-in-the-kcal-field Atwater mismatches, and sodium sibling
  *     outliers (the mayonnaise 5.33 g/100g class from the 2026-07-21
@@ -37,6 +39,7 @@ export type CorruptDirection =
     | 'panel-low'
     | 'panel-inflated'
     // detect-corrupt-nutrition.ts
+    | 'panel-inflated-serving'
     | 'kcal-impossible'
     | 'macro-sum-impossible'
     | 'fiber-impossible'
@@ -75,6 +78,20 @@ export interface CorruptScanFlag {
     value?: number;
     ratio?: number;
     check?: CorruptScanCheck;
+    /** panel-inflated-serving only: the raw inputs the rule is computed from, so
+     *  decideMark() can re-run the entire rule instead of trusting `value`. */
+    panel?: ServingScalePanel;
+}
+
+/** Raw per-100g panel plus the row's own serving mass — the complete input set
+ *  of the panel-inflated-serving rule. Carried on the flag so the marking script
+ *  re-derives the verdict from measurements, never from the scan's conclusion. */
+export interface ServingScalePanel {
+    kcal100: number;
+    servingGrams: number;
+    protein: number;
+    fat: number;
+    carbs: number;
 }
 
 /** Physical ceiling for a trustworthy sibling median. Pure fat is ~900 kcal/100g;
@@ -112,6 +129,119 @@ export const MIN_SODIUM_OUTLIER_GROUP = 4;
 export const MIN_SODIUM_OUTLIER_RATIO = 6;
 export const MIN_SODIUM_OUTLIER_G = 2;
 
+// ---- panel-inflated-serving thresholds (SIBLING-FREE per-serving-panel rule) ----
+//
+// The class: a per-SERVING panel stored in the per-100g fields. Same family as
+// detect-corrupt-panel.ts's `panel-inflated`, but that rule needs a same-name
+// sibling median (>= MIN_INFLATED_GROUP_SIZE members), and meal-kit / restaurant
+// / deli items are overwhelmingly name-space SINGLETONS — a measured 45 of 65
+// sampled members had no siblings at all. So the sibling median is structurally
+// unavailable exactly where the class lives, and this rule replaces it with two
+// absolute measurements the row carries on its own.
+//
+// Why this band exists at all (and why no per-field rule can see it): energy is
+// 4P + 4C + 9F, so a 400-650 kcal SERVING of a mixed meal carries ~95-130 g of
+// macronutrients. Written into the per-100g fields, that reads as a macro sum of
+// 95-130 g/100g. Above 105 the existing macro-sum-impossible rule already takes
+// it. The residual blind spot is precisely [95, MAX_MACRO_SUM_100G] — the slack
+// MAX_MACRO_SUM_100G deliberately grants to label rounding (see its comment).
+// This rule does NOT narrow that slack; it adds an independent second signal so
+// the slack band can be acted on without touching the 105 threshold.
+//
+/** Lower edge of the near-anhydrous band. A per-100g panel whose macros sum to
+ *  >= 95 g describes a food that is essentially water-free: refined oils, sugars,
+ *  hard candy, syrup solids, milk/protein powders. Nothing else reaches it. */
+export const MIN_DRY_MACRO_SUM_100G = 95;
+/** The panel must be internally coherent — calories within 10% of 4P + 4C + 9F.
+ *  Coherence is what makes the class invisible to every per-field rule: 59 of 65
+ *  sampled members are Atwater-consistent, so nothing looks individually wrong.
+ *  It is also affirmative evidence of a whole-panel SCALE slip rather than a
+ *  single corrupt field (one bad field breaks the Atwater identity). */
+export const ATWATER_CONSISTENT_TOL = 0.1;
+/** Serving-mass window for a single eating occasion. Below the floor a panel
+ *  slip cannot produce an absurd per-serving energy at all (and 100 g servings
+ *  make the two readings identical — detect-corrupt-panel.ts skips the same
+ *  90-110 g dead zone for that reason). Above the ceiling `servingGrams` is a
+ *  PACKAGE mass, not a serving: 1 kg of rice, a 1 L oil bottle, a 583 g bag of
+ *  cashews all imply thousands of kcal from a perfectly correct panel, so up
+ *  there an absurd implied energy is evidence about servingGrams, not the panel.
+ *  600 g is the same serving-plausibility ceiling detect-corrupt-panel.ts uses. */
+export const SERVING_WINDOW_MIN_G = 110;
+export const SERVING_WINDOW_MAX_G = 600;
+/** Implied energy of one serving if the per-100g field is believed. Calibrated
+ *  against the whole clean corpus (609,894 Atwater-consistent rows carrying a
+ *  serving mass): p50 145, p90 359, p99 692, p99.9 1,616 kcal. 1,500 therefore
+ *  sits at ~the 99.87th percentile. The largest LEGITIMATE single-serve item
+ *  measured in the corpus is a Keto Brick at 999.7 kcal (141 g at 709 kcal/100g,
+ *  a correct density); the largest legitimate families above it are mass-gainer
+ *  scoops and very-high-calorie meal-replacement bottles, topping out at ~1,300
+ *  kcal. 1,500 keeps ~200 kcal of headroom over the highest measured legitimate
+ *  single serving. Lowering it to 1,000 nearly doubles the selection (180 vs 104
+ *  rows) and pulls in those two legitimate families wholesale. */
+export const MIN_IMPLIED_SERVING_KCAL = 1500;
+
+/** Why a row is NOT a panel-inflated-serving candidate. Doubles as the
+ *  MarkDecision skip code, so a refusal always names the failing condition. */
+export type ServingScaleRejection =
+    | 'serving_scale_panel_missing'
+    | 'macro_sum_outside_dry_band'
+    | 'panel_not_atwater_consistent'
+    | 'serving_outside_single_serving_window'
+    | 'serving_grams_mirrors_calories'
+    | 'implied_serving_kcal_below_threshold';
+
+/** kcal of one serving implied by believing the per-100g field. */
+export function impliedServingKcal(panel: ServingScalePanel): number {
+    return (panel.kcal100 * panel.servingGrams) / 100;
+}
+
+/** Atwater estimate (4P + 4C + 9F) of the stored panel. */
+export function atwaterKcal(panel: ServingScalePanel): number {
+    return 4 * panel.protein + 4 * panel.carbs + 9 * panel.fat;
+}
+
+/**
+ * The panel-inflated-serving rule, sibling-free and computed only from the row.
+ * Returns null when the row IS a candidate, otherwise the failing condition.
+ *
+ * Deliberately NOT exported as a boolean: both the scan and decideMark() need
+ * the reason, and a named refusal is what makes the marker's re-verification
+ * auditable.
+ */
+export function rejectPanelInflatedServing(
+    panel: ServingScalePanel | null | undefined
+): ServingScaleRejection | null {
+    if (
+        !panel ||
+        !isFinite(panel.kcal100) || panel.kcal100 <= 0 ||
+        !isFinite(panel.servingGrams) || panel.servingGrams <= 0 ||
+        !isFinite(panel.protein) || !isFinite(panel.fat) || !isFinite(panel.carbs)
+    ) {
+        return 'serving_scale_panel_missing';
+    }
+    const macroSum = panel.protein + panel.fat + panel.carbs;
+    if (macroSum < MIN_DRY_MACRO_SUM_100G || macroSum > MAX_MACRO_SUM_100G) {
+        return 'macro_sum_outside_dry_band';
+    }
+    const atwater = atwaterKcal(panel);
+    if (atwater <= 0 || Math.abs(panel.kcal100 - atwater) > ATWATER_CONSISTENT_TOL * panel.kcal100) {
+        return 'panel_not_atwater_consistent';
+    }
+    if (panel.servingGrams <= SERVING_WINDOW_MIN_G || panel.servingGrams > SERVING_WINDOW_MAX_G) {
+        return 'serving_outside_single_serving_window';
+    }
+    // Measured ingest artifact: servingGrams carrying the calories value
+    // (543 g / 543 kcal, 524/524, 564/564 ...). The serving field is provably
+    // junk on those rows, so the implied energy says nothing about the panel.
+    if (Math.abs(panel.servingGrams - panel.kcal100) < 1) {
+        return 'serving_grams_mirrors_calories';
+    }
+    if (impliedServingKcal(panel) <= MIN_IMPLIED_SERVING_KCAL) {
+        return 'implied_serving_kcal_below_threshold';
+    }
+    return null;
+}
+
 export type MarkDecision =
     | { mark: true; reason: string }
     | {
@@ -121,7 +251,8 @@ export type MarkDecision =
               | 'inflated_group_too_small'
               | 'value_below_threshold'
               | 'outlier_group_too_small'
-              | 'outlier_below_thresholds';
+              | 'outlier_below_thresholds'
+              | ServingScaleRejection;
       };
 
 /**
@@ -145,6 +276,15 @@ export function decideMark(flag: CorruptScanFlag): MarkDecision {
                 return { mark: false, skip: 'inflated_group_too_small' };
             }
             return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'panel-inflated-serving': {
+            // Strictest re-verification of the set: the whole rule is re-run from
+            // the raw panel the scan recorded, so `value` (and any hand edit to
+            // it) is decorative — a flag can only mark if the MEASUREMENTS still
+            // satisfy every condition.
+            const rejection = rejectPanelInflatedServing(flag.panel);
+            if (rejection) return { mark: false, skip: rejection };
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        }
         case 'kcal-impossible':
             if ((flag.value ?? 0) <= MAX_KCAL_100G) {
                 return { mark: false, skip: 'value_below_threshold' };


### PR DESCRIPTION
## What

A **sibling-free** detector for the "per-SERVING panel stored in the per-100g fields" corruption family. Detection only — **this PR writes nothing**; marking stays a separate human-gated op.

## Why the existing rules cannot see it

- `detect-corrupt-panel.ts` needs a same-name sibling median (>= 4 members to compute, `MIN_INFLATED_GROUP_SIZE` = 8 to mark). Measured on the live corpus against the 98 rows this rule selects: **65 are the only clean row for their own name key**, only 16 have >= 4 members, and only **7 have >= 8** — so the sibling rule could mark at most 7 of 98. Meal-kit / restaurant / deli items are name-space singletons, so the median approach is structurally blind exactly where the class lives.
- `detect-corrupt-nutrition.ts`'s per-field rules cannot see it either: the panels are internally coherent. Every member is Atwater-consistent, so no individual field looks wrong.
- **`MAX_MACRO_SUM_100G = 105` is unchanged and must stay unchanged** — it is deliberate label-rounding slack. This PR does not narrow it; it adds an orthogonal second signal so the slack band can be acted on safely.

## Why the blind spot exists at exactly this macro sum

Energy is `4P + 4C + 9F`, so a 400–650 kcal **serving** of a mixed meal carries ~95–130 g of macronutrients. Written into the per-100g fields that reads as a macro sum of 95–130 g/100g. Above 105 `macro-sum-impossible` already claims the row. The residual blind spot is therefore precisely `[95, 105]` — the rounding slack. That is not a coincidence; it is the arithmetic of the defect.

## The rule (all five must hold)

| # | condition | constant |
|---|---|---|
| 1 | macro sum in the near-anhydrous band `[95, 105]` g/100g | `MIN_DRY_MACRO_SUM_100G` / existing `MAX_MACRO_SUM_100G` |
| 2 | panel Atwater-consistent — kcal within 10% of `4P + 4C + 9F` | `ATWATER_CONSISTENT_TOL` |
| 3 | serving mass inside one eating occasion, `(110, 600]` g | `SERVING_WINDOW_MIN_G` / `SERVING_WINDOW_MAX_G` |
| 4 | `servingGrams` is not a copy of the calories value | measured ingest artifact |
| 5 | implied per-serving energy `kcal100 * servingGrams / 100 > 1500` | `MIN_IMPLIED_SERVING_KCAL` |

Condition 1 is the class-defining one: a per-100g panel whose macros sum to >= 95 g describes an essentially water-free food (refined oil, sugar, hard candy, syrup solids, milk/protein powder). Nothing else reaches it — and none of those are eaten in 150–600 g single servings.

Condition 3's ceiling is what keeps the rule off staple foods. Above 600 g `servingGrams` is a **package** mass: 1 kg of long-grain rice, a 1 L oil bottle, a 583 g bag of cashews, a 500 g peanut-butter jar all imply thousands of kcal from a *perfectly correct* panel. Up there an absurd implied energy is evidence about `servingGrams`, not about the panel. 600 g is the same serving-plausibility ceiling `detect-corrupt-panel.ts` already uses.

## Calibration (measured, not guessed)

Distribution of implied per-serving energy across the **609,894** clean (`corruptReason IS NULL`, `duplicateOfBarcode IS NULL`) Atwater-consistent rows carrying a serving mass:

| p50 | p90 | p99 | p99.9 | p99.99 |
|---|---|---|---|---|
| 145 | 359 | 692 | 1,616 | 3,947 |

**1,500 kcal sits at ~the 99.87th percentile.**

The threshold has to clear every *legitimately* huge single serving. Measured, the largest in the corpus:

- **Keto Brick** (`0810056840174`) — 141 g at a correct 709 kcal/100g = **999.7 kcal in one bar**. This is the single largest legitimate single-serve item found.
- **Mass-gainer scoops** — Naked Mass 315 g at 390 kcal/100g = 1,229 kcal; ANS Performance 330 g = 1,300 kcal.
- **Very-high-calorie meal-replacement bottles** — Nestlé Boost 2.24, 237 ml = 1,256 kcal.

1,500 keeps ~200 kcal of headroom over the top of that band.

**Cost if the threshold is wrong.** Too low is the expensive direction: dropping to 1,000 nearly doubles the selection (180 vs 104 pre-guard rows) and swallows the mass-gainer and meal-replacement families wholesale plus package-as-serving snacks (200 g biscuit packs, 200 g Lindt bars, 198 g Lay's bags) — marking those deletes real staple products from search. Too high only costs recall, and the rows left behind stay exactly as visible as they are today.

## What it selects: 98 rows corpus-wide

Full scan run read-only against the live box (950,071 clean rows). Result: `{"panel-inflated-serving": 98, "sodium-sibling-outlier": 20}` — every one of the 98 is a row **no existing rule flags**.

Reviewed all 98 by hand: **84 true positives / 14 false positives (86% precision)**. The true positives are dominated by meal-kit trays (Factor/Factor 75 ~30 rows, Frichti, Sodebo, Mom's Meals, Freshly, Project Lean Nation), deli sandwiches and salads, and beverages whose panels claim ~100 g of macronutrients per 100 g of liquid.

All 14 false positives share one signature — `servingGrams` is the package mass and the per-100g panel is correct, i.e. the same failure mode the >600 g ceiling already excludes, just under 600 g:

- nut/seed/chocolate spreads in a 400–500 g jar: `6870351400835` Sesame Paste, `0239029991925` Tahini, `0246608664712` Bio Haselnuss Creme, `0716404903693` Ovomaltine crunchy cream
- confection/snack sold in a bag or box: `5391007002476` Dark Chocolate Egg 500 g, `5000159452595` Peanut M&M's 330 g, `6972076831564` Crisps 420 g, `8958901259015` EverFresh Namkeen 400 g, `9542020718813` Cebolla frita 275 g
- sugar/drink powder in a bag or tub: `9313010000498` Jam setting Sugar, `4008671821906` Bio Gelierzucker 2:1, `0052000131659` Orange thirst-quencher powder
- bread loaves where the claimed density is high but arguable: `2782407708809` Shuk round Challah, `0208001078756` Boule Froment

These are listed so the human-gated marking op can drop them by hand rather than have a brittle name guard try to guess them.

## Two carry-overs

**1. The `human-triage` Wendy's row is NOT flagged — confirmed.** `209752824208588986029219` "Wendy's, Spicy Chicken Sandwich" has `servingGrams = 100`, so it is refused by the serving window. Note it is otherwise a *perfect* fit: macro sum 102 (inside the dry band) and Atwater-exact (`4*30 + 4*51 + 9*21 = 513`, the stored calories, to the unit). It reaches the window and is refused there — which is the point of the floor: at a 100 g serving the two readings of the panel are identical, so there is nothing to detect. Pinned in a test.

**2. 65 of the 98 flagged rows (66%) are the only clean candidate for their own name key** (`normalizeNameKey`, computed over all 950,071 clean rows). Removing those makes the query fall through to AI backfill at 100 g. Group-size histogram of the 98: `{1: 65, 2: 14, 3: 3, 4-7: 9, >=8: 7}`. This is the same fact that makes the rule necessary and makes the marking op consequential — the marking PR should weigh AI-backfill-at-100g against a tray billed at 4–6x, per row.

## Cross-check against the two known members

- **`0681603525666` shrimp tacos — NOT flagged.** Its macros sum to 84.0 g/100g, below the dry band (it is also 13.2% off Atwater, so it fails condition 2 independently). Stating it plainly rather than tuning around it: this row was already caught and marked by the sibling rule (`panel-inflated:foodtype-sibling`), so it is out of the clean scan population anyway. Pinned as a test so the miss is a recorded property.
- **The 65-row list — 33 of 65 flagged.** Every one of the 32 misses is accounted for:

| reason | n |
|---|---|
| `implied_serving_kcal_below_threshold` | 24 |
| `panel_not_atwater_consistent` | 6 |
| `serving_outside_single_serving_window` | 1 |
| `serving_grams_mirrors_calories` | 1 |
| `macro_sum_outside_dry_band` | 1 |

The 6 Atwater failures are exactly the 6 rows the original finding already excluded ("59 of 65 are Atwater-consistent"). The 1 window rejection is `8413080019282` Gourmet refined sunflower oil — **the corpus maximum at 8,260 implied kcal, and a correct panel**: 826 kcal/100g *is* refined oil, with `servingGrams` = the 1 L bottle. It is not this class, and it is used as a negative control. The 1 `mirrors_calories` rejection is `9310645215297` (543 g / 543 kcal). The 24 below threshold are the deliberate recall cost.

## Self-verification

`decideMark()` re-runs the **entire** rule from the raw panel the flag carries, so `value` is decorative and a hand-edited or stale scan file cannot mark a row the rule would refuse today. Every refusal names the condition that refused it. `mark-corrupt-off.ts` additionally re-checks `servingGrams` against the live row for this direction — it is the one rule whose verdict depends on a field outside `nutrientsPer100g`, and the existing staleness check only ever looked at the nutrient field.

Reason string is `panel-inflated-serving:direct` — same `panel-inflated` family prefix, so `--clear-prefix panel-inflated` clears both generations while `--clear-prefix "panel-inflated:"` still selects only the sibling-median generation. Pinned in a test.

## Tests

34 new tests in `scripts/eval/__tests__/panel-inflated-serving.test.ts`, every fixture a real corpus row read on 2026-07-26. Negative controls are **non-vacuous** — each clears every condition except the one that refuses it, asserted explicitly:

| control | clears | refused by |
|---|---|---|
| 1 L sunflower oil (corpus max, 8,260 kcal implied) | dry band, Atwater, threshold | serving window |
| 700 g coconut oil jar | dry band, Atwater, threshold | serving window |
| Naked Mass 315 g scoop (a real 1,229 kcal serving) | dry band, Atwater, window | threshold |
| Keto Brick 141 g (999.7 kcal, largest legit single serve) | dry band, Atwater, window | threshold |
| 1.2 kg family brisket tray (2,256 kcal implied) | — | dry band |
| Coles Triple Chicken (543 g / 543 kcal) | dry band, Atwater, window | `servingGrams` mirrors calories |
| Wendy's human-triage row | dry band, Atwater-exact | serving window |
| shrimp tacos (known member this rule misses) | — | dry band |

Also pinned: `MAX_MACRO_SUM_100G` is still 105; `macro-sum-impossible`, `panel-inflated` and `panel-low` decide exactly as before, including when a flag carries a panel that would satisfy the new rule.

**Red/green proof** (committed first, then mutated, then `git checkout HEAD -- <file>`):

| mutation | result |
|---|---|
| `MIN_IMPLIED_SERVING_KCAL` 1500 -> 3000 | **11 failed**, 23 passed |
| drop the serving-window upper bound | **4 failed**, 30 passed (both oil controls fire) |
| `decideMark` trusts `flag.value` instead of re-running the rule | **3 failed**, 31 passed |
| restored | 34 passed |

## Gate

| check | branch | origin/master |
|---|---|---|
| `jest scripts/eval src/lib/mapping` | 1319 passed, 1 failed, 1320 total | 1285 passed, 1 failed, 1286 total |
| `tsc --noEmit` | exit 0 | exit 0 |
| `lint:ci` | exit 0, 442 warnings, 0 errors | exit 0, 442 warnings, 0 errors |

The single jest failure is **pre-existing** — `src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts:412`, identical on `origin/master`. +34 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx
