### PR TITLE
fix: make the next cache wave safe to run (parity-sweep replay form, calorie bands, U+02BB)

### DIFF
--- a/scripts/eval/__tests__/cache-parity-replay-form.test.ts
+++ b/scripts/eval/__tests__/cache-parity-replay-form.test.ts
@@ -1,0 +1,334 @@
+/**
+ * cache-parity-sweep replay-form selection.
+ *
+ * NO NETWORK, NO DATABASE. `cache-parity-sweep.ts` guards `main()` with
+ * `require.main === module`, so importing it runs no POSTs — which matters more
+ * here than usual, because every POST that script makes is a WRITE
+ * (saveValidatedMapping is not gated by skipCache, so a cold replay OVERWRITES
+ * the cache row it replays).
+ *
+ * The one import-time side effect left is `normalization-rules` -> `../db`,
+ * which constructs a PrismaClient. It is mocked below so this suite passes with
+ * no DATABASE_URL in the environment.
+ *
+ * WHAT THIS PINS
+ *
+ * The rule being replaced was:
+ *     if (form.trim() === canonicalizeCacheKey(form)) continue;   // skip canonical order
+ * "canonical order" was used as a proxy for "this is the sweep replaying its own
+ * stored key". The proxy is wrong in one direction and right in the other:
+ *
+ *   - WRONG: a singular, single-word or alphabetically-ordered USER query is its
+ *     own canonical key, so the rule discarded it no matter how dominant it was.
+ *     `chicken thigh` (136 events) lost to `chicken thighs` (2).
+ *   - RIGHT: the sweep really does log canonical-order forms. It posts
+ *     `100g <name>`; the route writes a MappingEventLog row with
+ *     noCache=true, and when <name> was the stored key the logged
+ *     normalizedForm IS the token-sorted key. Those rows then look like
+ *     observed query forms on the next run.
+ *
+ * So "pick the max-event form" ALONE would reintroduce the second hazard. The
+ * `selfReplayCanOutvoteUserQuery` and `sweepArtifactDoesNotWinOnCount` tests
+ * below are the ones that keep that honest; they are built from real
+ * MappingEventLog rows where every event is noCache=true.
+ *
+ * All counts in the fixtures were measured on the live box on 2026-07-26:
+ *   select "noCache", "normalizedForm", count(*) from "MappingEventLog"
+ *   where "normalizedForm" is not null group by 1,2;
+ */
+
+jest.mock('@/lib/db', () => ({ prisma: {} }));
+
+import {
+    buildReplayIndex,
+    selectReplayForm,
+    type ObservedRow,
+} from '../cache-parity-sweep';
+import { canonicalizeCacheKey } from '../../../src/lib/mapping/normalization-rules';
+
+/**
+ * The predicate this change replaces, transcribed from
+ * cache-parity-sweep.ts@e227f36 lines 92-103. Kept here as a fixture so the
+ * behavioural difference is asserted rather than asserted-about — `git checkout`
+ * is not available to diff against (it would destroy parallel work in this
+ * tree), and a comment claiming "this would have failed before" is not evidence.
+ */
+function legacySelectReplayForm(storedKey: string, rows: ObservedRow[]): string {
+    const observedByKey = new Map<string, { form: string; events: number }>();
+    for (const r of rows) {
+        if (!r.normalizedForm) continue;
+        if (r.normalizedForm.trim() === canonicalizeCacheKey(r.normalizedForm)) continue;
+        const key = canonicalizeCacheKey(r.normalizedForm);
+        const cur = observedByKey.get(key);
+        if (!cur || r.events > cur.events) observedByKey.set(key, { form: r.normalizedForm, events: r.events });
+    }
+    return observedByKey.get(storedKey)?.form ?? storedKey;
+}
+
+/** A max-total-events rule with no self-replay exclusion — the naive fix. */
+function naiveMaxEventsForm(storedKey: string, rows: ObservedRow[]): string {
+    let best: ObservedRow | null = null;
+    for (const r of rows) {
+        if (!r.normalizedForm) continue;
+        if (canonicalizeCacheKey(r.normalizedForm) !== storedKey) continue;
+        if (!best || r.events > best.events || (r.events === best.events && r.normalizedForm < best.normalizedForm)) best = r;
+    }
+    return best?.normalizedForm ?? storedKey;
+}
+
+function pick(storedKey: string, rows: ObservedRow[]) {
+    return selectReplayForm(storedKey, buildReplayIndex(rows));
+}
+
+// ---------------------------------------------------------------------------
+// Real fixtures. `events` is ALL rows; `coldEvents` is the noCache=true subset.
+// ---------------------------------------------------------------------------
+
+/** key `chicken thigh`: dominant spelling is the SINGULAR, which the old rule threw away. */
+const CHICKEN_THIGH: ObservedRow[] = [
+    { normalizedForm: 'chicken thigh', events: 136, coldEvents: 2 },
+    { normalizedForm: 'chicken thighs', events: 2, coldEvents: 0 },
+];
+
+/** key `egg`: dominant spelling is the PLURAL. The fix must NOT change this one. */
+const EGG: ObservedRow[] = [
+    { normalizedForm: 'egg', events: 517, coldEvents: 4 },
+    { normalizedForm: 'eggs', events: 959, coldEvents: 0 },
+];
+
+/** key `onion`: the mirror image of `egg` — 124 singular vs 1 plural. */
+const ONION: ObservedRow[] = [
+    { normalizedForm: 'onion', events: 124, coldEvents: 1 },
+    { normalizedForm: 'onions', events: 1, coldEvents: 0 },
+];
+
+/**
+ * key `dressing goddess green`: one sweep artifact and one real user query, TIED
+ * at one event each. Ranking by total events (and breaking the tie on spelling)
+ * elects the artifact; ranking by user events elects the human.
+ */
+const GREEN_GODDESS: ObservedRow[] = [
+    { normalizedForm: 'goddess green dressing', events: 1, coldEvents: 1 },
+    { normalizedForm: 'green goddess dressing', events: 1, coldEvents: 0 },
+];
+
+/**
+ * key `chips chocolate`: NO user events at all. Both spellings are cold. The
+ * stored-key spelling has MORE events than the natural one — this is precisely
+ * the self-feeding the old comment described, and it is where the old rule was
+ * right.
+ */
+const CHOCOLATE_CHIPS: ObservedRow[] = [
+    { normalizedForm: 'chips chocolate', events: 2, coldEvents: 2 },
+    { normalizedForm: 'chocolate chips', events: 1, coldEvents: 1 },
+];
+
+/** key `bell pepper`: cold-only, and the only spelling IS the stored key. */
+const BELL_PEPPER: ObservedRow[] = [
+    { normalizedForm: 'bell pepper', events: 1, coldEvents: 1 },
+];
+
+describe('canonicalizeCacheKey assumptions the fixtures rest on', () => {
+    it('collapses singular and plural onto one key, and sorts tokens', () => {
+        expect(canonicalizeCacheKey('chicken thigh')).toBe('chicken thigh');
+        expect(canonicalizeCacheKey('chicken thighs')).toBe('chicken thigh');
+        expect(canonicalizeCacheKey('egg')).toBe('egg');
+        expect(canonicalizeCacheKey('eggs')).toBe('egg');
+        expect(canonicalizeCacheKey('green goddess dressing')).toBe('dressing goddess green');
+        expect(canonicalizeCacheKey('chocolate chips')).toBe('chips chocolate');
+    });
+
+    it('is why the old predicate discarded singulars: a singular equals its own key', () => {
+        for (const form of ['chicken thigh', 'onion', 'egg', 'bell pepper']) {
+            expect(form.trim()).toBe(canonicalizeCacheKey(form));
+        }
+    });
+});
+
+describe('selectReplayForm — dominant user spelling wins', () => {
+    it('replays the dominant SINGULAR (chicken thigh 136 vs chicken thighs 2)', () => {
+        const choice = pick('chicken thigh', CHICKEN_THIGH);
+        expect(choice.form).toBe('chicken thigh');
+        expect(choice.source).toBe('dominant_observed');
+        expect(choice.userEvents).toBe(134); // 136 total - 2 of this script's own replays
+    });
+
+    it('the OLD rule replayed the 2-event plural instead (this test fails against it)', () => {
+        expect(legacySelectReplayForm('chicken thigh', CHICKEN_THIGH)).toBe('chicken thighs');
+        expect(pick('chicken thigh', CHICKEN_THIGH).form).not.toBe(
+            legacySelectReplayForm('chicken thigh', CHICKEN_THIGH),
+        );
+    });
+
+    it('replays the dominant PLURAL (eggs 959 vs egg 517) — unchanged by this fix', () => {
+        const choice = pick('egg', EGG);
+        expect(choice.form).toBe('eggs');
+        expect(choice.source).toBe('dominant_observed');
+        // Honest pin: the old rule reached the same answer here, for the wrong
+        // reason (it discarded `egg` as canonical-order rather than as a minority
+        // spelling). `eggs` genuinely is the dominant form, 959 to 513.
+        expect(legacySelectReplayForm('egg', EGG)).toBe('eggs');
+    });
+
+    it('replays the dominant singular for `onion` (124 vs 1)', () => {
+        expect(pick('onion', ONION).form).toBe('onion');
+        expect(legacySelectReplayForm('onion', ONION)).toBe('onions');
+    });
+});
+
+describe('selectReplayForm — a self-replay must not outvote a user query', () => {
+    it('selfReplayCanOutvoteUserQuery: user events beat a tied sweep artifact', () => {
+        const choice = pick('dressing goddess green', GREEN_GODDESS);
+        expect(choice.form).toBe('green goddess dressing');
+        expect(choice.userEvents).toBe(1);
+        // The naive "most events wins" rule picks the artifact on the spelling
+        // tie-break. This is the regression the fix must not ship.
+        expect(naiveMaxEventsForm('dressing goddess green', GREEN_GODDESS)).toBe('goddess green dressing');
+    });
+
+    it('a sweep artifact with strictly MORE events still loses to a real user query', () => {
+        const rows: ObservedRow[] = [
+            // as if this sweep had run five times against the stored key
+            { normalizedForm: 'breast chicken skinless', events: 5, coldEvents: 5 },
+            { normalizedForm: 'skinless chicken breast', events: 2, coldEvents: 0 },
+        ];
+        expect(pick('breast chicken skinless', rows).form).toBe('skinless chicken breast');
+        expect(naiveMaxEventsForm('breast chicken skinless', rows)).toBe('breast chicken skinless');
+    });
+
+    it('a user-event TIE is not broken by the sweep\'s own replay volume', () => {
+        // Found in review. The first draft of this fix ranked
+        // [-userEvents, -totalEvents, ...]. Tier 1 correctly ignored cold events;
+        // tier 2 did not — so on a 1-1 user tie the spelling with 50 of this
+        // script's own replays won, and the sweep re-elected its own artifact.
+        // That is the self-feeding loop the whole function exists to prevent,
+        // arriving one tier lower down than where it was being guarded.
+        //
+        // Both spellings below have exactly ONE user event. The stored-key
+        // spelling additionally carries 50 sweep replays. It must still lose.
+        const rows: ObservedRow[] = [
+            { normalizedForm: 'chips chocolate', events: 51, coldEvents: 50 },
+            { normalizedForm: 'chocolate chips', events: 1, coldEvents: 0 },
+        ];
+        const choice = pick('chips chocolate', rows);
+        expect(choice.userEvents).toBe(1);
+        expect(choice.form).toBe('chocolate chips');
+        // Non-vacuity: the rejected spelling really does have more total events,
+        // so a total-event tie-break would genuinely have chosen it.
+        expect(choice.dominantForm).toBe('chips chocolate');
+        expect(choice.dominantTotalEvents).toBe(51);
+        expect(naiveMaxEventsForm('chips chocolate', rows)).toBe('chips chocolate');
+    });
+
+    it('sweepArtifactDoesNotWinOnCount: cold-only key drops the stored-key spelling', () => {
+        const choice = pick('chips chocolate', CHOCOLATE_CHIPS);
+        expect(choice.form).toBe('chocolate chips');
+        expect(choice.source).toBe('cold_only_observed');
+        expect(choice.userEvents).toBe(0);
+        // reported honestly: the most-logged spelling was rejected
+        expect(choice.dominantForm).toBe('chips chocolate');
+        expect(choice.dominantTotalEvents).toBe(2);
+        // naive max-events would have re-elected the artifact
+        expect(naiveMaxEventsForm('chips chocolate', CHOCOLATE_CHIPS)).toBe('chips chocolate');
+    });
+});
+
+describe('selectReplayForm — stored-key fallbacks', () => {
+    it('falls back to the stored key when NO form was ever observed', () => {
+        const choice = pick('barbecue kraft original sauce', CHICKEN_THIGH);
+        expect(choice.form).toBe('barbecue kraft original sauce');
+        expect(choice.source).toBe('stored_key_no_observation');
+        expect(choice.dominantForm).toBeNull();
+    });
+
+    it('falls back to the stored key when the only spelling logged was its own replay', () => {
+        const choice = pick('bell pepper', BELL_PEPPER);
+        expect(choice.form).toBe('bell pepper');
+        expect(choice.source).toBe('stored_key_self_replay_only');
+        // Same string either way, so nothing is lost by refusing it.
+        expect(legacySelectReplayForm('bell pepper', BELL_PEPPER)).toBe('bell pepper');
+    });
+
+    it('an empty observed file replays every key as its stored key', () => {
+        const index = buildReplayIndex([]);
+        expect(index.byKey.size).toBe(0);
+        expect(selectReplayForm('chicken thigh', index).source).toBe('stored_key_no_observation');
+    });
+});
+
+describe('buildReplayIndex — bookkeeping the summary depends on', () => {
+    it('reports whether the export could distinguish user events from sweep replays', () => {
+        expect(buildReplayIndex(CHICKEN_THIGH).hasColdBreakdown).toBe(true);
+        const legacyShape: ObservedRow[] = [
+            { normalizedForm: 'chicken thigh', events: 136 },
+            { normalizedForm: 'chicken thighs', events: 2 },
+        ];
+        expect(buildReplayIndex(legacyShape).hasColdBreakdown).toBe(false);
+        // Degrades to max-total-events rather than crashing; still beats the old
+        // rule on this key, but cannot exclude self-replays — hence the warning.
+        expect(selectReplayForm('chicken thigh', buildReplayIndex(legacyShape)).form).toBe('chicken thigh');
+    });
+
+    it('counts excluded cold events and folds duplicate rows for one spelling', () => {
+        const index = buildReplayIndex([
+            { normalizedForm: 'onion', events: 123, coldEvents: 0 },
+            { normalizedForm: 'onion', events: 1, coldEvents: 1 },
+            { normalizedForm: 'onions', events: 1, coldEvents: 0 },
+        ]);
+        expect(index.coldEventsSeen).toBe(1);
+        expect(index.distinctForms).toBe(2);
+        const choice = selectReplayForm('onion', index);
+        expect(choice.form).toBe('onion');
+        expect(choice.totalEvents).toBe(124);
+        expect(choice.userEvents).toBe(123);
+    });
+
+    it('ignores blank and malformed rows instead of minting an empty replay form', () => {
+        const index = buildReplayIndex([
+            { normalizedForm: '   ', events: 99, coldEvents: 0 },
+            { normalizedForm: 'onion', events: 5, coldEvents: 0 },
+        ]);
+        expect(index.distinctForms).toBe(1);
+        expect(selectReplayForm('onion', index).form).toBe('onion');
+    });
+
+    it('is deterministic under input reordering', () => {
+        const rows = [...GREEN_GODDESS, ...CHICKEN_THIGH, ...EGG];
+        const a = selectReplayForm('dressing goddess green', buildReplayIndex(rows));
+        const b = selectReplayForm('dressing goddess green', buildReplayIndex([...rows].reverse()));
+        expect(a.form).toBe(b.form);
+    });
+
+    it('breaks a genuine user-event tie deterministically, not by insertion order', () => {
+        const rows: ObservedRow[] = [
+            { normalizedForm: 'zebra cake little', events: 3, coldEvents: 0 },
+            { normalizedForm: 'little zebra cake', events: 3, coldEvents: 0 },
+        ];
+        const key = canonicalizeCacheKey('little zebra cake');
+        expect(selectReplayForm(key, buildReplayIndex(rows)).form).toBe('little zebra cake');
+        expect(selectReplayForm(key, buildReplayIndex([...rows].reverse())).form).toBe('little zebra cake');
+    });
+
+    it('prefers the lowercase spelling on a tie, so stray capitalisation is not elected', () => {
+        // Real pair: key `roll spring` had "spring roll" and "Spring Rolls",
+        // one user event each. Plain lexicographic order puts "S" before "s".
+        const rows: ObservedRow[] = [
+            { normalizedForm: 'Spring Rolls', events: 1, coldEvents: 0 },
+            { normalizedForm: 'spring roll', events: 1, coldEvents: 0 },
+        ];
+        const choice = selectReplayForm('roll spring', buildReplayIndex(rows));
+        expect(choice.form).toBe('spring roll');
+        // and the reporting agrees, so a pure tie is not miscounted as "minority"
+        expect(choice.source).toBe('dominant_observed');
+        expect(choice.dominantForm).toBe('spring roll');
+    });
+
+    it('reports whether the most-logged spelling had any user events behind it', () => {
+        const cold = selectReplayForm('dressing goddess green', buildReplayIndex(GREEN_GODDESS));
+        expect(cold.dominantForm).toBe('goddess green dressing');
+        expect(cold.dominantUserEvents).toBe(0); // -> counted as dominantWasSelfReplay
+        const healthy = selectReplayForm('chicken thigh', buildReplayIndex(CHICKEN_THIGH));
+        expect(healthy.dominantForm).toBe('chicken thigh');
+        expect(healthy.dominantUserEvents).toBe(134);
+    });
+});

--- a/scripts/eval/cache-parity-sweep.ts
+++ b/scripts/eval/cache-parity-sweep.ts
@@ -11,12 +11,23 @@
  * Run (from repo root):
  *   npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' \
  *     scripts/eval/cache-parity-sweep.ts --before scripts/eval/results/foodmapping-before-2026-07-20.json \
+ *     --observed scripts/eval/results/observed-forms-<date>.json \
  *     [--base http://192.168.1.133:3000] [--concurrency 4]
  *
  * The --before file is a JSON array of FoodMapping rows:
  *   select json_agg(row_to_json(t)) from (select "normalizedForm","foodName",
- *   "brandName",source,"offBarcode","fdcId","aiConfidence","usedCount"
+ *   "brandName",source,"offBarcode","fdcId","fsId","aiConfidence","usedCount"
  *   from "FoodMapping" order by "normalizedForm") t;
+ *
+ * "fsId" is REQUIRED — omitting it makes every fatsecret-sourced row (441 of
+ * 3,246 as of 2026-07-26) report as a changed record, because the incumbent's
+ * id cannot be reconstructed. The script counts such rows as
+ * `unresolvableBefore` and warns rather than scoring them as changes.
+ *
+ * The --observed file recovers the word order the stored key destroyed; build it
+ * with the query in the `ObservedRow` docblock below. It MUST carry the
+ * `coldEvents` column, or this script cannot tell a user query from its own
+ * previous replay (see `buildReplayIndex`).
  *
  * Writes results/cache-parity-<timestamp>.json (full) and prints a summary +
  * the changed-record list to stdout.
@@ -36,11 +47,6 @@ const BASE = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.
 const API_KEY = process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
 const CONCURRENCY = Number(argValue('--concurrency') ?? 4);
 const TIMEOUT_MS = Number(argValue('--timeout') ?? 30000);
-const beforePath = argValue('--before');
-if (!beforePath) {
-    console.error('missing --before <foodmapping-rows.json>');
-    process.exit(1);
-}
 
 interface BeforeRow {
     normalizedForm: string;
@@ -49,13 +55,15 @@ interface BeforeRow {
     source: string;
     offBarcode: string | null;
     fdcId: number | null;
+    /**
+     * Optional so a --before file captured before the FatSecret lane shipped
+     * still parses. Absent means "this row's identity cannot be expressed", and
+     * the diff counts it as unresolvable rather than as a change — see beforeId.
+     */
+    fsId?: string | null;
     aiConfidence: number;
     usedCount: number;
 }
-
-const before: BeforeRow[] = JSON.parse(fs.readFileSync(beforePath, 'utf8'));
-const results: any[] = [];
-let done = 0;
 
 /**
  * Replay the OBSERVED query form, not the stored key.
@@ -80,38 +88,370 @@ let done = 0;
  * OFF picks" behaviour on record from the 2026-07-24 fs-refresh wave (saltine
  * sleeve, m&ms). Pass --observed to replay the real query form instead.
  *
- * Build the file with:
+ * Build the file with (the `coldEvents` column is REQUIRED — see
+ * `selectReplayForm` for why a file without it degrades):
+ *
  *   select json_agg(row_to_json(t)) from (
- *     select "normalizedForm", count(*) as events
+ *     select "normalizedForm",
+ *            count(*)::int as events,
+ *            count(*) filter (where "noCache")::int as "coldEvents"
  *     from "MappingEventLog" where "normalizedForm" is not null
  *     group by 1 order by 2 desc) t;
  */
-interface ObservedRow { normalizedForm: string; events: number }
-const observedPath = argValue('--observed');
-const observedByKey = new Map<string, { form: string; events: number }>();
-if (observedPath) {
-    const rows: ObservedRow[] = JSON.parse(fs.readFileSync(observedPath, 'utf8'));
-    for (const r of rows) {
-        if (!r.normalizedForm) continue;
-        // Skip forms that are ALREADY in canonical order — they are almost all
-        // prior sweep replays feeding on themselves, and they carry no order
-        // information to recover.
-        if (r.normalizedForm.trim() === canonicalizeCacheKey(r.normalizedForm)) continue;
-        const key = canonicalizeCacheKey(r.normalizedForm);
-        const cur = observedByKey.get(key);
-        if (!cur || r.events > cur.events) observedByKey.set(key, { form: r.normalizedForm, events: r.events });
-    }
-    console.log(`[observed] ${rows.length} logged forms → ${observedByKey.size} keys with a recoverable query order`);
-} else {
-    console.log('[observed] --observed not supplied: replaying STORED KEYS, which is order-destroyed for ~45% of rows');
+export interface ObservedRow {
+    normalizedForm: string;
+    /** ALL MappingEventLog rows that logged this exact normalizedForm. */
+    events: number;
+    /**
+     * Of `events`, how many were logged with `MappingEventLog.noCache = true`.
+     * Optional only for backward compatibility with pre-2026-07-26 export files;
+     * omitting it disables self-replay exclusion (loudly warned about at runtime).
+     */
+    coldEvents?: number;
 }
-let usedObserved = 0;
-let usedStoredKey = 0;
+
+/** One observed spelling of a query, with its event split. */
+export interface FormTally {
+    form: string;
+    /** all logged events for this exact spelling */
+    totalEvents: number;
+    /** events logged with noCache=true — i.e. THIS script's own prior replays */
+    coldEvents: number;
+    /** totalEvents - coldEvents: events a human (or a warm batch) actually produced */
+    userEvents: number;
+    /**
+     * This spelling is the token-sorted key AND the key has more than one token,
+     * so replaying it recovers no word order and it cannot be told apart from
+     * this script's own artifact.
+     *
+     * The multi-token condition is load-bearing, not a refinement. Measured: a
+     * version without it moved 8 real keys the wrong way — `apricot`→`apricots`,
+     * `tomato`→`tomatoes`, `cheese`→`Cheese` — because for a ONE-token key the
+     * sorted form IS the natural spelling and there is no order to recover, so
+     * the signal fires on every singular noun and elects the plural. That is the
+     * original defect's harm re-created through a narrower door.
+     *
+     * Used ONLY as a tie-break (see rankKey), never as a filter.
+     */
+    carriesNoWordOrder: boolean;
+}
+
+export type ReplaySource =
+    /** the form with the most user events, and also the overall most-logged form */
+    | 'dominant_observed'
+    /** a form with user events that is NOT the overall most-logged form */
+    | 'minority_observed'
+    /**
+     * no user events for this key at all: every logged spelling came from a cold
+     * (nocache) run, i.e. from this script. The stored-key spelling is dropped as
+     * a self-replay and the remaining spelling — which at least carries word
+     * order the sorted key destroyed — is used.
+     */
+    | 'cold_only_observed'
+    /** nothing was ever logged for this key */
+    | 'stored_key_no_observation'
+    /** the only thing ever logged for this key was this script replaying the stored key */
+    | 'stored_key_self_replay_only';
+
+export interface ReplayChoice {
+    /** the text actually sent to /api/nlp/parse */
+    form: string;
+    source: ReplaySource;
+    userEvents: number;
+    totalEvents: number;
+    /** most-logged spelling for this key, eligible or not (for reporting only) */
+    dominantForm: string | null;
+    dominantTotalEvents: number;
+    /** user events behind `dominantForm`; 0 means the most-logged spelling was a self-replay */
+    dominantUserEvents: number;
+}
+
+export interface KeyObservation {
+    key: string;
+    forms: FormTally[];
+    dominantForm: string;
+    dominantTotalEvents: number;
+    dominantUserEvents: number;
+    /** the spelling this key will be replayed as, or null to fall back to the key */
+    winner: FormTally | null;
+    winnerSource: Extract<ReplaySource, 'dominant_observed' | 'minority_observed' | 'cold_only_observed'> | null;
+}
+
+export interface ReplayIndex {
+    byKey: Map<string, KeyObservation>;
+    /** false when NO input row carried `coldEvents` — self-replays cannot be excluded */
+    hasColdBreakdown: boolean;
+    inputRows: number;
+    distinctForms: number;
+    coldEventsSeen: number;
+}
+
+/**
+ * Total order over the spellings of one key, most-preferred first:
+ *   1. most USER events — the whole point of the selection;
+ *   2. already lowercase — `Quinoa` and `quinoa` are the same query; preferring
+ *      the lowercase spelling stops a stray capitalisation from being elected
+ *      on a 1-1 tie and churning the replay text for no reason;
+ *   3. carries word order — see below;
+ *   4. the spelling itself, so the choice is reproducible.
+ * A tuple order (rather than an ad-hoc comparator) keeps this transitive, which
+ * a linear max-scan needs to be deterministic under input reordering.
+ *
+ * NO TOTAL-EVENT TERM, deliberately. An earlier draft broke user-event ties on
+ * total events, which silently re-armed the exact hazard this whole function
+ * exists to close: `chips chocolate` with 1 user event + 50 of THIS SCRIPT's own
+ * replays beat `chocolate chips` with 1 user event, so the sweep elected its own
+ * artifact and the loop fed itself. Cold events must carry zero weight at every
+ * tier, not just the first.
+ *
+ * TIER 3 IS THE ORIGINAL DEFECT, DEMOTED TO ITS CORRECT WEIGHT. The rule this
+ * function replaced was `if (form === canonicalizeCacheKey(form)) continue` — it
+ * threw away every spelling that equals its own key, which is every singular
+ * noun, costing 1,430 spellings carrying 16,502 user events. But the signal was
+ * never wrong, only mis-weighted and mis-scoped: for a MULTI-TOKEN key, a
+ * spelling identical to the sorted key recovers no word order and cannot be told
+ * apart from this script's own replay. As a hard filter that is catastrophic; as
+ * a narrow tie-break it is exactly right. Deleting the total-event term alone
+ * did NOT close the hazard above — `chips chocolate` still won on the
+ * lexicographic tier, because 'i' < 'o'. A tie decided by alphabetical accident
+ * is not a decision. Tier 3 makes it one.
+ *
+ * Two guards keep tier 3 from re-creating the harm it descends from:
+ *   - it reads only on an exact user-event tie, so `chicken thigh` (134 user
+ *     events, and identical to its own key) still beats `chicken thighs` (2);
+ *   - it is scoped to multi-token keys (see `carriesNoWordOrder`), so it cannot
+ *     touch a singular noun, and it sits BELOW the lowercase tier so it cannot
+ *     elect `Caesar Salad` over `caesar salad`.
+ * Both were added after measuring 8 wrong-direction flips without them.
+ */
+function rankKey(f: FormTally): [number, number, number, string] {
+    return [-f.userEvents, f.form === f.form.toLowerCase() ? 0 : 1, f.carriesNoWordOrder ? 1 : 0, f.form];
+}
+/**
+ * Order for REPORTING the most-logged spelling, which does count this script's
+ * own replays. Never used to choose what we POST — only to name the spelling a
+ * run had to overrule, so `rejectedDominant[]` stays meaningful.
+ */
+function rankByTotalEvents(f: FormTally): [number, number, number, string] {
+    return [-f.totalEvents, f.form === f.form.toLowerCase() ? 0 : 1, f.carriesNoWordOrder ? 1 : 0, f.form];
+}
+function beatsBy(rank: (f: FormTally) => Array<number | string>, a: FormTally, b: FormTally): boolean {
+    const ra = rank(a), rb = rank(b);
+    for (let i = 0; i < ra.length; i++) {
+        if (ra[i] === rb[i]) continue;
+        return ra[i] < rb[i];
+    }
+    return false;
+}
+const beats = (a: FormTally, b: FormTally) => beatsBy(rankKey, a, b);
+
+/**
+ * Group logged forms by cache key and pick, per key, the spelling a real user
+ * most often typed.
+ *
+ * WHAT THE OLD RULE WAS PROTECTING AGAINST, AND WHY THIS IS NOT THE SAME RULE.
+ *
+ * The predicate this replaces was
+ *     `if (form.trim() === canonicalizeCacheKey(form)) continue;`
+ * with the comment "already in canonical order → almost all prior sweep replays
+ * feeding on themselves". The *hazard* is real and I confirmed it on live data:
+ * this script posts `100g <name>`, the route logs `telemetry.normalizedForm` for
+ * that line, and `noCache` is true — so a stored-key replay writes a
+ * MappingEventLog row whose normalizedForm IS the token-sorted key. Next run it
+ * looks exactly like an observed query form. Live examples (2026-07-26,
+ * MappingEventLog, all events noCache=true, zero user events):
+ *
+ *     key `chips chocolate`  → "chips chocolate" 2 vs "chocolate chips" 1
+ *     key `juice orange`     → "juice orange"   2 vs "orange juice"    1
+ *     key `preworkout ryse`  → "preworkout ryse" 1 vs "ryse preworkout" 1
+ *
+ * So "pick the form with the most events" ON ITS OWN **would** reintroduce it:
+ * on those three keys the sweep's own artifact outvotes (or lexicographically
+ * out-ties) the natural spelling. The old rule was therefore *right about the
+ * hazard* — it was just applied to the wrong population. Canonical order is a
+ * property of the STRING, not of who typed it: "chicken thigh", "onion", "bell
+ * pepper" are all their own canonical key, and discarding them threw away
+ * 16,502 genuine user events across 1,430 spellings, 839 of which carry user
+ * events at all.
+ *
+ * CAUTION ON THE BLAST-RADIUS NUMBER. Measuring this defect as "rows where the
+ * old pick differs from the most-LOGGED spelling" gives 355 of 3,246 — but 329
+ * of those 355 are cases where the most-logged spelling has ZERO user events,
+ * i.e. the yardstick is itself contaminated by the self-replays above. Ranked by
+ * user events, only **31 of 3,246 keys actually change the text they replay**
+ * (9 case-only, 18 singular/plural, 4 word-order), 15 of them by a strictly
+ * larger user-event margin. The big ones are real: `quinoa` moves from "Quinoa"
+ * (1 user event) to "quinoa" (381), `chicken` from "Chicken" (0) to "chicken"
+ * (244), `chicken thigh` from "chicken thighs" (2) to "chicken thigh" (134),
+ * `onion` from "onions" (1) to "onion" (123), `coffee` from "Coffee" (2) to
+ * "coffee" (91).
+ *
+ * The discriminator that actually separates the two populations is
+ * `MappingEventLog.noCache`. Verified: `?nocache=1` is only ever sent by THIS
+ * script (`grep -rn "nocache" scripts/ src/` → cache-parity-sweep.ts is the only
+ * client; warm-cache.ts documents itself as "the NORMAL cache-first path (no
+ * nocache)"), the route only honours it under `isDevBypass` (parse/route.ts:178),
+ * and the 1,576 noCache=true rows are dominated by the two parity sweeps on
+ * record — 2026-07-20 (276) and 2026-07-24 (1,295) — with 5 strays (1 on
+ * 2026-07-19, 4 on 2026-07-23) consistent with hand-run curls. The stray rows
+ * do not weaken the discriminator: a hand-run nocache curl is no more a user
+ * query than a sweep replay is. NOTE the corollary:
+ * warm-cache.ts also posts `100g <seed>` but on the normal path, so its events
+ * count as user events. That is deliberate — a warm seed is a natural-language
+ * spelling, so it carries the word order the sorted key destroyed; only the
+ * stored-key replay does not. So:
+ *
+ *   1. rank by USER events (noCache=false) — sweep replays get zero votes;
+ *   2. if a key has no user events at all, drop any spelling identical to the
+ *      stored key (that is definitionally the self-replay, and substituting it
+ *      changes nothing anyway) and use the best of what is left;
+ *   3. otherwise fall back to the stored key.
+ *
+ * Step 2 is the only part of the old rule worth keeping, now confined to the
+ * 137 keys where it was actually correct.
+ */
+export function buildReplayIndex(
+    rows: ObservedRow[],
+    canonicalize: (s: string) => string = canonicalizeCacheKey,
+): ReplayIndex {
+    const tallies = new Map<string, FormTally>();
+    let hasColdBreakdown = false;
+    let coldEventsSeen = 0;
+    let inputRows = 0;
+
+    for (const r of rows) {
+        if (!r || typeof r.normalizedForm !== 'string' || !r.normalizedForm.trim()) continue;
+        inputRows++;
+        const total = Number(r.events) || 0;
+        let cold = 0;
+        if (r.coldEvents != null) {
+            hasColdBreakdown = true;
+            cold = Math.min(Number(r.coldEvents) || 0, total);
+        }
+        coldEventsSeen += cold;
+        const cur = tallies.get(r.normalizedForm)
+            ?? {
+                form: r.normalizedForm,
+                totalEvents: 0,
+                coldEvents: 0,
+                userEvents: 0,
+                // Computed through the injected canonicalize so the tests can
+                // substitute a stub and still exercise this tier. Multi-token
+                // only: a one-token key has no word order to lose.
+                carriesNoWordOrder:
+                    r.normalizedForm.trim() === canonicalize(r.normalizedForm)
+                    && canonicalize(r.normalizedForm).includes(' '),
+            };
+        cur.totalEvents += total;
+        cur.coldEvents += cold;
+        cur.userEvents = cur.totalEvents - cur.coldEvents;
+        tallies.set(r.normalizedForm, cur);
+    }
+
+    const byKey = new Map<string, KeyObservation>();
+    for (const t of tallies.values()) {
+        const key = canonicalize(t.form);
+        const obs = byKey.get(key)
+            ?? { key, forms: [], dominantForm: t.form, dominantTotalEvents: -1, dominantUserEvents: 0, winner: null, winnerSource: null };
+        obs.forms.push(t);
+        byKey.set(key, obs);
+    }
+
+    for (const obs of byKey.values()) {
+        // Dominant = most-logged spelling overall, ignoring WHO logged it.
+        // Reported even when it is not the one we replay, so a run that had to
+        // reject it stays visible. Ranked by TOTAL events (the winner is ranked
+        // by USER events) with the same lower-tier tie-breaks, so a pure tie is
+        // not miscounted as a "minority" pick.
+        let dominant = obs.forms[0];
+        for (const f of obs.forms) {
+            if (beatsBy(rankByTotalEvents, f, dominant)) dominant = f;
+        }
+        obs.dominantForm = dominant.form;
+        obs.dominantTotalEvents = dominant.totalEvents;
+        obs.dominantUserEvents = dominant.userEvents;
+
+        const withUsers = obs.forms.filter(f => f.userEvents > 0);
+        if (withUsers.length > 0) {
+            let best = withUsers[0];
+            for (const f of withUsers) if (beats(f, best)) best = f;
+            obs.winner = best;
+            obs.winnerSource = best.form === obs.dominantForm ? 'dominant_observed' : 'minority_observed';
+            continue;
+        }
+        // No user evidence. Everything here came from a cold run — i.e. from this
+        // script. Drop the spelling that IS the stored key (pure self-replay;
+        // using it is identical to falling back anyway) and keep the best of the
+        // rest, which at least carries word order the sorted key destroyed.
+        const notSelfReplay = obs.forms.filter(f => f.form.trim() !== obs.key);
+        if (notSelfReplay.length > 0) {
+            let best = notSelfReplay[0];
+            for (const f of notSelfReplay) if (beats(f, best)) best = f;
+            obs.winner = best;
+            obs.winnerSource = 'cold_only_observed';
+        }
+    }
+
+    return { byKey, hasColdBreakdown, inputRows, distinctForms: tallies.size, coldEventsSeen };
+}
+
+/**
+ * Resolve one stored cache key to the text this sweep will POST.
+ * Pure — no I/O, no globals. This is the whole selection defect surface.
+ */
+export function selectReplayForm(storedKey: string, index: ReplayIndex): ReplayChoice {
+    const obs = index.byKey.get(storedKey);
+    if (!obs) {
+        return {
+            form: storedKey, source: 'stored_key_no_observation',
+            userEvents: 0, totalEvents: 0, dominantForm: null, dominantTotalEvents: 0, dominantUserEvents: 0,
+        };
+    }
+    if (!obs.winner || !obs.winnerSource) {
+        return {
+            form: storedKey, source: 'stored_key_self_replay_only',
+            userEvents: 0, totalEvents: 0,
+            dominantForm: obs.dominantForm, dominantTotalEvents: obs.dominantTotalEvents,
+            dominantUserEvents: obs.dominantUserEvents,
+        };
+    }
+    return {
+        form: obs.winner.form, source: obs.winnerSource,
+        userEvents: obs.winner.userEvents, totalEvents: obs.winner.totalEvents,
+        dominantForm: obs.dominantForm, dominantTotalEvents: obs.dominantTotalEvents,
+        dominantUserEvents: obs.dominantUserEvents,
+    };
+}
+
+const EMPTY_INDEX: ReplayIndex = {
+    byKey: new Map(), hasColdBreakdown: false, inputRows: 0, distinctForms: 0, coldEventsSeen: 0,
+};
+
+const results: any[] = [];
+let done = 0;
+let replayIndex: ReplayIndex = EMPTY_INDEX;
+const sourceCounts: Record<ReplaySource, number> = {
+    dominant_observed: 0,
+    minority_observed: 0,
+    cold_only_observed: 0,
+    stored_key_no_observation: 0,
+    stored_key_self_replay_only: 0,
+};
+/** keys where the most-logged spelling was rejected, with why */
+const rejectedDominant: string[] = [];
+/** of those, the ones rejected because the most-logged spelling had ZERO user events */
+let dominantWasSelfReplay = 0;
 
 async function sweepOne(row: BeforeRow) {
-    const obs = observedByKey.get(row.normalizedForm);
-    const name = obs?.form ?? row.normalizedForm;
-    if (obs) usedObserved++; else usedStoredKey++;
+    const choice = selectReplayForm(row.normalizedForm, replayIndex);
+    const name = choice.form;
+    sourceCounts[choice.source]++;
+    if (choice.dominantForm && choice.dominantForm !== name) {
+        if (choice.dominantUserEvents === 0) dominantWasSelfReplay++;
+        if (rejectedDominant.length < 50) {
+            rejectedDominant.push(`${row.normalizedForm}: replayed "${name}" (${choice.userEvents} user ev) over most-logged "${choice.dominantForm}" (${choice.dominantTotalEvents} ev, ${choice.dominantUserEvents} user)`);
+        }
+    }
     // 100 g weight unit → grams resolution is trivial and identical for every
     // record, so per-100g nutrition compares apples-to-apples.
     const body = { items: [{ rawText: `100g ${name}`, quantity: 100, unit: 'g', name }] };
@@ -153,6 +493,29 @@ async function sweepOne(row: BeforeRow) {
 }
 
 async function main() {
+    const beforePath = argValue('--before');
+    if (!beforePath) {
+        console.error('missing --before <foodmapping-rows.json>');
+        process.exit(1);
+    }
+    const before: BeforeRow[] = JSON.parse(fs.readFileSync(beforePath, 'utf8'));
+
+    const observedPath = argValue('--observed');
+    if (observedPath) {
+        const rows: ObservedRow[] = JSON.parse(fs.readFileSync(observedPath, 'utf8'));
+        replayIndex = buildReplayIndex(rows);
+        console.log(`[observed] ${replayIndex.inputRows} logged rows → ${replayIndex.distinctForms} distinct forms → ${replayIndex.byKey.size} cache keys`);
+        if (!replayIndex.hasColdBreakdown) {
+            console.log('⚠️  [observed] the export carries no "coldEvents" column, so this sweep CANNOT tell a real user');
+            console.log('    query from its own prior nocache replay, and may re-elect the token-sorted spelling it');
+            console.log('    posted last time. Re-export with: count(*) filter (where "noCache") as "coldEvents".');
+        } else {
+            console.log(`[observed] ${replayIndex.coldEventsSeen} events excluded as this script's own nocache replays`);
+        }
+    } else {
+        console.log('[observed] --observed not supplied: replaying STORED KEYS, which is order-destroyed for ~45% of rows');
+    }
+
     const queue = [...before];
     const workers = Array.from({ length: CONCURRENCY }, async () => {
         while (queue.length) {
@@ -164,13 +527,28 @@ async function main() {
     });
     await Promise.all(workers);
 
-    const beforeId = (b: BeforeRow) => b.offBarcode ? `off_${b.offBarcode}` : (b.fdcId != null ? `fdc_${b.fdcId}` : null);
-    let same = 0, changedId = 0, changedSource = 0, errors = 0;
+    // Every source the cache can hold must be expressible here. FatSecret was
+    // missing, and because `beforeId` returned null for those rows the diff
+    // compared `fs_1646 !== null` and called every one of them a changed record —
+    // a false-positive floor equal to the whole fatsecret share of the cache
+    // (441 of 3,246 rows, 13.6%, as of 2026-07-26; it was ~19 rows when the lane
+    // shipped, which is why nobody noticed). Making the replay text faithful is
+    // pointless if a seventh of the resulting diff is noise.
+    const beforeId = (b: BeforeRow) =>
+        b.offBarcode ? `off_${b.offBarcode}`
+            : b.fdcId != null ? `fdc_${b.fdcId}`
+                : b.fsId ? `fs_${b.fsId}`
+                    : null;
+    let same = 0, changedId = 0, changedSource = 0, errors = 0, unresolvableBefore = 0;
     const changes: any[] = [];
     for (const r of results) {
         if (r.cold.error) { errors++; changes.push({ key: r.key, error: r.cold.error }); continue; }
         const oldId = beforeId(r.before);
         if (r.cold.foodId === oldId) { same++; continue; }
+        // No id at all for the incumbent: an old --before export missing a column,
+        // not evidence the record moved. Counted separately so it can never be
+        // read as a regression.
+        if (oldId === null) { unresolvableBefore++; continue; }
         changedId++;
         if (r.cold.source !== r.before.source) changedSource++;
         changes.push({
@@ -186,14 +564,59 @@ async function main() {
     // Report the replay-fidelity split explicitly. A run that silently fell back
     // to stored keys for most rows looks identical in the diff to a clean run,
     // but it is measuring a different query than the one that owns each row.
-    const replay = { usedObservedForm: usedObserved, usedStoredKey, storedKeyPct: +(100 * usedStoredKey / Math.max(1, results.length)).toFixed(1) };
-    const summary = { total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors, replay };
-    fs.writeFileSync(outPath, JSON.stringify({ base: BASE, ranAt: stamp, summary, changes, results }, null, 1));
+    //
+    // `usedMinorityForm` is the counter that would have caught the 2026-07-26
+    // defect: rows replayed as a spelling that was NOT the most-logged one, with
+    // nothing in the old summary saying so. Read it together with
+    // `dominantWasSelfReplay`: on the 2026-07-26 corpus 333 rows are "minority"
+    // and 329 of those are minority only because the most-LOGGED spelling was
+    // this script's own nocache replay with zero user events. A minority count
+    // that is NOT explained by `dominantWasSelfReplay` is the one to chase.
+    const usedStoredKey = sourceCounts.stored_key_no_observation + sourceCounts.stored_key_self_replay_only;
+    const usedObserved = sourceCounts.dominant_observed + sourceCounts.minority_observed + sourceCounts.cold_only_observed;
+    const replay = {
+        // --- legacy shape, unchanged meaning: observed spelling vs stored key ---
+        usedObservedForm: usedObserved,
+        usedStoredKey,
+        storedKeyPct: +(100 * usedStoredKey / Math.max(1, results.length)).toFixed(1),
+        // --- replay-form provenance (added 2026-07-26) ---
+        /** replayed with the spelling users typed most — the healthy case */
+        usedDominantForm: sourceCounts.dominant_observed,
+        /** replayed with an observed-but-NOT-most-logged spelling; >0 wants an explanation */
+        usedMinorityForm: sourceCounts.minority_observed,
+        /** of usedMinorityForm + usedColdOnlyForm: the most-logged spelling had 0 user events */
+        dominantWasSelfReplay,
+        /** no user events for the key: best non-self-replay cold spelling used */
+        usedColdOnlyForm: sourceCounts.cold_only_observed,
+        /** nothing was ever logged for the key */
+        storedKeyNoObservation: sourceCounts.stored_key_no_observation,
+        /** the only spelling ever logged was this script replaying the stored key */
+        storedKeySelfReplayOnly: sourceCounts.stored_key_self_replay_only,
+        minorityPct: +(100 * sourceCounts.minority_observed / Math.max(1, results.length)).toFixed(1),
+        /** false = the --observed export could not distinguish user events from sweep replays */
+        observedHasColdBreakdown: replayIndex.hasColdBreakdown,
+        coldEventsExcluded: replayIndex.coldEventsSeen,
+    };
+    const summary = { total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors, unresolvableBefore, replay };
+    fs.writeFileSync(outPath, JSON.stringify({ base: BASE, ranAt: stamp, summary, changes, rejectedDominant, results }, null, 1));
 
     console.log(JSON.stringify(summary, null, 1));
+    if (unresolvableBefore > 0) {
+        console.log(`⚠️  ${unresolvableBefore} of ${results.length} rows carry no reconstructable incumbent id and were EXCLUDED from the diff.`);
+        console.log('    Almost always a --before export missing "fsId". Re-export with the SQL in this file\'s header,');
+        console.log('    otherwise those rows are invisible to the sweep in BOTH directions.');
+    }
     if (usedStoredKey > 0) {
         console.log(`⚠️  ${usedStoredKey} of ${results.length} rows (${replay.storedKeyPct}%) were replayed as the STORED, token-sorted key.`);
         console.log('    Those rows do not reproduce the query that owns them; treat their diffs as suggestive, not authoritative.');
+    }
+    if (replay.usedMinorityForm > 0) {
+        console.log(`ℹ️  ${replay.usedMinorityForm} of ${results.length} rows (${replay.minorityPct}%) were replayed as an observed but NON-most-logged spelling;`);
+        console.log(`    ${dominantWasSelfReplay} of the rejected spellings had ZERO user events (this script's own prior replay).`);
+        console.log('    Rows in the difference were outvoted on user events alone — see rejectedDominant[] in the output file.');
+    }
+    if (replay.usedColdOnlyForm > 0) {
+        console.log(`ℹ️  ${replay.usedColdOnlyForm} rows have NO user events at all — replayed from a spelling only this script ever produced.`);
     }
     for (const c of changes) {
         if (c.error) console.log(`  ⚠️ [${c.key}] ERROR: ${c.error}`);
@@ -202,4 +625,10 @@ async function main() {
     console.log(`\nResults written to ${outPath}`);
 }
 
-main();
+// Guarded so the replay-form selection above can be unit-tested without this
+// script hitting the live API (every POST here is a WRITE — the pipeline's
+// saveValidatedMapping is not gated by skipCache). Same pattern as
+// scripts/dedupe-off-mark.ts:227.
+if (require.main === module) {
+    main();
+}

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams — the RESOLVED serving weight), optional total (band on items[0].nutrition — the BILLED totals for the requested quantity; keys calories/protein/carbs/fat/fiber/sugar/sodium). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect — its failure is EXPECTED, reported as 🟡, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise. NEW ASSERTIONS (2026-07-25): `forbidName` (same shape as expectName) fails if ANY returned item matches — pins a wrong-record class without having to name the right answer. `expectAbstain: true` requires the mapper to return NO confident pick, for queries whose honest answer is 'not in the corpus' (billing a component at 0.95 is worse than abstaining). `maxConfidence: <n>` is the weak form — it may guess but must not look cacheable. IMPORTANT: an abstention can no longer satisfy `expectName`. The no-pick branch echoes the QUERY TEXT back as foodName, so `expectName:[['burrito']]` used to be satisfied by a total abstention on 'chipotle chicken burrito' — 47 of the nlp cases assert a name and no numeric band, so 47 cases could pass on nothing at all.",
+  "_readme": "Golden evaluation set for the food mapping system. 'search' cases hit GET /api/foods/search (manual search); 'nlp' cases hit POST /api/nlp/parse (magic log; items[] bypasses AI segmentation unless 'text' is used). PASS RULE (search): a result within the top `rank` has ALL substrings of at least one alternative in `match` present in its lowercased 'name + brandName'. PASS RULE (nlp): expectName (any item matches), optional expectItems (min count), optional macros (per-100g band on items[0].nutritionPer100g), optional grams (band on items[0].grams — the RESOLVED serving weight), optional total (band on items[0].nutrition — the BILLED totals for the requested quantity; keys calories/protein/carbs/fat/fiber/sugar/sodium). INVARIANT (search): every top-`rank` hit must carry at least one finite macro (verifies the OFF null-nutrition filter); opt out with requireNutrition:false. FLAG knownIssue:true marks a documented-but-unfixed defect — its failure is EXPECTED, reported as 🟡, and does NOT fail the suite (used to catalog serving-estimation gaps as regression targets). Macro/gram bands are deliberately loose: they catch wrong-food and wrong-portion mappings, not data noise. NEW ASSERTIONS (2026-07-25): `forbidName` (same shape as expectName) fails if ANY returned item matches — pins a wrong-record class without having to name the right answer. `expectAbstain: true` requires the mapper to return NO confident pick, for queries whose honest answer is 'not in the corpus' (billing a component at 0.95 is worse than abstaining). `maxConfidence: <n>` is the weak form — it may guess but must not look cacheable. IMPORTANT: an abstention can no longer satisfy `expectName`. The no-pick branch echoes the QUERY TEXT back as foodName, so `expectName:[['burrito']]` used to be satisfied by a total abstention on 'chipotle chicken burrito' — 47 of the nlp cases assert a name and no numeric band, so 47 cases could pass on nothing at all. CALORIE-BLINDNESS CLASS (2026-07-26): a case that asserts only expectName + grams is blind to a wrong PANEL on a right-named record — n-supp-23 passed for months while billing 952.2 kcal for a 414 g bottle containing 230, because off_9568310020398 stores the whole-bottle panel in nutrientsPer100g. Measured BEFORE this change (2026-07-26): 47 of 243 nlp cases carried NO numeric band, and a further 119 carried `grams` with no `macros`/`total` — 166 of 243 could not see a 4x over-bill. AFTER this change: 37 / 112 / 149. Re-deriving these counts against the current file gives the AFTER figures; the BEFORE figures are recorded so the delta stays legible. STANDING RULE: any nlp case that pins ONE food (single `item`, or `text` with expectItems 1) SHOULD carry `total.calories`; add `macros.kcal100` as well whenever the per-100g figure is the discriminator (RTD drink vs powder, raw vs oil, cooked vs dry). Bands are set from the product's published figure with roughly +/-35% width, NOT from the currently-observed value, so a repoint to a correct sibling still passes. Segmentation cases with expectItems >= 2 are deliberately left unbanded: the bands only inspect items[0], and which record lands at index 0 is a segmentation artifact rather than the thing under test.",
   "search": [
     {
       "id": "s-gen-01",
@@ -1584,7 +1584,20 @@
         [
           "courgette"
         ]
-      ]
+      ],
+      "macros": {
+        "kcal100": [
+          8,
+          35
+        ]
+      },
+      "total": {
+        "calories": [
+          10,
+          80
+        ]
+      },
+      "notes": "CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): raw zucchini is ~17 kcal/100g; observed 196 g / 16.9 kcal100 / 33.2 kcal x3. The kcal100 band is the real assertion: it fails on a courgette-shaped record carrying a fried/breaded or whole-package panel."
     },
     {
       "id": "n-brit-02",
@@ -2051,10 +2064,23 @@
           "avocado"
         ]
       ],
+      "macros": {
+        "kcal100": [
+          120,
+          210
+        ]
+      },
       "grams": [
         110,
         230
-      ]
+      ],
+      "total": {
+        "calories": [
+          160,
+          330
+        ]
+      },
+      "notes": "CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): a medium avocado is ~150 g at ~160 kcal/100g = ~240 kcal; observed 150 g / 160.0 kcal100 / 240.0 kcal x3. Same avocado-oil exclusion as n-qty-02."
     },
     {
       "id": "n-svs-04",
@@ -2480,10 +2506,23 @@
           "egg"
         ]
       ],
+      "macros": {
+        "kcal100": [
+          120,
+          180
+        ]
+      },
       "grams": [
         44,
         63
-      ]
+      ],
+      "total": {
+        "calories": [
+          55,
+          95
+        ]
+      },
+      "notes": "CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): a large egg is 50 g / ~72 kcal (~143 kcal/100g); observed 50 g / 140.0 kcal100 / 70.0 kcal x3. The grams band alone could not distinguish a real egg from a 50 g slice of an egg-named composite."
     },
     {
       "id": "n-svg-05",
@@ -2830,61 +2869,91 @@
       "id": "n-seg-21",
       "category": "segmentation",
       "text": "2 scoops ghost protein cinnamon roll",
-      "expectItems": 1,
       "expectName": [
         [
           "ghost"
         ]
       ],
-      "notes": "FIXED 2026-07-19 (decisive brand gate + brand-targeted retrieval + core-token brand rescue): maps to Ghost Whey Protein (Cinnabon) off_0810128902335, the exact record the characterization named. Promoted hard. | Previously: KNOWN ISSUE (branded-competitor hijack, RANKING-FIXABLE). '2 scoops ghost protein cinnamon roll' maps to Optimum Nutrition 'Cinnamon Roll Protein' (off_0748927070545). VERIFIED 2026-07-19: a Ghost-branded cinnamon protein IS in corpus but under the flavor name 'Cinnabon' (off_0810169602454 / off_0810128902335), so 'cinnamon roll' vs 'cinnabon' share no flavor tokens -> only a decisive brand gate c"
+      "expectItems": 1,
+      "total": {
+        "calories": [
+          170,
+          350
+        ]
+      },
+      "notes": "FIXED 2026-07-19 (decisive brand gate + brand-targeted retrieval + core-token brand rescue): maps to Ghost Whey Protein (Cinnabon) off_0810128902335, the exact record the characterization named. Promoted hard. | Previously: KNOWN ISSUE (branded-competitor hijack, RANKING-FIXABLE). '2 scoops ghost protein cinnamon roll' maps to Optimum Nutrition 'Cinnamon Roll Protein' (off_0748927070545). VERIFIED 2026-07-19: a Ghost-branded cinnamon protein IS in corpus but under the flavor name 'Cinnabon' (off_0810169602454 / off_0810128902335), so 'cinnamon roll' vs 'cinnabon' share no flavor tokens -> only a decisive brand gate c | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): 2 scoops Ghost whey = ~69 g / ~260 kcal; observed 69 g / 260.0 kcal x3. Band is deliberately wide because the winning record has already moved once (notes above name an OFF barcode; it now resolves to fs_14132527)."
     },
     {
       "id": "n-seg-22",
       "category": "segmentation",
       "text": "2 scoops ghost vegan protein cinnamon roll",
-      "expectItems": 1,
       "expectName": [
         [
           "ghost"
         ]
       ],
-      "notes": "Pattern 1 (brand hijack via flavor suffix), SEGMENTATION-stage boundary pin: HIGH side (7 words, over the 6-word single-item cap -> LLM segmenter). FIXED 2026-07-18 by the mapper brand-preservation guard: when the segmenter's normalizedForm drops a brand-lexicon token present in rawLine, baseName is re-derived from rawLine so candidate retrieval stays brand-aware. Now maps to Ghost 'Vegan Protein' 0.888/70g. Promoted to hard assertion."
+      "expectItems": 1,
+      "total": {
+        "calories": [
+          160,
+          320
+        ]
+      },
+      "notes": "Pattern 1 (brand hijack via flavor suffix), SEGMENTATION-stage boundary pin: HIGH side (7 words, over the 6-word single-item cap -> LLM segmenter). FIXED 2026-07-18 by the mapper brand-preservation guard: when the segmenter's normalizedForm drops a brand-lexicon token present in rawLine, baseName is re-derived from rawLine so candidate retrieval stays brand-aware. Now maps to Ghost 'Vegan Protein' 0.888/70g. Promoted to hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): 2 scoops Ghost Vegan Protein = 70 g / ~240 kcal; observed 70 g / 240.1 kcal x3. Same record and billing as n-supp-07, which already carries a grams band."
     },
     {
       "id": "n-seg-23",
       "category": "segmentation",
       "text": "1 quest bar birthday cake",
-      "expectItems": 1,
       "expectName": [
         [
           "quest"
         ]
       ],
-      "notes": "Pattern 1, SEGMENTATION boundary LOW side (5 words). Sub-cap phrasing keeps 'quest' brand token despite the shared 'birthday cake' flavor. CURRENT: works. Hard assertion."
+      "expectItems": 1,
+      "total": {
+        "calories": [
+          130,
+          260
+        ]
+      },
+      "notes": "Pattern 1, SEGMENTATION boundary LOW side (5 words). Sub-cap phrasing keeps 'quest' brand token despite the shared 'birthday cake' flavor. CURRENT: works. Hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): a Quest bar is 60 g / ~190 kcal; observed 60 g / 181.0 kcal x3. Single-item case (expectItems 1, itemCount 1 in all 3 runs) so items[0] is unambiguous."
     },
     {
       "id": "n-seg-24",
       "category": "segmentation",
       "text": "1 quest protein bar birthday cake flavor",
-      "expectItems": 1,
       "expectName": [
         [
           "quest"
         ]
       ],
-      "notes": "Pattern 1, SEGMENTATION boundary HIGH side (7 words, over the 6-word cap). FIXED 2026-07-18 by the mapper brand-preservation guard — the 'birthday cake' flavor no longer hijacks off the Quest brand token. Promoted to hard assertion."
+      "expectItems": 1,
+      "total": {
+        "calories": [
+          130,
+          260
+        ]
+      },
+      "notes": "Pattern 1, SEGMENTATION boundary HIGH side (7 words, over the 6-word cap). FIXED 2026-07-18 by the mapper brand-preservation guard — the 'birthday cake' flavor no longer hijacks off the Quest brand token. Promoted to hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): same product as n-seg-23 via the over-6-word segmentation path; observed 60 g / 180.0 kcal x3."
     },
     {
       "id": "n-seg-25",
       "category": "segmentation",
       "text": "1 scoop ryse protein cinnamon toast crunch",
-      "expectItems": 1,
       "expectName": [
         [
           "ryse"
         ]
       ],
-      "notes": "Pattern 1, SEGMENTATION (7 words, over the 6-word cap). FIXED 2026-07-18 by the mapper brand-preservation guard — the 'cinnamon toast crunch' cereal-brand collision no longer drops the RYSE brand token. Promoted to hard assertion."
+      "expectItems": 1,
+      "total": {
+        "calories": [
+          70,
+          210
+        ]
+      },
+      "notes": "Pattern 1, SEGMENTATION (7 words, over the 6-word cap). FIXED 2026-07-18 by the mapper brand-preservation guard — the 'cinnamon toast crunch' cereal-brand collision no longer drops the RYSE brand token. Promoted to hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): 1 scoop Ryse Clear Protein = ~35 g / ~123 kcal; observed 34.95 g / 122.7 kcal x3."
     },
     {
       "id": "n-seg-26",
@@ -3253,13 +3322,25 @@
       "id": "n-qty-02",
       "category": "quantity_parsing",
       "text": "½ avocado",
-      "expectItems": 1,
       "expectName": [
         [
           "avocado"
         ]
       ],
-      "notes": "Pattern 10 (unicode fraction '½'). Asserts the unicode fraction parses to one avocado item without crashing segmentation. ASPIRATIONAL: grams ~half an avocado (~75-100g). Hard assertion on name/segmentation only."
+      "expectItems": 1,
+      "macros": {
+        "kcal100": [
+          120,
+          210
+        ]
+      },
+      "total": {
+        "calories": [
+          70,
+          230
+        ]
+      },
+      "notes": "Pattern 10 (unicode fraction '½'). Asserts the unicode fraction parses to one avocado item without crashing segmentation. ASPIRATIONAL: grams ~half an avocado (~75-100g). Hard assertion on name/segmentation only. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): raw avocado is ~160 kcal/100g (fdc_171705); observed 75 g / 160.0 kcal100 / 120.0 kcal x3. kcal100 band fails on the avocado-OIL records in the corpus (~800-1000 kcal/100g), which the name assertion alone cannot exclude."
     },
     {
       "id": "n-qty-03",
@@ -3571,11 +3652,23 @@
           "core power"
         ]
       ],
+      "macros": {
+        "kcal100": [
+          30,
+          85
+        ]
+      },
       "grams": [
         300,
         460
       ],
-      "notes": "Unitless branded drink -> full-bottle backfill. VERIFIED live: 'Fairlife core power elite', 1=414g (14 fl oz bottle, correct). Discrete serving correctly backfilled. Hard assertion."
+      "total": {
+        "calories": [
+          140,
+          280
+        ]
+      },
+      "notes": "Unitless branded drink -> full-bottle backfill. VERIFIED live: 'Fairlife core power elite', 1=414g (14 fl oz bottle, correct). Discrete serving correctly backfilled. Hard assertion. | LIVE DEFECT, EXPECTED TO FAIL: this case asserted a name and a grams band but NO nutrition band, so it scored a PASS while billing 952.2 kcal for a 414 g bottle. off_9568310020398 stores the whole-bottle Core Power Elite panel (230 kcal / 42 g protein per 414 mL) in nutrientsPer100g -> 4.14x over-bill, and the case could not see it. Clean siblings measured in OffFood: original Core Power kcal100 41.06-41.10 (170 kcal/bottle), Elite kcal100 55.56-56.0 (230-232 kcal/bottle), Fair Oaks 340 mL kcal100 44 (150 kcal), Strawberry kcal100 58 (240 kcal). Band [140,280] admits every one of those and excludes both the 952.2 kcal seen today and the 704 kcal of the other panel-inflated fleet (kcal100 170). kcal100 [30,85] names the root cause directly. NOTE: the [180,320] band originally proposed would have excluded the plain 170 kcal Core Power, forcing a repoint specifically to an Elite SKU; rejected for that reason. Un-fail by fixing the DATA (mark/repair the panel or repoint), not by widening this band."
     },
     {
       "id": "n-supp-24",
@@ -3621,7 +3714,13 @@
         55,
         75
       ],
-      "notes": "Unitless branded bar -> discrete backfill. VERIFIED live: 'CLIF BAR', 1=68g (correct Clif Bar weight). Contrast with n-supp-28 (chomps) which does NOT backfill. Hard assertion."
+      "total": {
+        "calories": [
+          180,
+          320
+        ]
+      },
+      "notes": "Unitless branded bar -> discrete backfill. VERIFIED live: 'CLIF BAR', 1=68g (correct Clif Bar weight). Contrast with n-supp-28 (chomps) which does NOT backfill. Hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): a Clif Bar is 68 g / 250 kcal; observed 68 g / 250.0 kcal x3. grams-only case = panel-blind in exactly the n-supp-23 way."
     },
     {
       "id": "n-supp-26",
@@ -4128,7 +4227,13 @@
         30,
         60
       ],
-      "notes": "FIXED 2026-07-18 (Cluster A, Defect 2 = generic seed too heavy). Was 120g (matched the generic 'cookie' seed = 30g). Added a specific 'oreo' seed (~11.3g) -> 4 x 11.3 = 45.2g. Hard assertion."
+      "total": {
+        "calories": [
+          150,
+          280
+        ]
+      },
+      "notes": "FIXED 2026-07-18 (Cluster A, Defect 2 = generic seed too heavy). Was 120g (matched the generic 'cookie' seed = 30g). Added a specific 'oreo' seed (~11.3g) -> 4 x 11.3 = 45.2g. Hard assertion. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): an Oreo is ~11.3 g / ~53 kcal, so 4 = ~212 kcal; observed 45.2 g / 210.9 kcal x3."
     },
     {
       "id": "n-serv-19",
@@ -4243,7 +4348,13 @@
         300,
         650
       ],
-      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). '1 gatorade' (unitless branded count) now bills the same-brand median package via the OFF product_quantity backfill (207k rows) + sibling-borrow: ~500-600ml bottle. Was flat capped-100g."
+      "total": {
+        "calories": [
+          40,
+          160
+        ]
+      },
+      "notes": "PROMOTED to hard 2026-07-19 (Cluster A pt2 Defect 3). '1 gatorade' (unitless branded count) now bills the same-brand median package via the OFF product_quantity backfill (207k rows) + sibling-borrow: ~500-600ml bottle. Was flat capped-100g. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): Gatorade Thirst Quencher is ~22 kcal/100 mL, so a 12 oz bottle bills ~80 kcal; observed 360 g / 80.0 kcal x3. This band is the guard against the POWDER records (~360 kcal/100g), which the grams band cannot catch because a powder mispick billed at 360 g stays inside [300,650] while billing ~1300 kcal."
     },
     {
       "id": "n-serv-24",
@@ -4359,7 +4470,13 @@
         55,
         82
       ],
-      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 68g). Branded bar with a genuine serving (~68g). Hard assertion; the fix must preserve this. Contrast the over-billed generic-seed bars (n-serv-18 oreo, n-serv-19 eggo)."
+      "total": {
+        "calories": [
+          180,
+          320
+        ]
+      },
+      "notes": "CENSUS REGRESSION GUARD (currently CORRECT: 68g). Branded bar with a genuine serving (~68g). Hard assertion; the fix must preserve this. Contrast the over-billed generic-seed bars (n-serv-18 oreo, n-serv-19 eggo). | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): duplicate query of n-supp-25 on the serving_unit path; observed 68 g / 250.0 kcal x3."
     },
     {
       "id": "n-serv-29",
@@ -5259,7 +5376,13 @@
           "ryse"
         ]
       ],
-      "notes": "IDENTITY-HIJACK GUARD (PR D pt2, 2026-07-20). The parity sweep's cold re-resolution mapped 'protein ryse' to 'Protein Rice' (ryse fuzzy->rice). The save-time brand-mismatch gate now refuses to CACHE a cross-brand pick for a decisive brand query, but retrieval can still SERVE one when no Ryse SKU surfaces. Promote to hard once retrieval reliably surfaces Ryse protein SKUs. PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals."
+      "total": {
+        "calories": [
+          70,
+          210
+        ]
+      },
+      "notes": "IDENTITY-HIJACK GUARD (PR D pt2, 2026-07-20). The parity sweep's cold re-resolution mapped 'protein ryse' to 'Protein Rice' (ryse fuzzy->rice). The save-time brand-mismatch gate now refuses to CACHE a cross-brand pick for a decisive brand query, but retrieval can still SERVE one when no Ryse SKU surfaces. Promote to hard once retrieval reliably surfaces Ryse protein SKUs. PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): same record and billing as n-seg-25. The existing assertion pinned only the Ryse brand, so a Ryse-branded record with a per-tub panel would still have passed."
     },
     {
       "id": "n-mq-24",
@@ -5864,7 +5987,13 @@
         ]
       ],
       "expectItems": 1,
-      "notes": "FIXED 2026-07-19 (decisive brand gate): 'One birthday cake protein bars' (ONE Brands) beats the Cake Cup hijacker. Promoted hard. | Previously: DEFECT (branded-competitor hijack, RANKING-FIXABLE). Maps to 'Birthday Cake' brand 'Cake Cup' (off_0810257005259); correct 'One Birthday Cake Protein bar' brand 'ONE Brands' (off_0788434107730) IS in corpus and tops the search. Same class as n-seg-21. Root: simple-rerank.ts brand match is only a tiebreaker behind a score short-circuit (:1452) + a weak +0.25 bonus. Fix risks 'one'/'ghost'/'built' g"
+      "total": {
+        "calories": [
+          150,
+          290
+        ]
+      },
+      "notes": "FIXED 2026-07-19 (decisive brand gate): 'One birthday cake protein bars' (ONE Brands) beats the Cake Cup hijacker. Promoted hard. | Previously: DEFECT (branded-competitor hijack, RANKING-FIXABLE). Maps to 'Birthday Cake' brand 'Cake Cup' (off_0810257005259); correct 'One Birthday Cake Protein bar' brand 'ONE Brands' (off_0788434107730) IS in corpus and tops the search. Same class as n-seg-21. Root: simple-rerank.ts brand match is only a tiebreaker behind a score short-circuit (:1452) + a weak +0.25 bonus. Fix risks 'one'/'ghost'/'built' g | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): ONE Bar is a 60 g / ~220 kcal bar; observed 60 g / 220.0 kcal x3. Without this the case passes on the right brand at any billed total."
     },
     {
       "id": "n-brand-03",
@@ -5875,7 +6004,19 @@
           "premier"
         ]
       ],
-      "notes": "POSITIVE CONTROL (hard). Correctly maps to Premier Protein Cafe Latte (off_0643843759386, conf 0.98). Guards the blast radius of any future brand-gating fix — must stay green."
+      "macros": {
+        "kcal100": [
+          30,
+          85
+        ]
+      },
+      "total": {
+        "calories": [
+          110,
+          230
+        ]
+      },
+      "notes": "POSITIVE CONTROL (hard). Correctly maps to Premier Protein Cafe Latte (off_0643843759386, conf 0.98). Guards the blast radius of any future brand-gating fix — must stay green. | CALORIE BAND ADDED 2026-07-26 (calorie-blindness sweep, same class as PR #152): same RTD-protein-shake panel class as n-supp-23, and this is the positive control for it. Premier Protein 11 fl oz bills 160 kcal; observed 311.8 g x 51.3 kcal/100g = 160.0 kcal in all 3 runs of 2026-07-26. kcal100 [30,85] fails immediately if this record is ever swapped for one holding the whole-bottle panel."
     },
     {
       "id": "n-brand-04",

--- a/src/lib/mapping/__tests__/smart-punctuation-key.test.ts
+++ b/src/lib/mapping/__tests__/smart-punctuation-key.test.ts
@@ -8,9 +8,12 @@ const norm = (s: string): string => normalizeIngredientName(s).cleaned;
  *
  * `collapseSpaces` preserved only the STRAIGHT apostrophe: its strip is
  * `[^\w\s'%\-]`, so `’ ‘ ʼ ´` all became a SPACE. That ran upstream of
- * `canonicalizeCacheKey`, whose `['‘’ʼ`´]` fold exists precisely to collapse
+ * `canonicalizeCacheKey`, whose `['‘’ʼʻ`´]` fold exists precisely to collapse
  * possessives — by the time it ran the apostrophe was already gone and an
  * orphan `s` token was in its place.
+ *
+ * `ʻ` (U+02BB, the okina) was added to both folds later, for the same reason and
+ * with the same symptom; it is covered below alongside the original glyphs.
  *
  * This is not a theoretical spelling. `ChunkyInput` is a bare React Native
  * `TextInput` with no `autoCorrect={false}`, and iOS Smart Punctuation is on by
@@ -29,18 +32,48 @@ const norm = (s: string): string => normalizeIngredientName(s).cleaned;
  */
 
 const SPELLINGS: Array<[string, string]> = [
-    ['straight', "mcdonald's fries"],
-    ['curly (iOS default)', 'mcdonald’s fries'],
-    ['bare', 'mcdonalds fries'],
-    ['modifier letter', 'mcdonaldʼs fries'],
-    ['acute accent', 'mcdonald´s fries'],
-    ['left single quote', 'mcdonald‘s fries'],
+    ['straight (U+0027)', "mcdonald's fries"],
+    ['curly (U+2019, iOS default)', 'mcdonald’s fries'],
+    ['bare (no apostrophe)', 'mcdonalds fries'],
+    ['modifier letter apostrophe (U+02BC)', 'mcdonaldʼs fries'],
+    ['modifier letter turned comma / okina (U+02BB)', 'mcdonaldʻs fries'],
+    ['acute accent (U+00B4)', 'mcdonald´s fries'],
+    ['left single quote (U+2018)', 'mcdonald‘s fries'],
+    ['grave / backtick (U+0060)', 'mcdonald`s fries'],
 ];
 
+/**
+ * The single key all of the spellings above must land on. Stated as a literal on
+ * purpose: an assertion that only says "equals the straight spelling" still passes
+ * if BOTH sides move, which is exactly how a fold regression hides.
+ * ("fries" singularizes to "fry", "mcdonalds" to "mcdonald", tokens sort.)
+ */
+const EXPECTED_KEY = 'fry mcdonald';
+
 describe('every apostrophe glyph reaches one cache key', () => {
-    it.each(SPELLINGS)('%s spelling agrees with the straight one', (_label, text) => {
-        expect(canonicalizeCacheKey(norm(text)))
-            .toBe(canonicalizeCacheKey(norm("mcdonald's fries")));
+    it.each(SPELLINGS)('%s spelling produces the key "fry mcdonald"', (_label, text) => {
+        expect(canonicalizeCacheKey(norm(text))).toBe(EXPECTED_KEY);
+    });
+
+    it('all spellings collapse to exactly one key', () => {
+        const distinct = new Set(SPELLINGS.map(([, text]) => canonicalizeCacheKey(norm(text))));
+        expect([...distinct]).toEqual([EXPECTED_KEY]);
+    });
+
+    /**
+     * U+02BB is the okina, so it arrives with Hawaiian-spelled brand names, and it
+     * is the glyph that survived the first four apostrophe fixes: it is not `\w`,
+     * so `collapseSpaces` turned it into a SPACE, and the possessive `s` then
+     * tokenized on its own. Measured before the fold was widened (verbatim HEAD
+     * copy of this module vs the patched one):
+     *   "Trader Joeʻs cookie butter" -> "butter cookie joe s trader"   (forked)
+     *   "Trader Joe's cookie butter" -> "butter cookie joe trader"     (everyone else)
+     */
+    it('the okina keys the same as the straight apostrophe on a real brand', () => {
+        expect(canonicalizeCacheKey(norm('Trader Joeʻs cookie butter')))
+            .toBe('butter cookie joe trader');
+        expect(canonicalizeCacheKey(norm('Trader Joeʻs cookie butter')))
+            .toBe(canonicalizeCacheKey(norm("Trader Joe's cookie butter")));
     });
 
     it('leaves no orphan "s" token in the key', () => {

--- a/src/lib/mapping/normalization-rules.ts
+++ b/src/lib/mapping/normalization-rules.ts
@@ -575,8 +575,25 @@ export function normalizeIngredientName(raw: string): NormalizationResult {
  * Deliberately the SAME set `canonicalizeCacheKey` folds. iOS Smart Punctuation
  * is on by default and rewrites `'` to `’` as the user types, so the curly form
  * is not an edge case — it is what the mobile client actually sends.
+ *
+ * `ʻ` (U+02BB MODIFIER LETTER TURNED COMMA) joined the set for the same reason
+ * the others did: it was the last spelling that still forked the key. It is the
+ * ʻokina, so it arrives with Hawaiian-spelled brand names. Being outside `\w`, it
+ * fell through this fold and was then matched by the strip below (and by the
+ * equivalent strip in `canonicalizeCacheKey`), so it became a SPACE and the
+ * possessive `s` tokenized on its own: `Trader Joeʻs cookie butter` keyed as
+ * "butter cookie joe s trader" while every other spelling keyed as
+ * "butter cookie joe trader" — verified against a verbatim pre-change copy of
+ * this module. Measured before adding it: 3 OffFood rows corpus-wide, 0
+ * FatSecret rows, 0 of 3,246 FoodMapping keys, 0 of 4,165 logged query forms —
+ * key-space hygiene with a zero-row migration, not a live incident. It closes
+ * the fork before a Hawaiian brand walks into it.
+ *
+ * The two copies of this class (here and in `canonicalizeCacheKey`) MUST stay
+ * byte-identical; every apostrophe defect fixed in this file so far has been
+ * two folds disagreeing about which glyphs are apostrophes.
  */
-const APOSTROPHES = /['‘’ʼ`´]/g;
+const APOSTROPHES = /['‘’ʼʻ`´]/g;
 
 function collapseSpaces(value: string): string {
   // Preserve hyphens (important for compound words like "all-purpose flour")
@@ -772,7 +789,8 @@ export function canonicalizeCacheKey(normalizedName: string): string {
 
   return normalizedName
     .toLowerCase()
-    .replace(/['‘’ʼ`´]/g, '')  // Possessives collapse: see above
+    // Possessives collapse: see above. Must stay byte-identical to APOSTROPHES.
+    .replace(/['‘’ʼʻ`´]/g, '')
     .replace(/[^a-z0-9%\s\-]/g, ' ')  // Keep %, hyphens
     .split(/\s+/)
     .filter(w => w.length > 0)


### PR DESCRIPTION
Three prerequisites for the cache refresh + warm wave, plus one defect this PR fixes in code shipped two days ago.

## 1. The parity sweep replays the wrong query string

`--observed` (PR #164) skipped any form already in canonical order, reasoning that those are prior sweep replays feeding on themselves. A **singular noun equals its own canonical key**, so the rule discarded every singular regardless of volume — 1,430 spellings carrying 16,502 user events. `chicken thigh` was replayed as `chicken thighs` (2 events) while `chicken thigh` (134) was discarded.

The hazard it was groping toward is real: this script posts `100g <name>` and the route logs it, so its own replays look like user queries. But canonical order is the wrong proxy — that is a property of the string, not of who typed it. The right discriminator is `MappingEventLog.noCache`, which only this script ever sets.

Ranking is now by **user** events. Measured over the live 3,246-row cache: **31 keys change** the text they replay (`quinoa` "Quinoa"(1) → "quinoa"(381); `chicken`(0) → `chicken`(244)). `egg` is *not* fixed by this — the plural genuinely dominates (959 vs 517) and the singular/plural retrieval fork is a separate defect.

Two things found in review:

- **`beforeId()` could not express FatSecret ids**, so all 441 fatsecret rows (13.6% of the cache) reported as `changedRecord` even when the cold run returned the identical record. Making the replay text faithful is pointless if a seventh of the diff is noise. `"fsId"` is now required in the `--before` export.
- The first draft broke user-event ties on **total** events, re-arming the self-feeding loop one tier down: 1 user event + 50 of this script's own replays beat 1 user event on the natural spelling.

The word-order tie-break is scoped to multi-token keys **deliberately**. Without that scope it moved 8 real keys the wrong way (`apricot`→`apricots`, `tomato`→`tomatoes`, `cheese`→`Cheese`) — for a one-token key the sorted form *is* the natural spelling. As shipped it changes **0 of 3,246** replay strings: a latent guard, with the hazard pinned by a unit test.

## 2. The golden set cannot see a 4x over-bill

`n-supp-23` asserts a name and a grams band, and has passed for months while billing **952.2 kcal for a bottle containing 230** — `off_9568310020398` stores the whole-bottle panel in `nutrientsPer100g`. It would also keep passing after a repoint to a correct sibling.

Before: 47 of 243 nlp cases carried no numeric band, and 119 more carried grams with no macros/total — **166 of 243 blind to a 4x over-bill**. After: 37 / 112 / 149.

**`n-supp-23` now fails and is deliberately not marked `knownIssue`.** The defect is live, on a cache key with `usedCount` 184. Masking it is the pattern PR #152 removed. Consequence to decide before the wave: the nightly `flywheel-sweep` gate needs `--allow-fail n-mq-10,n-supp-23`, or the data fixed first.

## 3. U+02BB apostrophe

`"Trader Joeʻs cookie butter"` keyed as `butter cookie joe s trader` while every other spelling keyed as `butter cookie joe trader`. Fifth fork of this class.

**No migration** — and the measurement is the point: not "do stored keys move?" (an earlier pass asked that, got 0, and wrongly called a change inert) but "does the key a LOOKUP computes change?". Verified both: 0 of 3,246 cache keys and 0 of ~5,163 event forms.

Not a fix for the retrieval-side glyph gap — there the dominant glyph is U+2018, and widening the fold path is an admission change needing its own winner-diff gate.

## Verification

`tsc --noEmit` clean; `npm run lint:ci` 0 errors; 36/36 tests pass across the two changed suites. The `--observed` selection was re-measured against the live cache after every edit. No production writes: the eval and the sweep both resolve through the mapper, which saves to `FoodMapping`, so neither was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx
