### PR TITLE
fix(mapping): confidenceGate becomes a backstop + a committed winner-diff harness

### DIFF
--- a/scripts/eval/__tests__/winner-diff.test.ts
+++ b/scripts/eval/__tests__/winner-diff.test.ts
@@ -1,0 +1,841 @@
+/**
+ * winner-diff.test.ts — the parts of the winner-diff harness that have a right and
+ * a wrong answer, pinned against fixtures.
+ *
+ * NO DATABASE, NO NETWORK. It imports only ./winner-diff-screens, which by
+ * construction touches nothing under src/lib. Importing ../winner-diff would
+ * construct a PrismaClient and force env flags at module load — that is exactly the
+ * shape of untestability that let the abstention hole in run-eval.ts survive.
+ *
+ * WHAT THIS FILE DOES NOT COVER, stated so nobody mistakes green for proven:
+ *   - the TRANSCRIPTION in winner-diff.ts section 9. Only `winner-diff verify`
+ *     (real mapper, real pool, foodId compare) can test that, and it needs the box.
+ *   - the drift hashes. They are a change detector over a file this test cannot see
+ *     without pinning a hash that would break on every unrelated caller edit.
+ *   - snapshot capture. It requires Typesense, FatSecret and the LLM.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+    ATWATER_BAND,
+    CLASS_NOUNS,
+    GoldenCase,
+    NoiseFloorLedger,
+    NoiseFloorReceipt,
+    PanelLike,
+    ReplayFile,
+    ReplayRow,
+    SelectionPath,
+    WinnerInfo,
+    assertedBands,
+    atwaterInconsistent,
+    atwaterRatio,
+    checkGoldenBands,
+    classifyOrigin,
+    classifyVerdict,
+    counterfactualSummary,
+    deltaHistogram,
+    extraClassNouns,
+    findReceipt,
+    formatGoldenScreen,
+    gateReasonHistogram,
+    goldenCoverage,
+    isDeterministicSingleItemText,
+    isSingleIngredientCase,
+    isTokenSorted,
+    kcalDeltaPct,
+    noiseGate,
+    originSplit,
+    parseGoldenSet,
+    parseQueryFile,
+    pathHistogram,
+    rowHasMovement,
+    runGoldenScreen,
+    runScreens,
+    structurallyBlindBands,
+    windowChurn,
+    windowChurnIsMeaningless,
+} from '../winner-diff-screens';
+
+// ============================================================
+// fixtures
+// ============================================================
+
+function panel(kcal: number, protein = 0, carbs = 0, fat = 0, per100g = true): PanelLike {
+    return { kcal, protein, carbs, fat, per100g };
+}
+
+function win(id: string, name: string, p: PanelLike | null = panel(100, 5, 10, 4), extra: Partial<WinnerInfo> = {}): WinnerInfo {
+    return {
+        foodId: id,
+        foodName: name,
+        brandName: null,
+        source: 'openfoodfacts',
+        kcalPer100g: p && p.per100g ? p.kcal : null,
+        panel: p,
+        confidence: 0.9,
+        selectionReason: 'rerank',
+        indexInFiltered: 0,
+        inTop10: true,
+        inRerankWindow: true,
+        ...extra,
+    };
+}
+
+function row(q: string, winner: WinnerInfo | null, over: Partial<ReplayRow> = {}): ReplayRow {
+    return {
+        query: q,
+        path: (winner ? 'rerank' : 'no_winner_rerank_declined') as SelectionPath,
+        relaxedRecovery: false,
+        pool: {
+            gather: 40, afterTokenFilter: 20, afterCoreToken: 18, afterZeroMacro: 18,
+            afterPlausibility: 17, afterDenylist: 17, admitted: 17, rerankWindow: 10,
+        },
+        rerankWindowIds: ['a', 'b', 'c'],
+        admittedIds: ['a', 'b', 'c'],
+        rerankRan: true,
+        gate: { skipAiRerank: false, reason: 'margin_too_small (0.010 < 0.150)', confidence: 0.9 },
+        winner,
+        notes: [],
+        ...over,
+    };
+}
+
+function replayFile(over: Partial<ReplayFile> = {}): ReplayFile {
+    return {
+        kind: 'winner-diff/replay',
+        version: 1,
+        label: 'A',
+        variant: 'baseline',
+        ranAt: '2026-07-26T00:00:00.000Z',
+        gitHead: 'abc1234',
+        gitDirty: 'deadbeef',
+        snapshotTakenAt: '2026-07-26T00:00:00.000Z',
+        snapshotPopulation: '--from-file fixtures',
+        callerHash: 'cafe',
+        helpersHash: 'babe',
+        rows: [],
+        ...over,
+    };
+}
+
+function receipt(over: Partial<NoiseFloorReceipt> = {}): NoiseFloorReceipt {
+    return {
+        kind: 'winner-diff/noise-floor',
+        version: 1,
+        ranAt: '2026-07-26T01:00:00.000Z',
+        snapshotTakenAt: '2026-07-26T00:00:00.000Z',
+        gitHead: 'abc1234',
+        gitDirty: 'deadbeef',
+        variant: 'baseline',
+        rows: 40,
+        winnerDiffs: 0,
+        pathDiffs: 0,
+        ...over,
+    };
+}
+
+function ledger(...rs: NoiseFloorReceipt[]): NoiseFloorLedger {
+    return { kind: 'winner-diff/noise-floor-ledger', version: 1, receipts: rs };
+}
+
+// ============================================================
+// 1. verdict table — the measurement the harness exists to produce
+// ============================================================
+
+describe('classifyVerdict', () => {
+    it('reports a moved winner as WINNER-CHANGED', () => {
+        expect(classifyVerdict(row('q', win('x', 'X')), row('q', win('y', 'Y')))).toBe('WINNER-CHANGED');
+    });
+
+    it('distinguishes both directions of appearing/disappearing winners', () => {
+        expect(classifyVerdict(row('q', null), row('q', win('y', 'Y')))).toBe('NOWINNER->WINNER');
+        expect(classifyVerdict(row('q', win('x', 'X')), row('q', null))).toBe('WINNER->NOWINNER');
+    });
+
+    it('reports the same food reached by a different path as PATH-CHANGED, not SAME', () => {
+        const a = row('q', win('x', 'X'), { path: 'confidence_gate_early_exit' });
+        const b = row('q', win('x', 'X'), { path: 'rerank' });
+        expect(classifyVerdict(a, b)).toBe('PATH-CHANGED');
+    });
+
+    it('treats relaxed-recovery flips as PATH-CHANGED even when the winner holds', () => {
+        const a = row('q', win('x', 'X'), { relaxedRecovery: true });
+        const b = row('q', win('x', 'X'), { relaxedRecovery: false });
+        expect(classifyVerdict(a, b)).toBe('PATH-CHANGED');
+    });
+
+    it('is SAME only when identity AND path AND recovery all hold', () => {
+        expect(classifyVerdict(row('q', win('x', 'X')), row('q', win('x', 'X')))).toBe('SAME');
+    });
+
+    it('errors on either side dominate', () => {
+        expect(classifyVerdict(row('q', win('x', 'X'), { path: 'replay_error' }), row('q', win('x', 'X')))).toBe('ERROR');
+        expect(classifyVerdict(row('q', win('x', 'X')), row('q', win('x', 'X'), { path: 'snapshot_failed' }))).toBe('ERROR');
+    });
+});
+
+describe('movement detection (HARD RULE: measure winners, but surface silent churn)', () => {
+    it('flags an unchanged winner whose admitted pool moved', () => {
+        const a = row('q', win('x', 'X'));
+        const b = row('q', win('x', 'X'), { pool: { ...a.pool, admitted: 18 } });
+        expect(classifyVerdict(a, b)).toBe('SAME');
+        expect(rowHasMovement(a, b)).toBe(true);
+    });
+
+    it('flags an unchanged winner whose rerank window churned', () => {
+        const a = row('q', win('x', 'X'), { rerankWindowIds: ['a', 'b'] });
+        const b = row('q', win('x', 'X'), { rerankWindowIds: ['a', 'z'] });
+        expect(rowHasMovement(a, b)).toBe(true);
+        expect(windowChurn(a, b)).toEqual({ evicted: ['b'], added: ['z'] });
+    });
+
+    it('suppresses the eviction claim across a gate flip, where the window was never built', () => {
+        const a = row('q', win('x', 'X'), { rerankRan: false, rerankWindowIds: [] });
+        const b = row('q', win('x', 'X'), { rerankRan: true, rerankWindowIds: ['a', 'b'] });
+        expect(windowChurnIsMeaningless(a, b)).toBe(true);
+        expect(windowChurnIsMeaningless(row('q', null), row('q', null))).toBe(false);
+    });
+});
+
+// ============================================================
+// 2. gate-reason histogram — the 6x misread
+// ============================================================
+
+describe('gateReasonHistogram', () => {
+    it('separates firings from declines, and derives firing from skipAiRerank not from a reason list', () => {
+        const rows = [
+            row('a', win('1', 'A'), { gate: { skipAiRerank: false, reason: 'margin_too_small (0.01 < 0.15)', confidence: 0.9 } }),
+            row('b', win('2', 'B'), { gate: { skipAiRerank: false, reason: 'margin_too_small (0.02 < 0.15)', confidence: 0.9 } }),
+            row('c', win('3', 'C'), { gate: { skipAiRerank: false, reason: 'confidence_below_threshold (0.4 < 0.8)', confidence: 0.4 } }),
+            row('d', win('4', 'D'), { gate: { skipAiRerank: true, reason: 'high_confidence_clear_winner', confidence: 0.95 } }),
+            row('e', win('5', 'E'), { gate: { skipAiRerank: true, reason: 'basic_produce_bypass', confidence: 1 } }),
+            // a firing reason that did NOT occur in the original read; a hardcoded
+            // reason list would have silently dropped it from the firing bucket.
+            row('f', win('6', 'F'), { gate: { skipAiRerank: true, reason: 'yeast_variant_preference', confidence: 0.95 } }),
+        ];
+        const h = gateReasonHistogram(rows);
+        expect(h.firingTotal).toBe(3);
+        expect(h.nonFiringTotal).toBe(3);
+        expect(h.firing.map(([k]) => k).sort()).toEqual(['basic_produce_bypass', 'high_confidence_clear_winner', 'yeast_variant_preference']);
+        // the parenthesised measurement is stripped so the reasons group
+        expect(h.nonFiring.find(([k]) => k === 'margin_too_small')![1]).toBe(2);
+    });
+
+    it('pathHistogram is sorted by frequency', () => {
+        const rows = [row('a', win('1', 'A')), row('b', win('2', 'B')), row('c', null, { path: 'no_winner_all_filtered' })];
+        expect(pathHistogram(rows)[0]).toEqual(['rerank', 2]);
+    });
+});
+
+// ============================================================
+// 3. screens
+// ============================================================
+
+describe('atwater screen', () => {
+    it('computes (4P+4C+9F)/kcal and flags outside the band', () => {
+        expect(atwaterRatio(panel(100, 10, 10, 20 / 9))!).toBeCloseTo(1.0, 3);
+        expect(atwaterRatio(null)).toBeNull();
+        expect(atwaterRatio(panel(0, 10, 10, 10))).toBeNull();  // kcal 0 is not a ratio
+        expect(atwaterInconsistent(panel(100, 0, 0, 0))).toBe(true);       // ratio 0
+        expect(atwaterInconsistent(panel(100, 10, 10, 20 / 9))).toBe(false);
+        expect(ATWATER_BAND).toBe(0.25);
+    });
+});
+
+describe('class-drift screen', () => {
+    it('fires when the winner name carries a food-class noun the query never used', () => {
+        expect(extraClassNouns('subway cold cut combo', 'Cold Cut Combo Salad')).toEqual(['salad']);
+    });
+
+    it('does NOT fire when the query itself asked for that class', () => {
+        expect(extraClassNouns('chicken salad', 'Chicken Salad')).toEqual([]);
+    });
+
+    it('every CLASS_NOUN is a lowercase food-class noun, and the list is deduplicated', () => {
+        expect(new Set(CLASS_NOUNS).size).toBe(CLASS_NOUNS.length);
+        for (const n of CLASS_NOUNS) expect(n).toBe(n.toLowerCase());
+        expect(CLASS_NOUNS.length).toBeGreaterThanOrEqual(48);
+    });
+});
+
+describe('kcal delta histogram', () => {
+    it('is a > threshold histogram with median/mean/max', () => {
+        const h = deltaHistogram([1, 6, 11, 51, 201]);
+        expect(h.n).toBe(5);
+        expect(h.buckets.find(b => b.threshold === 0)!.count).toBe(5);
+        expect(h.buckets.find(b => b.threshold === 5)!.count).toBe(4);
+        expect(h.buckets.find(b => b.threshold === 50)!.count).toBe(2);
+        expect(h.buckets.find(b => b.threshold === 200)!.count).toBe(1);
+        expect(h.median).toBe(11);
+        expect(h.max).toBe(201);
+    });
+
+    it('survives an empty input rather than dividing by zero', () => {
+        const h = deltaHistogram([]);
+        expect(h.n).toBe(0);
+        expect(h.median).toBeNull();
+        expect(h.buckets.every(b => b.pct === 0)).toBe(true);
+    });
+
+    it('kcalDeltaPct refuses to divide by a zero baseline', () => {
+        expect(kcalDeltaPct(win('a', 'A', panel(0)), win('b', 'B', panel(50)))).toBeNull();
+        expect(kcalDeltaPct(win('a', 'A', panel(100)), win('b', 'B', panel(150)))).toBeCloseTo(50);
+        expect(kcalDeltaPct(win('a', 'A', null), win('b', 'B', panel(150)))).toBeNull();
+    });
+});
+
+describe('runScreens', () => {
+    const pairs = [
+        // identical pick — excluded from every screen
+        { query: 'apple', a: win('1', 'Apple'), b: win('1', 'Apple') },
+        // B drifted to a different class AND doubled kcal
+        { query: 'subway cold cut combo', a: win('2', 'Cold Cut Combo', panel(70, 5, 5, 4)), b: win('3', 'Cold Cut Combo Salad', panel(15, 1, 2, 0.5)) },
+        // A's panel violates Atwater, B's does not
+        { query: 'greek yogurt', a: win('4', 'Greek Yogurt', panel(100, 0, 0, 0)), b: win('5', 'Greek Yoghurt', panel(100, 10, 10, 20 / 9)) },
+        // B picked nothing
+        { query: 'ghost cinnamon roll', a: win('6', 'Ghost Whey'), b: null },
+    ];
+
+    it('counts disagreements, one-sided picks and the direction split', () => {
+        const s = runScreens(pairs, 'GATE', 'RERANK');
+        expect(s.disagreements).toBe(2);
+        expect(s.aOnly).toBe(1);   // "B picked nothing" is NOT a disagreement
+        expect(s.bOnly).toBe(0);
+        expect(s.neither).toBe(0);
+        // The cold-cut pair moved 70 -> 15 kcal (A higher). The yogurt pair is a
+        // different RECORD at the same 100 kcal, so it lands in `equal` — a record
+        // swap with no kcal movement still has to be counted somewhere.
+        expect(s.direction).toEqual({ aLower: 0, aHigher: 1, equal: 1 });
+        expect(s.delta.n).toBe(2);
+    });
+
+    it('attributes class drift to the right side and sorts the worst list by |kcal delta|', () => {
+        const s = runScreens(pairs, 'GATE', 'RERANK');
+        expect(s.classDrift.onlyB).toBe(1);
+        expect(s.classDrift.onlyA).toBe(0);
+        expect(s.classDrift.worstB[0].nouns).toEqual(['salad']);
+    });
+
+    it('attributes Atwater inconsistency to the right side', () => {
+        const s = runScreens(pairs, 'GATE', 'RERANK');
+        expect(s.atwater.onlyA).toBe(1);
+        expect(s.atwater.onlyB).toBe(0);
+    });
+
+    it('counts no-panel winners per side — an asymmetry that can run against the change', () => {
+        const s = runScreens([
+            { query: 'x', a: win('1', 'A', panel(100)), b: win('2', 'B', null) },
+            { query: 'y', a: win('3', 'C', panel(100)), b: win('4', 'D', null) },
+        ]);
+        expect(s.noPanel).toEqual({ a: 0, b: 2 });
+    });
+});
+
+// ============================================================
+// 4. noise-floor gate — it must actually REFUSE
+// ============================================================
+
+describe('noiseGate', () => {
+    const A = replayFile({ label: 'BASE', gitDirty: 'aaaa1111' });
+    const B = replayFile({ label: 'BRANCH', gitDirty: 'bbbb2222' });
+
+    it('passes only with a zero receipt for BOTH trees', () => {
+        const led = ledger(receipt({ gitDirty: 'aaaa1111' }), receipt({ gitDirty: 'bbbb2222' }));
+        expect(noiseGate(led, A, B, { crossSnapshot: false }).ok).toBe(true);
+    });
+
+    it('refuses when a receipt is missing, and names which side', () => {
+        const led = ledger(receipt({ gitDirty: 'aaaa1111' }));
+        const v = noiseGate(led, A, B, { crossSnapshot: false });
+        expect(v.ok).toBe(false);
+        expect(v.problems.join(' ')).toContain('side B');
+    });
+
+    it('refuses when the receipt exists but is NON-ZERO', () => {
+        const led = ledger(receipt({ gitDirty: 'aaaa1111' }), receipt({ gitDirty: 'bbbb2222', winnerDiffs: 2 }));
+        const v = noiseGate(led, A, B, { crossSnapshot: false });
+        expect(v.ok).toBe(false);
+        expect(v.problems.join(' ')).toContain('NON-ZERO');
+    });
+
+    it('refuses entirely when there is no ledger at all', () => {
+        expect(noiseGate(null, A, B, { crossSnapshot: false }).ok).toBe(false);
+    });
+
+    it('refuses a cross-snapshot diff unless it is asked for explicitly', () => {
+        const A2 = replayFile({ gitDirty: 'aaaa1111', snapshotTakenAt: '2026-07-26T00:00:00.000Z' });
+        const B2 = replayFile({ gitDirty: 'bbbb2222', snapshotTakenAt: '2026-07-26T00:05:00.000Z' });
+        const led = ledger(
+            receipt({ gitDirty: 'aaaa1111', snapshotTakenAt: '2026-07-26T00:00:00.000Z' }),
+            receipt({ gitDirty: 'bbbb2222', snapshotTakenAt: '2026-07-26T00:05:00.000Z' }),
+        );
+        const strict = noiseGate(led, A2, B2, { crossSnapshot: false });
+        expect(strict.ok).toBe(false);
+        expect(strict.problems.join(' ')).toContain('DIFFERENT snapshots');
+        expect(noiseGate(led, A2, B2, { crossSnapshot: true }).ok).toBe(true);
+    });
+
+    it('will not accept a receipt taken against a different snapshot or variant', () => {
+        expect(findReceipt(ledger(receipt()), 'OTHER-TIME', 'deadbeef', 'baseline')).toBeNull();
+        expect(findReceipt(ledger(receipt()), '2026-07-26T00:00:00.000Z', 'deadbeef', 'gate-backstop')).toBeNull();
+        expect(findReceipt(ledger(receipt()), '2026-07-26T00:00:00.000Z', 'deadbeef', 'baseline')).not.toBeNull();
+    });
+});
+
+// ============================================================
+// 5. populations
+// ============================================================
+
+describe('parseQueryFile', () => {
+    it('strips comments and blanks, keeps order', () => {
+        expect(parseQueryFile('# note\n\n 200g chicken breast \n1 apple\n')).toEqual(['200g chicken breast', '1 apple']);
+    });
+});
+
+describe('origin tagging (population contamination)', () => {
+    it('tags a token-sorted 100g-prefixed line as warmer-shaped', () => {
+        // Both of these are real cache-parity-sweep lines: "100g " + a token-SORTED
+        // FoodMapping key. They read like gibberish precisely because word order was
+        // destroyed by the key, which is why they exercise different filters than a
+        // sentence a user types (deriveMustHaveTokens is order-sensitive).
+        expect(classifyOrigin('100g debbie little roll swiss')).toBe('warmer');
+        expect(classifyOrigin('100g bar big colossal met rx')).toBe('warmer');
+        expect(classifyOrigin('2 eggs and toast')).toBe('user');
+        // A 100g-prefixed line whose tokens are NOT sorted is a real measurement request.
+        expect(classifyOrigin('100g chicken breast')).toBe('user');
+        expect(classifyOrigin('100g chicken')).toBe('user');  // single token: not evidence
+    });
+
+    it('isTokenSorted needs at least two tokens', () => {
+        expect(isTokenSorted('apple')).toBe(false);
+        expect(isTokenSorted('apple banana')).toBe(true);
+        expect(isTokenSorted('banana apple')).toBe(false);
+    });
+
+    it('originSplit reports a percentage that a report can print', () => {
+        const s = originSplit(['100g a b c', 'two eggs', '100g c b a']);
+        expect(s.warmer).toBe(1);
+        expect(s.user).toBe(2);
+        expect(s.warmerPct).toBeCloseTo(33.3, 1);
+    });
+});
+
+const GOLDEN_PATH = path.join(__dirname, '..', 'golden-set.json');
+const GOLDEN_RAW = JSON.parse(fs.readFileSync(GOLDEN_PATH, 'utf8'));
+
+/** A GoldenCase built by hand. Defaults are the single-ingredient shape. */
+function gcase(over: Partial<GoldenCase> = {}): GoldenCase {
+    return {
+        id: 'n-gen-01',
+        category: 'generic_staples',
+        rawText: '200g chicken breast',
+        expectName: [['chicken']],
+        shape: 'item',
+        deterministicSingleItem: true,
+        ...over,
+    };
+}
+
+describe('parseGoldenSet', () => {
+    it('reads the {_readme, search, nlp} OBJECT shape — reading it as an array yields nothing', () => {
+        expect(Array.isArray(GOLDEN_RAW)).toBe(false);
+        const cases = parseGoldenSet(GOLDEN_RAW);
+        expect(cases.length).toBeGreaterThan(100);
+        expect(cases.every(c => c.shape === 'item')).toBe(true);
+        expect(cases.find(c => c.id === 'n-gen-01')!.rawText).toBe('200g chicken breast');
+    });
+
+    it('excludes multi-item `text` lines by default and includes them on request', () => {
+        const single = parseGoldenSet(GOLDEN_RAW);
+        const all = parseGoldenSet(GOLDEN_RAW, { includeMultiItem: true });
+        expect(all.length).toBeGreaterThan(single.length);
+        expect(all.some(c => c.shape === 'text')).toBe(true);
+    });
+
+    it('throws rather than silently returning an empty population on the wrong shape', () => {
+        expect(() => parseGoldenSet([{ id: 'x' }])).toThrow(/nlp/);
+    });
+
+    /**
+     * NON-VACUITY: the previous GoldenCase carried `expectName` and `macros` only, so
+     * every count below except those two was ZERO — `grams`, `total` and `expectItems`
+     * were dropped on the floor by the parser and could not be asserted on at all.
+     * These are the numbers re-derived directly from golden-set.json on 2026-07-26; if
+     * the corpus changes, this test is where the screen's coverage claim is renewed.
+     */
+    it('carries EVERY assertion kind run-eval supports, at the counts the corpus actually has', () => {
+        const all = parseGoldenSet(GOLDEN_RAW, { includeMultiItem: true });
+        const nlp = (GOLDEN_RAW as { nlp: Array<Record<string, unknown>> }).nlp;
+        expect(all.length).toBe(nlp.length);
+        expect(all.length).toBe(243);
+
+        const n = (pred: (c: GoldenCase) => boolean) => all.filter(pred).length;
+        expect(n(c => c.expectName.length > 0)).toBe(243);
+        expect(n(c => !!c.grams)).toBe(148);              // the majority assertion
+        expect(n(c => !!c.macros)).toBe(59);
+        expect(n(c => typeof c.expectItems === 'number')).toBe(47);
+        expect(n(c => !!c.total)).toBe(18);
+        // documented in _readme, no live case uses them — parsed anyway so the screen
+        // does not go blind the moment one is added back
+        expect(n(c => !!c.forbidName)).toBe(0);
+        expect(n(c => c.expectAbstain === true)).toBe(0);
+        expect(n(c => typeof c.maxConfidence === 'number')).toBe(0);
+        // no case asserts nothing at all
+        expect(n(c => assertedBands(c).length === 0)).toBe(0);
+        // 47 assert a name and no numeric band — the population the _readme names
+        expect(n(c => !c.grams && !c.total && !c.macros)).toBe(47);
+
+        // split by shape: `--golden` replays item-shaped cases unless --include-multi-item
+        const item = all.filter(c => c.shape === 'item');
+        const text = all.filter(c => c.shape === 'text');
+        expect([item.length, text.length]).toEqual([160, 83]);
+        expect(item.filter(c => c.grams).length).toBe(117);
+        expect(item.filter(c => c.macros).length).toBe(43);
+        expect(item.filter(c => c.total).length).toBe(7);
+        expect(text.filter(c => c.grams).length).toBe(31);
+        expect(text.filter(c => typeof c.expectItems === 'number').length).toBe(47);
+
+        // and the individual bands survive the round-trip
+        expect(all.find(c => c.id === 'n-qty-04')!.grams).toEqual([24, 120]);
+        expect(all.find(c => c.id === 'n-qty-08')!.grams).toEqual([240, 500]);
+        expect(all.find(c => c.id === 'n-qty-09')!.grams).toEqual([480, 1100]);
+        expect(all.find(c => c.id === 'n-serv-39')!.total).toEqual({ calories: [60, 180] });
+        expect(all.find(c => c.id === 'n-serv-14')!.unit).toBe('tsp');
+    });
+});
+
+/**
+ * NON-VACUITY: this function did not exist. Without it every `text` case would have
+ * to be either evaluated (wrong for a segmenter line) or blanket-skipped (wrong for
+ * "7up"), and the three cases named in the defect report — n-qty-04/08/09 — are all
+ * `text`-shaped, so a blanket skip would have hidden them a second time.
+ */
+describe('isDeterministicSingleItemText (mirror of route.ts singleItemFromText)', () => {
+    it('accepts the short separator-free lines the route maps WITHOUT the segmenter', () => {
+        expect(isDeterministicSingleItemText('7up')).toBe(true);
+        expect(isDeterministicSingleItemText('2 7up')).toBe(true);
+        expect(isDeterministicSingleItemText('three slices of bacon')).toBe(true);
+        expect(isDeterministicSingleItemText('chicken breast for lunch')).toBe(true);  // meal suffix stripped
+    });
+
+    it('rejects everything the route hands to the LLM segmenter', () => {
+        expect(isDeterministicSingleItemText('2 eggs and toast')).toBe(false);   // "and"
+        expect(isDeterministicSingleItemText('coffee, bagel')).toBe(false);      // comma
+        expect(isDeterministicSingleItemText('a b c d e f g')).toBe(false);      // > 6 words
+        expect(isDeterministicSingleItemText('x'.repeat(61))).toBe(false);       // > 60 chars
+        expect(isDeterministicSingleItemText('   ')).toBe(false);
+        expect(isDeterministicSingleItemText('for lunch')).toBe(false);          // nothing left after the suffix
+    });
+
+    it('agrees with the corpus: every item-shaped case is single-item by construction', () => {
+        const all = parseGoldenSet(GOLDEN_RAW, { includeMultiItem: true });
+        expect(all.filter(c => c.shape === 'item').every(c => c.deterministicSingleItem)).toBe(true);
+        expect(all.find(c => c.id === 'n-qty-08')!.deterministicSingleItem).toBe(true);
+    });
+
+    /**
+     * The flag is optional so a hand-built case cannot become a compile error in the
+     * runner. An omitted flag must therefore default the SAFE way: unjudgeable, not
+     * silently judged. This is the same failure mode as the grams band, one level up.
+     */
+    it('defaults an unspecified `text` case to segmenter-bound rather than judgeable', () => {
+        const c: GoldenCase = { id: 'x', category: 'x', rawText: '2 eggs and toast', expectName: [['egg']], shape: 'text' };
+        expect(isSingleIngredientCase(c)).toBe(false);
+        expect(checkGoldenBands(c, win('1', 'Eggs')).verdict).toBe('UNKNOWN');
+        expect(isSingleIngredientCase({ ...c, shape: 'item', rawText: '2 eggs' })).toBe(true);
+    });
+});
+
+describe('checkGoldenBands (HARD RULE 6: assert the right answer)', () => {
+    const c = gcase({ macros: { protein100: [15, 40] } });
+
+    it('passes a winner that satisfies the positive expectation', () => {
+        expect(checkGoldenBands(c, win('1', 'Chicken Breast', panel(165, 31, 0, 3.6))).verdict).toBe('PASS');
+    });
+
+    it('FAILS a winner that moved to a different wrong food, not just a named wrong brand', () => {
+        const v = checkGoldenBands(c, win('2', 'Turkey Breast', panel(135, 30, 0, 1)));
+        expect(v.verdict).toBe('FAIL');
+        expect(v.failures[0]).toContain('expectName');
+    });
+
+    it('FAILS a macro band violation even when the name matches', () => {
+        const v = checkGoldenBands(c, win('3', 'Chicken Broth', panel(5, 1, 0, 0)));
+        expect(v.verdict).toBe('FAIL');
+        expect(v.failures.join(' ')).toContain('protein100');
+    });
+
+    it('reports UNKNOWN, not PASS, when the band cannot be measured', () => {
+        const v = checkGoldenBands(c, win('4', 'Chicken Breast', null));
+        expect(v.verdict).toBe('UNKNOWN');
+    });
+
+    it('a total abstention is a FAIL, never a pass', () => {
+        expect(checkGoldenBands(c, null).verdict).toBe('FAIL');
+    });
+});
+
+// ============================================================
+// 5b. THE BLINDNESS THIS SECTION EXISTS TO REMOVE
+//
+// Every test below FAILS against the pre-2026-07-26 implementation, in which
+// GoldenCase carried `expectName` + `macros` only and checkGoldenBands returned a
+// clean PASS for any winner whose NAME matched — regardless of the grams/total/
+// expectItems band the case actually asserted. 148 of 243 nlp cases assert grams.
+// ============================================================
+
+describe('grams / total / expectItems are reported UNKNOWN, never silently satisfied', () => {
+    /**
+     * NON-VACUITY: old code ignored `grams` entirely, so this returned PASS. The whole
+     * defect is that PASS -> PASS across a winner move reads as "nothing changed".
+     */
+    it('a grams band makes the verdict UNKNOWN even when the name matches perfectly', () => {
+        const v = checkGoldenBands(gcase({ grams: [24, 120] }), win('1', 'Chicken Breast'));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.blind).toEqual(['grams']);
+        expect(v.violations).toEqual([]);
+        expect(v.notEvaluable.join(' ')).toMatch(/grams comes from serving resolution/);
+        expect(v.failures.join(' ')).toContain('NOT-EVALUABLE');
+    });
+
+    /** NON-VACUITY: `total` was not even a field on GoldenCase. */
+    it('a total band is UNKNOWN — total = panel x grams/100 and grams is not resolved', () => {
+        const v = checkGoldenBands(gcase({ total: { calories: [60, 180] } }), win('1', 'Chicken Breast'));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.blind).toEqual(['total']);
+    });
+
+    /** NON-VACUITY: `expectItems` was not a field either. */
+    it('an expectItems band is UNKNOWN — a single-query replay never runs the segmenter', () => {
+        const v = checkGoldenBands(gcase({ expectItems: 2 }), win('1', 'Chicken Breast'));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.blind).toEqual(['expectItems']);
+    });
+
+    /**
+     * A judged band still fails loudly while an unjudgeable one sits beside it — a
+     * blind band must not launder a real violation into UNKNOWN.
+     */
+    it('a real violation still wins over an unjudgeable band', () => {
+        const v = checkGoldenBands(gcase({ grams: [24, 120] }), win('1', 'Turkey Breast'));
+        expect(v.verdict).toBe('FAIL');
+        expect(v.blind).toEqual(['grams']);
+    });
+
+    /**
+     * NON-VACUITY: old code did `if (v === undefined) continue` on an unrecognised
+     * macro key, so a band on `fiber100` — which the replay panel cannot carry —
+     * silently produced PASS. Same class of bug, one field over.
+     */
+    it('a macro band on a key the replay panel does not carry is UNKNOWN, not skipped', () => {
+        const v = checkGoldenBands(gcase({ macros: { fiber100: [1, 5] } }), win('1', 'Chicken Breast', panel(165, 31, 0, 3.6)));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.blind).toEqual(['macros']);
+    });
+
+    it('a mixed macro band judges what it can and says which key it did not', () => {
+        const v = checkGoldenBands(
+            gcase({ macros: { kcal100: [100, 200], fiber100: [1, 5] } }),
+            win('1', 'Chicken Breast', panel(165, 31, 0, 3.6)),
+        );
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.violations).toEqual([]);
+        expect(v.notEvaluable.join(' ')).toContain('fiber100');
+        // and the measurable half is genuinely enforced
+        expect(checkGoldenBands(
+            gcase({ macros: { kcal100: [100, 200], fiber100: [1, 5] } }),
+            win('1', 'Chicken Breast', panel(500, 31, 0, 3.6)),
+        ).verdict).toBe('FAIL');
+    });
+
+    /**
+     * NON-VACUITY: old code evaluated a multi-item `text` case's expectName against
+     * the single replayed winner, which is a different function from the one run-eval
+     * asserts on ("any of items[] matches").
+     */
+    it('a segmenter-bound `text` case is blind end to end, but a route-bypassed one is not', () => {
+        const seg = gcase({ id: 'n-seg-01', rawText: '2 eggs and toast', shape: 'text', deterministicSingleItem: false, expectItems: 2 });
+        const v = checkGoldenBands(seg, win('1', 'Eggs'));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.blind.sort()).toEqual(['expectItems', 'expectName']);
+
+        const bypassed = gcase({ id: 'n-qty-08', rawText: '7up', shape: 'text', deterministicSingleItem: true, expectName: [['7up']] });
+        expect(checkGoldenBands(bypassed, win('1', '7UP Soda')).verdict).toBe('PASS');
+        expect(checkGoldenBands(bypassed, win('1', 'Sprite')).verdict).toBe('FAIL');
+    });
+});
+
+describe('the assertion kinds run-eval supports that the screen never consulted', () => {
+    /** NON-VACUITY: forbidName was deliberately unread; a winner landing on a forbidden record scored PASS. */
+    it('forbidName is a CONJUNCT — it can add a failure, never manufacture a pass', () => {
+        const c = gcase({ forbidName: [["mary's"]] });
+        expect(checkGoldenBands(c, win('1', 'Chicken Breast', panel(165, 31, 0, 3.6), { brandName: "Mary's Chicken" })).verdict).toBe('FAIL');
+        expect(checkGoldenBands(c, win('2', 'Chicken Breast', panel(165, 31, 0, 3.6), { brandName: 'Great Value' })).verdict).toBe('PASS');
+        // forbid-only cases are never a clean PASS: not matching a wrong name is not
+        // evidence the answer is right.
+        const forbidOnly = gcase({ expectName: [], forbidName: [["mary's"]] });
+        const v = checkGoldenBands(forbidOnly, win('3', 'Anything Else'));
+        expect(v.verdict).toBe('UNKNOWN');
+        expect(v.notEvaluable.join(' ')).toContain('WEAK ASSERTION');
+    });
+
+    /** NON-VACUITY: old code returned FAIL for EVERY null winner, so an expectAbstain case could never pass. */
+    it('expectAbstain is the one assertion a no-winner row satisfies', () => {
+        const c = gcase({ expectAbstain: true, expectName: [] });
+        expect(checkGoldenBands(c, null).verdict).toBe('PASS');
+        const v = checkGoldenBands(c, win('1', 'Chipotle, Chicken'));
+        expect(v.verdict).toBe('FAIL');
+        expect(v.violations.join(' ')).toContain('expected abstention');
+    });
+
+    /** NON-VACUITY: maxConfidence was not a field; a cache-worthy confidence on a guess scored PASS. */
+    it('maxConfidence is enforced against the winner confidence', () => {
+        const c = gcase({ maxConfidence: 0.6 });
+        expect(checkGoldenBands(c, win('1', 'Chicken Breast', panel(165), { confidence: 0.5 })).verdict).toBe('PASS');
+        const v = checkGoldenBands(c, win('1', 'Chicken Breast', panel(165), { confidence: 0.95 }));
+        expect(v.verdict).toBe('FAIL');
+        expect(v.violations.join(' ')).toContain('maxConfidence');
+    });
+});
+
+describe('structurallyBlindBands / goldenCoverage over the REAL corpus', () => {
+    const all = parseGoldenSet(GOLDEN_RAW, { includeMultiItem: true });
+
+    /**
+     * NON-VACUITY: goldenCoverage did not exist, and the data it counts (grams/total/
+     * expectItems) was not parsed. This is the table that replaces "no golden case
+     * changed verdict" as the thing a reader is allowed to quote.
+     */
+    it('reports how much of the corpus this screen can and cannot judge', () => {
+        const cov = goldenCoverage(all);
+        const kind = (k: string) => cov.byKind.find(b => b.kind === k)!;
+        expect(cov.cases).toBe(243);
+        expect(kind('grams')).toEqual({ kind: 'grams', asserted: 148, blind: 148 });
+        expect(kind('total')).toEqual({ kind: 'total', asserted: 18, blind: 18 });
+        expect(kind('expectItems')).toEqual({ kind: 'expectItems', asserted: 47, blind: 47 });
+        // expectName is judgeable except on the segmenter-bound text lines
+        const en = kind('expectName');
+        expect(en.asserted).toBe(243);
+        expect(en.blind).toBeGreaterThan(0);
+        expect(en.blind).toBeLessThan(243);
+        // every grams band in the corpus is unjudgeable here...
+        expect(cov.gramsCases).toBe(148);
+        // ...and only a handful would be record-INdependent even with a resolver,
+        // i.e. the blindness sits exactly where a winner change moves the answer.
+        expect(cov.gramsRecordIndependent).toBeLessThanOrEqual(5);
+    });
+
+    it('the item-only population (what `--golden` replays by default) is mostly blind too', () => {
+        const cov = goldenCoverage(all.filter(c => c.shape === 'item'));
+        expect(cov.cases).toBe(160);
+        expect(cov.byKind.find(b => b.kind === 'grams')).toEqual({ kind: 'grams', asserted: 117, blind: 117 });
+        expect(cov.casesWithBlindBand).toBe(117 + 7 - all.filter(c => c.shape === 'item' && c.grams && c.total).length);
+    });
+
+    it('an item case with only a name and a measurable macro band is fully judgeable', () => {
+        expect(structurallyBlindBands(gcase({ macros: { protein100: [15, 40] } }))).toEqual([]);
+    });
+});
+
+describe('runGoldenScreen — the population the old clearance line swallowed', () => {
+    const c = gcase({ id: 'n-qty-08', rawText: '7up', shape: 'text', deterministicSingleItem: true, expectName: [['7up'], ['7 up']], grams: [240, 500] });
+    const a = [row('7up', win('off_a', '7UP Soda 330ml'), { goldenId: 'n-qty-08' })];
+    const b = [row('7up', win('off_b', '7UP Free 2L Bottle'))];
+
+    /**
+     * NON-VACUITY, and this is the exact reported defect. Under the old code both
+     * sides returned PASS (name matches, grams invisible), reportGoldenBands compared
+     * `va.verdict !== vb.verdict`, saw equality, and printed "no golden case changed
+     * verdict" — while the record behind a 240-500g band had moved from a can to a 2L
+     * bottle. The verdict column is STILL quiet here (UNKNOWN -> UNKNOWN); what makes
+     * the move visible is `movedButBlind`, which did not exist.
+     */
+    it('surfaces a moved winner sitting behind a band it cannot judge', () => {
+        const s = runGoldenScreen([c], a, b);
+        expect(s.matched).toBe(1);
+        expect(s.winnerMoved).toBe(1);
+        expect(s.changed).toEqual([]);                    // verdict comparison alone says NOTHING
+        expect(s.movedButBlind).toHaveLength(1);
+        expect(s.movedButBlind[0].id).toBe('n-qty-08');
+        expect(s.movedButBlind[0].b.blind).toEqual(['grams']);
+    });
+
+    it('still reports an ordinary verdict flip', () => {
+        const bWrong = [row('7up', win('off_c', 'Sprite Lemon Lime'))];
+        const s = runGoldenScreen([c], a, bWrong);
+        expect(s.changed).toHaveLength(1);
+        expect([s.changed[0].a.verdict, s.changed[0].b.verdict]).toEqual(['UNKNOWN', 'FAIL']);
+    });
+
+    it('counts rows it could not pair rather than silently dropping them', () => {
+        const s = runGoldenScreen([c], [...a, row('unpaired', win('x', 'X'), { goldenId: 'n-qty-08' })], b);
+        expect(s.unmatched).toBe(1);
+        expect(s.matched).toBe(1);
+    });
+
+    it('never prints a bare clearance line — the coverage table always comes with it', () => {
+        const quiet = runGoldenScreen([c], a, [row('7up', win('off_a', '7UP Soda 330ml'))]);
+        expect(quiet.changed).toEqual([]);
+        expect(quiet.movedButBlind).toEqual([]);
+        const out = formatGoldenScreen(quiet).join('\n');
+        expect(out).toContain('NOT EVALUABLE');
+        expect(out).toContain('grams');
+        expect(out).toMatch(/only worth as much as the coverage table/);
+        // the moved-winner case prints the unjudged bands by name
+        expect(formatGoldenScreen(runGoldenScreen([c], a, b)).join('\n'))
+            .toMatch(/WINNER MOVED but the case has a band this screen CANNOT judge: 1/);
+    });
+});
+
+// ============================================================
+// 6. counterfactual summary
+// ============================================================
+
+describe('counterfactualSummary', () => {
+    const mk = (q: string, gateWin: WinnerInfo, cfWin: WinnerInfo | null, reason: string): ReplayRow =>
+        row(q, gateWin, {
+            path: 'confidence_gate_early_exit',
+            rerankRan: false,
+            rerankWindowIds: [],
+            gate: { skipAiRerank: true, reason, confidence: 0.95 },
+            counterMicros: 120,
+            counter: { path: cfWin ? 'rerank' : 'no_winner_rerank_declined', rerankWindow: 10, rerankWindowIds: [], winner: cfWin, notes: [] },
+        });
+
+    const rows: ReplayRow[] = [
+        mk('carrots', win('1', 'Carrots'), win('1', 'Carrots'), 'basic_produce_bypass'),
+        mk('subway cold cut combo', win('2', 'Cold Cut Combo Salad', panel(15)), win('3', 'Cold Cut Combo', panel(70)), 'high_confidence_clear_winner'),
+        mk('mystery', win('4', 'Mystery'), null, 'high_confidence_clear_winner'),
+        row('normal', win('9', 'Normal')),   // never reached the gate's firing branch
+    ];
+
+    it('counts agree/disagree/declined over ONLY the early-exit population', () => {
+        const s = counterfactualSummary(rows);
+        expect(s.rows).toBe(4);
+        expect(s.earlyExit).toBe(3);
+        expect(s.agree).toBe(1);
+        expect(s.disagree).toBe(1);
+        expect(s.rerankDeclined).toBe(1);
+    });
+
+    it('breaks the disagreement rate down by exit reason', () => {
+        const byReason = Object.fromEntries(counterfactualSummary(rows).byReason);
+        expect(byReason['high_confidence_clear_winner']).toEqual({ disagree: 1, total: 2 });
+        expect(byReason['basic_produce_bypass']).toEqual({ disagree: 0, total: 1 });
+    });
+
+    it('hands the disagreements to the screens as GATE-vs-RERANK pairs', () => {
+        const s = counterfactualSummary(rows);
+        expect(s.pairs).toHaveLength(1);
+        const screens = runScreens(s.pairs, 'GATE', 'RERANK');
+        expect(screens.classDrift.onlyA).toBe(1);   // "Salad" is on the gate side
+        expect(screens.delta.n).toBe(1);
+    });
+
+    it('reports the measured cost of the Step 4 the gate skipped', () => {
+        expect(counterfactualSummary(rows).medianCounterMicros).toBe(120);
+    });
+});

--- a/scripts/eval/winner-diff-screens.ts
+++ b/scripts/eval/winner-diff-screens.ts
@@ -1,0 +1,1346 @@
+/**
+ * winner-diff-screens.ts — the PURE half of the frozen-pool winner-diff harness.
+ * ==========================================================================
+ * Everything in this file is a pure function of its arguments: no database, no
+ * network, no filesystem, no `src/lib` import that constructs a PrismaClient.
+ * That is deliberate and load-bearing.
+ *
+ * WHY THE SPLIT EXISTS
+ * `scripts/` used to be entirely untestable (memory: eval-harness-blindness — the
+ * abstention hole in run-eval.ts survived for months because importing the script
+ * ran a full eval). The runner (`winner-diff.ts`) must load `src/lib/mapping/*`
+ * with forced env flags and a live Prisma client; the moment a test imports that,
+ * it needs the box. So the verdict table, the screens, the population parsers and
+ * the noise-floor receipt gate — every part with a right and a wrong answer — live
+ * here, and `__tests__/winner-diff.test.ts` pins them against fixtures.
+ *
+ * READ-ONLY: this file performs no I/O of any kind.
+ *
+ * OPEN WIRING REQUIREMENT (2026-07-26). winner-diff.ts's reportGoldenBands() still
+ * prints only the cases whose VERDICT differs between A and B, and falls back to the
+ * line "no golden case changed verdict". With grams/total/expectItems now correctly
+ * reported as UNKNOWN (see THE HONEST LIMIT in section 6), most cases are UNKNOWN on
+ * BOTH sides, so that comparison stays quiet and the clearance line remains exactly as
+ * misleading as it was. It must be replaced with:
+ *     sayAll(formatGoldenScreen(runGoldenScreen(cases, A.rows, B.rows)));
+ * which prints the coverage table and the moved-winner-behind-an-unjudged-band list.
+ * Until that one line lands, DO NOT quote the runner's golden clearance line.
+ */
+
+import { matchesAlt, textOf } from './assertions';
+
+// ============================================================
+// 1. Wire types — shared with winner-diff.ts, kept here so tests need no runner
+// ============================================================
+
+export type SelectionPath =
+    /** confidenceGate returned skipAiRerank+selected: simpleRerank NEVER RAN. */
+    | 'confidence_gate_early_exit'
+    /** VARIANT ONLY (gate-backstop): rerank declined, the gate's pick was used as a backstop. */
+    | 'confidence_gate_backstop'
+    | 'rerank'
+    | 'scored_by_confidence'
+    | 'no_winner_rerank_declined'
+    | 'no_winner_all_filtered'
+    | 'no_winner_no_candidates'
+    /** the snapshot row itself errored — excluded from every screen */
+    | 'snapshot_failed'
+    | 'replay_error';
+
+export interface PanelLike {
+    kcal: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    per100g: boolean;
+}
+
+export interface WinnerInfo {
+    foodId: string;
+    foodName: string;
+    brandName: string | null;
+    source: string;
+    kcalPer100g: number | null;
+    /**
+     * FULL macro panel, never kcal alone. A name-only comparison in an earlier
+     * session called a protein-halving swap "lateral"; identity plus one number
+     * is not enough to adjudicate a winner change.
+     */
+    panel: PanelLike | null;
+    confidence: number;
+    selectionReason: string;
+    /** index in `filtered` (GATHER order) — >= 10 means it was outside slice(0,10) */
+    indexInFiltered: number;
+    inTop10: boolean;
+    inRerankWindow: boolean;
+}
+
+export interface PoolLadder {
+    gather: number;
+    afterTokenFilter: number;
+    afterCoreToken: number;
+    afterZeroMacro: number;
+    afterPlausibility: number;
+    afterDenylist: number;
+    /** final `filtered.length` fed to the sort / gate / rerank */
+    admitted: number;
+    /** candidatesForRerank.length */
+    rerankWindow: number;
+}
+
+export interface CounterfactualInfo {
+    path: SelectionPath;
+    rerankWindow: number;
+    rerankWindowIds: string[];
+    rerankReason?: string;
+    winner: WinnerInfo | null;
+    notes: string[];
+}
+
+export interface ReplayRow {
+    query: string;
+    /** population tag, so a report can separate real user lines from warmer keys */
+    origin?: QueryOrigin;
+    /** golden-set case id when the population came from --golden */
+    goldenId?: string;
+    path: SelectionPath;
+    relaxedRecovery: boolean;
+    pool: PoolLadder;
+    rerankWindowIds: string[];
+    /** every id in `filtered` at admission time, in GATHER order */
+    admittedIds: string[];
+    /** false ⇒ no rerank window was ever built (NOT "the window was empty") */
+    rerankRan: boolean;
+    gate: { skipAiRerank: boolean; reason: string; confidence: number };
+    rerankReason?: string;
+    winner: WinnerInfo | null;
+    /** present only when the gate pre-empted: what simpleRerank would have picked */
+    counter?: CounterfactualInfo;
+    counterMicros?: number;
+    notes: string[];
+    error?: string;
+}
+
+export interface ReplayFile {
+    kind: 'winner-diff/replay';
+    version: 1;
+    label: string;
+    /** which transcribed selection variant produced these rows */
+    variant: string;
+    ranAt: string;
+    gitHead: string;
+    /**
+     * SHA over every .ts in src/lib/mapping — NOT `git diff`. A/B trees are
+     * routinely plain copies with no .git at all, so `git rev-parse` cannot
+     * identify the code under test. Two replays with the same gitDirty provably
+     * ran the same mapping code; that is exactly the property the noise floor needs.
+     */
+    gitDirty: string;
+    snapshotTakenAt: string;
+    snapshotPopulation: string;
+    callerHash: string;
+    helpersHash: string;
+    rows: ReplayRow[];
+}
+
+// ============================================================
+// 2. Verdicts
+// ============================================================
+
+export type Verdict =
+    | 'SAME'
+    | 'WINNER-CHANGED'
+    | 'NOWINNER->WINNER'
+    | 'WINNER->NOWINNER'
+    | 'PATH-CHANGED'
+    | 'ERROR';
+
+export const VERDICTS: readonly Verdict[] = [
+    'SAME', 'WINNER-CHANGED', 'NOWINNER->WINNER', 'WINNER->NOWINNER', 'PATH-CHANGED', 'ERROR',
+];
+
+/**
+ * The measurement this whole harness exists to produce: did the WINNER move?
+ *
+ * Deliberately NOT a set comparison over pools. Four downstream consumers are
+ * non-monotone in pool size (slice(0,10) over gather order; relaxed recovery gated
+ * on length===0; basic_produce_bypass returning candidates[0]; brand macro-consensus
+ * gated on siblings.length>=3), so "the pool only grew" says nothing about the answer.
+ * A pool-set Jaccard is the measurement that makes those bugs invisible.
+ */
+export function classifyVerdict(a: ReplayRow, b: ReplayRow): Verdict {
+    if (a.path === 'replay_error' || b.path === 'replay_error'
+        || a.path === 'snapshot_failed' || b.path === 'snapshot_failed') return 'ERROR';
+    if (!a.winner && b.winner) return 'NOWINNER->WINNER';
+    if (a.winner && !b.winner) return 'WINNER->NOWINNER';
+    if (a.winner && b.winner && a.winner.foodId !== b.winner.foodId) return 'WINNER-CHANGED';
+    if (a.path !== b.path || a.relaxedRecovery !== b.relaxedRecovery) return 'PATH-CHANGED';
+    return 'SAME';
+}
+
+/** Window ids present in A but not B, and vice versa. */
+export function windowChurn(a: ReplayRow, b: ReplayRow): { evicted: string[]; added: string[] } {
+    const aw = new Set(a.rerankWindowIds);
+    const bw = new Set(b.rerankWindowIds);
+    return {
+        evicted: a.rerankWindowIds.filter(i => !bw.has(i)),
+        added: b.rerankWindowIds.filter(i => !aw.has(i)),
+    };
+}
+
+/**
+ * "Any movement" — winner OR pool OR rerank window. Surfaces silent churn hiding
+ * under an unchanged winner, which is the early-warning signal for a change that
+ * is one candidate away from flipping something.
+ */
+export function rowHasMovement(a: ReplayRow, b: ReplayRow): boolean {
+    if (classifyVerdict(a, b) !== 'SAME') return true;
+    if (a.pool.admitted !== b.pool.admitted) return true;
+    const churn = windowChurn(a, b);
+    return churn.evicted.length > 0 || churn.added.length > 0;
+}
+
+/**
+ * True when the rerank-window eviction line would be misleading: across a gate
+ * flip the window was never BUILT on one side, so "evicted 10 ids" describes a
+ * window that does not exist rather than candidates that lost a seat.
+ */
+export function windowChurnIsMeaningless(a: ReplayRow, b: ReplayRow): boolean {
+    return a.rerankRan !== b.rerankRan;
+}
+
+// ============================================================
+// 3. Histograms — path + gate reason, with the FIRING split
+// ============================================================
+
+export function counter<T extends string>(items: T[]): Array<[T, number]> {
+    const m = new Map<T, number>();
+    for (const it of items) m.set(it, (m.get(it) ?? 0) + 1);
+    return [...m.entries()].sort((x, y) => y[1] - x[1]);
+}
+
+export function pathHistogram(rows: ReplayRow[]): Array<[SelectionPath, number]> {
+    return counter(rows.map(r => r.path));
+}
+
+/**
+ * Gate-reason histogram, split by whether the gate ACTUALLY FIRED.
+ *
+ * THE TRAP THIS FIXES: confidenceGate is called on every row that reaches Step 3a
+ * and its verdict string is recorded whether or not it pre-empted the reranker. A
+ * flat histogram therefore reads `margin_too_small 2670` — which is 2,670 times the
+ * gate DECLINED, not 2,670 firings. On the 4,165-row WARM population the real firing
+ * count was 441 (308 high_confidence_clear_winner + 133 basic_produce_bypass), a 6x
+ * misread. Firing is derived from `gate.skipAiRerank`, never from a hardcoded reason
+ * list — `yeast_variant_preference` also fires and simply did not occur there.
+ */
+export function gateReasonHistogram(rows: ReplayRow[]): {
+    firing: Array<[string, number]>;
+    nonFiring: Array<[string, number]>;
+    firingTotal: number;
+    nonFiringTotal: number;
+} {
+    const norm = (r: ReplayRow) => (r.gate.reason || '(empty)').split(' (')[0];
+    const fire = rows.filter(r => r.gate.skipAiRerank);
+    const dont = rows.filter(r => !r.gate.skipAiRerank);
+    return {
+        firing: counter(fire.map(norm)),
+        nonFiring: counter(dont.map(norm)),
+        firingTotal: fire.length,
+        nonFiringTotal: dont.length,
+    };
+}
+
+// ============================================================
+// 4. Screens
+// ============================================================
+
+/**
+ * Food-class nouns. If the winner's NAME carries one of these and the QUERY never
+ * used it, the pick has drifted to a different class of food ("subway cold cut
+ * combo" -> "Cold Cut Combo SALAD", 15.7 vs 69.5 kcal/100g).
+ *
+ * This is a COMMITTED CONSTANT with a test, not a hand-edited literal in an ad-hoc
+ * script — the scratch version was a 48-item list that lived only in a Python file
+ * on one machine. Additions must keep the list to nouns that name a food CLASS;
+ * adjectives and brand words belong nowhere near it.
+ */
+export const CLASS_NOUNS: readonly string[] = [
+    'salad', 'jerky', 'mix', 'powder', 'soup', 'chips', 'bar', 'sandwich',
+    'frittata', 'sauce', 'dressing', 'seasoning', 'flavored', 'flavour',
+    'drink', 'juice', 'smoothie', 'shake', 'cookie', 'cake', 'pie',
+    'bowl', 'wrap', 'burrito', 'pizza', 'ice cream', 'yogurt', 'candy',
+    'crackers', 'cereal', 'bread', 'syrup', 'concentrate', 'extract',
+    'spread', 'dip', 'kit', 'meal', 'dinner', 'nuggets', 'patties',
+    'sticks', 'bites', 'roll', 'muffin', 'donut', 'pudding', 'jelly',
+];
+
+/** Atwater ratio (4P + 4C + 9F) / kcal. null when the panel cannot be checked. */
+export function atwaterRatio(panel: PanelLike | null | undefined): number | null {
+    if (!panel) return null;
+    if (!panel.kcal || panel.kcal <= 0) return null;
+    return (4 * panel.protein + 4 * panel.carbs + 9 * panel.fat) / panel.kcal;
+}
+
+export const ATWATER_BAND = 0.25;
+
+export function atwaterInconsistent(panel: PanelLike | null | undefined): boolean {
+    const r = atwaterRatio(panel);
+    return r != null && Math.abs(r - 1) > ATWATER_BAND;
+}
+
+/** Food-class nouns present in the winner name that the query never used. */
+export function extraClassNouns(query: string, name: string | null | undefined): string[] {
+    const q = (query || '').toLowerCase();
+    const n = (name || '').toLowerCase();
+    return CLASS_NOUNS.filter(c => n.includes(c) && !q.includes(c));
+}
+
+/** Signed % change in kcal/100g from A's panel to B's panel. null when incomparable. */
+export function kcalDeltaPct(a: WinnerInfo | null, b: WinnerInfo | null): number | null {
+    if (!a || !b) return null;
+    const pa = a.panel;
+    const pb = b.panel;
+    if (!pa || !pb) return null;
+    if (!pa.kcal) return null;
+    return (100 * (pb.kcal - pa.kcal)) / pa.kcal;
+}
+
+export const DELTA_THRESHOLDS: readonly number[] = [0, 5, 10, 20, 30, 50, 100, 200];
+
+export interface DeltaHistogram {
+    n: number;
+    buckets: Array<{ threshold: number; count: number; pct: number }>;
+    median: number | null;
+    mean: number | null;
+    max: number | null;
+}
+
+export function deltaHistogram(absDeltas: number[]): DeltaHistogram {
+    const n = absDeltas.length;
+    const buckets = DELTA_THRESHOLDS.map(t => {
+        const count = absDeltas.filter(x => x > t).length;
+        return { threshold: t, count, pct: n ? (100 * count) / n : 0 };
+    });
+    if (n === 0) return { n, buckets, median: null, mean: null, max: null };
+    const sorted = [...absDeltas].sort((x, y) => x - y);
+    const mid = Math.floor(n / 2);
+    const median = n % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    return {
+        n,
+        buckets,
+        median,
+        mean: absDeltas.reduce((s, x) => s + x, 0) / n,
+        max: sorted[n - 1],
+    };
+}
+
+export interface ScreenPair {
+    query: string;
+    a: WinnerInfo | null;
+    b: WinnerInfo | null;
+}
+
+export interface ScreenResult {
+    labelA: string;
+    labelB: string;
+    /** pairs where both sides picked something AND the picks differ */
+    disagreements: number;
+    aOnly: number;
+    bOnly: number;
+    neither: number;
+    delta: DeltaHistogram;
+    direction: { aLower: number; aHigher: number; equal: number };
+    noPanel: { a: number; b: number };
+    atwater: {
+        comparable: number;
+        onlyA: number;
+        onlyB: number;
+        both: number;
+        rows: Array<{ query: string; side: 'A' | 'B'; ratioA: number; ratioB: number; nameA: string; nameB: string }>;
+    };
+    classDrift: {
+        onlyA: number;
+        onlyB: number;
+        both: number;
+        neither: number;
+        worstA: Array<{ query: string; name: string; nouns: string[]; deltaPct: number | null; kcalA: number | null; kcalB: number | null }>;
+        worstB: Array<{ query: string; name: string; nouns: string[]; deltaPct: number | null; kcalA: number | null; kcalB: number | null }>;
+    };
+}
+
+/**
+ * The four mechanical screens. NONE of them is an adjudicator on its own — on the
+ * confidenceGate population the kcal direction split (117 A-lower / 114 A-higher)
+ * and Atwater (6 / 4) were a wash, and only class drift (53 / 2) was asymmetric.
+ * Print all four so a future reader can see which ones are washes rather than
+ * being handed the one that happens to favour the change.
+ */
+export function runScreens(pairs: ScreenPair[], labelA = 'A', labelB = 'B'): ScreenResult {
+    const dis: ScreenPair[] = [];
+    let aOnly = 0;
+    let bOnly = 0;
+    let neither = 0;
+    for (const p of pairs) {
+        if (p.a && p.b) {
+            if (p.a.foodId !== p.b.foodId) dis.push(p);
+        } else if (p.a && !p.b) aOnly++;
+        else if (!p.a && p.b) bOnly++;
+        else neither++;
+    }
+
+    const signed = dis
+        .map(p => kcalDeltaPct(p.a, p.b))
+        .filter((x): x is number => x != null);
+    const delta = deltaHistogram(signed.map(Math.abs));
+
+    const direction = {
+        aLower: signed.filter(x => x > 0).length,
+        aHigher: signed.filter(x => x < 0).length,
+        equal: signed.filter(x => x === 0).length,
+    };
+
+    const noPanel = {
+        a: dis.filter(p => !p.a?.panel).length,
+        b: dis.filter(p => !p.b?.panel).length,
+    };
+
+    let comparable = 0;
+    let atOnlyA = 0;
+    let atOnlyB = 0;
+    let atBoth = 0;
+    const atRows: ScreenResult['atwater']['rows'] = [];
+    for (const p of dis) {
+        const ra = atwaterRatio(p.a?.panel);
+        const rb = atwaterRatio(p.b?.panel);
+        if (ra == null || rb == null) continue;
+        comparable++;
+        const badA = Math.abs(ra - 1) > ATWATER_BAND;
+        const badB = Math.abs(rb - 1) > ATWATER_BAND;
+        if (badA && badB) atBoth++;
+        else if (badA) {
+            atOnlyA++;
+            atRows.push({ query: p.query, side: 'A', ratioA: ra, ratioB: rb, nameA: p.a!.foodName, nameB: p.b!.foodName });
+        } else if (badB) {
+            atOnlyB++;
+            atRows.push({ query: p.query, side: 'B', ratioA: ra, ratioB: rb, nameA: p.a!.foodName, nameB: p.b!.foodName });
+        }
+    }
+
+    let cdOnlyA = 0;
+    let cdOnlyB = 0;
+    let cdBoth = 0;
+    let cdNeither = 0;
+    const listA: ScreenResult['classDrift']['worstA'] = [];
+    const listB: ScreenResult['classDrift']['worstB'] = [];
+    for (const p of dis) {
+        const ea = extraClassNouns(p.query, p.a?.foodName);
+        const eb = extraClassNouns(p.query, p.b?.foodName);
+        const d = kcalDeltaPct(p.a, p.b);
+        const rec = (name: string, nouns: string[]) => ({
+            query: p.query,
+            name,
+            nouns,
+            deltaPct: d,
+            kcalA: p.a?.panel?.kcal ?? null,
+            kcalB: p.b?.panel?.kcal ?? null,
+        });
+        if (ea.length && !eb.length) { cdOnlyA++; listA.push(rec(p.a!.foodName, ea)); }
+        else if (eb.length && !ea.length) { cdOnlyB++; listB.push(rec(p.b!.foodName, eb)); }
+        else if (ea.length && eb.length) cdBoth++;
+        else cdNeither++;
+    }
+    const byDelta = (x: { deltaPct: number | null }, y: { deltaPct: number | null }) =>
+        Math.abs(y.deltaPct ?? 0) - Math.abs(x.deltaPct ?? 0);
+    listA.sort(byDelta);
+    listB.sort(byDelta);
+
+    return {
+        labelA,
+        labelB,
+        disagreements: dis.length,
+        aOnly,
+        bOnly,
+        neither,
+        delta,
+        direction,
+        noPanel,
+        atwater: { comparable, onlyA: atOnlyA, onlyB: atOnlyB, both: atBoth, rows: atRows },
+        classDrift: { onlyA: cdOnlyA, onlyB: cdOnlyB, both: cdBoth, neither: cdNeither, worstA: listA, worstB: listB },
+    };
+}
+
+export function formatScreens(s: ScreenResult, top = 30): string[] {
+    const L: string[] = [];
+    const A = s.labelA;
+    const B = s.labelB;
+    L.push('');
+    L.push(`SCREENS over ${s.disagreements} disagreement(s)  ` +
+        `[${A}-only-picked ${s.aOnly}, ${B}-only-picked ${s.bOnly}, neither-picked ${s.neither}]`);
+    L.push('');
+    L.push(`  |kcal/100g delta| over ${s.delta.n} pair(s) with BOTH panels present`);
+    for (const b of s.delta.buckets) {
+        L.push(`      >${String(b.threshold).padStart(3)}%  ${String(b.count).padStart(5)}  (${b.pct.toFixed(1)}%)`);
+    }
+    if (s.delta.n > 0) {
+        L.push(`      median ${s.delta.median!.toFixed(1)}%   mean ${s.delta.mean!.toFixed(1)}%   max ${s.delta.max!.toFixed(1)}%`);
+    }
+    L.push(`  direction: ${A} lower than ${B} on ${s.direction.aLower} rows, ${A} higher on ${s.direction.aHigher} rows` +
+        (s.direction.equal ? `, equal on ${s.direction.equal}` : ''));
+    L.push(`      (a SYMMETRIC split adjudicates nothing — say so rather than quoting one side)`);
+    L.push('');
+    L.push(`  no-nutrition winner:  ${A} ${s.noPanel.a}   ${B} ${s.noPanel.b}`);
+    L.push('');
+    L.push(`  ATWATER  (4P+4C+9F)/kcal outside [${(1 - ATWATER_BAND).toFixed(2)}, ${(1 + ATWATER_BAND).toFixed(2)}] over ${s.atwater.comparable} comparable pairs`);
+    L.push(`      only ${A} inconsistent: ${s.atwater.onlyA}      only ${B} inconsistent: ${s.atwater.onlyB}      both: ${s.atwater.both}`);
+    L.push('');
+    L.push('  CLASS-DRIFT  (winner name carries a food-class noun the query never used)');
+    L.push(`      only ${A} drifts: ${s.classDrift.onlyA}      only ${B} drifts: ${s.classDrift.onlyB}      both: ${s.classDrift.both}      neither: ${s.classDrift.neither}`);
+    for (const [side, list] of [[A, s.classDrift.worstA], [B, s.classDrift.worstB]] as const) {
+        if (!list.length) continue;
+        L.push('');
+        L.push(`      worst ${Math.min(top, list.length)} ${side}-only class drifts (query | winner | extra nouns | kcal delta):`);
+        for (const r of list.slice(0, top)) {
+            const d = r.deltaPct == null ? '' : `${r.deltaPct >= 0 ? '+' : ''}${r.deltaPct.toFixed(0)}%`;
+            L.push(`        ${r.query.slice(0, 44).padEnd(46)} | ${r.name.slice(0, 44).padEnd(46)} | ` +
+                `${r.nouns.join(',').slice(0, 22).padEnd(24)} | ${d}  (${A} ${r.kcalA ?? '?'} -> ${B} ${r.kcalB ?? '?'})`);
+        }
+    }
+    return L;
+}
+
+// ============================================================
+// 5. Noise-floor receipts
+// ============================================================
+
+export interface NoiseFloorReceipt {
+    kind: 'winner-diff/noise-floor';
+    version: 1;
+    ranAt: string;
+    snapshotTakenAt: string;
+    gitHead: string;
+    gitDirty: string;
+    variant: string;
+    rows: number;
+    winnerDiffs: number;
+    pathDiffs: number;
+}
+
+export interface NoiseFloorLedger {
+    kind: 'winner-diff/noise-floor-ledger';
+    version: 1;
+    receipts: NoiseFloorReceipt[];
+}
+
+export function emptyLedger(): NoiseFloorLedger {
+    return { kind: 'winner-diff/noise-floor-ledger', version: 1, receipts: [] };
+}
+
+export function findReceipt(
+    ledger: NoiseFloorLedger | null,
+    snapshotTakenAt: string,
+    gitDirty: string,
+    variant: string,
+): NoiseFloorReceipt | null {
+    if (!ledger) return null;
+    const hits = ledger.receipts.filter(r =>
+        r.snapshotTakenAt === snapshotTakenAt && r.gitDirty === gitDirty && r.variant === variant);
+    if (!hits.length) return null;
+    return hits.sort((x, y) => (x.ranAt < y.ranAt ? 1 : -1))[0];
+}
+
+export interface NoiseGateVerdict {
+    ok: boolean;
+    problems: string[];
+    receiptA: NoiseFloorReceipt | null;
+    receiptB: NoiseFloorReceipt | null;
+}
+
+/**
+ * The gate that stops `diff` from reporting a number that means nothing.
+ *
+ * A diff is only a measurement if replaying the SAME variant twice on the SAME
+ * snapshot produces zero winner changes — and that property is PER TREE, so both
+ * sides need their own receipt. Two numbers are involved and they are NOT the same:
+ *   replayNoise     same snapshot, same tree      MUST be 0 (this gate)
+ *   retrievalNoise  DIFFERENT snapshots, same tree — is genuinely non-zero, and is
+ *                   not a bug (Typesense/FatSecret return a different pool minutes
+ *                   apart). A scratch log labelled a cross-snapshot run "the noise
+ *                   floor. Expect 0 changed rows" and it was simply false.
+ */
+export function noiseGate(
+    ledger: NoiseFloorLedger | null,
+    a: ReplayFile,
+    b: ReplayFile,
+    opts: { crossSnapshot: boolean },
+): NoiseGateVerdict {
+    const problems: string[] = [];
+
+    if (a.snapshotTakenAt !== b.snapshotTakenAt && !opts.crossSnapshot) {
+        problems.push(
+            `A and B replayed DIFFERENT snapshots (${a.snapshotTakenAt} vs ${b.snapshotTakenAt}). ` +
+            'Retrieval nondeterminism is inside the signal. Re-replay both sides from ONE snapshot, ' +
+            'or pass --cross-snapshot to accept a RETRIEVAL-NOISE-CONTAMINATED report.');
+    }
+
+    const ra = findReceipt(ledger, a.snapshotTakenAt, a.gitDirty, a.variant);
+    const rb = findReceipt(ledger, b.snapshotTakenAt, b.gitDirty, b.variant);
+
+    for (const [side, f, r] of [['A', a, ra], ['B', b, rb]] as const) {
+        if (!r) {
+            problems.push(
+                `no noise-floor receipt for side ${side} (snapshot ${f.snapshotTakenAt}, ` +
+                `tree ${f.gitDirty}, variant ${f.variant}). Run: winner-diff noise-floor ` +
+                `--snapshot <snap.json> --variant ${f.variant}   FROM THAT TREE.`);
+        } else if (r.winnerDiffs !== 0 || r.pathDiffs !== 0) {
+            problems.push(
+                `side ${side} noise floor is NON-ZERO (${r.winnerDiffs} winner / ${r.pathDiffs} path ` +
+                `differences over ${r.rows} rows). The replay is not deterministic on this tree; ` +
+                'any diff number below would be noise plus signal with no way to separate them.');
+        }
+    }
+
+    return { ok: problems.length === 0, problems, receiptA: ra, receiptB: rb };
+}
+
+// ============================================================
+// 6. Populations
+// ============================================================
+
+export type QueryOrigin = 'user' | 'warmer';
+
+export interface PopulationLine {
+    query: string;
+    origin: QueryOrigin;
+    /** occurrences in the source table, when the source provides one */
+    count?: number;
+    goldenId?: string;
+}
+
+/** Newline list; `#` comments and blank lines dropped. */
+export function parseQueryFile(text: string): string[] {
+    return text.split('\n').map(s => s.trim()).filter(s => s.length > 0 && !s.startsWith('#'));
+}
+
+/** True when the tokens are already in ascending order (>= 2 tokens required). */
+export function isTokenSorted(s: string): boolean {
+    const toks = s.trim().split(/\s+/).filter(Boolean);
+    if (toks.length < 2) return false;
+    for (let i = 1; i < toks.length; i++) {
+        if (toks[i - 1] > toks[i]) return false;
+    }
+    return true;
+}
+
+/**
+ * HEURISTIC origin tag. `cache-parity-sweep.ts` posts `100g ${name}` where `name`
+ * is a token-SORTED FoodMapping key, so a third of MappingEventLog is our own
+ * warmer wearing user-traffic clothes ("100g debbie little roll swiss"). Word order
+ * is signal in this pipeline (deriveMustHaveTokens is order-sensitive), so scrambled
+ * keys exercise different filters than sentences users type — a rate computed over
+ * the raw event log is a rate over a mixed distribution.
+ *
+ * IT IS A HEURISTIC AND IT UNDERCOUNTS. Measured over the real 4,165-line event
+ * population (scratchpad/zz-cg-harm-popALL.txt):
+ *     `^100g ` prefix alone        1297  (31.1%)
+ *     this function ('warmer')      957  (23.0%)
+ *     prefixed but tagged 'user'    340
+ * Most of that 340 is SINGLE-TOKEN keys — "100g honey", "100g salt" — which
+ * `isTokenSorted` refuses to call sorted because one token is no evidence of
+ * anything. Those really are warmer lines, so 23.0% is a FLOOR on contamination,
+ * not an estimate of it. In the other direction, a genuine user line that happens
+ * to be alphabetical is tagged 'warmer'. Report the split; never silently drop rows
+ * on it, and never quote either number as "the" warmer share.
+ */
+export function classifyOrigin(line: string): QueryOrigin {
+    const m = line.match(/^100g\s+(.*)$/i);
+    if (!m) return 'user';
+    return isTokenSorted(m[1]) ? 'warmer' : 'user';
+}
+
+export function originSplit(lines: string[]): { user: number; warmer: number; warmerPct: number } {
+    const warmer = lines.filter(l => classifyOrigin(l) === 'warmer').length;
+    return {
+        user: lines.length - warmer,
+        warmer,
+        warmerPct: lines.length ? (100 * warmer) / lines.length : 0,
+    };
+}
+
+// ---- golden set --------------------------------------------------------
+
+/**
+ * Every assertion kind `run-eval.ts` supports on an `nlp` case.
+ *
+ * THIS LIST IS THE FIX FOR THE WORST DEFECT THIS HARNESS HAS HAD. `GoldenCase`
+ * used to carry `expectName` and `macros` and NOTHING ELSE, so `checkGoldenBands`
+ * printed "no golden case changed verdict" while it could not see the assertion
+ * type the corpus is mostly made of. Re-derived from scripts/eval/golden-set.json
+ * on 2026-07-26 over all 243 nlp cases (`search` cases are a different runner and
+ * are not screened here):
+ *
+ *     expectName     243  (100.0%)  — every case
+ *     grams          148  ( 60.9%)  <-- the majority assertion, previously INVISIBLE
+ *     macros          59  ( 24.3%)
+ *     expectItems     47  ( 19.3%)  — all 47 are `text`-shaped
+ *     total           18  (  7.4%)  <-- previously INVISIBLE
+ *     forbidName       0            — documented in _readme, no live case uses it
+ *     expectAbstain    0            —      "
+ *     maxConfidence    0            —      "
+ *     cases with no assertion at all: 0
+ *     cases with a name but NO numeric band: 47   (= the 47 in the _readme)
+ *
+ * Split by shape, because `--golden` replays only `item` cases unless
+ * `--include-multi-item` is passed:
+ *     item-shaped 160:  grams 117, macros 43, total  7, expectItems  0
+ *     text-shaped  83:  grams  31, macros 16, total 11, expectItems 47
+ *
+ * forbidName/expectAbstain/maxConfidence are parsed and evaluated anyway. They
+ * cost nothing to support and the corpus has carried them before (n-mq-38..42 held
+ * a forbidName that was removed on 2026-07-26 because enumerating wrong brands only
+ * ever excludes the wrong answers you have already seen). A screen that only knows
+ * the assertions in today's file is one commit away from being blind again.
+ */
+export type GoldenBandKind =
+    | 'expectName'
+    | 'forbidName'
+    | 'expectAbstain'
+    | 'maxConfidence'
+    | 'expectItems'
+    | 'macros'
+    | 'grams'
+    | 'total';
+
+export const GOLDEN_BAND_KINDS: readonly GoldenBandKind[] = [
+    'expectName', 'forbidName', 'expectAbstain', 'maxConfidence', 'expectItems', 'macros', 'grams', 'total',
+];
+
+/**
+ * ============================================================================
+ * THE HONEST LIMIT — read this before quoting anything this screen prints.
+ * ============================================================================
+ * A frozen-pool replay selects a WINNER. It re-runs the mapper's Step 3a/Step 4
+ * selection over a recorded candidate pool and stops there. It does NOT run:
+ *
+ *   - serving resolution (`resolveServing` / simple-serving-estimator / the unit
+ *     heuristics at map-ingredient-with-fallback.ts:3209+), which is what produces
+ *     `grams`;
+ *   - the grams -> nutrition scaling (`const scale = mapped.grams / 100`,
+ *     route.ts:375), which is what produces the billed `nutrition` block;
+ *   - the post-selection sanity check (MAX_REASONABLE_GRAMS / MAX_REASONABLE_KCAL,
+ *     mapper :3063) which can turn a selected winner into a no-pick;
+ *   - the LLM segmenter, which is what produces more than one item.
+ *
+ * Therefore `grams`, `total` and `expectItems` are NOT EVALUABLE from a replay,
+ * and this file reports them as such — never as a satisfied band. They are not
+ * derivable either: `WinnerInfo` carries identity, source, confidence and a macro
+ * panel, and no serving/portion rows at all. Making `grams` evaluable is a RUNNER
+ * change (winner-diff.ts would have to record the winner's serving rows and run the
+ * resolver), not something this pure module can fake.
+ *
+ * And the blindness is not academic. Of the 117 item-shaped `grams` cases, exactly
+ * 3 use an explicit weight unit (`g` x2, `oz` x1) whose grams are fixed by the
+ * parsed quantity regardless of which record wins. The other 114 resolve their
+ * grams FROM THE WINNER RECORD's serving data — so a winner change is precisely the
+ * event that moves them, and precisely the event this screen could not see.
+ */
+export const REPLAY_BLIND_BANDS: Readonly<Record<string, string>> = {
+    grams: 'grams comes from serving resolution, which runs AFTER winner selection; the replay stops at selection',
+    total: 'total = per-100g panel x grams/100, and grams is not resolved by a replay',
+    expectItems: 'item count comes from the LLM segmenter, which a single-query replay never runs',
+};
+
+/** The only per-100g keys a replay `PanelLike` can answer. A band on any other key is blind. */
+export const MEASURABLE_MACRO_KEYS: readonly string[] = ['kcal100', 'protein100', 'carbs100', 'fat100'];
+
+/**
+ * Mirrors `isWeightUnit` at map-ingredient-with-fallback.ts:2410. Volume units
+ * (cup/tbsp/tsp) are deliberately absent: their grams go through a density that is
+ * itself record-dependent, so they are not "fixed by the quantity".
+ */
+const WEIGHT_UNIT_RE = /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms)$/i;
+
+export interface GoldenCase {
+    id: string;
+    category: string;
+    rawText: string;
+    /** alternatives; each alternative is a list of required substrings (AND within, OR across) */
+    expectName: string[][];
+    /** same shape as expectName; run-eval FAILS if any returned item matches */
+    forbidName?: string[][];
+    /** the mapper is required to produce no confident pick */
+    expectAbstain?: boolean;
+    /** it may guess, but must not look authoritative enough to cache */
+    maxConfidence?: number;
+    /** minimum number of segmented items */
+    expectItems?: number;
+    /** band on items[0].nutritionPer100g */
+    macros?: Record<string, [number, number]>;
+    /** band on items[0].grams — the RESOLVED serving weight */
+    grams?: [number, number];
+    /** band on items[0].nutrition — the BILLED totals for the requested quantity */
+    total?: Record<string, [number, number]>;
+    knownIssue?: boolean;
+    /** 'item' = single-ingredient case; 'text' = multi-item line meant for the segmenter */
+    shape: 'item' | 'text';
+    /** item.unit as written in the case, when there is one */
+    unit?: string;
+    /** item.quantity as written in the case, when there is one */
+    quantity?: number;
+    /**
+     * True for a `text` case that /api/nlp/parse resolves WITHOUT the segmenter.
+     * See isDeterministicSingleItemText — for these a one-query replay is faithful;
+     * for the rest it is a different function and every band is blind.
+     *
+     * OPTIONAL, and the default is the CONSERVATIVE one (see isSingleIngredientCase):
+     * a hand-built `text` case that does not say is treated as segmenter-bound, i.e.
+     * unjudgeable. parseGoldenSet always sets it explicitly.
+     */
+    deterministicSingleItem?: boolean;
+}
+
+const MEAL_SUFFIX_RE = /\s*(?:for|at|as)\s+(breakfast|lunch|dinner|snacks?)\s*\.?\s*$/i;
+const MULTI_ITEM_SIGNALS_RE = /[,;\n+&]|\b(?:and|with|plus)\b/i;
+
+/**
+ * Byte-for-byte mirror of `singleItemFromText` (src/app/api/nlp/parse/route.ts:29-45).
+ *
+ * WHY IT MATTERS HERE: a `text` case does not automatically mean "the segmenter ran".
+ * The route short-circuits short, separator-free lines straight to one
+ * mapIngredientWithFallback call — which is exactly what a replay does — so
+ * "7up", "2 7up" and "three slices of bacon" ARE faithfully reproduced by a
+ * single-query replay, while "2 eggs and toast" is not. Blanket-marking every
+ * `text` case unevaluable would be as dishonest in the other direction as the
+ * silent pass this file exists to remove.
+ *
+ * If the route's rule changes, this must change with it. It is pinned by a test.
+ */
+export function isDeterministicSingleItemText(text: string): boolean {
+    const trimmed = (text ?? '').trim();
+    if (trimmed.length === 0 || trimmed.length > 60) return false;
+    let rawText = trimmed;
+    const mealMatch = trimmed.match(MEAL_SUFFIX_RE);
+    if (mealMatch) rawText = trimmed.slice(0, mealMatch.index).trim();
+    if (rawText.length === 0 || MULTI_ITEM_SIGNALS_RE.test(rawText)) return false;
+    if (rawText.split(/\s+/).length > 6) return false;
+    return true;
+}
+
+/**
+ * Is one mapIngredientWithFallback call over this case's raw text the same function
+ * the real eval runs? Defaults to `shape === 'item'` when the case does not say —
+ * the conservative direction, because being wrong here in the other direction means
+ * reporting a judged verdict for a case the replay never actually reproduced.
+ */
+export function isSingleIngredientCase(c: GoldenCase): boolean {
+    return c.deterministicSingleItem ?? (c.shape === 'item');
+}
+
+/** Every assertion kind this case actually carries, in a stable order. */
+export function assertedBands(c: GoldenCase): GoldenBandKind[] {
+    const out: GoldenBandKind[] = [];
+    if (c.expectName && c.expectName.length > 0) out.push('expectName');
+    if (c.forbidName && c.forbidName.length > 0) out.push('forbidName');
+    if (c.expectAbstain) out.push('expectAbstain');
+    if (typeof c.maxConfidence === 'number') out.push('maxConfidence');
+    if (typeof c.expectItems === 'number') out.push('expectItems');
+    if (c.macros && Object.keys(c.macros).length) out.push('macros');
+    if (c.grams) out.push('grams');
+    if (c.total && Object.keys(c.total).length) out.push('total');
+    return out;
+}
+
+/**
+ * Bands this case can NEVER be judged on from a replay, independent of which
+ * winner came back. Winner-dependent gaps (a winner with no per-100g panel) are
+ * NOT here — those are decided per winner inside checkGoldenBands.
+ */
+export function structurallyBlindBands(c: GoldenCase): GoldenBandKind[] {
+    const asserted = assertedBands(c);
+    // A `text` case that the route hands to the LLM segmenter is a different
+    // function from the one a replay runs. Nothing about it is evaluable here.
+    if (!isSingleIngredientCase(c)) return asserted;
+    return asserted.filter(k => {
+        if (k in REPLAY_BLIND_BANDS) return true;
+        if (k === 'macros') {
+            return Object.keys(c.macros ?? {}).every(key => !MEASURABLE_MACRO_KEYS.includes(key));
+        }
+        return false;
+    });
+}
+
+/** True when the case's grams band is fixed by the parsed quantity rather than by the record. */
+export function gramsBandIsRecordIndependent(c: GoldenCase): boolean {
+    return !!c.grams && !!c.unit && WEIGHT_UNIT_RE.test(c.unit);
+}
+
+/**
+ * golden-set.json is an OBJECT `{_readme, search[], nlp[]}`, not an array — reading
+ * it as an array yields nothing and the population silently becomes empty.
+ *
+ * Only `nlp` cases are usable here, and by default only those with `item.rawText`:
+ * a `text` case is a multi-ingredient line whose real path goes through the LLM
+ * segmenter in /api/nlp/parse, not through one mapIngredientWithFallback call.
+ * Passing includeMultiItem accepts them anyway, and the caller must say so in-band.
+ */
+export function parseGoldenSet(raw: unknown, opts: { includeMultiItem?: boolean } = {}): GoldenCase[] {
+    const root = raw as { nlp?: unknown[] } | null;
+    if (!root || !Array.isArray(root.nlp)) {
+        throw new Error('golden-set.json: expected an object with an `nlp` array (shape {_readme, search[], nlp[]})');
+    }
+    const out: GoldenCase[] = [];
+    for (const c of root.nlp as Array<Record<string, any>>) {
+        const item = c.item as { rawText?: string; unit?: string; quantity?: number } | undefined;
+        const rawText = item?.rawText ?? (typeof c.text === 'string' ? c.text : undefined);
+        if (!rawText) continue;
+        const shape: 'item' | 'text' = item?.rawText ? 'item' : 'text';
+        if (shape === 'text' && !opts.includeMultiItem) continue;
+        out.push({
+            id: String(c.id),
+            category: String(c.category ?? ''),
+            rawText,
+            expectName: Array.isArray(c.expectName) ? (c.expectName as string[][]) : [],
+            forbidName: Array.isArray(c.forbidName) ? (c.forbidName as string[][]) : undefined,
+            expectAbstain: c.expectAbstain === true ? true : undefined,
+            maxConfidence: typeof c.maxConfidence === 'number' ? c.maxConfidence : undefined,
+            expectItems: typeof c.expectItems === 'number' ? c.expectItems : undefined,
+            macros: c.macros as Record<string, [number, number]> | undefined,
+            grams: Array.isArray(c.grams) ? (c.grams as [number, number]) : undefined,
+            total: c.total as Record<string, [number, number]> | undefined,
+            knownIssue: !!c.knownIssue,
+            shape,
+            unit: typeof item?.unit === 'string' && item.unit ? item.unit : undefined,
+            quantity: typeof item?.quantity === 'number' ? item.quantity : undefined,
+            // An `item` case is by definition one mapIngredientWithFallback call.
+            deterministicSingleItem: shape === 'item' ? true : isDeterministicSingleItemText(rawText),
+        });
+    }
+    return out;
+}
+
+export type GoldenVerdict = 'PASS' | 'FAIL' | 'UNKNOWN';
+
+export interface GoldenBandResult {
+    verdict: GoldenVerdict;
+    /**
+     * Everything a reader must see, violations first then `NOT-EVALUABLE:` notices.
+     * winner-diff.ts prints this array verbatim, which is why the blind spots are in
+     * it rather than tucked away in a field the runner does not know about.
+     */
+    failures: string[];
+    /** bands the winner genuinely violated */
+    violations: string[];
+    /** bands that could not be judged, each with its reason */
+    notEvaluable: string[];
+    /** every assertion kind the case carries */
+    asserted: GoldenBandKind[];
+    /** the subset actually judged against this winner */
+    evaluated: GoldenBandKind[];
+    /** the subset that could not be judged (structural OR winner-dependent) */
+    blind: GoldenBandKind[];
+}
+
+/**
+ * Does this winner still satisfy the case's assertions — and, just as importantly,
+ * WHICH of them could be judged at all?
+ *
+ * HARD RULE, unchanged: assert the right answer, never enumerate the wrong ones. A
+ * case that merely forbids one wrong brand passes the moment the winner moves to a
+ * DIFFERENT wrong brand. `forbidName` is therefore evaluated only as a CONJUNCT — it
+ * can add a failure, never turn one into a pass — and a case whose only assertion is
+ * a forbid is reported as such rather than as a clean PASS.
+ *
+ * VERDICT RULE:
+ *   FAIL     at least one asserted band was judged and violated
+ *   UNKNOWN  nothing was violated, but at least one asserted band could not be judged
+ *   PASS     every asserted band was judged and satisfied
+ *
+ * UNKNOWN is the whole point. Before 2026-07-26 this function knew about
+ * `expectName` and `macros` only, so a case asserting `grams: [24, 120]` returned a
+ * clean PASS on any winner whose NAME matched — and 148 of the 243 nlp cases assert
+ * grams. Both sides of a diff returned PASS, the runner compared the two verdicts,
+ * saw no change, and printed "no golden case changed verdict" over a screen that
+ * could not see the majority of the corpus. An unmeasurable band is not a satisfied
+ * band; see REPLAY_BLIND_BANDS above for exactly what a replay cannot see and why.
+ *
+ * Semantics mirror run-eval.ts runNlpCase() band-for-band, including WHICH object
+ * each band reads: macros -> items[0].nutritionPer100g, total -> items[0].nutrition,
+ * grams -> items[0].grams. A replay has only the first of those three.
+ */
+export function checkGoldenBands(c: GoldenCase, w: WinnerInfo | null): GoldenBandResult {
+    const violations: string[] = [];
+    const notEvaluable: string[] = [];
+    const asserted = assertedBands(c);
+    const blind = new Set<GoldenBandKind>();
+
+    const markBlind = (k: GoldenBandKind, why: string) => {
+        if (blind.has(k)) return;
+        blind.add(k);
+        notEvaluable.push(`NOT-EVALUABLE: ${k} — ${why}`);
+    };
+
+    // ---- structural blindness, decided by the CASE, not by the winner ----
+    if (!isSingleIngredientCase(c)) {
+        for (const k of asserted) {
+            markBlind(k, 'multi-item `text` case: /api/nlp/parse segments it with the LLM and '
+                + 'asserts over items[]; a replay maps the WHOLE LINE as one ingredient, which is a '
+                + 'different function. Nothing about this case is evaluable from a replay.');
+        }
+        return finish();
+    }
+    for (const k of asserted) {
+        const why = REPLAY_BLIND_BANDS[k];
+        if (why) markBlind(k, why);
+    }
+
+    // ---- expectAbstain: the only assertion a no-winner row can SATISFY ----
+    if (c.expectAbstain) {
+        if (w) {
+            violations.push(`expected abstention, got "${w.foodName}" conf=${w.confidence.toFixed(2)}`);
+        }
+        // Caveat, deliberately not a silent pass-through: the route can still turn a
+        // selected winner into a no-pick after selection (mapper :3063 sanity check),
+        // so a replay winner is an upper bound on what the real eval would see.
+    }
+
+    if (!w) {
+        if (!c.expectAbstain) {
+            violations.push('no winner — nothing was picked, so no positive assertion can be satisfied');
+        }
+        return finish();
+    }
+
+    const text = textOf({ name: w.foodName, brand: w.brandName });
+
+    if (c.expectName.length > 0) {
+        if (!matchesAlt(text, c.expectName)) {
+            violations.push(`expectName not satisfied by "${w.foodName}"${w.brandName ? ` [${w.brandName}]` : ''} ` +
+                `(wanted any of ${JSON.stringify(c.expectName)})`);
+        }
+    }
+
+    if (c.forbidName && c.forbidName.length > 0) {
+        if (matchesAlt(text, c.forbidName)) {
+            violations.push(`forbidName matched by "${w.foodName}"${w.brandName ? ` [${w.brandName}]` : ''} ` +
+                `(forbidden: ${JSON.stringify(c.forbidName)})`);
+        }
+        if (c.expectName.length === 0) {
+            notEvaluable.push('WEAK ASSERTION: this case only forbids names. Not matching a forbidden '
+                + 'name is not evidence the answer is right — the winner may have moved to a '
+                + 'different wrong record.');
+        }
+    }
+
+    if (typeof c.maxConfidence === 'number') {
+        if (w.confidence > c.maxConfidence) {
+            violations.push(`confidence=${w.confidence.toFixed(3)} exceeds maxConfidence ${c.maxConfidence} ` +
+                `(mapped: "${w.foodName}")`);
+        }
+    }
+
+    if (c.macros) {
+        const p = w.panel;
+        const keys = Object.keys(c.macros);
+        const unknownKeys = keys.filter(k => !MEASURABLE_MACRO_KEYS.includes(k));
+        if (!p || !p.per100g) {
+            markBlind('macros', 'winner has no per-100g panel at selection time');
+        } else {
+            const got: Record<string, number> = {
+                kcal100: p.kcal, protein100: p.protein, carbs100: p.carbs, fat100: p.fat,
+            };
+            for (const [k, band] of Object.entries(c.macros)) {
+                if (!MEASURABLE_MACRO_KEYS.includes(k)) continue;
+                const v = got[k];
+                if (v < band[0] || v > band[1]) {
+                    violations.push(`${k} ${v} outside [${band[0]}, ${band[1]}] (mapped: "${w.foodName}")`);
+                }
+            }
+            if (unknownKeys.length === keys.length) {
+                // every key is off-panel: the band as a whole was not judged
+                markBlind('macros', `no key is on the replay panel (${unknownKeys.join(', ')}; `
+                    + `panel carries ${MEASURABLE_MACRO_KEYS.join('/')})`);
+            } else if (unknownKeys.length) {
+                notEvaluable.push(`PARTIAL: macros keys ${unknownKeys.join(', ')} are not on the replay `
+                    + `panel (${MEASURABLE_MACRO_KEYS.join('/')}) and were NOT judged`);
+            }
+        }
+    }
+
+    return finish();
+
+    function finish(): GoldenBandResult {
+        const failures = [...violations, ...notEvaluable];
+        const blindList = asserted.filter(k => blind.has(k));
+        const evaluated = asserted.filter(k => !blind.has(k));
+        // A weak/partial note with no blind band still means "do not read this as clean".
+        const softOnly = notEvaluable.length > 0 && blindList.length === 0;
+        const verdict: GoldenVerdict = violations.length > 0
+            ? 'FAIL'
+            : (blindList.length > 0 || softOnly ? 'UNKNOWN' : 'PASS');
+        return { verdict, failures, violations, notEvaluable, asserted, evaluated, blind: blindList };
+    }
+}
+
+// ---- golden screen (the reportable object) -----------------------------
+
+export interface GoldenScreenCase {
+    id: string;
+    rawText: string;
+    category: string;
+    knownIssue: boolean;
+    shape: 'item' | 'text';
+    winnerMoved: boolean;
+    a: GoldenBandResult;
+    b: GoldenBandResult;
+    verdictChanged: boolean;
+    /** same verdict on both sides, but the reasons moved (FAIL -> FAIL for a new reason) */
+    failuresChanged: boolean;
+}
+
+export interface GoldenCoverage {
+    cases: number;
+    /** per assertion kind: how many cases carry it, and on how many it cannot be judged */
+    byKind: Array<{ kind: GoldenBandKind; asserted: number; blind: number }>;
+    casesWithBlindBand: number;
+    casesFullyBlind: number;
+    gramsCases: number;
+    /** grams cases whose band is fixed by the parsed quantity, not by the winner record */
+    gramsRecordIndependent: number;
+}
+
+export interface GoldenScreenResult {
+    matched: number;
+    /** golden rows in A with no case definition or no B counterpart */
+    unmatched: number;
+    winnerMoved: number;
+    coverage: GoldenCoverage;
+    /** verdict differs between A and B */
+    changed: GoldenScreenCase[];
+    /** verdict identical but the failure/blind reasons moved */
+    reasonsChanged: GoldenScreenCase[];
+    /**
+     * THE POPULATION THE OLD SCREEN SWALLOWED: the winner moved, and the case carries
+     * at least one band this replay cannot judge. A "no golden case changed verdict"
+     * line says nothing whatsoever about these.
+     */
+    movedButBlind: GoldenScreenCase[];
+}
+
+export function goldenCoverage(cases: GoldenCase[]): GoldenCoverage {
+    const byKind = GOLDEN_BAND_KINDS.map(kind => ({ kind, asserted: 0, blind: 0 }));
+    const index = new Map(byKind.map(b => [b.kind, b]));
+    let casesWithBlindBand = 0;
+    let casesFullyBlind = 0;
+    let gramsCases = 0;
+    let gramsRecordIndependent = 0;
+    for (const c of cases) {
+        const asserted = assertedBands(c);
+        const blind = new Set(structurallyBlindBands(c));
+        for (const k of asserted) {
+            const slot = index.get(k)!;
+            slot.asserted++;
+            if (blind.has(k)) slot.blind++;
+        }
+        if (blind.size > 0) casesWithBlindBand++;
+        if (asserted.length > 0 && blind.size === asserted.length) casesFullyBlind++;
+        if (c.grams) {
+            gramsCases++;
+            if (gramsBandIsRecordIndependent(c)) gramsRecordIndependent++;
+        }
+    }
+    return {
+        cases: cases.length,
+        byKind: byKind.filter(b => b.asserted > 0),
+        casesWithBlindBand,
+        casesFullyBlind,
+        gramsCases,
+        gramsRecordIndependent,
+    };
+}
+
+/**
+ * The golden screen as a value, so the runner prints it instead of re-deriving it.
+ *
+ * Matching mirrors what winner-diff.ts's reportGoldenBands already does: A rows carry
+ * `goldenId`, B is looked up by query text.
+ *
+ * NOTE FOR THE RUNNER: the old reportGoldenBands compared `va.verdict !== vb.verdict`
+ * and `continue`d otherwise. With grams/total/expectItems correctly reported as
+ * UNKNOWN, most cases are now UNKNOWN on BOTH sides — so that comparison stays quiet
+ * and the clearance line would be exactly as misleading as before. `movedButBlind`
+ * and `coverage` exist so the report can say what it could not see. Print
+ * formatGoldenScreen() — never a bare clearance line.
+ */
+export function runGoldenScreen(
+    cases: GoldenCase[] | Map<string, GoldenCase>,
+    aRows: ReplayRow[],
+    bRows: ReplayRow[],
+): GoldenScreenResult {
+    const byId = cases instanceof Map ? cases : new Map(cases.map(c => [c.id, c]));
+    const bByQuery = new Map(bRows.map(r => [r.query, r]));
+
+    const matchedCases: GoldenCase[] = [];
+    const changed: GoldenScreenCase[] = [];
+    const reasonsChanged: GoldenScreenCase[] = [];
+    const movedButBlind: GoldenScreenCase[] = [];
+    let unmatched = 0;
+    let winnerMoved = 0;
+
+    for (const a of aRows) {
+        if (!a.goldenId) continue;
+        const c = byId.get(a.goldenId);
+        const b = bByQuery.get(a.query);
+        if (!c || !b) { unmatched++; continue; }
+        matchedCases.push(c);
+
+        const va = checkGoldenBands(c, a.winner);
+        const vb = checkGoldenBands(c, b.winner);
+        const moved = (a.winner?.foodId ?? null) !== (b.winner?.foodId ?? null);
+        if (moved) winnerMoved++;
+
+        const rec: GoldenScreenCase = {
+            id: c.id,
+            rawText: c.rawText,
+            category: c.category,
+            knownIssue: !!c.knownIssue,
+            shape: c.shape,
+            winnerMoved: moved,
+            a: va,
+            b: vb,
+            verdictChanged: va.verdict !== vb.verdict,
+            failuresChanged: va.failures.join('|') !== vb.failures.join('|'),
+        };
+        if (rec.verdictChanged) changed.push(rec);
+        else if (rec.failuresChanged) reasonsChanged.push(rec);
+        if (moved && vb.blind.length > 0) movedButBlind.push(rec);
+    }
+
+    return {
+        matched: matchedCases.length,
+        unmatched,
+        winnerMoved,
+        coverage: goldenCoverage(matchedCases),
+        changed,
+        reasonsChanged,
+        movedButBlind,
+    };
+}
+
+export function formatGoldenScreen(s: GoldenScreenResult, top = 30): string[] {
+    const L: string[] = [];
+    L.push('');
+    L.push(`GOLDEN-BAND SCREEN over ${s.matched} matched case(s)` +
+        (s.unmatched ? `  (${s.unmatched} golden row(s) had no case definition or no B counterpart)` : ''));
+    L.push('');
+    L.push('  WHAT THIS SCREEN CANNOT SEE — a frozen-pool replay selects a WINNER. It does not');
+    L.push('  run serving resolution, grams-scaling of nutrition, or the LLM segmenter, so');
+    L.push('  `grams`, `total` and `expectItems` are NOT EVALUABLE here and are reported as');
+    L.push('  UNKNOWN, never as satisfied. Do NOT read a quiet verdict column as clearance.');
+    L.push('');
+    L.push('  band coverage over the matched cases (asserted / of those, blind):');
+    for (const b of s.coverage.byKind) {
+        const flag = b.blind === b.asserted && b.asserted > 0 ? '  <-- NOT EVALUABLE'
+            : b.blind > 0 ? '  <-- partly blind' : '';
+        L.push(`      ${b.kind.padEnd(14)} asserted ${String(b.asserted).padStart(4)}   blind ${String(b.blind).padStart(4)}${flag}`);
+    }
+    L.push(`      ${s.coverage.casesWithBlindBand} of ${s.coverage.cases} case(s) carry at least one band this screen cannot judge` +
+        `; ${s.coverage.casesFullyBlind} are fully blind.`);
+    if (s.coverage.gramsCases) {
+        L.push(`      of ${s.coverage.gramsCases} grams band(s), ${s.coverage.gramsRecordIndependent} are fixed by the parsed quantity ` +
+            `(explicit weight unit) and ${s.coverage.gramsCases - s.coverage.gramsRecordIndependent} resolve FROM THE WINNER RECORD` +
+            ` — i.e. a winner change is exactly what moves them.`);
+    }
+    L.push('');
+    L.push(`  winner moved on ${s.winnerMoved} of ${s.matched} matched case(s)`);
+    L.push('');
+
+    const block = (title: string, list: GoldenScreenCase[], render: (r: GoldenScreenCase) => string[]) => {
+        L.push(`  ${title}: ${list.length}`);
+        for (const r of list.slice(0, top)) L.push(...render(r));
+        if (list.length > top) L.push(`      ... ${list.length - top} more`);
+        L.push('');
+    };
+
+    block('VERDICT CHANGED', s.changed, r => {
+        const out = [`      ${r.id} ${r.knownIssue ? '(knownIssue) ' : ''}"${r.rawText}"   ${r.a.verdict} -> ${r.b.verdict}`];
+        for (const f of r.b.failures) out.push(`          B: ${f}`);
+        for (const f of r.a.failures) out.push(`          A: ${f}`);
+        return out;
+    });
+
+    block('WINNER MOVED but the case has a band this screen CANNOT judge', s.movedButBlind, r =>
+        [`      ${r.id} "${r.rawText}"   verdict ${r.a.verdict} -> ${r.b.verdict}   unjudged: ${r.b.blind.join(', ')}`]);
+
+    block('same verdict, different reasons', s.reasonsChanged, r =>
+        [`      ${r.id} "${r.rawText}"   ${r.b.verdict} (reasons moved)`]);
+
+    if (!s.changed.length && !s.movedButBlind.length && !s.reasonsChanged.length) {
+        L.push('  no golden case changed verdict AND no moved winner sits behind an unjudged band.');
+        L.push('  (That sentence is only worth as much as the coverage table above.)');
+    }
+    return L;
+}
+
+// ============================================================
+// 7. Counterfactual summary (gate early-exit vs what rerank would have picked)
+// ============================================================
+
+export interface CounterfactualSummary {
+    rows: number;
+    earlyExit: number;
+    earlyExitPct: number;
+    agree: number;
+    disagree: number;
+    rerankDeclined: number;
+    /** exit reason -> [disagreements, firings] */
+    byReason: Array<[string, { disagree: number; total: number }]>;
+    medianCounterMicros: number | null;
+    pairs: ScreenPair[];
+}
+
+/**
+ * The cheapest standing monitor of the confidence gate: ONE replay, no B tree.
+ *
+ * `rerankDeclined` is the load-bearing row for any "demote the gate to a backstop"
+ * proposal — if it is 0 the reranker never abstains where the gate fires, so the
+ * demotion cannot manufacture a no-winner fall-through into AI backfill.
+ *
+ * `counter` is a COUNTERFACTUAL, not an outcome: it shows what simpleRerank WOULD
+ * have returned on the frozen pool. It never shows which pick is correct.
+ */
+export function counterfactualSummary(rows: ReplayRow[]): CounterfactualSummary {
+    const exits = rows.filter(r => r.path === 'confidence_gate_early_exit' && r.counter);
+    let agree = 0;
+    let disagree = 0;
+    let declined = 0;
+    const byReason = new Map<string, { disagree: number; total: number }>();
+    const pairs: ScreenPair[] = [];
+    const micros: number[] = [];
+    for (const r of exits) {
+        const reason = (r.gate.reason || '(empty)').split(' (')[0];
+        const slot = byReason.get(reason) ?? { disagree: 0, total: 0 };
+        slot.total++;
+        const cw = r.counter?.winner ?? null;
+        if (typeof r.counterMicros === 'number') micros.push(r.counterMicros);
+        if (!cw) declined++;
+        else if (r.winner && cw.foodId === r.winner.foodId) agree++;
+        else {
+            disagree++;
+            slot.disagree++;
+            pairs.push({ query: r.query, a: r.winner, b: cw });
+        }
+        byReason.set(reason, slot);
+    }
+    micros.sort((a, b) => a - b);
+    return {
+        rows: rows.length,
+        earlyExit: exits.length,
+        earlyExitPct: rows.length ? (100 * exits.length) / rows.length : 0,
+        agree,
+        disagree,
+        rerankDeclined: declined,
+        byReason: [...byReason.entries()].sort((x, y) => y[1].total - x[1].total),
+        medianCounterMicros: micros.length ? micros[Math.floor(micros.length / 2)] : null,
+        pairs,
+    };
+}

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -1,0 +1,2481 @@
+/**
+ * winner-diff.ts — FROZEN-POOL WINNER-DIFF HARNESS
+ * ==========================================================================
+ * The gate `sync-docs/mapping_investigation_playbook.md` demands before any
+ * admission or ranking change may be called safe:
+ *
+ *   > Any change to admission requires a before/after diff of the pipeline's
+ *   > WINNER over the affected population. Not a set-membership Jaccard on
+ *   > `r.filtered` — that is the measurement that makes this bug invisible.
+ *
+ * A pool comparison is broken because FOUR downstream consumers are NON-MONOTONE
+ * in candidate-pool size, so a change that only ADDS candidates can still flip the
+ * answer ("admit-only by inspection is not a safety argument" — burned this project
+ * three separate times):
+ *   1. map-ingredient-with-fallback.ts:1660  `filtered.slice(0, 10)` truncates over
+ *      GATHER order, not score order. A new admit EVICTS a candidate that reaches
+ *      the reranker today.
+ *   2. map-ingredient-with-fallback.ts:1598-1616  relaxed recovery fires ONLY when
+ *      `filtered.length === 0`, and its output is a strict SUPERSET. Admitting one
+ *      candidate SUPPRESSES the retry and swaps a superset for a subset.
+ *   3. gather-candidates.ts:591-607  `basic_produce_bypass` returns `candidates[0]`
+ *      with skipAiRerank — a new higher-score record wins with NO rerank at all.
+ *   4. simple-rerank.ts:1883  brand macro-consensus median over siblings, gated
+ *      `siblings.length >= 3` — a longer sibling list moves the median and flips
+ *      the penalty.
+ *
+ * ==========================================================================
+ * STRICTLY READ-ONLY  (this is a promise, and it is enforced in code)
+ * ==========================================================================
+ * This script NEVER writes to FoodMapping or any other table. A Prisma `$use`
+ * middleware (`installWriteGuard`) intercepts every mutating operation
+ * (create/createMany/update/updateMany/upsert/delete/deleteMany/executeRaw/
+ * executeRawUnsafe) and NO-OPS it, tallying model+action into `suppressedWrites`,
+ * which is printed. Nothing here calls warm-cache, saveValidatedMapping, or any
+ * repoint/evict path. `snapshot` additionally ABORTS the mapper at gather, so the
+ * save path is not merely guarded — it is never reached.
+ *
+ * The guard NO-OPs rather than THROWS on purpose. `getAiNormalizeCache`
+ * (validated-mapping-helpers.ts:978) bumps `useCount` with an `update` INSIDE the
+ * same try/catch that returns the cached row, so a throwing guard converts a genuine
+ * cache HIT into a `null` MISS and silently deletes `aiNutritionEstimate` and
+ * `isBrandedQuery` from the snapshot.
+ *
+ * ==========================================================================
+ * MODES
+ * ==========================================================================
+ *   snapshot        Run the REAL mapper up to and including gatherCandidates,
+ *                   freeze the gather output + every Step-3 input to disk, then
+ *                   abort. Retrieval runs ONCE, so every later replay compares
+ *                   selection logic against an IDENTICAL pool and retrieval
+ *                   nondeterminism cannot contaminate the diff.
+ *   replay          Re-run the Step-3 -> winner chain of the CURRENT tree against
+ *                   a frozen snapshot. Deterministic: no network, no LLM, one
+ *                   batched read.
+ *   noise-floor     Replay the SAME variant on the SAME snapshot TWICE and assert
+ *                   0 winner differences. Writes a receipt that `diff` requires.
+ *   diff            Classify replay A vs replay B per query and report WINNER
+ *                   changes (plus the screens).
+ *   counterfactual  One replay, no B tree: for every confidenceGate early exit,
+ *                   what would simpleRerank have picked on the identical pool?
+ *   verify          The only mode that PROVES the transcription below is faithful:
+ *                   runs the real mapper end to end and compares foodId.
+ *   transcript      Print the real caller slice next to this file's transcription.
+ *   hashes          Print the drift hashes.
+ *   help
+ *
+ * ==========================================================================
+ * WHAT THIS HARNESS STRUCTURALLY CANNOT SEE — do not soften these
+ * ==========================================================================
+ * (A) RETRIEVAL. The pool is frozen at gatherCandidates' output. Any change to
+ *     gather-candidates.ts, query-builder.ts, Typesense querying/indexing, the
+ *     FatSecret lane or embeddings INVALIDATES the diff entirely — both variants
+ *     replay a pool neither would have produced. Re-snapshot per version for those,
+ *     and accept that retrieval nondeterminism is then inside your signal.
+ * (B) EVERYTHING AFTER WINNER SELECTION. The mapper is aborted at gather, so
+ *     hydration, serving/gram resolution, AI backfill, the save-time plausibility
+ *     gate, the brand-mismatch gate and the FoodMapping write never run. A
+ *     WINNER-CHANGED here may be discarded by a save gate; a SAME here does NOT
+ *     prove the cached row is identical.
+ * (C) WARM BEHAVIOUR. `skipCache: true` is forced, so this measures COLD resolution
+ *     only. A change that looks harmless cold still POISONS the cache the moment
+ *     those keys are re-warmed.
+ * (D) CASES THE CHANGE IS SUPPOSED TO CREATE. --from-events and --from-cache
+ *     contain only queries ALREADY ASKED. A change whose whole point is to make a
+ *     currently-failing or never-attempted query succeed shows SAME on 100% of
+ *     rows, because the query that would prove it is not in the population. That
+ *     blind spot has invalidated a gate before. Pair every diff with a hand-written
+ *     positive case list asserting the RIGHT answer.
+ * (E) POPULATION CONTAMINATION. cache-parity-sweep.ts posts `100g <token-sorted
+ *     FoodMapping key>` into MappingEventLog, so roughly a third of the event log
+ *     is our own warmer. Rows are tagged `origin` and the split is printed.
+ * (F) SUPPRESSED WRITES CHANGE FUTURE RUNS, NOT THIS ONE. persistFatSecretHits,
+ *     saveAiNormalizeCache and learnedSynonym upserts are no-ops here; in
+ *     production those rows would exist for the NEXT query to hydrate from. It is
+ *     also why SNAPSHOTTING IS NOT REPRODUCIBLE (an uncached query re-hits the
+ *     LLM every snapshot run) — which is precisely why the snapshot is taken once
+ *     and shared by both sides.
+ *
+ * ==========================================================================
+ * USAGE — always from a backend repo root, with ts-node (never tsx)
+ * ==========================================================================
+ *   RUN='npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/winner-diff.ts'
+ *
+ *   $RUN snapshot --from-events --limit 400 --out /tmp/wd-snap.json
+ *   $RUN noise-floor --snapshot /tmp/wd-snap.json                    # MUST be 0
+ *   $RUN replay --snapshot /tmp/wd-snap.json --out /tmp/wd-A.json --label BASE
+ *   # copy the tree, edit the copy, run the same command from there:
+ *   $RUN replay --snapshot /tmp/wd-snap.json --out /tmp/wd-B.json --label BRANCH
+ *   $RUN diff --a /tmp/wd-A.json --b /tmp/wd-B.json --screens
+ *
+ * NEVER switch variants with `git checkout <sha> -- <file>`. That is how
+ * uncommitted work gets destroyed. Copy the tree and edit the copy.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+import {
+    ReplayFile,
+    ReplayRow,
+    SelectionPath,
+    WinnerInfo,
+    GoldenCase,
+    NoiseFloorLedger,
+    NoiseFloorReceipt,
+    PopulationLine,
+    QueryOrigin,
+    ScreenPair,
+    Verdict,
+    VERDICTS,
+    classifyOrigin,
+    classifyVerdict,
+    counterfactualSummary,
+    emptyLedger,
+    formatScreens,
+    gateReasonHistogram,
+    kcalDeltaPct,
+    noiseGate,
+    originSplit,
+    parseGoldenSet,
+    parseQueryFile,
+    pathHistogram,
+    rowHasMovement,
+    runScreens,
+    windowChurn,
+    windowChurnIsMeaningless,
+    runGoldenScreen,
+    formatGoldenScreen,
+} from './winner-diff-screens';
+
+// ============================================================
+// 0. env — load the machine .env, then FORCE production flags
+//    (before ANY src/lib require: config.ts snapshots flags at module load)
+// ============================================================
+
+const REPO_ROOT = process.cwd();
+
+function loadDotEnv(): string[] {
+    const tried: string[] = [];
+    const candidates = [
+        process.env.WINNER_DIFF_ENV_FILE,
+        path.join(REPO_ROOT, '.env'),
+        path.join(REPO_ROOT, '.env.local'),
+        '/Users/diego/Documents/Github/Recipe App/Recipe-App/.env',
+    ].filter(Boolean) as string[];
+    for (const f of candidates) {
+        tried.push(f);
+        if (!fs.existsSync(f)) continue;
+        const txt = fs.readFileSync(f, 'utf8');
+        for (const line of txt.split('\n')) {
+            const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+            if (!m) continue;
+            let v = m[2].trim();
+            if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+                v = v.slice(1, -1);
+            }
+            if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+        }
+        return [f];
+    }
+    return tried;
+}
+
+const ENV_FILES = loadDotEnv();
+
+/**
+ * Production parity (box /home/owner/Recipe-App/.env). Dev .env files predate the
+ * FatSecret lane; without the force the whole fs lane returns [] and the snapshot
+ * pool is silently wrong — a diff over a pool production would never see.
+ */
+const FORCED_FLAGS: Record<string, string> = {
+    FATSECRET_RETRIEVAL_ENABLED: '1',
+    OFF_ENABLED: 'true',
+    SEARCH_PROVIDER: 'typesense',
+    SEMANTIC_SEARCH_ENABLED: 'true',
+    EVAL_MODE: 'fatsecret',
+    OLLAMA_ENABLED: 'false',
+};
+for (const [k, v] of Object.entries(FORCED_FLAGS)) process.env[k] = v;
+
+// ============================================================
+// 1. stdout muzzle (the Prisma client is constructed with log:['query',...])
+// ============================================================
+
+const REAL_STDOUT = process.stdout.write.bind(process.stdout);
+const REAL_STDERR = process.stderr.write.bind(process.stderr);
+let muzzled = false;
+function muzzle(on: boolean) {
+    if (process.argv.includes('--verbose')) return;
+    if (on && !muzzled) {
+        (process.stdout as any).write = () => true;
+        (process.stderr as any).write = () => true;
+        muzzled = true;
+    } else if (!on && muzzled) {
+        (process.stdout as any).write = REAL_STDOUT;
+        (process.stderr as any).write = REAL_STDERR;
+        muzzled = false;
+    }
+}
+function say(s = '') { REAL_STDOUT(s + '\n'); }
+function sayAll(lines: string[]) { for (const l of lines) say(l); }
+
+// ============================================================
+// 2. DRIFT GUARD
+//    A change DETECTOR, not a correctness proof. It says "the source did not
+//    move"; it says nothing about whether the transcription was ever right.
+//    Only `verify` mode tests faithfulness.
+//
+//    LINE-ENDING SENSITIVE. The hash is computed over
+//    fs.readFileSync(f,'utf8').split('\n') — reading the same file with a reader
+//    that performs universal-newline translation (e.g. Python's open()) produces a
+//    DIFFERENT hash and a false DRIFT. If you are about to "fix" a drift, first
+//    reproduce the hash with this exact reader.
+// ============================================================
+
+const MAPPER_FILE = path.join(REPO_ROOT, 'src/lib/mapping/map-ingredient-with-fallback.ts');
+
+const CALLER_START_ANCHOR = '// Step 3: Apply must-have token filter';
+const CALLER_END_ANCHOR = "selectionReason = 'scored_by_confidence';";
+
+function callerBlockSource(): { text: string; startLine: number; endLine: number; lines: string[] } {
+    const src = fs.readFileSync(MAPPER_FILE, 'utf8').split('\n');
+    const start = src.findIndex(l => l.includes(CALLER_START_ANCHOR));
+    const end = src.findIndex(l => l.includes(CALLER_END_ANCHOR));
+    if (start < 0 || end < 0 || end <= start) {
+        throw new Error('drift-guard: could not locate the Step-3 caller block anchors in ' + MAPPER_FILE);
+    }
+    const lines = src.slice(start, end + 1);
+    return { text: lines.join('\n'), startLine: start + 1, endLine: end + 1, lines };
+}
+
+/** The caller-local, NON-EXPORTED helpers copied verbatim into section 4. */
+const COPIED_HELPERS = [
+    'function candidateHasCountLabel(',
+    'function requestBillsByServing(',
+    'function candidateHasServingData(',
+    'function isMatchableVolumeUnit(',
+    'function servingLeadingCount(',
+];
+function copiedHelperSource(): string {
+    const src = fs.readFileSync(MAPPER_FILE, 'utf8').split('\n');
+    const out: string[] = [];
+    for (const anchor of COPIED_HELPERS) {
+        const i = src.findIndex(l => l.trimStart().startsWith(anchor));
+        if (i < 0) throw new Error('drift-guard: helper not found: ' + anchor);
+        let j = i;
+        while (j < src.length && src[j] !== '}') j++;
+        out.push(src.slice(i, j + 1).join('\n'));
+    }
+    return out.join('\n---\n');
+}
+
+function sha(s: string) { return createHash('sha256').update(s).digest('hex').slice(0, 16); }
+
+/**
+ * EVERY caller-block shape this file knows how to transcribe, mapped to the
+ * `--variant` that reproduces it. A hash outside this table means the caller has
+ * moved to a shape section 9 has never seen.
+ *
+ *   3a20888d65bd8cbd  master 874f786, lines 1485-1768. confidenceGate PRE-EMPTS
+ *                     Step 4: `if (skipAiRerank && selected) { winner = selected }
+ *                     else { ...rerank... }`.
+ *   5190a9ae93dbf642  the gate demotion, lines 1485-1884. Step 4 always runs;
+ *                     `gateSelection` is consulted only when simpleRerank named
+ *                     nobody, ahead of the 0.80 raw-score grab. SUPERSEDED by
+ *                     349af8359fd7b90b — kept so an older tree still resolves, but a
+ *                     tree on this hash is missing both mitigations below.
+ *   349af8359fd7b90b  the gate demotion PLUS the two review mitigations, lines
+ *                     1485-1955. Same shape as 5190a9ae93dbf642 plus:
+ *                     (A) `gateSelection` appended to `candidatesForRerank` when
+ *                         absent, so the gate's pick competed even from past the
+ *                         `filtered.slice(0,10)` gather-order cutoff.
+ *                     (B) when the reranker re-selects the gate's own record,
+ *                         `confidence` becomes `Math.max(rerank, gate)` — UNSCOPED,
+ *                         i.e. on any gate exit reason.
+ *                     SUPERSEDED by 4ea700da8becee0c: a second review measured both
+ *                     and reverted (A) outright and scoped (B). Kept so an older tree
+ *                     still resolves, but section 9 NO LONGER TRANSCRIBES THIS SHAPE.
+ *   4ea700da8becee0c  CURRENT, lines 1485-1987. 349af835 with (A) REVERTED and (B)
+ *                     SCOPED. Concretely:
+ *                     (A) REVERTED — caller 1746-1778 is now a comment where the push
+ *                         used to be. Measured against the project's own adjudication
+ *                         of all 296 disagreements, the push restored 5 of the 17
+ *                         past-index-10 gate picks, 2 of them adjudicated
+ *                         rerank-BETTER, so the regression count did not improve — it
+ *                         only moved which rows were wrong. With (B) it also took
+ *                         `buffalo wild wings boneless wings` from 0.710 (below the
+ *                         0.75 sub-threshold floor, so uncached) to 1.000, a
+ *                         displacing upsert of an adjudicated-WRONG record; and it
+ *                         flattered its own measurement, since a restored row scores
+ *                         SAME and drops out of the screen population. The 17
+ *                         deletions remain real and unfixed — they belong to
+ *                         `slice(0,10)` over gather order, to be fixed there.
+ *                     (B) KEPT but scoped to `gateResult.reason ===
+ *                         'high_confidence_clear_winner'` (caller 1912-1918). The
+ *                         gate's other two exits are not on the confidence scale at
+ *                         all: `basic_produce_bypass` returns a CLAMPED RAW ENGINE
+ *                         SCORE (saturates at 1.000 for any OFF candidate) and
+ *                         `yeast_variant_preference` returns a hardcoded 0.95.
+ *                         Unscoped, 27 of the 132 lifted rows were
+ *                         basic_produce_bypass and 5 crossed the 0.85 save gate on a
+ *                         saturated retrieval score.
+ *                     Still gated on the gate having fired, so `--variant baseline`
+ *                     remains byte-for-byte unaffected and pin 3a20888d65bd8cbd
+ *                     stays valid.
+ *                     NOTE, AND IT IS WHY `verify` GREW A SECOND AXIS: (B) moves no
+ *                     foodId, and with (A) gone NOTHING that separates this caller
+ *                     from the baseline moves a foodId on a row where the reranker
+ *                     names someone. A foodId-only `verify` therefore could not fail
+ *                     on this shape for ANY population — so `verify` now also
+ *                     compares `confidence` on the rows whose foodId already agreed.
+ *                     Measured: stubbing the scope out gives 27 CONF-UNEXPLAINED and
+ *                     still 0 MISMATCH-UNEXPLAINED. See the RECEIPTS block in
+ *                     section 9.
+ *
+ * WHY A TABLE AND NOT ONE PIN: it lets ONE tree replay BOTH shapes off ONE frozen
+ * snapshot, which is what makes an A/B of a CALLER change possible at all without
+ * copying trees or — never do this — `git checkout <sha> -- <file>`.
+ *
+ * THE CONSTRAINT THAT COMES WITH IT: a single-tree A/B via --variant is valid only
+ * when the change is confined to the caller block. Everything else the replay uses
+ * (simpleRerank, confidenceGate, the filters) is imported from THIS tree, so if the
+ * change also touched an imported module, both "variants" run the new module and the
+ * diff is confounded. `gitDirty` records the whole of src/lib/mapping so you can tell
+ * — but it cannot tell you for you. Two trees, one snapshot, for those.
+ *
+ * IF A HASH IS NOT IN THIS TABLE: FIX THE TRANSCRIPTION in section 9 and add the new
+ * hash with its variant. Do not just re-pin. Results from a drifted harness are not a
+ * measurement of the pipeline.
+ *
+ * The hashes are LINE-ENDING SENSITIVE (see the section header). Reproduce with
+ * `winner-diff hashes` before concluding anything drifted.
+ */
+const KNOWN_CALLERS: Record<string, SelectionVariant> = {
+    // The pre-demotion shape. Still transcribed exactly, still the A-side of every
+    // A/B of the demotion; nothing in either mitigation round touched it.
+    '3a20888d65bd8cbd': 'baseline',
+    // SUPERSEDED (shape 1 of 3 in the gate-backstop family). The demotion with NO
+    // mitigations. Left in the table because it is a real shape a tree can still be
+    // on, but it is the shape the first adversarial review found defective, and
+    // section 9 no longer reproduces it.
+    '5190a9ae93dbf642': 'gate-backstop',
+    // SUPERSEDED (shape 2 of 3). The demotion + Mitigation A (gate pick appended to
+    // the rerank window) + Mitigation B UNSCOPED. Pinned 2026-07-26 and abandoned the
+    // same day: the second review measured A against the 296-row adjudication and
+    // found it bought no regression reduction while turning one adjudicated-wrong
+    // record into a CACHED one, and found B's other two gate exits return numbers
+    // that are not confidences. Section 9 no longer reproduces this shape either.
+    '349af8359fd7b90b': 'gate-backstop',
+    // CURRENT — the shape section 9 actually transcribes. A reverted, B scoped to
+    // `high_confidence_clear_winner`. Pinned only AFTER re-reading the caller and
+    // re-running `transcript` + `verify` against it, and only after the verify was
+    // shown capable of going RED on THIS shape (stub the B scope -> mismatches).
+    // Receipts are in the section 9 RECEIPTS block; they are measurements, not
+    // inherited from the 349af835 pin.
+    '4ea700da8becee0c': 'gate-backstop',
+    // CURRENT. Behaviourally IDENTICAL to 4ea700da — the only edits were comments,
+    // correcting three false claims a review found in them (simpleRerank's confidence
+    // range, "the gate handed back candidates[0]", and attributing every gate
+    // confidence to assessConfidence). Proven comment-only by stripping comments and
+    // blank lines from the whole file and diffing: 4,474 code lines on both sides,
+    // identical. (Compare the WHOLE file, not the caller window — the window moves
+    // when comments are added, and a windowed diff reports phantom tail hunks.)
+    //
+    // Re-pinned rather than left drifting because the guard hashes the block TEXT, so
+    // it cannot tell a comment from a statement. That is the right conservative
+    // default; the cost is that a documentation fix needs a re-pin plus a proof like
+    // the one above. Do not skip the proof — "it was only comments" is exactly the
+    // claim a hash exists to check.
+    '3fc2ca073ff0f047': 'gate-backstop',
+};
+const PINNED_HELPERS_HASH = 'af86765a0a67abd6';
+
+/**
+ * The ONE caller hash section 9 actually transcribes.
+ *
+ * KNOWN_CALLERS maps hash -> variant NAME, and three distinct hashes now map to
+ * 'gate-backstop'. Comparing NAMES to decide "does the replay mirror this tree?"
+ * therefore green-lights two shapes the transcription no longer reproduces — the
+ * drift guard's own failure mode, reintroduced one level up.
+ *
+ * This is not hypothetical in a repo Syncthing-mirrored across three machines whose
+ * git histories routinely diverge. A tree still on 5190a9ae (the demotion with no
+ * mitigations) would be told "MATCHES this tree's caller", and the replay would
+ * apply Mitigation B on 141 rows that tree does not contain — reporting confidence
+ * 1.000 where the tree actually ships <= 0.98. Since confidence is the
+ * cache-admission signal, the resulting coverage delta is wrong in the FLATTERING
+ * direction, which is the direction nobody double-checks.
+ *
+ * So fit is decided by hash. A superseded pin still suppresses the DRIFT banner
+ * (that shape is genuinely known, and naming it is more useful than "unrecognised"),
+ * but it can no longer claim the replay mirrors it.
+ */
+const TRANSCRIBED_CALLER = '3fc2ca073ff0f047';
+
+interface DriftResult {
+    caller: string;
+    helpers: string;
+    drifted: boolean;
+    /** which --variant faithfully reproduces THIS tree's caller, if we recognise it */
+    treeVariant: SelectionVariant | null;
+}
+
+function checkDrift(allowDrift: boolean): DriftResult {
+    const cb = callerBlockSource();
+    const callerHash = sha(cb.text);
+    const helpersHash = sha(copiedHelperSource());
+    const treeVariant = KNOWN_CALLERS[callerHash] ?? null;
+    const drifted = treeVariant === null || PINNED_HELPERS_HASH !== helpersHash;
+    if (drifted) {
+        say('');
+        say('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+        say('!! DRIFT: this tree\'s caller block is a shape the harness has never seen.');
+        say('!!   caller  actual=' + callerHash + '   known: ' +
+            Object.entries(KNOWN_CALLERS).map(([h, v]) => `${h}=${v}`).join(', '));
+        say('!!   helpers pinned=' + PINNED_HELPERS_HASH + '  actual=' + helpersHash);
+        say('!! Re-transcribe replaySelection() from ' + MAPPER_FILE);
+        say('!! lines ' + cb.startLine + '-' + cb.endLine + ', run `winner-diff verify`, THEN add the');
+        say('!! new hash to KNOWN_CALLERS with the variant it corresponds to.');
+        say('!! (Check the hash was not produced by a newline-translating reader first.)');
+        say('!! Results from a drifted harness are NOT a measurement of the pipeline.');
+        say('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+        say('');
+        if (!allowDrift) {
+            throw new Error('drift-guard tripped; pass --allow-drift only after re-reading the caller.');
+        }
+    }
+    return { caller: callerHash, helpers: helpersHash, drifted, treeVariant };
+}
+
+/**
+ * Say out loud when the replayed variant is a MODEL of a caller this tree does not
+ * contain. That is a legitimate and useful thing to do — it is how one tree produces
+ * both sides of a caller-change A/B — but it is not the same claim as "I ran this
+ * tree's code", and conflating the two is how a diff of nothing gets reported as a
+ * diff of something.
+ */
+function announceVariantFit(drift: DriftResult, variant: SelectionVariant) {
+    if (drift.treeVariant === null) {
+        say(`variant=${variant}: this tree's caller is UNRECOGNISED, so nothing here is verified against it.`);
+        return;
+    }
+    if (drift.treeVariant === variant && drift.caller !== TRANSCRIBED_CALLER) {
+        // Right variant NAME, wrong SHAPE. The most dangerous case in this function:
+        // without this branch it printed "MATCHES" and the caller believed the replay
+        // was mirroring code that is not in the tree.
+        say(`variant=${variant}: SUPERSEDED SHAPE. This tree's caller is ${drift.caller}, which is a`);
+        say(`  recognised '${variant}' shape but NOT the one section 9 transcribes (${TRANSCRIBED_CALLER}).`);
+        say('  The replay models the CURRENT transcription, not this tree. Any diff you take here is a');
+        say('  measurement of the harness against a shape the tree does not contain — re-transcribe, or');
+        say('  move the tree to the current shape, before quoting a number.');
+        return;
+    }
+    if (drift.treeVariant === variant) {
+        say(`variant=${variant}: MATCHES this tree's caller (${drift.caller}) — the replay mirrors the code actually present.`);
+    } else {
+        say(`variant=${variant}: MODELLED. This tree's caller is '${drift.treeVariant}' (${drift.caller}).`);
+        say(`  The replay transcribes the '${variant}' shape while importing THIS tree's`);
+        say('  simpleRerank/confidenceGate/filters. Valid for an A/B only while the change');
+        say('  under test is confined to the caller block — check gitDirty if unsure.');
+    }
+}
+
+// ============================================================
+// 3. Real modules — required (not imported) so the FORCED_FLAGS above are already
+//    in process.env when config.ts snapshots them.
+// ============================================================
+
+import type { ParsedIngredient } from '../../src/lib/parse/ingredient-line';
+import type { UnifiedCandidate, GatherOptions } from '../../src/lib/mapping/gather-candidates';
+import type { MappingTelemetry } from '../../src/lib/mapping/map-ingredient-with-fallback';
+
+const dbMod = require('../../src/lib/db');
+const prisma = dbMod.prisma;
+
+const gatherMod = require('../../src/lib/mapping/gather-candidates');
+const filterMod = require('../../src/lib/mapping/filter-candidates');
+const rerankMod = require('../../src/lib/mapping/simple-rerank');
+const mapperMod = require('../../src/lib/mapping/map-ingredient-with-fallback');
+const countLabelMod = require('../../src/lib/mapping/count-label');
+const plausibilityMod = require('../../src/lib/mapping/macro-plausibility');
+const aiNormalizeMod = require('../../src/lib/mapping/ai-normalize');
+const vmHelpersMod = require('../../src/lib/mapping/validated-mapping-helpers');
+
+// Everything below is IMPORTED FROM THE REAL MODULES, never reimplemented. A probe
+// that reimplements the caller's argument list is a different function.
+const { confidenceGate } = gatherMod;
+const { filterCandidatesByTokens, hasCoreTokenMismatch, hasNullOrInvalidMacros, detectGrainCookingContext } = filterMod;
+const { simpleRerank, toRerankCandidate, stripPrepModifiers } = rerankMod;
+const {
+    computeFloorHitIds, dropDenylistedCandidates, makeSortedFilteredComparator, candidateHasVolumeServing,
+} = mapperMod;
+const { countedPieceNoun, extractLabelServingUnit, GENERIC_PIECE_WORDS, servingLabelCountsPiece } = countLabelMod;
+const { assessMacroPlausibility } = plausibilityMod;
+
+// ============================================================
+// 4. VERBATIM COPIES of caller-local helpers (drift-guarded above)
+//    Source: map-ingredient-with-fallback.ts :4446, :4477, :4488, :4524, :4537
+//    They are not exported, so they cannot be imported. Any edit to them upstream
+//    moves PINNED_HELPERS_HASH and this harness refuses to run.
+// ============================================================
+
+function copy_servingLeadingCount(description: string): number {
+    const frac = description.match(/^\s*(\d+)\s*\/\s*(\d+)/);
+    if (frac) {
+        const denom = parseFloat(frac[2]);
+        return denom > 0 ? parseFloat(frac[1]) / denom : 1;
+    }
+    const m = description.match(/^\s*(\d+(?:\.\d+)?)/);
+    if (!m) return 1;
+    const n = parseFloat(m[1]);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function copy_candidateHasCountLabel(candidate: UnifiedCandidate, pieceNoun: string): boolean {
+    if (candidate.source === 'fatsecret') {
+        return !!candidate.servings?.some((s: any) => {
+            if (!(typeof s.grams === 'number' && s.grams > 0)) return false;
+            const labelWord = extractLabelServingUnit(s.description);
+            if (labelWord !== pieceNoun && !(labelWord && GENERIC_PIECE_WORDS.has(labelWord))) return false;
+            const count = copy_servingLeadingCount(s.description);
+            const perPiece = s.grams / (count > 0 ? count : 1);
+            return perPiece >= 0.2 && perPiece <= 500;
+        });
+    }
+    if (candidate.source !== 'openfoodfacts') return false;
+    const raw = candidate.rawData as { servingSize?: string | null; servingGrams?: number | null } | undefined;
+    return servingLabelCountsPiece(raw?.servingSize, raw?.servingGrams, pieceNoun);
+}
+
+const COPY_EXPLICIT_MEASURE_UNIT_RE = /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|ml|milliliter|milliliters|l|liter|liters|floz|fl\s*oz|fluid\s*ounces?|pint|pints|quart|quarts|gallon|gallons)$/i;
+function copy_requestBillsByServing(parsed: ParsedIngredient | null): boolean {
+    return !(parsed?.unit && COPY_EXPLICIT_MEASURE_UNIT_RE.test(parsed.unit.trim()));
+}
+
+function copy_candidateHasServingData(candidate: UnifiedCandidate): boolean {
+    if (candidate.source === 'openfoodfacts') {
+        const raw = candidate.rawData as { servingGrams?: number | null } | undefined;
+        return typeof raw?.servingGrams === 'number' && raw.servingGrams > 0;
+    }
+    if (candidate.source === 'fdc') {
+        return !!candidate.servings?.some((s: any) => typeof s.grams === 'number' && s.grams > 0);
+    }
+    if (candidate.source === 'fatsecret') {
+        return !!candidate.servings?.some((s: any) => typeof s.grams === 'number' && s.grams > 0);
+    }
+    return false;
+}
+
+const COPY_VOLUME_UNIT_STEMS: Record<string, string[]> = {
+    cup: ['cup'], cups: ['cup'],
+    tbsp: ['tbsp', 'tablespoon'], tablespoon: ['tbsp', 'tablespoon'], tablespoons: ['tbsp', 'tablespoon'],
+    tsp: ['tsp', 'teaspoon'], teaspoon: ['tsp', 'teaspoon'], teaspoons: ['tsp', 'teaspoon'],
+    floz: ['fl oz', 'fluid ounce'], 'fl oz': ['fl oz', 'fluid ounce'],
+};
+function copy_isMatchableVolumeUnit(unit: string): boolean {
+    return COPY_VOLUME_UNIT_STEMS[unit.toLowerCase().trim()] != null;
+}
+
+// ============================================================
+// 5. WRITE GUARD  (see the READ-ONLY promise in the header)
+// ============================================================
+
+const MUTATING = new Set([
+    'create', 'createMany', 'createManyAndReturn', 'update', 'updateMany',
+    'upsert', 'delete', 'deleteMany', 'executeRaw', 'executeRawUnsafe',
+]);
+
+let suppressedWrites: Record<string, number> = {};
+let guardInstalled = false;
+
+function installWriteGuard() {
+    if (guardInstalled) return;
+    guardInstalled = true;
+    prisma.$use(async (params: any, next: any) => {
+        if (MUTATING.has(params.action)) {
+            const key = `${params.model ?? 'raw'}.${params.action}`;
+            suppressedWrites[key] = (suppressedWrites[key] ?? 0) + 1;
+            // NO-OP, never throw — see the header note on getAiNormalizeCache.
+            return null;
+        }
+        return next(params);
+    });
+}
+
+function totalSuppressed(entries: Array<{ suppressedWrites: Record<string, number> }>): Record<string, number> {
+    const t: Record<string, number> = {};
+    for (const e of entries) for (const [k, v] of Object.entries(e.suppressedWrites)) t[k] = (t[k] ?? 0) + v;
+    return t;
+}
+
+// ============================================================
+// 6. Snapshot types
+// ============================================================
+
+interface AiEstimate {
+    caloriesPer100g: number;
+    proteinPer100g: number;
+    carbsPer100g: number;
+    fatPer100g: number;
+    confidence: number;
+}
+
+interface SnapshotEntry {
+    query: string;
+    origin: QueryOrigin;
+    goldenId?: string;
+    ok: boolean;
+    error?: string;
+    /** arg 1 the mapper handed gatherCandidates */
+    gatherRawLine: string;
+    /** gatherRawLine.trim() — what filterCandidatesByTokens receives as options.rawLine */
+    trimmed: string;
+    parsed: ParsedIngredient | null;
+    normalizedName: string;
+    isBrandedQuery: boolean;
+    targetBrand?: string;
+    aiSynonyms: string[];
+    aiCanonicalBase?: string;
+    /** captured PRE-Step-4 only; the FDC fallback is version-dependent and re-derived per replay */
+    aiNutritionEstimate?: AiEstimate;
+    aiEstimateSource: 'llm_normalize' | 'normalize_cache' | 'none';
+    candidates: UnifiedCandidate[];
+    suppressedWrites: Record<string, number>;
+    elapsedMs: number;
+}
+
+interface SnapshotFile {
+    kind: 'winner-diff/snapshot';
+    version: 1;
+    takenAt: string;
+    repoRoot: string;
+    gitHead: string;
+    gitDirty: string;
+    /** how the population was built, verbatim, so a reader can rebuild it */
+    population: string;
+    envFiles: string[];
+    forcedFlags: Record<string, string>;
+    callerHash: string;
+    helpersHash: string;
+    entries: SnapshotEntry[];
+}
+
+// ============================================================
+// 7. SNAPSHOT
+// ============================================================
+
+class GatherCaptured extends Error {
+    constructor(public payload: any) { super('WINNER_DIFF_GATHER_CAPTURED'); }
+}
+
+interface GatherCapture {
+    gatherRawLine: string;
+    parsed: ParsedIngredient | null;
+    normalizedName: string;
+    isBrandedQuery: boolean;
+    targetBrand?: string;
+    aiSynonyms: string[];
+    candidates: UnifiedCandidate[];
+}
+
+/**
+ * Intercept gatherCandidates. `mode` decides what happens after the capture:
+ *   'abort'    throw a sentinel so the mapper stops at Step 3 (snapshot mode) —
+ *              nothing downstream runs, so no save path is even reachable.
+ *   'continue' return the real result and let the mapper finish (verify mode).
+ *
+ * It deliberately IGNORES the QUICK gather (`options.skipOff === true`, mapper
+ * :1160) and captures only the FULL gather (:1479) that feeds Step 3.
+ */
+function installGatherInterceptor(mode: 'abort' | 'continue', sink: { capture: GatherCapture | null }) {
+    const realGather = gatherMod.gatherCandidates;
+    gatherMod.gatherCandidates = async function (
+        rawLine: string, parsed: ParsedIngredient | null, normalizedName: string, options: GatherOptions = {},
+    ) {
+        const result = await realGather(rawLine, parsed, normalizedName, options);
+        if ((options as any).skipOff === true) return result;
+        sink.capture = {
+            gatherRawLine: rawLine,
+            parsed: parsed ? JSON.parse(JSON.stringify(parsed)) : null,
+            normalizedName,
+            isBrandedQuery: !!(options as any).isBrandedQuery,
+            targetBrand: (options as any).targetBrand,
+            aiSynonyms: (options as any).aiSynonyms ?? [],
+            candidates: JSON.parse(JSON.stringify(result)),
+        };
+        if (mode === 'abort') throw new GatherCaptured(sink.capture);
+        return result;
+    };
+    return () => { gatherMod.gatherCandidates = realGather; };
+}
+
+/**
+ * Read the capture back out of the sink.
+ *
+ * Why a function and not `const c = sink.capture`: the interceptor assigns the sink
+ * from a closure TypeScript's control-flow analysis cannot see, so after the
+ * `sink.capture = null` reset at the top of the loop it narrows the property to
+ * `null` and every field access below becomes `never`. A function call result is
+ * not narrowed.
+ */
+function takeCapture(sink: { capture: GatherCapture | null }): GatherCapture | null {
+    return sink.capture;
+}
+
+interface AiSink { llm: any; cache: any }
+
+function installAiInterceptors(sink: AiSink) {
+    const realAiNormalize = aiNormalizeMod.aiNormalizeIngredient;
+    const realGetCache = vmHelpersMod.getAiNormalizeCache;
+    aiNormalizeMod.aiNormalizeIngredient = async function (...args: any[]) {
+        const r = await realAiNormalize(...args);
+        sink.llm = r;
+        return r;
+    };
+    vmHelpersMod.getAiNormalizeCache = async function (...args: any[]) {
+        const r = await realGetCache(...args);
+        sink.cache = r;
+        return r;
+    };
+    return () => {
+        aiNormalizeMod.aiNormalizeIngredient = realAiNormalize;
+        vmHelpersMod.getAiNormalizeCache = realGetCache;
+    };
+}
+
+/** Reproduce the caller's if/else at mapper :1180 vs :1209 exactly. */
+function resolveAiEstimate(sink: AiSink): Pick<SnapshotEntry, 'aiCanonicalBase' | 'aiNutritionEstimate' | 'aiEstimateSource'> {
+    if (sink.llm && sink.llm.status === 'success') {
+        return {
+            aiCanonicalBase: sink.llm.canonicalBase,
+            aiNutritionEstimate: sink.llm.nutritionEstimate,
+            aiEstimateSource: 'llm_normalize',
+        };
+    }
+    if (sink.cache?.nutritionEstimate) {
+        return {
+            aiCanonicalBase: sink.cache.canonicalBase,
+            aiNutritionEstimate: sink.cache.nutritionEstimate,
+            aiEstimateSource: 'normalize_cache',
+        };
+    }
+    return { aiEstimateSource: 'none' };
+}
+
+async function runSnapshot(pop: PopulationLine[], outPath: string, population: string, debug: boolean, resume: boolean) {
+    installWriteGuard();
+
+    const ndjsonPath = outPath + '.ndjson';
+    const done = new Set<string>();
+    const entries: SnapshotEntry[] = [];
+
+    // --resume: the 4,165-query snapshot that produced the confidenceGate read cost
+    // ~2.5h of LLM + FatSecret API. A dropped SSH session must not be a restart.
+    if (resume && fs.existsSync(ndjsonPath)) {
+        for (const line of fs.readFileSync(ndjsonPath, 'utf8').split('\n')) {
+            if (!line.trim()) continue;
+            try {
+                const e = JSON.parse(line) as SnapshotEntry;
+                if (done.has(e.query)) continue;
+                done.add(e.query);
+                entries.push(e);
+            } catch { /* truncated tail line from a killed run — ignore */ }
+        }
+        say(`--resume: ${done.size} entries recovered from ${ndjsonPath}`);
+    } else if (fs.existsSync(ndjsonPath)) {
+        fs.unlinkSync(ndjsonPath);
+    }
+
+    const sink = { capture: null as GatherCapture | null };
+    const aiSink: AiSink = { llm: null, cache: null };
+    const restoreGather = installGatherInterceptor('abort', sink);
+    const restoreAi = installAiInterceptors(aiSink);
+
+    const todo = pop.filter(p => !done.has(p.query));
+    for (let i = 0; i < todo.length; i++) {
+        const p = todo[i];
+        sink.capture = null; aiSink.llm = null; aiSink.cache = null;
+        suppressedWrites = {};
+        const t0 = Date.now();
+        let err: string | undefined;
+        muzzle(true);
+        try {
+            await mapperMod.mapIngredientWithFallback(p.query, {
+                skipCache: true,          // force COLD: bypass the FoodMapping short-circuit
+                debug,
+                allowLiveFallback: true,
+                skipOnLock: true,
+            });
+            err = 'mapper returned without reaching the full gatherCandidates call';
+        } catch (e: any) {
+            if (!(e instanceof GatherCaptured) && e?.message !== 'WINNER_DIFF_GATHER_CAPTURED') {
+                err = e?.message ?? String(e);
+            }
+        }
+        muzzle(false);
+
+        const c = takeCapture(sink);
+        const entry: SnapshotEntry = {
+            query: p.query,
+            origin: p.origin,
+            goldenId: p.goldenId,
+            ok: c != null && !err,
+            error: err,
+            gatherRawLine: c?.gatherRawLine ?? p.query,
+            trimmed: (c?.gatherRawLine ?? p.query).trim(),
+            parsed: c?.parsed ?? null,
+            normalizedName: c?.normalizedName ?? '',
+            isBrandedQuery: c?.isBrandedQuery ?? false,
+            targetBrand: c?.targetBrand,
+            aiSynonyms: c?.aiSynonyms ?? [],
+            ...resolveAiEstimate(aiSink),
+            candidates: c?.candidates ?? [],
+            suppressedWrites: { ...suppressedWrites },
+            elapsedMs: Date.now() - t0,
+        };
+        entries.push(entry);
+        fs.appendFileSync(ndjsonPath, JSON.stringify(entry) + '\n');
+        say(`  [${i + 1}/${todo.length}] ${p.query}  ->  pool=${c?.candidates?.length ?? 0}` +
+            ` norm="${c?.normalizedName ?? ''}"` + (err ? `  ERROR: ${err}` : ''));
+    }
+
+    restoreGather();
+    restoreAi();
+
+    const drift = checkDrift(true);
+    const snap: SnapshotFile = {
+        kind: 'winner-diff/snapshot',
+        version: 1,
+        takenAt: new Date().toISOString(),
+        repoRoot: REPO_ROOT,
+        gitHead: gitHead(),
+        gitDirty: gitDirtyHash(),
+        population,
+        envFiles: ENV_FILES,
+        forcedFlags: FORCED_FLAGS,
+        callerHash: drift.caller,
+        helpersHash: drift.helpers,
+        entries,
+    };
+    writeJsonAtomic(outPath, snap);
+
+    const tw = totalSuppressed(entries);
+    say('');
+    say(`snapshot written: ${outPath}   (incremental log: ${ndjsonPath})`);
+    say(`  population: ${population}`);
+    say(`  queries: ${entries.length}   ok: ${entries.filter(e => e.ok).length}   failed: ${entries.filter(e => !e.ok).length}`);
+    const split = originSplit(entries.map(e => e.query));
+    say(`  origin: user ${split.user}   warmer-shaped ${split.warmer} (${split.warmerPct.toFixed(1)}%)  ` +
+        '<- "100g <token-sorted key>" lines written by cache-parity-sweep, not user traffic');
+    say('  SUPPRESSED WRITES (these would have hit the DB in production; none were performed):');
+    for (const [k, v] of Object.entries(tw).sort((a, b) => b[1] - a[1])) say(`    ${k}: ${v}`);
+    if (!Object.keys(tw).length) say('    (none)');
+}
+
+// ============================================================
+// 8. Replay variants
+// ============================================================
+
+/**
+ * Which selection shape the replay transcribes.
+ *
+ *   baseline       caller 3a20888d65bd8cbd (master 874f786, lines 1485-1768):
+ *                  confidenceGate PRE-EMPTS Step 4 when it fires.
+ *   gate-backstop  caller 4ea700da8becee0c (lines 1485-1987), and the two earlier
+ *                  shapes it supersedes: Step 4 ALWAYS runs; `gateSelection` is used
+ *                  ONLY when simpleRerank named nobody, ahead of the raw
+ *                  `sortedFiltered[0].score >= 0.80` grab, plus a confidence lift on
+ *                  agreement that is scoped to the gate's `high_confidence_clear_winner`
+ *                  exit.
+ *
+ * A HAZARD TO KNOW ABOUT: `gate-backstop` names a FAMILY of three pinned hashes, and
+ * the transcription reproduces only the CURRENT one (4ea700da). announceVariantFit
+ * resolves the tree's hash to a variant NAME and then compares NAMES, so a tree
+ * sitting on 5190a9ae or 349af835 is told `MATCHES this tree's caller` when in fact
+ * the transcription models a later shape. The hash it prints alongside is the thing
+ * to read. The superseded pins are kept because a tree CAN still be on them (and
+ * the record of what each shape was is the point of the table) — but only
+ * 4ea700da8becee0c is transcribed, so only in that tree does `verify` prove anything.
+ *
+ * Both are real caller shapes (see KNOWN_CALLERS), so a tree containing EITHER can
+ * replay BOTH off one frozen snapshot — which is the only way to A/B a change to the
+ * caller itself without copying trees or `git checkout -- <file>`.
+ *
+ * `winner-diff verify` can only prove the variant that MATCHES the tree it runs in;
+ * for the other one it would be comparing the transcription against code that is not
+ * there. Run verify in each tree for the variant that tree contains. Every mode prints
+ * whether the requested variant matches the tree (see announceVariantFit).
+ */
+export type SelectionVariant = 'baseline' | 'gate-backstop';
+const VARIANTS: SelectionVariant[] = ['baseline', 'gate-backstop'];
+
+// ============================================================
+// 9. THE TRANSCRIPTION
+//
+// >>> TRANSCRIPTION BEGIN
+// Mirrors src/lib/mapping/map-ingredient-with-fallback.ts between the anchors
+// `// Step 3: Apply must-have token filter` .. `selectionReason =
+// 'scored_by_confidence';`, statement for statement.
+//
+// TWO CALLER SHAPES ARE TRANSCRIBED HERE (see KNOWN_CALLERS):
+//   --variant baseline       caller 3a20888d65bd8cbd, lines 1485-1768
+//   --variant gate-backstop  caller 4ea700da8becee0c, lines 1485-1987
+// Steps 3 through 3e and the sort are IDENTICAL in both (the demotion diff starts
+// at the caller's line 1641, immediately after `confidenceGate(...)`), so the line
+// numbers below are the BASELINE's. In the gate-backstop caller everything from
+// the gate onward is shifted by the ~220 lines of comment the demotion and the two
+// review rounds added; the statements are the same, plus the `gateSelection`
+// backstop, the scoped confidence lift and two logger calls (the loggers have no
+// effect on selection). References to gate-backstop-ONLY statements use THIS
+// tree's line numbers and say so.
+//
+// `winner-diff transcript` prints the real caller and this block side by side, and
+// `winner-diff verify` is the only thing that PROVES the copy right.
+//
+// HISTORY OF THIS TRANSCRIPTION, because it has now been wrong twice by being
+// RIGHT ABOUT AN OLDER CALLER:
+//   5190a9ae93dbf642  demotion, no mitigations.
+//   349af8359fd7b90b  demotion + Mitigation A (gate pick appended to the rerank
+//                     window) + Mitigation B UNSCOPED (max(rerank, gate) on any
+//                     agreement).
+//   4ea700da8becee0c  CURRENT. A REVERTED (see the deleted-A note in runStep4);
+//                     B KEPT but scoped to gateResult.reason ===
+//                     'high_confidence_clear_winner'.
+// Both changes were transcribed on 2026-07-26 by reading the caller, not by
+// editing the previous transcription's numbers.
+//
+// ---------------------------------------------------------------------------
+// RECEIPTS — CURRENT (4ea700da8becee0c / A-reverted, B-scoped), 2026-07-26,
+// variant gate-backstop, tree 184f45f2. Re-measured; NOTHING carried over from
+// the 349af835 pin.
+//
+// POPULATION (65 queries, built from the frozen-pool replays zzv-repB-mit /
+// zzv-repC-nomit restricted to rows Mitigation A never moved, so they behave in
+// this tree as they did in both):
+//   27  gate fires basic_produce_bypass AND the reranker re-selects the gate pick
+//       -> B is SUPPRESSED here by the scope
+//   18  gate fires high_confidence_clear_winner AND the reranker re-selects it
+//       -> B is ACTIVE here
+//   10  gate fires, no lift
+//   10  gate does not fire (controls)
+//   As RUN, the gate fired on 55 of the 65 (33 basic_produce_bypass /
+//   22 high_confidence_clear_winner) — live retrieval reclassified a few.
+//
+// RESULT:  65 MATCH / 0 MISMATCH-EXPLAINED / 0 MISMATCH-UNEXPLAINED / 0 NO-GATHER
+//          65 CONF-MATCH / 0 CONF-REWRITTEN / 0 CONF-UNEXPLAINED
+//
+// SENSITIVITY — and this one changed how the mode works, so read it.
+// Stub 1, the B SCOPE removed (`backstop.reason === '...'` -> `true`, i.e. the
+// abandoned 349af835 behaviour), identical population, identical caller:
+//     MISMATCH-UNEXPLAINED  0        <- the foodId axis SAW NOTHING
+//     CONF-UNEXPLAINED      27       <- every basic_produce_bypass agreement row,
+//                                       real 0.762..0.980 vs replay 1.000
+// Stub 2, B removed entirely (`-> false`):
+//     MISMATCH-UNEXPLAINED  0        <- again nothing
+//     CONF-UNEXPLAINED      18       <- every high_confidence_clear_winner
+//                                       agreement row, real 1.000 vs replay 0.95/0.98
+// Both stubs were applied to a COPY-and-restore discipline and the restore proven
+// byte-identical by shasum (93d2b7a2cef1c92c).
+//
+// BASELINE INVARIANCE — MEASURED, not argued from "it is gated on `backstop`".
+// A 65-query frozen snapshot was built from the same population and replayed under
+// BOTH variants by BOTH the pre-edit file (A + unscoped B) and this one, then
+// compared row by row on winner id + confidence + path + rerank-window size:
+//   --variant baseline       65 / 65 IDENTICAL, 0 winners moved, 0 confidences moved
+//   --variant gate-backstop  37 identical, 0 winners moved, 27 confidences moved
+//                            (every one basic_produce_bypass, 1.000 -> the real
+//                            rerank confidence: the B scope), plus 1 rerank-window
+//                            change, `1 bottle premier protein caramel shake` 11 ->
+//                            10, which is Mitigation A's append disappearing.
+// The gate-backstop population was deliberately restricted to rows A never moved, so
+// "0 winners moved" there is expected and is NOT evidence that A was inert — over
+// the full 4,165-row corpus A moved 5.
+//
+// THE LESSON THE STUBS TAUGHT: before this pin, `verify` compared foodId ONLY.
+// With Mitigation A reverted, NOTHING that distinguishes the gate-backstop caller
+// from the baseline moves a foodId on a row where the reranker names someone — so
+// a foodId-only verify was structurally incapable of failing on the one mitigation
+// that remains, for EVERY possible population. It would have printed a green
+// receipt over a transcription of the wrong caller. That is why the confidence
+// axis was added rather than the population extended: the earlier receipt's
+// sensitivity (6 MISMATCH-UNEXPLAINED under a stub) was a property of Mitigation
+// A, and it left the file the moment A did.
+// ---------------------------------------------------------------------------
+//
+//   caller 1485-1493  Step 3   filterCandidatesByTokens                 -> pool.afterTokenFilter
+//   caller 1494-1539  Step 3b  hasCoreTokenMismatch + brand rescue      -> pool.afterCoreToken
+//   caller 1541-1557  Step 3c  zero/invalid macros + all-drop restore   -> pool.afterZeroMacro
+//   caller 1559-1592  Step 3d  assessMacroPlausibility (drop/penalise)  -> pool.afterPlausibility
+//   caller 1594-1596  Step 3e  dropDenylistedCandidates                 -> pool.afterDenylist
+//   caller 1598-1616  NON-MONOTONE #2 relaxed recovery (length===0)     -> relaxedRecovery
+//   caller 1626-1628  BASIC_PRODUCE (caller-local 11-string list)       -> isBasicProduce
+//   caller 1637-1640  computeFloorHitIds + makeSortedFilteredComparator -> sortedFiltered
+//   caller 1642       confidenceGate(searchQuery, sortedFiltered, trimmed)
+//   caller 1644-1647  NON-MONOTONE #3 gate pre-emption                  -> path=confidence_gate_early_exit
+//   caller 1657       countedPieceNoun(parsed)
+//   caller 1660-1668  NON-MONOTONE #1 filtered.slice(0,10) over GATHER order + count-label
+//                     extension to a hard cap of 13                     -> pool.rerankWindow
+//   caller 1669-1696  ai_generated nutrition read (pre-enriched in bulk before replay)
+//   caller 1703-1722  FDC fallback for aiNutritionEstimate (version-dependent: re-derived)
+//   caller 1724-1733  requestBillsByServing + grainVolumeUnit
+//   caller 1734-1745  toRerankCandidate({... countLabelMatch, servingLabelMatch})
+//   caller 1750-1751  rerankQuery + simpleRerank (NON-MONOTONE #4 lives inside:
+//                     simple-rerank.ts:1883 `siblings.length >= 3`)
+//   caller 1753-1760  re-resolve the winner out of `filtered` by id     -> path=rerank
+//   caller 1762-1768  MIN_FALLBACK_CONFIDENCE = 0.80 on sortedFiltered[0].score
+//
+// gate-backstop ONLY (no counterpart in the baseline caller; line numbers verified
+// by grep in THIS tree at caller hash 4ea700da8becee0c, not inferred from the diff):
+//   caller 1724       `gateSelection = gateResult.skipAiRerank ? gateResult.selected : undefined`
+//   caller 1746-1778  where MITIGATION A USED TO BE. The caller reverted the
+//                     `candidatesForRerank.push(gateSelection)` and left a 33-line
+//                     comment ("NOT DONE HERE, DELIBERATELY") in its place, so the
+//                     rerank window is now filtered.slice(0,10) + the countedNoun
+//                     extension in BOTH variants and `pool.rerankWindow` no longer
+//                     differs between them. The 17 past-index-10 gate picks are still
+//                     silently deleted; that is a slice(0,10) defect, not this
+//                     harness's to model. See the deleted-A note in runStep4.
+//   caller 1869-1918  MITIGATION B — on winner.id === gateSelection.id AND
+//                     `gateResult.reason === 'high_confidence_clear_winner'` (the
+//                     reason scope is caller 1915),
+//                     `confidence = Math.max(confidence, gateResult.confidence)`.
+//                     Changes no winner id; visible only in the confidence field.
+//   caller 1952-1981  `if (!winner) { if (gateSelection) { winner = gateSelection;
+//                     selectionReason = 'confidence_gate_backstop' } else if (...0.80...) }`
+//                     — note the gate branch SKIPS the 0.80 floor entirely
+//   caller 1922-1951  `mapping.confidence_gate_overridden` logging: observation only,
+//                     deliberately NOT transcribed (it cannot change a winner)
+//
+// TWO CALLER-LOCAL LISTS THAT LOOK ALIKE AND ARE NOT:
+//   BASIC_PRODUCE          (caller :1627) an 11-string literal matched by
+//                          normalizedName.includes(p). Drives only the SORT.
+//   BASIC_PRODUCE_PATTERNS (confidenceGate, gather-candidates.ts :578) a regex list,
+//                          additionally `&& !/\b(canned|cooked|dried)\b/`. Drives the
+//                          BYPASS. Transcribing one for the other silently changes
+//                          which rows early-exit.
+// ============================================================
+
+function replaySelection(e: SnapshotEntry, debug: boolean, variant: SelectionVariant): ReplayRow {
+    const notes: string[] = [];
+    const row: ReplayRow = {
+        query: e.query,
+        origin: e.origin,
+        goldenId: e.goldenId,
+        path: 'no_winner_no_candidates',
+        relaxedRecovery: false,
+        pool: {
+            gather: e.candidates.length, afterTokenFilter: 0, afterCoreToken: 0,
+            afterZeroMacro: 0, afterPlausibility: 0, afterDenylist: 0, admitted: 0, rerankWindow: 0,
+        },
+        rerankWindowIds: [],
+        admittedIds: [],
+        rerankRan: false,
+        gate: { skipAiRerank: false, reason: '(not reached)', confidence: 0 },
+        winner: null,
+        notes,
+    };
+
+    if (!e.ok) { row.path = 'snapshot_failed'; row.error = e.error; return row; }
+
+    // MANDATORY fresh deep copy: Step 3d rebuilds objects and the caller's Step 4
+    // MUTATES `candidate.nutrition` in place. Without this the second replay of the
+    // same snapshot is not the first, and the noise floor stops meaning anything.
+    const allCandidates: UnifiedCandidate[] = JSON.parse(JSON.stringify(e.candidates));
+    const trimmed = e.trimmed;
+    const normalizedName = e.normalizedName;
+    const parsed = e.parsed;
+    const isBrandedQuery = e.isBrandedQuery;
+    const matchedBrand = e.targetBrand;
+    const aiCanonicalBase = e.aiCanonicalBase;
+
+    if (allCandidates.length === 0) { row.path = 'no_winner_no_candidates'; return row; }
+
+    let winner: UnifiedCandidate | null = null;
+    let confidence = 0;
+    let selectionReason = '';
+
+    // ---- caller 1485-1493: Step 3, must-have token filter ------------------
+    const filterResult = filterCandidatesByTokens(allCandidates, normalizedName, { debug, rawLine: trimmed });
+    let filtered: UnifiedCandidate[] = filterResult.filtered;
+    row.pool.afterTokenFilter = filtered.length;
+
+    // ---- caller 1494-1539: Step 3b, core token validation + brand rescue ---
+    const rescueBrand = matchedBrand?.toLowerCase().trim();
+    filtered = filtered.filter((c: UnifiedCandidate) => {
+        const mismatch = hasCoreTokenMismatch(normalizedName, c.name, c.brandName);
+        if (!mismatch) return true;
+        if (rescueBrand && (
+            c.brandName?.toLowerCase().includes(rescueBrand) ||
+            new RegExp(`\\b${rescueBrand.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(c.name.toLowerCase())
+        )) return true;
+        return false;
+    });
+    row.pool.afterCoreToken = filtered.length;
+
+    // ---- caller 1541-1557: Step 3c, zero/invalid macros (all-drop restore) -
+    const macroValid = filtered.filter((c: UnifiedCandidate) =>
+        !c.nutrition?.per100g || !hasNullOrInvalidMacros(c.nutrition, c.name));
+    if (macroValid.length > 0 && macroValid.length < filtered.length) filtered = macroValid;
+    row.pool.afterZeroMacro = filtered.length;
+
+    // ---- caller 1559-1592: Step 3d, macro plausibility --------------------
+    const plausibilityChecked = filtered.map((c: UnifiedCandidate) => {
+        if (!c.nutrition?.per100g) return c;
+        const assessment = assessMacroPlausibility(normalizedName, c.name, c.nutrition);
+        if (assessment.plausible) return c;
+        if (assessment.impossible) return null;
+        return { ...c, score: c.score * assessment.penalty };
+    });
+    const plausibleCandidates = plausibilityChecked.filter((c: any): c is UnifiedCandidate => c !== null);
+    if (plausibleCandidates.length > 0) filtered = plausibleCandidates;
+    row.pool.afterPlausibility = filtered.length;
+
+    // ---- caller 1594-1596: Step 3e, denylist ------------------------------
+    filtered = dropDenylistedCandidates(filtered, trimmed);
+    row.pool.afterDenylist = filtered.length;
+
+    // ---- caller 1598-1616: NON-MONOTONE #2, relaxed recovery --------------
+    // Fires ONLY when strict is EMPTY. Relaxed keeps just the LAST must-have token,
+    // so its output is a strict SUPERSET — admitting one candidate above therefore
+    // SUPPRESSES this retry and swaps a superset for a subset.
+    // Faithful to the caller: the relaxed output is NOT re-run through 3b-3e.
+    if (filtered.length === 0) {
+        const relaxed = filterCandidatesByTokens(allCandidates, normalizedName, { debug, rawLine: trimmed, relaxed: true });
+        if (relaxed.filtered.length > 0) {
+            filtered = relaxed.filtered;
+            row.relaxedRecovery = true;
+            notes.push(`relaxed_recovery admitted ${filtered.length} (strict was empty; 3b-3e NOT re-applied)`);
+        }
+    }
+
+    row.pool.admitted = filtered.length;
+    row.admittedIds = filtered.map((c: UnifiedCandidate) => c.id);
+
+    // caller 1623: `if (filtered.length > 0)` — everything below is inside it.
+    if (filtered.length === 0) { row.path = 'no_winner_all_filtered'; return row; }
+
+    // ---- caller 1626-1628: searchQuery + the caller-local BASIC_PRODUCE list
+    const searchQuery = parsed?.name || normalizedName;
+    const BASIC_PRODUCE = ['potato', 'potatoes', 'lentil', 'lentils', 'beans', 'chickpea', 'chickpeas', 'spinach', 'broccoli', 'carrot', 'carrots'];
+    const isBasicProduce = BASIC_PRODUCE.some(p => normalizedName.toLowerCase().includes(p));
+
+    // ---- caller 1637-1640: floor-hit partition + the sort -----------------
+    const floorHitIds = computeFloorHitIds(normalizedName, filtered);
+    const sortedFiltered = [...filtered].sort(makeSortedFilteredComparator(normalizedName, isBasicProduce, floorHitIds));
+
+    // ---- caller 1642: Step 3a, the confidence gate ------------------------
+    const gateResult = confidenceGate(searchQuery, sortedFiltered, trimmed);
+    row.gate = {
+        skipAiRerank: !!gateResult.skipAiRerank,
+        reason: gateResult.reason ?? '',
+        confidence: gateResult.confidence ?? 0,
+    };
+
+    /**
+     * caller 1649-1778 — the ENTIRE else-branch of the gate, extracted into a closure
+     * so it can ALSO be run as the counterfactual when the gate pre-empts. Identical
+     * statements in identical order; the only change is that the caller's assignments
+     * to `winner` / `confidence` / `selectionReason` became locals that are returned.
+     *
+     * NOTE THE SCOPE: the `MIN_FALLBACK_CONFIDENCE = 0.80` fallback (caller 1762-1778)
+     * is INSIDE this else-branch, so when the gate fires today the 0.80 floor never
+     * runs either. Putting it inside this closure is what makes `counter` answer the
+     * question the demotion decision actually needs — "what would the caller have
+     * returned here?" — rather than the narrower "what would simpleRerank alone have
+     * returned?". Getting that wrong would understate `rerankDeclined`.
+     *
+     * `aiNutritionEstimate` is a per-invocation local (the caller assigns to an
+     * outer-scope variable, but the caller only ever runs Step 4 once — keeping it
+     * local means the counterfactual cannot leak the FDC fallback into anything).
+     *
+     * `backstop` is non-null ONLY in the modelled `gate-backstop` variant.
+     */
+    const runStep4 = (
+        backstop: { selected: UnifiedCandidate; confidence: number; reason: string } | null,
+    ): NonNullable<ReplayRow['counter']> => {
+        const s4notes: string[] = [];
+        let s4winner: UnifiedCandidate | null = null;
+        let s4confidence = 0;
+        let s4reason = '';
+        let s4path: SelectionPath = 'no_winner_rerank_declined';
+        let aiNutritionEstimate = e.aiNutritionEstimate ? { ...e.aiNutritionEstimate } : undefined;
+
+        // caller 1657
+        const countedNoun = countedPieceNoun(parsed);
+
+        // caller 1660-1668: NON-MONOTONE #1 — slice over GATHER order, not score
+        // order; the count-label extension pulls from filtered.slice(10) to a hard
+        // cap of 13. In BOTH variants this is now the ONLY way a candidate with
+        // indexInFiltered >= 10 can reach the reranker.
+        const candidatesForRerank: UnifiedCandidate[] = filtered.slice(0, 10);
+        if (countedNoun) {
+            for (const c of filtered.slice(10)) {
+                if (candidatesForRerank.length >= 13) break;
+                if (copy_candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
+            }
+        }
+
+        // ---- MITIGATION A: DELETED FROM THIS TRANSCRIPTION, 2026-07-26 --------
+        // A `candidatesForRerank.push(backstop.selected)` used to sit HERE, mirroring
+        // a caller that appended `gateSelection` to the rerank window so the gate's
+        // pick competed even from past the `filtered.slice(0, 10)` cutoff. THE CALLER
+        // REVERTED IT (caller 1746-1778 is now a ~33-line comment in its place saying
+        // "NOT DONE HERE, DELIBERATELY"), so the transcription drops it too. Keeping
+        // it would have made this file model a shape no tree contains.
+        //
+        // Why the caller reverted it, recorded here so nobody re-adds it on the same
+        // reasoning that put it in: scored against the project's own adjudication of
+        // all 296 disagreements it restored 5 of the 17 past-index-10 rows, 2 of them
+        // adjudicated rerank-BETTER, so the regression count did not move — it only
+        // changed which rows were wrong. Combined with Mitigation B it took
+        // `buffalo wild wings boneless wings` from 0.710 (below the 0.75
+        // sub-threshold floor, therefore not cached at all) to 1.000 — a displacing
+        // upsert of an adjudicated-WRONG record. And it flattered its own
+        // measurement: a restored row scores SAME in a baseline-vs-change diff and so
+        // drops out of the screen population entirely.
+        //
+        // The 17 silent deletions are REAL and still unfixed. They are a defect of
+        // `slice(0, 10)` over gather order, to be fixed where that lives with its own
+        // gate — not special-cased for the gate pick. Consequence for this harness:
+        // on those rows a gate-backstop replay shows the reranker deciding without
+        // the gate's record present, which is what the caller does.
+        //
+        // `backstop` therefore now affects EXACTLY TWO things: the confidence lift
+        // below (scoped), and the no-winner backstop further down.
+
+        // caller 1669-1696: the ai_generated nutrition read. Batched into
+        // preEnrichAiGenerated() before the replay loop so this stays synchronous
+        // and therefore trivially deterministic.
+        const missingNutr = candidatesForRerank.filter(c => c.source === 'ai_generated' && !c.nutrition);
+        if (missingNutr.length > 0) {
+            s4notes.push(`${missingNutr.length} ai_generated candidate(s) still lack nutrition after the batched pre-enrich read`);
+        }
+
+        // caller 1703-1722: FDC fallback for the tiebreaker. Derived from
+        // candidatesForRerank, hence VERSION-DEPENDENT — re-derived per replay,
+        // never baked into the snapshot.
+        if (!aiNutritionEstimate) {
+            const fdcRef = candidatesForRerank.find(c =>
+                c.source === 'fdc' && c.nutrition?.per100g && (c.nutrition.kcal > 0 || c.nutrition.protein > 0));
+            if (fdcRef && fdcRef.nutrition) {
+                aiNutritionEstimate = {
+                    caloriesPer100g: fdcRef.nutrition.kcal,
+                    proteinPer100g: fdcRef.nutrition.protein,
+                    carbsPer100g: fdcRef.nutrition.carbs,
+                    fatPer100g: fdcRef.nutrition.fat,
+                    confidence: 0.6,
+                };
+                s4notes.push(`aiNutritionEstimate synthesised from FDC candidate "${fdcRef.name}" (${fdcRef.id})`);
+            }
+        }
+
+        // caller 1724-1733
+        const billsByServing = copy_requestBillsByServing(parsed);
+        const grainVolumeUnit = !billsByServing && parsed?.unit
+            && copy_isMatchableVolumeUnit(parsed.unit)
+            && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+            ? parsed.unit : null;
+
+        // caller 1734-1745
+        const rerankCandidates = candidatesForRerank.map(c => toRerankCandidate({
+            id: c.id,
+            name: c.name,
+            brandName: c.brandName,
+            foodType: c.foodType,
+            score: c.score,
+            source: c.source,
+            nutrition: c.nutrition,
+            countLabelMatch: countedNoun ? copy_candidateHasCountLabel(c, countedNoun) : undefined,
+            servingLabelMatch: billsByServing ? copy_candidateHasServingData(c)
+                : grainVolumeUnit ? candidateHasVolumeServing(c, grainVolumeUnit) : undefined,
+        }));
+
+        // caller 1750-1751. NON-MONOTONE #4 lives inside simpleRerank.
+        const rerankQuery = aiCanonicalBase || stripPrepModifiers(searchQuery);
+        const rerankResult = simpleRerank(
+            rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed,
+            isBrandedQuery, matchedBrand ?? undefined, countedNoun != null,
+        );
+
+        // caller 1753-1760
+        if (rerankResult && rerankResult.winner) {
+            const selected = filtered.find((c: UnifiedCandidate) => c.id === rerankResult.winner!.id);
+            if (selected) {
+                s4winner = selected;
+                s4confidence = rerankResult.confidence;
+                s4reason = rerankResult.reason;
+                s4path = 'rerank';
+
+                // ---- MITIGATION B, gate-backstop variant only (caller 1869-1918) --
+                // AGREEMENT KEEPS THE HIGHER CONFIDENCE. The demotion is about WHICH
+                // RECORD wins, but `confidence` is also the cache-admission signal
+                // (`admitToCache = confidence >= 0.85 || subThreshold`), and the two
+                // stages report on different scales: the gate exits at >= 0.85 by
+                // construction, simpleRerank returns min(0.5 + score*0.5, 0.95) with a
+                // 0.70 floor. Taking the rerank number unconditionally therefore
+                // DEMOTED lines whose answer did not change at all — 37 of the 441
+                // gate lines fall under the save gate, 9 with an UNCHANGED winner, 2
+                // of those under SUB_THRESHOLD_SAVE_FLOOR (0.75) so they stop being
+                // cached; and the ones that survive via `insertOnly` can then never be
+                // REFRESHED, which is what the parity sweep and the nightly flywheel
+                // rely on.
+                //
+                // TWO scopes, both transcribed from the caller, both load-bearing.
+                //
+                // (1) AGREEMENT. On disagreement the gate's confidence describes a
+                // candidate that was just rejected, so carrying it over would be
+                // laundering.
+                //
+                // (2) `high_confidence_clear_winner` ONLY — ADDED 2026-07-26 when the
+                // caller scoped it (caller 1912-1918). "The gate exits at >= 0.85 by
+                // construction" is true of exactly ONE of the gate's three exits.
+                // `basic_produce_bypass` (gather-candidates.ts:605) returns
+                // `Math.max(0, Math.min(1, top1.score))` — a CLAMPED RAW ENGINE SCORE,
+                // which for any OFF candidate saturates at exactly 1.000 and says
+                // nothing about match quality; `yeast_variant_preference` (:634)
+                // returns a hardcoded 0.95. Only `high_confidence_clear_winner` (:706)
+                // carries assessConfidence's actual match score. Measured on the 132
+                // rows the unscoped lift touched: 27 were basic_produce_bypass, every
+                // one at exactly 1.000, and 5 crossed the 0.85 save gate on it.
+                //
+                // `backstop.reason` is `gateResult.reason || 'confidence_gate'`, so
+                // this check is EXACTLY the caller's `gateResult.reason ===
+                // 'high_confidence_clear_winner'`: the default only substitutes for a
+                // falsy reason, and both a falsy reason and 'confidence_gate' fail the
+                // comparison the same way the caller's does.
+                //
+                // Note this changes NO winner id — it is invisible to a foodId-only
+                // diff and to `verify`, which compares foodId. Confidence is carried on
+                // WinnerInfo, so a `diff` reading the confidence field is the only
+                // screen that can see it.
+                if (
+                    backstop
+                    && s4winner.id === backstop.selected.id
+                    && backstop.reason === 'high_confidence_clear_winner'
+                ) {
+                    s4confidence = Math.max(s4confidence, backstop.confidence);
+                }
+            }
+        }
+
+        // ---- gate-backstop variant only -------------------------------------
+        // The gate demoted from pre-emption to backstop: `gateSelection` is consulted
+        // only when simpleRerank named nobody, and it takes precedence over the raw
+        // sortedFiltered[0].score >= 0.80 grab below (which is therefore skipped
+        // entirely on these rows — mirror of the caller's
+        // `if (!winner) { if (gateSelection) ... else if (sortedFiltered.length) ... }`).
+        //
+        // selectionReason is the BARE CONSTANT 'confidence_gate_backstop', matching the
+        // caller exactly: the under_gate funnel class is
+        // `selectionReason.split(':')[0]` through normalizeClassId, which strips digits
+        // and parentheses, so echoing the gate's own reason string here would silently
+        // put a different class in the telemetry than production emits.
+        if (!s4winner && backstop) {
+            s4winner = backstop.selected;
+            s4confidence = backstop.confidence;
+            s4reason = 'confidence_gate_backstop';
+            s4path = 'confidence_gate_backstop';
+            s4notes.push(`gate BACKSTOP (gate reason: ${backstop.reason}) — rerank declined, gate pick used ahead of the 0.80 score floor`);
+        }
+
+        // caller 1762-1778: fall back to the top scorer ONLY above the floor.
+        if (!s4winner && sortedFiltered.length > 0) {
+            const MIN_FALLBACK_CONFIDENCE = 0.80;
+            if (sortedFiltered[0].score >= MIN_FALLBACK_CONFIDENCE) {
+                s4winner = sortedFiltered[0];
+                s4confidence = sortedFiltered[0].score;
+                s4reason = 'scored_by_confidence';
+                s4path = 'scored_by_confidence';
+            } else {
+                s4path = 'no_winner_rerank_declined';
+                s4notes.push(`top scorer "${sortedFiltered[0].name}" score ${sortedFiltered[0].score.toFixed(3)} < ${MIN_FALLBACK_CONFIDENCE} floor`);
+            }
+        }
+
+        const windowIds = candidatesForRerank.map(c => c.id);
+        return {
+            path: s4path,
+            rerankWindow: candidatesForRerank.length,
+            rerankWindowIds: windowIds,
+            rerankReason: rerankResult?.reason,
+            winner: s4winner ? mkWinner(s4winner, s4confidence, s4reason, filtered, true, windowIds) : null,
+            notes: s4notes,
+        };
+    };
+
+    if (variant === 'baseline' && gateResult.skipAiRerank && gateResult.selected) {
+        // ---- caller 1644-1647: NON-MONOTONE #3 --------------------------------
+        // basic_produce_bypass / high_confidence_clear_winner / yeast_variant_preference
+        // return candidates[0] of the SORTED list, and the reranker never runs.
+        winner = gateResult.selected as UnifiedCandidate;
+        confidence = gateResult.confidence;
+        selectionReason = gateResult.reason || 'confidence_gate';
+        row.path = 'confidence_gate_early_exit';
+        notes.push(`gate early-exit (${selectionReason}) — the reranker never ran`);
+
+        // Record the winner BEFORE running the counterfactual, so nothing the
+        // counterfactual touches can be read back into the primary result.
+        row.winner = mkWinner(winner, confidence, selectionReason, filtered, false, []);
+
+        // ---- COUNTERFACTUAL LENS (an ADDITION, not part of the caller) --------
+        // Same pool, same process, same `filtered` array: what would the gate's
+        // else-branch have returned? Timed, because the gate is defended as a
+        // latency optimisation and the cost it avoids should be a measured number.
+        //
+        // READ BEFORE QUOTING A COUNTERFACTUAL NUMBER: this passes `null`, so it
+        // models the BASELINE caller's else-branch faithfully — and that is what it is
+        // for. Since the Mitigation-A revert (caller 4ea700da) the rerank WINDOW is
+        // built identically with and without `backstop`, so on the gate-firing rows
+        // this lens now reproduces the current gate-backstop caller's SELECTION too:
+        // the only things `backstop` still changes are the scoped confidence lift
+        // (which moves no id) and the no-winner backstop (which this lens reports as
+        // `rerankDeclined` rather than resolving). It was a LOWER BOUND while
+        // Mitigation A was in the tree; it is not one now. What it still cannot show
+        // is the 17 gate picks sitting past `filtered.slice(0,10)`: neither caller
+        // shows those to the reranker, so a "disagreement" on such a row is a
+        // truncation artefact, not an adjudication. For confidence-field effects,
+        // diff two replays (baseline vs gate-backstop) instead.
+        const t0 = process.hrtime.bigint();
+        row.counter = runStep4(null);
+        row.counterMicros = Number(process.hrtime.bigint() - t0) / 1000;
+        return row;
+    }
+
+    // Step 4 runs. In `baseline` this is the gate's else-branch; in `gate-backstop`
+    // it is unconditional and carries the gate pick down as a backstop.
+    const backstop = variant === 'gate-backstop' && gateResult.skipAiRerank && gateResult.selected
+        ? { selected: gateResult.selected as UnifiedCandidate, confidence: gateResult.confidence ?? 0, reason: gateResult.reason || 'confidence_gate' }
+        : null;
+    const s4 = runStep4(backstop);
+    row.rerankRan = true;
+    row.path = s4.path;
+    row.pool.rerankWindow = s4.rerankWindow;
+    row.rerankWindowIds = s4.rerankWindowIds;
+    row.rerankReason = s4.rerankReason;
+    for (const n of s4.notes) notes.push(n);
+
+    if (s4.winner) {
+        winner = filtered.find((c: UnifiedCandidate) => c.id === s4.winner!.foodId) ?? null;
+        confidence = s4.winner.confidence;
+        selectionReason = s4.winner.selectionReason;
+    }
+
+    if (winner) {
+        row.winner = mkWinner(winner, confidence, selectionReason, filtered, row.rerankRan, row.rerankWindowIds);
+    }
+    return row;
+}
+// <<< TRANSCRIPTION END
+
+/** Winner record including the FULL macro panel — identity plus one number is not enough. */
+function mkWinner(
+    w: UnifiedCandidate, confidence: number, selectionReason: string,
+    filtered: UnifiedCandidate[], rerankRan: boolean, windowIds: string[],
+): WinnerInfo {
+    const idx = filtered.findIndex((c: UnifiedCandidate) => c.id === w.id);
+    const n: any = w.nutrition;
+    return {
+        foodId: w.id,
+        foodName: w.name,
+        brandName: w.brandName ?? null,
+        source: w.source,
+        kcalPer100g: n?.per100g ? n.kcal : null,
+        panel: n ? {
+            kcal: n.kcal ?? 0, protein: n.protein ?? 0, carbs: n.carbs ?? 0,
+            fat: n.fat ?? 0, per100g: !!n.per100g,
+        } : null,
+        confidence,
+        selectionReason,
+        indexInFiltered: idx,
+        inTop10: idx >= 0 && idx < 10,
+        inRerankWindow: rerankRan && windowIds.includes(w.id),
+    };
+}
+
+/**
+ * The one async step inside the caller's Step 4 (mapper :1669-1696), hoisted into a
+ * single batched read so replaySelection stays synchronous and therefore trivially
+ * deterministic. This is a SELECT; the write guard leaves reads alone.
+ */
+async function preEnrichAiGenerated(entries: SnapshotEntry[]): Promise<number> {
+    const ids = new Set<string>();
+    for (const e of entries) {
+        for (const c of e.candidates) if (c.source === 'ai_generated' && !c.nutrition) ids.add(c.id);
+    }
+    if (ids.size === 0) return 0;
+    const rows = await prisma.aiGeneratedFood.findMany({
+        where: { id: { in: [...ids] } },
+        select: { id: true, caloriesPer100g: true, proteinPer100g: true, carbsPer100g: true, fatPer100g: true },
+    });
+    const byId = new Map<string, any>(rows.map((r: any) => [r.id, r]));
+    let n = 0;
+    for (const e of entries) {
+        for (const c of e.candidates) {
+            if (c.source === 'ai_generated' && !c.nutrition && byId.has(c.id)) {
+                const r = byId.get(c.id);
+                c.nutrition = {
+                    kcal: r.caloriesPer100g, protein: r.proteinPer100g,
+                    carbs: r.carbsPer100g, fat: r.fatPer100g, per100g: true,
+                };
+                n++;
+            }
+        }
+    }
+    return n;
+}
+
+// ============================================================
+// 10. REPLAY mode
+// ============================================================
+
+async function buildReplay(
+    snap: SnapshotFile, label: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean,
+): Promise<{ file: ReplayFile; enriched: number }> {
+    const drift = checkDrift(allowDrift);
+    announceVariantFit(drift, variant);
+
+    if (snap.callerHash !== drift.caller) {
+        say('');
+        say('NOTE: the caller-block hash differs from the tree the SNAPSHOT was taken on');
+        say(`      (snapshot=${snap.callerHash}  now=${drift.caller}).`);
+        say('      Harmless for a caller-only change: the snapshot froze the GATHER output,');
+        say('      which the caller block does not influence. It is NOT harmless if the tree');
+        say('      also changed retrieval — then re-snapshot, and read limit (A) in the header.');
+        say('');
+    }
+
+    installWriteGuard();
+    muzzle(true);
+    const enriched = await preEnrichAiGenerated(snap.entries);
+    const rows: ReplayRow[] = [];
+    for (const e of snap.entries) {
+        try {
+            rows.push(replaySelection(e, debug, variant));
+        } catch (err: any) {
+            rows.push({
+                query: e.query, origin: e.origin, goldenId: e.goldenId, path: 'replay_error', relaxedRecovery: false,
+                pool: { gather: e.candidates.length, afterTokenFilter: -1, afterCoreToken: -1, afterZeroMacro: -1, afterPlausibility: -1, afterDenylist: -1, admitted: -1, rerankWindow: -1 },
+                rerankWindowIds: [], admittedIds: [], rerankRan: false,
+                gate: { skipAiRerank: false, reason: 'error', confidence: 0 },
+                winner: null, notes: [], error: err?.stack ?? err?.message ?? String(err),
+            });
+        }
+    }
+    muzzle(false);
+
+    const file: ReplayFile = {
+        kind: 'winner-diff/replay',
+        version: 1,
+        label,
+        variant,
+        ranAt: new Date().toISOString(),
+        gitHead: gitHead(),
+        gitDirty: gitDirtyHash(),
+        snapshotTakenAt: snap.takenAt,
+        snapshotPopulation: snap.population,
+        callerHash: drift.caller,
+        helpersHash: drift.helpers,
+        rows,
+    };
+    return { file, enriched };
+}
+
+function printReplaySummary(f: ReplayFile, enriched: number, verbose: boolean) {
+    say('');
+    say(`=== REPLAY [${f.label}]  variant=${f.variant}  head=${f.gitHead} dirty=${f.gitDirty}  caller=${f.callerHash} helpers=${f.helpersHash}`);
+    say(`    snapshot taken ${f.snapshotTakenAt}   population: ${f.snapshotPopulation}`);
+    say(`    rows ${f.rows.length};  ai_generated candidates enriched by the batched read: ${enriched}`);
+    say('');
+    say('  PATH HISTOGRAM');
+    for (const [k, v] of pathHistogram(f.rows)) {
+        say(`    ${k.padEnd(34)} ${String(v).padStart(5)}  (${((100 * v) / f.rows.length).toFixed(1)}%)`);
+    }
+    const g = gateReasonHistogram(f.rows);
+    say('');
+    say('  GATE REASONS — split by whether the gate ACTUALLY FIRED (skipAiRerank).');
+    say('    A flat histogram mixes the two and reads 6x too high: `margin_too_small` is');
+    say('    the gate DECLINING, not firing.');
+    say(`    FIRING (pre-empted the reranker): ${g.firingTotal}`);
+    for (const [k, v] of g.firing) say(`        ${k.padEnd(38)} ${String(v).padStart(5)}`);
+    say(`    NON-FIRING (Step 4 ran anyway):   ${g.nonFiringTotal}`);
+    for (const [k, v] of g.nonFiring) say(`        ${k.padEnd(38)} ${String(v).padStart(5)}`);
+    const relaxed = f.rows.filter(r => r.relaxedRecovery).length;
+    const outsideTop10 = f.rows.filter(r => r.winner && r.winner.indexInFiltered >= 10).length;
+    say('');
+    say(`  relaxed-recovery rows: ${relaxed}`);
+    say(`  winners with indexInFiltered >= 10 (entered ONLY via the count-label window extension): ${outsideTop10}`);
+    const os = originSplit(f.rows.map(r => r.query));
+    say(`  population origin: user ${os.user}   warmer-shaped ${os.warmer} (${os.warmerPct.toFixed(1)}%)`);
+
+    if (verbose) {
+        say('');
+        for (const r of f.rows) {
+            const p = r.pool;
+            say(`  ${r.query}`);
+            say(`      pool  gather=${p.gather} -> token=${p.afterTokenFilter} -> core=${p.afterCoreToken} -> zeromacro=${p.afterZeroMacro} -> plaus=${p.afterPlausibility} -> denylist=${p.afterDenylist} -> ADMITTED=${p.admitted}  rerankWindow=${p.rerankWindow}`);
+            say(`      path  ${r.path}${r.relaxedRecovery ? '  (+relaxed_recovery)' : ''}   gate=${r.gate.reason}${r.gate.skipAiRerank ? ' SKIP_RERANK' : ''}${r.rerankReason ? '   rerank=' + r.rerankReason : ''}`);
+            say(`      win   ${fmtWinner(r.winner)}`);
+            if (r.counter) {
+                const agree = (r.winner?.foodId ?? null) === (r.counter.winner?.foodId ?? null);
+                say(`      CF    ${agree ? 'AGREE' : 'DISAGREE'}  rerank-would-have-picked: ${fmtWinner(r.counter.winner)}`);
+            }
+            for (const n of r.notes) say(`      note  ${n}`);
+            if (r.error) say(`      ERR   ${r.error}`);
+        }
+    }
+}
+
+function fmtWinner(w: WinnerInfo | null): string {
+    if (!w) return '(no winner)';
+    const brand = w.brandName ? ` [${w.brandName}]` : '';
+    const p = w.panel;
+    const pan = p
+        ? `${p.kcal.toFixed(0)}kcal ${p.protein.toFixed(1)}P ${p.carbs.toFixed(1)}C ${p.fat.toFixed(1)}F${p.per100g ? '/100g' : ' (NOT per100g)'}`
+        : 'no-nutrition';
+    return `${w.source}:${w.foodId} "${w.foodName}"${brand}  ${pan}  conf=${w.confidence.toFixed(3)} reason=${w.selectionReason} idx=${w.indexInFiltered}`;
+}
+
+// ============================================================
+// 11. NOISE FLOOR
+// ============================================================
+
+function receiptPath(snapPath: string): string {
+    return snapPath.replace(/\.json$/, '') + '.noise-floor.json';
+}
+
+function readLedger(p: string): NoiseFloorLedger | null {
+    if (!fs.existsSync(p)) return null;
+    try { return JSON.parse(fs.readFileSync(p, 'utf8')) as NoiseFloorLedger; } catch { return null; }
+}
+
+/**
+ * Replay the SAME variant on the SAME snapshot TWICE and assert 0 winner changes.
+ *
+ * Two different numbers must never be confused:
+ *   replayNoise     same snapshot + same tree. MUST be 0. This is what we measure.
+ *   retrievalNoise  DIFFERENT snapshots + same tree. Genuinely non-zero and NOT a
+ *                   bug — Typesense/FatSecret return different pools minutes apart.
+ * A scratch log once labelled a cross-snapshot run "the harness NOISE FLOOR. Expect
+ * 0 changed rows" and reported 2 changes; both statements cannot be true, and the
+ * label was the wrong one.
+ */
+async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean) {
+    const snap: SnapshotFile = readSnapshot(snapPath);
+    const a = await buildReplay(snap, 'noise-1', variant, debug, allowDrift);
+    const b = await buildReplay(snap, 'noise-2', variant, debug, allowDrift);
+
+    const byQ = new Map(b.file.rows.map(r => [r.query, r]));
+    let winnerDiffs = 0;
+    let pathDiffs = 0;
+    const offenders: string[] = [];
+    for (const ra of a.file.rows) {
+        const rb = byQ.get(ra.query);
+        if (!rb) { winnerDiffs++; offenders.push(`${ra.query}: MISSING in the second replay`); continue; }
+        const wa = ra.winner?.foodId ?? null;
+        const wb = rb.winner?.foodId ?? null;
+        if (wa !== wb) { winnerDiffs++; offenders.push(`${ra.query}: winner ${wa} -> ${wb}`); }
+        if (ra.path !== rb.path) { pathDiffs++; offenders.push(`${ra.query}: path ${ra.path} -> ${rb.path}`); }
+    }
+
+    const receipt: NoiseFloorReceipt = {
+        kind: 'winner-diff/noise-floor',
+        version: 1,
+        ranAt: new Date().toISOString(),
+        snapshotTakenAt: snap.takenAt,
+        gitHead: a.file.gitHead,
+        gitDirty: a.file.gitDirty,
+        variant,
+        rows: a.file.rows.length,
+        winnerDiffs,
+        pathDiffs,
+    };
+
+    const rp = receiptPath(snapPath);
+    const ledger = readLedger(rp) ?? emptyLedger();
+    ledger.receipts = ledger.receipts
+        .filter(r => !(r.snapshotTakenAt === receipt.snapshotTakenAt && r.gitDirty === receipt.gitDirty && r.variant === receipt.variant))
+        .concat(receipt);
+    writeJsonAtomic(rp, ledger);
+
+    say('');
+    say('================================================================================');
+    say('NOISE FLOOR  (replayNoise: same snapshot, same tree, same variant — MUST be 0)');
+    say(`  snapshot ${snap.takenAt}   tree ${receipt.gitDirty}   variant ${variant}`);
+    say(`  rows ${receipt.rows}   winner-diffs ${receipt.winnerDiffs}   path-diffs ${receipt.pathDiffs}`);
+    if (winnerDiffs === 0 && pathDiffs === 0) {
+        say('  RESULT: 0 — the replay is deterministic on this tree. A diff run may proceed.');
+    } else {
+        say('  RESULT: NON-ZERO. !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+        say('  The replay is NOT deterministic on this tree, so any A/B number would be');
+        say('  noise plus signal with no way to separate them. Do NOT report a diff. Fix');
+        say('  the nondeterminism (shared mutable candidate objects are the usual cause —');
+        say('  check the per-row JSON.parse(JSON.stringify(...)) deep copy) and re-run.');
+        for (const o of offenders.slice(0, 40)) say(`    ${o}`);
+        if (offenders.length > 40) say(`    ... and ${offenders.length - 40} more`);
+    }
+    say(`  receipt written: ${rp}`);
+    say('  NOTE: this is NOT retrievalNoise. Snapshotting the same population twice and');
+    say('        diffing those replays measures Typesense/FatSecret nondeterminism, which');
+    say('        is a different, genuinely non-zero number.');
+    say('================================================================================');
+
+    if (winnerDiffs !== 0 || pathDiffs !== 0) process.exitCode = 1;
+}
+
+// ============================================================
+// 12. DIFF
+// ============================================================
+
+function runDiff(aPath: string, bPath: string, opts: {
+    screens: boolean; crossSnapshot: boolean; top: number; jsonOut?: string; goldenPath?: string;
+}) {
+    const A: ReplayFile = JSON.parse(fs.readFileSync(aPath, 'utf8'));
+    const B: ReplayFile = JSON.parse(fs.readFileSync(bPath, 'utf8'));
+
+    // The noise floor is a PRECONDITION, not a footnote. Without it the number
+    // below has no denominator.
+    const ledgerPath = receiptPath(guessSnapshotPath(A, aPath));
+    const ledger = readLedger(ledgerPath);
+    const gate = noiseGate(ledger, A, B, { crossSnapshot: opts.crossSnapshot });
+
+    say('');
+    say('================================================================================');
+    say(`WINNER DIFF   A=[${A.label}] ${A.variant} ${A.gitHead}/${A.gitDirty}   B=[${B.label}] ${B.variant} ${B.gitHead}/${B.gitDirty}`);
+    say(`snapshot: A ${A.snapshotTakenAt}   B ${B.snapshotTakenAt}`);
+    say(`population: ${A.snapshotPopulation}`);
+    say('================================================================================');
+
+    if (!gate.ok) {
+        say('');
+        say('REFUSING TO REPORT — the noise floor is not established:');
+        for (const p of gate.problems) say(`  * ${p}`);
+        say('');
+        say(`  (looked for receipts in ${ledgerPath})`);
+        process.exitCode = 2;
+        return;
+    }
+    say(`noise floor: A ${gate.receiptA!.winnerDiffs}/${gate.receiptA!.rows} winner diffs, ` +
+        `B ${gate.receiptB!.winnerDiffs}/${gate.receiptB!.rows} — both 0, so the numbers below are signal.`);
+    if (A.snapshotTakenAt !== B.snapshotTakenAt) {
+        say('');
+        say('*** RETRIEVAL-NOISE-CONTAMINATED: A and B replayed DIFFERENT snapshots. Some of');
+        say('*** the changes below are Typesense/FatSecret returning a different pool, not');
+        say('*** your code. Do not quote this as a clean winner diff.');
+    }
+    if (A.gitDirty === B.gitDirty && A.variant === B.variant) {
+        say('NOTE: identical tree AND identical variant — this run is itself a noise-floor check.');
+    }
+
+    const byQ = new Map(B.rows.map(r => [r.query, r]));
+    const counts: Record<Verdict, number> = {
+        'SAME': 0, 'WINNER-CHANGED': 0, 'NOWINNER->WINNER': 0, 'WINNER->NOWINNER': 0, 'PATH-CHANGED': 0, 'ERROR': 0,
+    };
+    let movement = 0;
+    const pairs: ScreenPair[] = [];
+    const changedRows: Array<{ a: ReplayRow; b: ReplayRow; verdict: Verdict }> = [];
+
+    for (const a of A.rows) {
+        const b = byQ.get(a.query);
+        if (!b) { say(`  ${a.query}: MISSING IN B`); counts.ERROR++; continue; }
+        const verdict = classifyVerdict(a, b);
+        counts[verdict]++;
+        pairs.push({ query: a.query, a: a.winner, b: b.winner });
+        if (!rowHasMovement(a, b)) continue;
+        movement++;
+        changedRows.push({ a, b, verdict });
+    }
+
+    for (const { a, b, verdict } of changedRows.slice(0, opts.top)) {
+        const churn = windowChurn(a, b);
+        const poolDelta = b.pool.admitted - a.pool.admitted;
+        say('');
+        say(`  [${verdict}] ${a.query}${a.goldenId ? `   (golden ${a.goldenId})` : ''}${a.origin === 'warmer' ? '   (warmer-shaped line)' : ''}`);
+        say(`     pool admitted ${a.pool.admitted} -> ${b.pool.admitted} (${poolDelta >= 0 ? '+' : ''}${poolDelta})   ` +
+            `token ${a.pool.afterTokenFilter}->${b.pool.afterTokenFilter}   relaxed ${a.relaxedRecovery}->${b.relaxedRecovery}`);
+        if (windowChurnIsMeaningless(a, b)) {
+            say(`     rerank window ${a.pool.rerankWindow} -> ${b.pool.rerankWindow}   !! rerank ${a.rerankRan ? 'RAN -> SKIPPED' : 'SKIPPED -> RAN'} ` +
+                '— the window was never BUILT on one side, so there is no eviction to report');
+        } else {
+            say(`     rerank window ${a.pool.rerankWindow} -> ${b.pool.rerankWindow}   ` +
+                `EVICTED ${churn.evicted.length} ${churn.evicted.slice(0, 6).join(',')}   ADDED ${churn.added.length} ${churn.added.slice(0, 6).join(',')}`);
+        }
+        say(`     path  ${a.path} -> ${b.path}    gate ${a.gate.reason} -> ${b.gate.reason}`);
+        say(`     A win ${fmtWinner(a.winner)}`);
+        say(`     B win ${fmtWinner(b.winner)}`);
+        const d = kcalDeltaPct(a.winner, b.winner);
+        if (d != null && a.winner && b.winner && a.winner.foodId !== b.winner.foodId) {
+            say(`     kcal/100g ${a.winner.panel!.kcal} -> ${b.winner.panel!.kcal}  (${d >= 0 ? '+' : ''}${d.toFixed(1)}%)`);
+        }
+    }
+    if (changedRows.length > opts.top) {
+        say('');
+        say(`  ... ${changedRows.length - opts.top} more moved rows suppressed (--top ${opts.top})`);
+    }
+
+    say('');
+    say('--------------------------------------------------------------------------------');
+    say('VERDICT COUNTS');
+    for (const k of VERDICTS) say(`  ${k.padEnd(18)} ${counts[k]}`);
+    say(`  rows with ANY movement (winner, pool or rerank window): ${movement} / ${A.rows.length}`);
+    say('--------------------------------------------------------------------------------');
+
+    if (opts.screens) sayAll(formatScreens(runScreens(pairs, A.label, B.label), opts.top));
+
+    if (opts.goldenPath) {
+        // runGoldenScreen, NOT the old reportGoldenBands. The old one compared the
+        // two sides' verdicts and printed "no golden case changed verdict" when they
+        // matched — which silently swallowed every case whose only assertion is a
+        // band the replay cannot evaluate, because UNKNOWN == UNKNOWN. That is the
+        // majority of the golden set, and it is the exact blindness this screen was
+        // written to remove; leaving the old call site in place would have shipped
+        // the fix as dead code.
+        const goldenCases = parseGoldenSet(
+            JSON.parse(fs.readFileSync(opts.goldenPath, 'utf8')),
+            { includeMultiItem: true },
+        );
+        sayAll(formatGoldenScreen(runGoldenScreen(goldenCases, A.rows, B.rows), opts.top));
+    }
+
+    say('');
+    say('REMINDER — a SAME verdict does NOT clear the change. This gate is blind to:');
+    say('  (a) retrieval effects (the gather output is frozen);');
+    say('  (b) everything after winner selection — hydration, serving resolution, AI');
+    say('      backfill, the save-time plausibility and brand-mismatch gates, the write;');
+    say('  (c) warm-key behaviour (skipCache is forced, so this is COLD resolution);');
+    say('  (d) any case the change is supposed to CREATE — this population contains only');
+    say('      queries that were already asked. Pair this with a hand-written positive');
+    say('      case list that asserts the RIGHT answer.');
+    say('');
+
+    if (opts.jsonOut) {
+        writeJsonAtomic(opts.jsonOut, {
+            kind: 'winner-diff/diff', version: 1, ranAt: new Date().toISOString(),
+            a: { label: A.label, variant: A.variant, gitHead: A.gitHead, gitDirty: A.gitDirty },
+            b: { label: B.label, variant: B.variant, gitHead: B.gitHead, gitDirty: B.gitDirty },
+            snapshotTakenAt: A.snapshotTakenAt, population: A.snapshotPopulation,
+            noiseFloor: { a: gate.receiptA, b: gate.receiptB },
+            counts, movement, rows: A.rows.length,
+            screens: runScreens(pairs, A.label, B.label),
+            changed: changedRows.map(({ a, b, verdict }) => ({ query: a.query, verdict, a, b })),
+        });
+        say(`diff json written: ${opts.jsonOut}`);
+    }
+}
+
+/** Where the snapshot that produced this replay lives, for the receipt lookup. */
+function guessSnapshotPath(f: ReplayFile, replayPath: string): string {
+    const explicit = argStr('snapshot');
+    if (explicit) return explicit;
+    // Replays are conventionally written next to their snapshot; fall back to the
+    // population string only for the message.
+    const dir = path.dirname(replayPath);
+    const guesses = fs.existsSync(dir) ? fs.readdirSync(dir).filter(n => n.endsWith('.noise-floor.json')) : [];
+    if (guesses.length === 1) return path.join(dir, guesses[0].replace(/\.noise-floor\.json$/, '.json'));
+    return path.join(dir, 'snapshot.json');
+}
+
+// ============================================================
+// 13. COUNTERFACTUAL — one replay, no B tree
+// ============================================================
+
+function runCounterfactual(replayPath: string, top: number) {
+    const f: ReplayFile = JSON.parse(fs.readFileSync(replayPath, 'utf8'));
+    if (f.variant !== 'baseline') {
+        say(`NOTE: variant=${f.variant}. The counterfactual lens only populates on 'baseline',`);
+        say('      where the gate pre-empts Step 4. Nothing to report.');
+    }
+    const s = counterfactualSummary(f.rows);
+    say('');
+    say('================================================================================');
+    say(`CONFIDENCE-GATE COUNTERFACTUAL   [${f.label}] variant=${f.variant} tree=${f.gitDirty}`);
+    say(`snapshot ${f.snapshotTakenAt}   population: ${f.snapshotPopulation}`);
+    say('================================================================================');
+    say(`EARLY-EXIT POPULATION: ${s.earlyExit} of ${s.rows} rows (${s.earlyExitPct.toFixed(1)}%)`);
+    if (s.earlyExit === 0) { say('  (the gate never fired on this population)'); return; }
+    say(`   gate winner == rerank winner (AGREE):    ${String(s.agree).padStart(5)}  (${((100 * s.agree) / s.earlyExit).toFixed(1)}%)`);
+    say(`   gate winner != rerank winner (DISAGREE): ${String(s.disagree).padStart(5)}  (${((100 * s.disagree) / s.earlyExit).toFixed(1)}%)`);
+    say(`   rerank would have DECLINED (no winner):  ${String(s.rerankDeclined).padStart(5)}  (${((100 * s.rerankDeclined) / s.earlyExit).toFixed(1)}%)`);
+    say('   ^ the declined row is load-bearing for any "demote the gate to a backstop"');
+    say('     proposal: at 0 the reranker never abstains where the gate fires, so the');
+    say('     demotion cannot manufacture a no-winner fall-through into AI backfill.');
+    say('');
+    say('exit reason -> disagreement rate');
+    for (const [k, v] of s.byReason) say(`   ${k.padEnd(34)} ${String(v.disagree).padStart(4)}/${String(v.total).padStart(4)}`);
+    if (s.medianCounterMicros != null) {
+        say('');
+        say(`median wall time of the Step 4 the gate skipped: ${s.medianCounterMicros.toFixed(0)} us`);
+        say('   (simpleRerank is a pure function — there is no LLM in src/lib/mapping — so');
+        say('    this is the entire cost the gate avoids. Measure it; do not assert it.)');
+    }
+    sayAll(formatScreens(runScreens(s.pairs, 'GATE', 'RERANK'), top));
+    say('');
+    say('LIMIT: `counter` is a COUNTERFACTUAL, not an outcome. It shows what simpleRerank');
+    say('WOULD have returned on the frozen pool. It never shows which pick is CORRECT.');
+    say('Two of the three mechanical screens were a wash on the original read (kcal');
+    say('direction 117/114, Atwater 6/4); only class drift was asymmetric (53/2).');
+}
+
+// ============================================================
+// 14. VERIFY — the only mode that proves the transcription faithful
+// ============================================================
+
+/**
+ * Run the REAL mapper end to end with the gather interceptor in record-and-continue
+ * mode, then replay the captured pool through replaySelection() and compare the
+ * selection on TWO axes: foodId, and (on rows where foodId agreed) confidence.
+ *
+ * Buckets:
+ *   MATCH                the transcription reproduced the real pipeline's foodId
+ *   MISMATCH-EXPLAINED   the mapper's own telemetry shows a POST-SELECTION override
+ *                        (save-gate rejection, AI backfill, no_match). Selection
+ *                        agreed; something after Step 4 changed the answer.
+ *   MISMATCH-UNEXPLAINED a transcription bug. MUST BE 0.
+ *   NO-GATHER            the full gather never ran (fast path / cache / early error);
+ *                        there is nothing to compare.
+ *
+ * WHY CONFIDENCE IS COMPARED AT ALL (added 2026-07-26, and it is not decoration).
+ * Until the Mitigation-A revert, the gate-backstop caller differed from the baseline
+ * in a way that MOVED RECORDS, so a foodId-only verify could go red on it and was
+ * demonstrated to (stubbing the mitigations produced 6 MISMATCH-UNEXPLAINED). After
+ * the revert the ONLY things `backstop` still changes on a row where the reranker
+ * names someone are the confidence lift and its scope — and neither moves a foodId.
+ * A foodId-only verify is therefore STRUCTURALLY INCAPABLE of failing on Mitigation
+ * B, for every possible population: it is not that the population is too small, it
+ * is that the comparison does not look at the field. That is exactly the shape of
+ * "a green receipt from a test that cannot fail", so the comparison was widened
+ * rather than the population.
+ *
+ * The confidence axis is deliberately restricted to rows that already MATCHED on
+ * foodId: two different records have two incomparable confidences, and comparing
+ * them would manufacture noise on precisely the rows that are already reported.
+ *
+ * CONF-DIVERGED is NOT automatically a transcription bug — the mapper can legally
+ * rewrite `confidence` after Step 4 (the AI-simplify fallback, the dietary fallback
+ * and the AI-generated path all assign their own), so a diverged row on a
+ * non-`rerank`/`confidence_gate_*` funnel stage is expected. Rows where the mapper
+ * returned the Step 4 record untouched are the ones that must agree, and those are
+ * counted separately as CONF-UNEXPLAINED, which MUST BE 0.
+ */
+/** Absolute tolerance for the confidence comparison — float noise only, not slack. */
+const CONF_EPSILON = 1e-6;
+async function runVerify(pop: PopulationLine[], variant: SelectionVariant, debug: boolean, allowDrift: boolean, outPath?: string) {
+    const drift = checkDrift(allowDrift);
+    announceVariantFit(drift, variant);
+    if (drift.treeVariant !== variant) {
+        say('');
+        say('REFUSING: `verify` compares the transcription against the REAL mapper running in');
+        say('this tree. Verifying a variant the tree does not contain would compare the copy');
+        say(`against code that is not here. Run this in a tree whose caller is '${variant}',`);
+        say(`or verify --variant ${drift.treeVariant ?? '<the tree\'s shape>'} instead.`);
+        process.exitCode = 2;
+        return;
+    }
+    installWriteGuard();
+
+    const sink = { capture: null as GatherCapture | null };
+    const aiSink: AiSink = { llm: null, cache: null };
+    const restoreGather = installGatherInterceptor('continue', sink);
+    const restoreAi = installAiInterceptors(aiSink);
+
+    const results: any[] = [];
+    let match = 0;
+    let explained = 0;
+    let unexplained = 0;
+    let noGather = 0;
+    let confMatch = 0;
+    let confRewritten = 0;
+    let confUnexplained = 0;
+    const confDiverged: any[] = [];
+
+    for (let i = 0; i < pop.length; i++) {
+        const p = pop[i];
+        sink.capture = null; aiSink.llm = null; aiSink.cache = null;
+        suppressedWrites = {};
+        const telemetry: MappingTelemetry = {};
+        let real: any = null;
+        let err: string | undefined;
+        muzzle(true);
+        try {
+            real = await mapperMod.mapIngredientWithFallback(p.query, {
+                skipCache: true, debug, allowLiveFallback: true, skipOnLock: true, telemetry,
+            });
+        } catch (e: any) {
+            err = e?.message ?? String(e);
+        }
+        muzzle(false);
+
+        const c = takeCapture(sink);
+        if (!c) {
+            noGather++;
+            results.push({ query: p.query, bucket: 'NO-GATHER', funnelStage: telemetry.funnelStage, error: err });
+            say(`  [${i + 1}/${pop.length}] NO-GATHER   ${p.query}   (funnel=${telemetry.funnelStage ?? '?'})`);
+            continue;
+        }
+
+        const entry: SnapshotEntry = {
+            query: p.query, origin: p.origin, goldenId: p.goldenId, ok: true,
+            gatherRawLine: c.gatherRawLine, trimmed: c.gatherRawLine.trim(),
+            parsed: c.parsed, normalizedName: c.normalizedName,
+            isBrandedQuery: c.isBrandedQuery, targetBrand: c.targetBrand, aiSynonyms: c.aiSynonyms,
+            ...resolveAiEstimate(aiSink),
+            candidates: c.candidates, suppressedWrites: { ...suppressedWrites }, elapsedMs: 0,
+        };
+        await preEnrichAiGenerated([entry]);
+        const row = replaySelection(entry, debug, variant);
+
+        const realId: string | null = real && typeof real === 'object' && 'foodId' in real ? String(real.foodId) : null;
+        const replayId = row.winner?.foodId ?? null;
+
+        let bucket: string;
+        if (realId === replayId) { bucket = 'MATCH'; match++; }
+        else {
+            // A post-selection override is the only benign explanation.
+            const stage = telemetry.funnelStage;
+            const postSelection =
+                stage === 'save_rejected' || stage === 'no_match' || stage === 'error' ||
+                stage === 'all_filtered' || stage === 'no_candidates' || stage === 'fast_path' ||
+                stage === 'cache_hit' ||
+                // AI backfill invented a record that was never in the pool
+                (realId != null && !entry.candidates.some(x => x.id === realId));
+            if (postSelection) { bucket = 'MISMATCH-EXPLAINED'; explained++; }
+            else { bucket = 'MISMATCH-UNEXPLAINED'; unexplained++; }
+        }
+
+        // ---- CONFIDENCE AXIS (only meaningful where the record already agreed) ----
+        const realConf: number | null =
+            real && typeof real === 'object' && typeof (real as any).confidence === 'number'
+                ? (real as any).confidence : null;
+        const replayConf: number | null = row.winner?.confidence ?? null;
+        let confBucket: string | null = null;
+        if (bucket === 'MATCH' && realConf != null && replayConf != null) {
+            if (Math.abs(realConf - replayConf) <= CONF_EPSILON) { confBucket = 'CONF-MATCH'; confMatch++; }
+            else {
+                // The mapper legally reassigns `confidence` on the paths that build
+                // their own result (AI simplify, dietary fallback, ai_generated).
+                // Those are not transcription bugs. The rows that MUST agree are the
+                // ones where Step 4's own winner was carried to the return: the
+                // replay resolved through a Step 4 path AND the funnel stage is one of
+                // the three that a Step 4 winner can end on.
+                const step4Path = row.path === 'rerank' || row.path === 'confidence_gate_backstop'
+                    || row.path === 'confidence_gate_early_exit' || row.path === 'scored_by_confidence';
+                const step4Stage = telemetry.funnelStage === 'saved'
+                    || telemetry.funnelStage === 'under_gate' || telemetry.funnelStage === 'save_rejected';
+                if (step4Path && step4Stage) { confBucket = 'CONF-UNEXPLAINED'; confUnexplained++; }
+                else { confBucket = 'CONF-REWRITTEN'; confRewritten++; }
+                confDiverged.push({
+                    query: p.query, realConf, replayConf, funnelStage: telemetry.funnelStage ?? null,
+                    gateReason: row.gate.reason, gateFired: row.gate.skipAiRerank,
+                    path: row.path, confBucket,
+                });
+            }
+        }
+
+        results.push({
+            query: p.query, bucket, realId, replayId,
+            realName: real?.foodName ?? null, replayName: row.winner?.foodName ?? null,
+            realSource: real?.source ?? null, funnelStage: telemetry.funnelStage,
+            dropReason: telemetry.dropReason, path: row.path, gate: row.gate, error: err,
+            realConf, replayConf, confBucket,
+        });
+        say(`  [${i + 1}/${pop.length}] ${bucket.padEnd(20)} ${(confBucket && confBucket !== 'CONF-MATCH' ? confBucket : '').padEnd(17)} ${p.query}` +
+            (bucket === 'MATCH' ? '' : `   real=${realId} (${real?.foodName ?? '-'})  replay=${replayId} (${row.winner?.foodName ?? '-'})  funnel=${telemetry.funnelStage ?? '?'}`) +
+            (confBucket && confBucket !== 'CONF-MATCH' ? `   conf real=${realConf?.toFixed(3)} replay=${replayConf?.toFixed(3)} funnel=${telemetry.funnelStage ?? '?'}` : ''));
+    }
+
+    restoreGather();
+    restoreAi();
+
+    say('');
+    say('================================================================================');
+    say(`TRANSCRIPTION VERIFY   variant=${variant}   tree=${gitDirtyHash()}`);
+    say(`  MATCH                 ${match}`);
+    say(`  MISMATCH-EXPLAINED    ${explained}   (post-selection override: save gate / AI backfill / no_match)`);
+    say(`  MISMATCH-UNEXPLAINED  ${unexplained}   <- MUST BE 0`);
+    say(`  NO-GATHER             ${noGather}   (fast path or cache; nothing to compare)`);
+    say('  --- confidence axis, over the MATCH rows only ---');
+    say(`  CONF-MATCH            ${confMatch}`);
+    say(`  CONF-REWRITTEN        ${confRewritten}   (mapper reassigned confidence after Step 4)`);
+    say(`  CONF-UNEXPLAINED      ${confUnexplained}   <- MUST BE 0`);
+    say('================================================================================');
+    for (const d of confDiverged) {
+        say(`  ${d.confBucket.padEnd(17)} ${d.query}  real=${d.realConf?.toFixed(3)} replay=${d.replayConf?.toFixed(3)}` +
+            `  funnel=${d.funnelStage ?? '?'}  path=${d.path}  gate=${d.gateFired ? d.gateReason : 'off'}`);
+    }
+    if (unexplained > 0) {
+        say('The transcription in section 9 does NOT reproduce the real pipeline. Every');
+        say('number this harness produces is suspect until that is 0.');
+        process.exitCode = 1;
+    }
+    if (confUnexplained > 0) {
+        say('The transcription agrees on the RECORD but not on the CONFIDENCE the caller');
+        say('assigned it, on a row the mapper carried straight out of Step 4. That is the');
+        say('same class of bug as a moved winner — `confidence` is the cache-admission');
+        say('signal — and it is what the confidence axis exists to catch.');
+        process.exitCode = 1;
+    }
+    if (outPath) {
+        writeJsonAtomic(outPath, {
+            kind: 'winner-diff/verify', version: 2, ranAt: new Date().toISOString(),
+            gitHead: gitHead(), gitDirty: gitDirtyHash(), variant,
+            callerHash: checkDrift(true).caller,
+            counts: { match, explained, unexplained, noGather, confMatch, confRewritten, confUnexplained },
+            rows: results,
+        });
+        say(`verify receipt written: ${outPath}`);
+    }
+}
+
+// ============================================================
+// 15. TRANSCRIPT — eyeball the copy against the original in one command
+// ============================================================
+
+function runTranscript() {
+    const cb = callerBlockSource();
+    const self = fs.readFileSync(__filename.replace(/\.js$/, '.ts'), 'utf8').split('\n');
+    const s = self.findIndex(l => l.includes('>>> TRANSCRIPTION BEGIN'));
+    const eIdx = self.findIndex(l => l.includes('<<< TRANSCRIPTION END'));
+
+    say('');
+    say('================================================================================');
+    say(`REAL CALLER — ${MAPPER_FILE} lines ${cb.startLine}-${cb.endLine}`);
+    say(`  (hash ${sha(cb.text)} = variant '${KNOWN_CALLERS[sha(cb.text)] ?? 'UNRECOGNISED'}')`);
+    say('================================================================================');
+    cb.lines.forEach((l, i) => say(String(cb.startLine + i).padStart(6) + '  ' + l));
+    say('');
+    say('================================================================================');
+    say('HARNESS TRANSCRIPTION — winner-diff.ts (between the TRANSCRIPTION anchors)');
+    say('================================================================================');
+    if (s < 0 || eIdx < 0) { say('  (anchors not found — is this file compiled/minified?)'); return; }
+    self.slice(s, eIdx + 1).forEach((l, i) => say(String(s + 1 + i).padStart(6) + '  ' + l));
+    say('');
+    say('Diff these BY EYE. The drift hash only proves the left-hand side did not move;');
+    say('`winner-diff verify` is the only mode that proves the right-hand side is right.');
+}
+
+// ============================================================
+// 16. POPULATIONS
+// ============================================================
+
+async function buildPopulation(): Promise<{ lines: PopulationLine[]; description: string }> {
+    const limit = argInt('limit') ?? 200;
+
+    if (has('--from-file')) {
+        const f = argStr('from-file');
+        if (!f) throw new Error('--from-file needs a path');
+        const lines = parseQueryFile(fs.readFileSync(f, 'utf8')).slice(0, limit);
+        return {
+            lines: lines.map(q => ({ query: q, origin: classifyOrigin(q) })),
+            description: `--from-file ${f} (limit ${limit})`,
+        };
+    }
+
+    if (has('--golden')) {
+        const gp = argStr('golden-set') ?? path.join(REPO_ROOT, 'scripts/eval/golden-set.json');
+        const includeMultiItem = has('--include-multi-item');
+        const cases: GoldenCase[] = parseGoldenSet(JSON.parse(fs.readFileSync(gp, 'utf8')), { includeMultiItem })
+            .slice(0, limit);
+        return {
+            lines: cases.map(c => ({ query: c.rawText, origin: 'user' as QueryOrigin, goldenId: c.id })),
+            description: `--golden ${gp} (nlp cases${includeMultiItem ? ' incl. multi-item `text` lines' : ', single-item only'}, limit ${limit})`,
+        };
+    }
+
+    if (has('--from-cache')) {
+        const order = argStr('order') ?? 'used';
+        const decorate = argStr('decorate');
+        let rows: Array<{ normalizedForm: string; usedCount: number }>;
+        if (order === 'random') {
+            rows = await prisma.$queryRawUnsafe(
+                'SELECT "normalizedForm", "usedCount" FROM "FoodMapping" ORDER BY random() LIMIT $1', limit);
+        } else {
+            rows = await prisma.foodMapping.findMany({
+                select: { normalizedForm: true, usedCount: true },
+                orderBy: order === 'recent' ? { lastUsedAt: 'desc' } : { usedCount: 'desc' },
+                take: limit,
+            });
+        }
+        const lines = rows.map(r => {
+            const q = decorate ? decorate.replace('{key}', r.normalizedForm) : r.normalizedForm;
+            return { query: q, origin: classifyOrigin(q), count: r.usedCount };
+        });
+        return { lines, description: `--from-cache order=${order} limit=${limit}${decorate ? ` decorate="${decorate}"` : ''}` };
+    }
+
+    // default: --from-events
+    const sinceRaw = argStr('since') ?? '30d';
+    const minCount = argInt('min-count') ?? 1;
+    const days = parseInt(sinceRaw.replace(/[^0-9]/g, ''), 10) || 30;
+    const since = new Date(Date.now() - days * 24 * 3600 * 1000);
+    // KNOWN LIMITATION: --min-count is applied AFTER the DB `take`, so a large
+    // --min-count can return fewer than --limit rows even when enough qualifying
+    // lines exist. The 3x over-fetch covers the common cases. If you need it exact,
+    // move the predicate into a groupBy `having` — do not silently accept a short
+    // population, because a population smaller than you asked for is a denominator
+    // you did not choose.
+    const grouped = await prisma.mappingEventLog.groupBy({
+        by: ['rawLine'],
+        where: { createdAt: { gte: since } },
+        _count: { rawLine: true },
+        orderBy: { _count: { rawLine: 'desc' } },
+        take: limit * 3,
+    });
+    const lines = grouped
+        .filter((g: any) => g._count.rawLine >= minCount)
+        .slice(0, limit)
+        .map((g: any) => ({ query: g.rawLine as string, origin: classifyOrigin(g.rawLine), count: g._count.rawLine }));
+    return { lines, description: `--from-events since=${days}d min-count=${minCount} limit=${limit}` };
+}
+
+function printPopulationCaveat(desc: string, lines: PopulationLine[]) {
+    const split = originSplit(lines.map(l => l.query));
+    say('');
+    say(`POPULATION: ${desc}   -> ${lines.length} queries`);
+    say(`  origin split: user ${split.user}   warmer-shaped ${split.warmer} (${split.warmerPct.toFixed(1)}%)`);
+    if (desc.startsWith('--from-events') || desc.startsWith('--from-cache')) {
+        say('  CAVEAT: this population contains ONLY queries that have ALREADY BEEN ASKED.');
+        say('  It therefore CANNOT see any case the change is supposed to CREATE — such a');
+        say('  change will show SAME on 100% of rows because the query that would prove it');
+        say('  is not here. Pair the diff with a hand-written positive case list.');
+    }
+    if (desc.startsWith('--from-events')) {
+        say('  CAVEAT: MappingEventLog also holds lines our own warmers wrote —');
+        say('  cache-parity-sweep.ts posts "100g <token-sorted FoodMapping key>". Word order');
+        say('  is signal here (deriveMustHaveTokens is order-sensitive), so those exercise');
+        say('  different filters than sentences users type.');
+    }
+    if (desc.startsWith('--from-cache')) {
+        say('  CAVEAT: FoodMapping.normalizedForm is token-SORTED and singularized. Feeding');
+        say('  keys back through the mapper is a legitimate PARITY population, but it is not');
+        say('  the user distribution.');
+    }
+}
+
+// ============================================================
+// 17. plumbing
+// ============================================================
+
+function writeJsonAtomic(p: string, obj: unknown) {
+    const tmp = p + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2));
+    fs.renameSync(tmp, p);
+}
+
+function readSnapshot(p: string): SnapshotFile {
+    const s = JSON.parse(fs.readFileSync(p, 'utf8')) as SnapshotFile;
+    if (s.kind !== 'winner-diff/snapshot') throw new Error(`${p} is not a winner-diff snapshot (kind=${(s as any).kind})`);
+    return s;
+}
+
+function gitHead(): string {
+    if (process.env.WINNER_DIFF_TREE_ID) return process.env.WINNER_DIFF_TREE_ID;
+    try { return require('child_process').execSync('git rev-parse --short HEAD', { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim(); }
+    catch { return 'nogit'; }
+}
+
+/**
+ * Identity of the code actually under test. NOT `git diff` — A/B trees are routinely
+ * plain copies with no .git at all, where `git rev-parse` reports the wrong thing or
+ * nothing. Hashing src/lib/mapping/*.ts means two replays with the same value provably
+ * ran the same mapping code, which is exactly the property the noise floor needs.
+ */
+function gitDirtyHash(): string {
+    try {
+        const dir = path.join(REPO_ROOT, 'src/lib/mapping');
+        const parts: string[] = [];
+        for (const f of fs.readdirSync(dir).sort()) {
+            if (!f.endsWith('.ts')) continue;
+            parts.push(f + ':' + sha(fs.readFileSync(path.join(dir, f), 'utf8')));
+        }
+        return sha(parts.join('\n')).slice(0, 8);
+    } catch { return 'unknown'; }
+}
+
+function has(flag: string): boolean { return process.argv.includes(flag); }
+
+function argStr(name: string): string | undefined {
+    const eq = process.argv.find(a => a.startsWith(`--${name}=`));
+    if (eq) return eq.slice(name.length + 3);
+    const i = process.argv.indexOf('--' + name);
+    if (i < 0) return undefined;
+    const v = process.argv[i + 1];
+    return v && !v.startsWith('--') ? v : undefined;
+}
+
+function argInt(name: string): number | undefined {
+    const v = argStr(name);
+    if (v === undefined) return undefined;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+function resolveVariant(): SelectionVariant {
+    const v = (argStr('variant') ?? 'baseline') as SelectionVariant;
+    if (!VARIANTS.includes(v)) throw new Error(`--variant must be one of ${VARIANTS.join(' | ')}`);
+    return v;
+}
+
+const HELP = `
+winner-diff — frozen-pool WINNER diff for admission / ranking changes.   READ-ONLY.
+
+MODES
+  snapshot        Freeze the real gathered+filtered candidate pool per query.
+                  Runs retrieval + LLM ONCE; every later replay shares it, so
+                  retrieval nondeterminism cannot contaminate the diff.
+  replay          Run selection over a frozen snapshot. Deterministic.
+  noise-floor     Replay the SAME variant on the SAME snapshot twice and assert
+                  0 winner differences. Writes the receipt \`diff\` requires.
+  diff            Compare replay A vs replay B. Reports WINNER changes — never a
+                  pool-set Jaccard, which is the measurement that hides
+                  non-monotone consumers.
+  counterfactual  One replay, no B tree: for every confidenceGate early exit,
+                  what would simpleRerank have picked on the identical pool?
+  verify          Run the REAL mapper end to end and compare the transcription's
+                  selection with it on TWO axes: foodId, and confidence on the rows
+                  whose foodId agreed. The only proof the transcription is faithful.
+                  MISMATCH-UNEXPLAINED and CONF-UNEXPLAINED must both be 0.
+                  (Confidence is not decoration: it is the cache-admission signal,
+                  and since the Mitigation-A revert it is the ONLY axis on which the
+                  gate-backstop caller differs from the baseline when the reranker
+                  names a winner.)
+  transcript      Print the real caller and this file's transcription side by side.
+  hashes          Print the drift hashes.
+
+POPULATION FLAGS  (snapshot, verify)
+  --from-events [--since 30d] [--min-count N] [--limit N]      MappingEventLog.rawLine
+  --from-cache  [--order used|recent|random] [--decorate "100g {key}"] [--limit N]
+  --from-file <path>                                           newline list, # comments
+  --golden [--golden-set <path>] [--include-multi-item]        scripts/eval/golden-set.json
+
+  READ THIS BEFORE QUOTING A RATE: --from-events and --from-cache contain ONLY
+  queries that have ALREADY BEEN ASKED. They therefore CANNOT see any case the
+  change is supposed to CREATE — such a change shows SAME on 100% of rows because
+  the query that would prove it is not in the population. That blind spot has
+  invalidated a gate before. Always pair the diff with a hand-written positive case
+  list that asserts the RIGHT answer (never one that merely forbids a wrong one).
+
+  --from-events additionally mixes user traffic with lines our own warmers wrote
+  ("100g <token-sorted FoodMapping key>", ~31% of the log on the last measured
+  population). Rows are tagged \`origin\` and the split is printed.
+
+COMMON FLAGS
+  --variant baseline|gate-backstop   which selection shape to transcribe
+  --debug        pass debug:true into the real filter (FilterResult reasons log)
+  --verbose      do not muzzle library stdout; replay also prints every row
+  --allow-drift  run even though the caller block moved (re-transcribe first)
+  --top N        max rows printed per section (default 30)
+  --screens      diff: print the class-drift / Atwater / kcal-delta screens
+  --cross-snapshot  diff: accept A and B from DIFFERENT snapshots. The report is
+                    then labelled RETRIEVAL-NOISE-CONTAMINATED, because some of the
+                    changes are Typesense/FatSecret returning a different pool, not
+                    your code. That is retrievalNoise, a different number from the
+                    replay noise floor, and it is genuinely non-zero.
+  --resume       snapshot: continue an interrupted run from the .ndjson sidecar
+
+TYPICAL SEQUENCE
+  RUN='npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/winner-diff.ts'
+  $RUN snapshot --from-events --limit 400 --out /tmp/wd-snap.json
+  $RUN noise-floor --snapshot /tmp/wd-snap.json
+  $RUN replay --snapshot /tmp/wd-snap.json --out /tmp/wd-A.json --label BASE
+  # copy the tree, edit the COPY, run the same replay from there (NEVER
+  # \`git checkout -- <file>\`: that silently discards uncommitted work)
+  $RUN diff --a /tmp/wd-A.json --b /tmp/wd-B.json --screens --snapshot /tmp/wd-snap.json
+
+READ-ONLY GUARANTEE
+  A Prisma \$use middleware no-ops every create/update/upsert/delete/executeRaw and
+  tallies what it suppressed. \`snapshot\` also aborts the mapper at gather, so the
+  save path is never reached. Nothing here calls warm-cache or saveValidatedMapping.
+`;
+
+async function main() {
+    let mode = process.argv[2];
+    if (has('--noise-floor') && mode !== 'noise-floor') mode = 'noise-floor';
+    const debug = has('--debug');
+    const allowDrift = has('--allow-drift');
+    const verbose = has('--verbose');
+    const top = argInt('top') ?? 30;
+
+    if (!mode || mode === 'help' || mode === '--help' || mode === '-h') { say(HELP); return; }
+
+    say(`winner-diff  mode=${mode}  repo=${REPO_ROOT}`);
+    say(`env: ${ENV_FILES.join(', ')}   forced: ${Object.entries(FORCED_FLAGS).map(([k, v]) => k + '=' + v).join(' ')}`);
+    say('READ-ONLY: every DB mutation is intercepted and no-oped; nothing is written to FoodMapping.');
+
+    if (mode === 'snapshot') {
+        const out = argStr('out');
+        if (!out) throw new Error('snapshot needs --out <file>');
+        checkDrift(true);
+        const { lines, description } = await buildPopulation();
+        printPopulationCaveat(description, lines);
+        say('');
+        say(`snapshotting ${lines.length} queries — the LLM and the FatSecret API WILL be called; writes are suppressed.`);
+        await runSnapshot(lines, out, description, debug, has('--resume'));
+
+    } else if (mode === 'replay') {
+        const snapPath = argStr('snapshot');
+        const out = argStr('out');
+        if (!snapPath || !out) throw new Error('replay needs --snapshot <file> --out <file> [--label X]');
+        const snap = readSnapshot(snapPath);
+        const { file, enriched } = await buildReplay(snap, argStr('label') ?? 'unlabelled', resolveVariant(), debug, allowDrift);
+        writeJsonAtomic(out, file);
+        printReplaySummary(file, enriched, verbose);
+        say('');
+        say(`replay written: ${out}`);
+
+    } else if (mode === 'noise-floor' || mode === 'noise') {
+        const snapPath = argStr('snapshot');
+        if (!snapPath) throw new Error('noise-floor needs --snapshot <file>');
+        await runNoiseFloor(snapPath, resolveVariant(), debug, allowDrift);
+
+    } else if (mode === 'diff') {
+        const a = argStr('a');
+        const b = argStr('b');
+        if (!a || !b) throw new Error('diff needs --a <replayA.json> --b <replayB.json>');
+        runDiff(a, b, {
+            screens: has('--screens'),
+            crossSnapshot: has('--cross-snapshot'),
+            top,
+            jsonOut: argStr('json'),
+            goldenPath: has('--golden') ? (argStr('golden-set') ?? path.join(REPO_ROOT, 'scripts/eval/golden-set.json')) : undefined,
+        });
+
+    } else if (mode === 'counterfactual') {
+        const r = argStr('replay');
+        if (!r) throw new Error('counterfactual needs --replay <replay.json>');
+        runCounterfactual(r, top);
+
+    } else if (mode === 'verify') {
+        const { lines, description } = await buildPopulation();
+        printPopulationCaveat(description, lines);
+        say('');
+        say('verify runs the FULL mapper (LLM + API calls). Writes remain suppressed.');
+        await runVerify(lines, resolveVariant(), debug, allowDrift, argStr('out'));
+
+    } else if (mode === 'transcript') {
+        runTranscript();
+
+    } else if (mode === 'hashes') {
+        const d = checkDrift(true);
+        const cb = callerBlockSource();
+        say(`caller=${d.caller}  helpers=${d.helpers}  callerLines=${cb.startLine}-${cb.endLine}  mappingDir=${gitDirtyHash()}`);
+        say(`known callers: ${Object.entries(KNOWN_CALLERS).map(([h, v]) => `${h}=${v}`).join('  ')}`);
+        say(`this tree is: ${d.treeVariant ?? 'UNRECOGNISED'}   helpers ${d.helpers === PINNED_HELPERS_HASH ? 'match' : 'DRIFTED'}`);
+
+    } else {
+        say(HELP);
+        process.exitCode = 2;
+    }
+}
+
+// Only run when invoked as a script. Importing this file (e.g. from a test) must
+// not execute a full run — that is exactly how the abstention hole in run-eval.ts
+// stayed invisible.
+if (require.main === module) {
+    main()
+        .then(async () => { muzzle(true); try { await prisma.$disconnect(); } catch { /* noop */ } muzzle(false); process.exit(process.exitCode ?? 0); })
+        .catch(async (e) => { muzzle(false); say('FATAL: ' + (e?.stack ?? e?.message ?? String(e))); try { await prisma.$disconnect(); } catch { /* noop */ } process.exit(1); });
+}
+
+export { replaySelection, mkWinner };
+export type { SnapshotEntry, SnapshotFile };

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -1641,125 +1641,376 @@ export async function mapIngredientWithFallback(
 
                     const gateResult = confidenceGate(searchQuery, sortedFiltered, trimmed);
 
-                    if (gateResult.skipAiRerank && gateResult.selected) {
-                        winner = gateResult.selected;
-                        confidence = gateResult.confidence;
-                        selectionReason = gateResult.reason || 'confidence_gate';
-                    } else {
-                        // Step 4: Simple rerank (Token-based)
-                        // Use filtered (not sortedFiltered) to ensure high-overlap candidates aren't pushed out
-                        // simpleRerank will do its own scoring based on token overlap + other factors
+                    // Step 3b (Jul 2026): the confidence gate is a BACKSTOP, not a
+                    // pre-emption. It used to short-circuit Step 4 outright —
+                    // `skipAiRerank` handed back its own pick and simpleRerank never
+                    // ran at all — and that shortcut is what three separate
+                    // investigations in one week kept tripping over.
+                    //
+                    // Why the short-circuit had to go:
+                    //
+                    //  * The gate's judge is PURE RECALL. assessConfidence
+                    //    (gather-candidates.ts) is `overlap / queryTokens`, plus a
+                    //    position bonus, plus +0.15 for substring containment. It never
+                    //    penalises tokens the CANDIDATE carries that the query never
+                    //    used, and it reads `candidate.name` only — `brandName` is
+                    //    invisible to it. "subway cold cut combo" against
+                    //    "Subway, Cold Cut Combo Salad" (15.7 kcal/100g against the
+                    //    sandwich's 69.5) scores 0.85 — still enough to exit, because
+                    //    the extra noun that changes what the food IS costs nothing.
+                    //    It reaches a clean 1.000 when the brand-stripped `parsed.name`
+                    //    ("cold cut combo") is what arrives at the gate, which is the
+                    //    common case and the sharper statement of the defect.
+                    //    simpleRerank is the only stage on this path that carries
+                    //    precision terms — and it was the stage being skipped.
+                    //
+                    //  * The name is a fossil. `skipAiRerank` reads as if the gate is
+                    //    saving an expensive LLM call. It is not. Nothing on the
+                    //    confidenceGate/simpleRerank path awaits an LLM — simpleRerank
+                    //    is pure and synchronous (`grep -c "await " simple-rerank.ts`
+                    //    is 0), measured at p50 116µs / p95 253µs over 441 gate lines.
+                    //    Be precise about this, because the looser version of the claim
+                    //    is false and has already been written down once: there ARE
+                    //    LLM clients in this directory (ai-rerank.ts is a full
+                    //    OpenAI-compatible client, and `aiSimplifyIngredient` is
+                    //    awaited by THIS file further down) — they simply are not on
+                    //    the path the gate short-circuits. The gate was buying a
+                    //    fraction of a millisecond and paying for it in wrong records.
+                    //
+                    //  * Measured, not reasoned about. Replayed over the FROZEN
+                    //    candidate pool so both paths saw an identical pool, with the
+                    //    write guard on (noise floor re-measured at 0.0%): the gate
+                    //    fires on 10.6% of logged lines and disagrees with simpleRerank
+                    //    on 60.8% of them. All 296 unique disagreements were then
+                    //    adjudicated row by row (not sampled and scaled): 115 IMPROVE,
+                    //    50 REGRESS, 110 lateral, 12 both-wrong, 9 undetermined —
+                    //    net +65, a 2.3:1 ratio. The sharpest screen is class drift: 53
+                    //    rows where ONLY the gate's winner carries a food-class noun the
+                    //    query never used (salad / soup / sauce / mix), against 2 rows
+                    //    for the reranker.
+                    //
+                    //    The 50 REGRESS rows are pre-existing simpleRerank defects that
+                    //    the gate was MASKING, not damage this change causes. They are
+                    //    enumerated so they can be fixed where they live. Two caveats
+                    //    that survived review and should temper the number: at least
+                    //    one row (`popeyes red beans and rice`) is both-wrong rather
+                    //    than a regression, and at least one (`dr pepper`) is a
+                    //    RETRIEVAL defect — its pool contains no plain Dr Pepper record
+                    //    at all because the normalized query is "dr black pepper" — so
+                    //    no ranking change can fix it.
+                    //
+                    // What survives: the gate still RUNS, its verdict is still computed
+                    // and logged, and it is still honoured — but only when simpleRerank
+                    // declines to name anyone. As a last resort it strictly beats the
+                    // raw `sortedFiltered[0].score >= 0.80` grab underneath it, because
+                    // it has at least asked a question about the query rather than
+                    // trusting the search engine's own ordering.
+                    //
+                    // Known, accepted cost of the demotion: on lines where the two
+                    // stages pick DIFFERENT records, `confidence` now comes from
+                    // simpleRerank's scale instead of the gate's, so some formerly
+                    // gate-selected lines land under the `confidence >= 0.85` save gate
+                    // at Step 6 and reach the cache only through sub-threshold
+                    // admission, which is insert-only. That is coverage traded for
+                    // record identity, on purpose. Lines where the two stages AGREE on
+                    // the record AND the gate exited via `high_confidence_clear_winner`
+                    // are held at the higher of the two — see the rerank winner
+                    // assignment below; without that, identical answers lost their cache
+                    // save (`restaurant hibachi chicken` kept its record and went
+                    // 0.917 -> 0.707, under both the 0.85 gate and the 0.75 floor).
+                    // `mapping.confidence_gate_overridden` below is how the trade is
+                    // watched in production.
+                    const gateSelection = gateResult.skipAiRerank ? gateResult.selected : undefined;
 
-                        // Count-labeled SKU preference (Cluster A pt2, Jul 2026): when the
-                        // user is counting pieces, nudge rerank toward SKUs whose label
-                        // declares that piece's count — their per-piece weight is
-                        // authoritative via the label-count-derived path in buildOffResult.
-                        const countedNoun = countedPieceNoun(parsed);
+                    // Step 4: Simple rerank (Token-based)
+                    // Use filtered (not sortedFiltered) to ensure high-overlap candidates aren't pushed out
+                    // simpleRerank will do its own scoring based on token overlap + other factors
 
-                        // Enrich Generic candidates with cached nutrition data.
-                        const candidatesForRerank = filtered.slice(0, 10);
-                        // Counted queries: let count-labeled SKUs below the top-10 cutoff
-                        // compete too (they still have to win the rerank on merit).
-                        if (countedNoun) {
-                            for (const c of filtered.slice(10)) {
-                                if (candidatesForRerank.length >= 13) break;
-                                if (candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
-                            }
+                    // Count-labeled SKU preference (Cluster A pt2, Jul 2026): when the
+                    // user is counting pieces, nudge rerank toward SKUs whose label
+                    // declares that piece's count — their per-piece weight is
+                    // authoritative via the label-count-derived path in buildOffResult.
+                    const countedNoun = countedPieceNoun(parsed);
+
+                    // Enrich Generic candidates with cached nutrition data.
+                    const candidatesForRerank = filtered.slice(0, 10);
+                    // Counted queries: let count-labeled SKUs below the top-10 cutoff
+                    // compete too (they still have to win the rerank on merit).
+                    if (countedNoun) {
+                        for (const c of filtered.slice(10)) {
+                            if (candidatesForRerank.length >= 13) break;
+                            if (candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
                         }
-                        const fsCandidatesMissingNutr = candidatesForRerank
-                            .filter(c => c.source === 'ai_generated' && !c.nutrition);
-                        if (fsCandidatesMissingNutr.length > 0) {
-                            const { prisma } = await import('../db');
-                            const fsIds = fsCandidatesMissingNutr.map(c => c.id);
-                            const cachedFoods = await prisma.aiGeneratedFood.findMany({
-                                where: { id: { in: fsIds } },
-                                select: {
-                                    id: true,
-                                    caloriesPer100g: true,
-                                    proteinPer100g: true,
-                                    carbsPer100g: true,
-                                    fatPer100g: true,
-                                },
-                            });
-                            for (const cf of cachedFoods) {
-                                const cand = candidatesForRerank.find(c => c.id === cf.id);
-                                if (cand && !cand.nutrition) {
-                                    cand.nutrition = {
-                                        kcal: cf.caloriesPer100g,
-                                        protein: cf.proteinPer100g,
-                                        carbs: cf.carbsPer100g,
-                                        fat: cf.fatPer100g,
-                                        per100g: true,
-                                    };
-                                }
-                            }
-                        }
-
-                        // FDC-based fallback for AI nutrition estimate.
-                        // FDC candidates always have per-100g nutrition inline from
-                        // the search API. When no AI estimate is available (LLM gate
-                        // skipped and no cached estimate), use the best-matching FDC
-                        // candidate's nutrition as a synthetic reference for the tiebreaker.
-                        if (!aiNutritionEstimate) {
-                            const fdcRef = candidatesForRerank.find(
-                                c => c.source === 'fdc' && c.nutrition?.per100g && (c.nutrition.kcal > 0 || c.nutrition.protein > 0)
-                            );
-                            if (fdcRef && fdcRef.nutrition) {
-                                aiNutritionEstimate = {
-                                    caloriesPer100g: fdcRef.nutrition.kcal,
-                                    proteinPer100g: fdcRef.nutrition.protein,
-                                    carbsPer100g: fdcRef.nutrition.carbs,
-                                    fatPer100g: fdcRef.nutrition.fat,
-                                    confidence: 0.6,  // Lower confidence than LLM estimate
+                    }
+                    // NOT DONE HERE, DELIBERATELY, AND THE REASON IS WORTH KEEPING.
+                    //
+                    // `filtered.slice(0, 10)` above truncates over GATHER order, not
+                    // score order. On 17 of the 441 measured gate-firing lines the
+                    // gate's pick sits past index 10, so simpleRerank cannot re-select
+                    // it — those lines are a DELETION, not an adjudication, and the
+                    // backstop below cannot rescue them because the reranker did return
+                    // a winner, just a different one. `kirkland almonds` is the sharpest:
+                    // the Kirkland record is at gather index 22, so the reranker only
+                    // ever sees a Members Mark record.
+                    //
+                    // The obvious repair — append `gateSelection` to candidatesForRerank
+                    // — was written, measured, and REVERTED. Scored against the project's
+                    // own adjudication of all 296 disagreements it bought nothing: it
+                    // restored 5 of the 17, of which 2 were adjudicated rerank-better, so
+                    // the regression count did not move. It only changed WHICH rows were
+                    // wrong. And it was not free: combined with the confidence
+                    // restoration below it took `buffalo wild wings boneless wings` from
+                    // 0.710 (below the sub-threshold floor, so not cached at all) to
+                    // 1.000 — a full displacing upsert of an adjudicated-WRONG record
+                    // ("Buffalo style alaska wild wings", a frozen seafood product, over
+                    // the real BWW 6-count). Turning a transient wrong answer into a
+                    // cached one is the worse failure.
+                    //
+                    // It also flattered its own measurement: restored rows become SAME in
+                    // a baseline-vs-change diff, so they drop out of the screen population
+                    // and the class-drift number is computed on a set with the change's
+                    // own regressions removed by construction.
+                    //
+                    // The real defect is the truncation itself — `slice(0, 10)` over
+                    // gather order is the same mechanism as the composite-to-component
+                    // drift class. Fix that where it lives, with its own gate. Do not
+                    // special-case the gate pick past it.
+                    const fsCandidatesMissingNutr = candidatesForRerank
+                        .filter(c => c.source === 'ai_generated' && !c.nutrition);
+                    if (fsCandidatesMissingNutr.length > 0) {
+                        const { prisma } = await import('../db');
+                        const fsIds = fsCandidatesMissingNutr.map(c => c.id);
+                        const cachedFoods = await prisma.aiGeneratedFood.findMany({
+                            where: { id: { in: fsIds } },
+                            select: {
+                                id: true,
+                                caloriesPer100g: true,
+                                proteinPer100g: true,
+                                carbsPer100g: true,
+                                fatPer100g: true,
+                            },
+                        });
+                        for (const cf of cachedFoods) {
+                            const cand = candidatesForRerank.find(c => c.id === cf.id);
+                            if (cand && !cand.nutrition) {
+                                cand.nutrition = {
+                                    kcal: cf.caloriesPer100g,
+                                    protein: cf.proteinPer100g,
+                                    carbs: cf.carbsPer100g,
+                                    fat: cf.fatPer100g,
+                                    per100g: true,
                                 };
-                                logger.debug('mapping.fdc_nutrition_fallback', {
-                                    rawLine: trimmed,
-                                    fdcName: fdcRef.name,
-                                    fdcId: fdcRef.id,
-                                    estimate: aiNutritionEstimate.caloriesPer100g,
-                                });
                             }
                         }
+                    }
 
-                        const billsByServing = requestBillsByServing(parsed);
-                        // Cooked-grain volume requests (n-serv-06): the re-retrieval must
-                        // prefer candidates that OWN a matching volume serving over ones
-                        // that would fall back to generic density. requestBillsByServing
-                        // excludes explicit volume units by design (PR D pt2), so the
-                        // serving-shape flag is wired through this grain-scoped path.
-                        const grainVolumeUnit = !billsByServing && parsed?.unit
-                            && isMatchableVolumeUnit(parsed.unit)
-                            && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
-                            ? parsed.unit : null;
-                        const rerankCandidates = candidatesForRerank.map(c => toRerankCandidate({
-                            id: c.id,
-                            name: c.name,
-                            brandName: c.brandName,
-                            foodType: c.foodType,
-                            score: c.score,
-                            source: c.source,
-                            nutrition: c.nutrition,  // Include for Route C macro sanity check + nutrition tiebreaker
-                            countLabelMatch: countedNoun ? candidateHasCountLabel(c, countedNoun) : undefined,
-                            servingLabelMatch: billsByServing ? candidateHasServingData(c)
-                                : grainVolumeUnit ? candidateHasVolumeServing(c, grainVolumeUnit) : undefined,
-                        }));
+                    // FDC-based fallback for AI nutrition estimate.
+                    // FDC candidates always have per-100g nutrition inline from
+                    // the search API. When no AI estimate is available (LLM gate
+                    // skipped and no cached estimate), use the best-matching FDC
+                    // candidate's nutrition as a synthetic reference for the tiebreaker.
+                    if (!aiNutritionEstimate) {
+                        const fdcRef = candidatesForRerank.find(
+                            c => c.source === 'fdc' && c.nutrition?.per100g && (c.nutrition.kcal > 0 || c.nutrition.protein > 0)
+                        );
+                        if (fdcRef && fdcRef.nutrition) {
+                            aiNutritionEstimate = {
+                                caloriesPer100g: fdcRef.nutrition.kcal,
+                                proteinPer100g: fdcRef.nutrition.protein,
+                                carbsPer100g: fdcRef.nutrition.carbs,
+                                fatPer100g: fdcRef.nutrition.fat,
+                                confidence: 0.6,  // Lower confidence than LLM estimate
+                            };
+                            logger.debug('mapping.fdc_nutrition_fallback', {
+                                rawLine: trimmed,
+                                fdcName: fdcRef.name,
+                                fdcId: fdcRef.id,
+                                estimate: aiNutritionEstimate.caloriesPer100g,
+                            });
+                        }
+                    }
 
-                        // Hybrid prep stripping: prefer AI canonicalBase (strips prep but preserves
-                        // nutritional modifiers), fall back to local prep-word stripping.
-                        // The raw line (trimmed) is still passed for modifier constraint extraction.
-                        const rerankQuery = aiCanonicalBase || stripPrepModifiers(searchQuery);
-                        const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNoun != null);
+                    const billsByServing = requestBillsByServing(parsed);
+                    // Cooked-grain volume requests (n-serv-06): the re-retrieval must
+                    // prefer candidates that OWN a matching volume serving over ones
+                    // that would fall back to generic density. requestBillsByServing
+                    // excludes explicit volume units by design (PR D pt2), so the
+                    // serving-shape flag is wired through this grain-scoped path.
+                    const grainVolumeUnit = !billsByServing && parsed?.unit
+                        && isMatchableVolumeUnit(parsed.unit)
+                        && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+                        ? parsed.unit : null;
+                    const rerankCandidates = candidatesForRerank.map(c => toRerankCandidate({
+                        id: c.id,
+                        name: c.name,
+                        brandName: c.brandName,
+                        foodType: c.foodType,
+                        score: c.score,
+                        source: c.source,
+                        nutrition: c.nutrition,  // Include for Route C macro sanity check + nutrition tiebreaker
+                        countLabelMatch: countedNoun ? candidateHasCountLabel(c, countedNoun) : undefined,
+                        servingLabelMatch: billsByServing ? candidateHasServingData(c)
+                            : grainVolumeUnit ? candidateHasVolumeServing(c, grainVolumeUnit) : undefined,
+                    }));
 
-                        if (rerankResult && rerankResult.winner) {
-                            const selected = filtered.find(c => c.id === rerankResult.winner!.id);
-                            if (selected) {
-                                winner = selected;
-                                confidence = rerankResult.confidence;
-                                selectionReason = rerankResult.reason;
+                    // Hybrid prep stripping: prefer AI canonicalBase (strips prep but preserves
+                    // nutritional modifiers), fall back to local prep-word stripping.
+                    // The raw line (trimmed) is still passed for modifier constraint extraction.
+                    const rerankQuery = aiCanonicalBase || stripPrepModifiers(searchQuery);
+                    const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNoun != null);
+
+                    if (rerankResult && rerankResult.winner) {
+                        const selected = filtered.find(c => c.id === rerankResult.winner!.id);
+                        if (selected) {
+                            winner = selected;
+                            confidence = rerankResult.confidence;
+                            selectionReason = rerankResult.reason;
+                            // AGREEMENT KEEPS THE HIGHER CONFIDENCE.
+                            //
+                            // This change is about WHICH RECORD wins, not about how sure
+                            // we are. But `confidence` is also the cache-admission
+                            // signal (`admitToCache = confidence >= 0.85 || ...` below),
+                            // and the two stages report on different scales.
+                            //
+                            // Be careful about HOW they differ — an earlier draft of
+                            // this comment said simpleRerank returns
+                            // `min(0.5 + score*0.5, 0.95)` with a 0.70 floor, and that
+                            // is wrong for most of the corpus: `exact_match` adds +0.1
+                            // capped at 0.98, `branded_exact_match` lifts to 0.88, and
+                            // `cooked_grain_preference` floors at 0.75. Measured over
+                            // the 3,475 pure-rerank rows, 2,454 sit at exactly 0.98.
+                            // simpleRerank is NOT systematically lower than the gate.
+                            //
+                            // The real asymmetry is narrower and is what this guards:
+                            // on the rows where the gate fired and BOTH stages then
+                            // picked the same record, the reranker's number can still
+                            // land under 0.85 while the gate's did not. Taking the
+                            // rerank number unconditionally there silently DEMOTES a
+                            // line whose answer did not change — the record is
+                            // identical and the cache save disappears.
+                            //
+                            // Measured on the 441 gate-firing lines: 37 fall under the
+                            // 0.85 save gate, 9 of them with an UNCHANGED winner, and 2
+                            // of those also fall under SUB_THRESHOLD_SAVE_FLOOR (0.75)
+                            // so they are not cached at all. `restaurant hibachi
+                            // chicken` keeps the same record while going 0.917 -> 0.707.
+                            // Worse, the 7 that survive via `insertOnly` can never be
+                            // REFRESHED afterwards, which is exactly what the parity
+                            // sweep and the nightly flywheel rely on.
+                            //
+                            // TWO scopes, both load-bearing.
+                            //
+                            // (1) Agreement only. When the reranker names a DIFFERENT
+                            // record, the gate's confidence describes a candidate we
+                            // just rejected, and carrying it over would be laundering.
+                            //
+                            // (2) `high_confidence_clear_winner` only. The gate has
+                            // three exits and they are NOT on the same scale, despite
+                            // what "the gate exits at >= 0.85" suggests. Only this one
+                            // returns assessConfidence's actual match score.
+                            // `basic_produce_bypass` returns
+                            // `Math.max(0, Math.min(1, top1.score))` — a CLAMPED RAW
+                            // ENGINE SCORE (its own comment notes OFF runs ~0-10 and FDC
+                            // ~0-1.5), so for any OFF candidate it saturates at exactly
+                            // 1.000 and says nothing about match quality;
+                            // `yeast_variant_preference` returns a hardcoded 0.95.
+                            // Restoring those would launder a retrieval score into the
+                            // cache-admission signal. Measured: of the 132 rows this
+                            // lift touched unscoped, 27 were basic_produce_bypass, every
+                            // one at exactly 1.000, and 5 of them crossed the 0.85 save
+                            // gate on it (steamed broccoli, boiled potatoes, roasted
+                            // carrots, roasted sweet potato, 100g cooked rice white).
+                            if (
+                                gateSelection
+                                && winner.id === gateSelection.id
+                                && gateResult.reason === 'high_confidence_clear_winner'
+                            ) {
+                                confidence = Math.max(confidence, gateResult.confidence);
                             }
                         }
+                    }
 
-                        if (!winner && sortedFiltered.length > 0) {
+                    // Monitoring hook for the demotion above. Fires on exactly the
+                    // population the change exists to move — the gate would have
+                    // pre-empted, and the reranker named someone else — and carries
+                    // BOTH records (id + name + source) plus the gate's own reason, so
+                    // a production read can be adjudicated the same way the offline
+                    // replay was without reconstructing the pool. `poolSize` is here
+                    // because pool=1/pool=2 is a diagnosis in its own right: a
+                    // disagreement over a pool of one is an admission defect upstream,
+                    // not a ranking one. Silence on a gate line means the two agree and
+                    // the demotion was inert there.
+                    if (gateSelection && winner && winner.id !== gateSelection.id) {
+                        logger.info('mapping.confidence_gate_overridden', {
+                            rawLine: trimmed,
+                            query: searchQuery,
+                            gateReason: gateResult.reason,
+                            gateId: gateSelection.id,
+                            gateName: gateSelection.name,
+                            gateBrand: gateSelection.brandName ?? null,
+                            gateSource: gateSelection.source,
+                            gateConfidence: gateResult.confidence,
+                            rerankId: winner.id,
+                            rerankName: winner.name,
+                            rerankBrand: winner.brandName ?? null,
+                            rerankSource: winner.source,
+                            rerankConfidence: confidence,
+                            rerankReason: selectionReason,
+                            poolSize: filtered.length,
+                        });
+                    }
+
+                    if (!winner) {
+                        if (gateSelection) {
+                            // BACKSTOP. simpleRerank declined to name anyone, so the
+                            // gate's pick is the best-informed candidate left standing.
+                            // Deliberately ahead of the raw-score grab below: the gate
+                            // at least scored the candidate against the query.
+                            //
+                            // Distinct selectionReason so telemetry can separate a
+                            // backstop from the old pre-emptive firing (the previous
+                            // strings 'high_confidence_clear_winner' /
+                            // 'basic_produce_bypass' / 'yeast_variant_preference' now
+                            // vanish from the under_gate column entirely — expect that
+                            // in any run-over-run histogram). It is a bare constant with
+                            // no digits and no parentheses on purpose: the under_gate
+                            // class is `selectionReason.split(':')[0]` through
+                            // normalizeClassId, which strips both.
+                            // Takes the gate's confidence with NO reason scope, unlike
+                            // the agreement lift above. That asymmetry is deliberate,
+                            // not an oversight, and it is worth stating because the two
+                            // sit 100 lines apart and look inconsistent.
+                            //
+                            // On this branch simpleRerank named nobody, so there is no
+                            // second number to choose between — the alternative is not a
+                            // better-scaled confidence, it is no winner at all and a
+                            // fall-through to the AI-simplify path. Baseline behaved
+                            // exactly this way on exactly these rows, so scoping here
+                            // would be a NEW regression rather than a restoration.
+                            //
+                            // The cost is real and small: of the 9 backstop rows in the
+                            // 4,165-query population, 6 are `basic_produce_bypass` and
+                            // are therefore cached at a saturated raw engine score of
+                            // 1.000 (`chicken and rice bowl`, `rice and peas`,
+                            // `steamed carrots`, `steamed rice`, `sauteed spinach`).
+                            // That laundering predates this change. The honest fix is to
+                            // put `basic_produce_bypass` on a real confidence scale in
+                            // gather-candidates.ts, which would correct both sites at
+                            // once — not to special-case it here.
+                            winner = gateSelection;
+                            confidence = gateResult.confidence;
+                            selectionReason = 'confidence_gate_backstop';
+                            logger.info('mapping.confidence_gate_backstop', {
+                                rawLine: trimmed,
+                                query: searchQuery,
+                                gateReason: gateResult.reason,
+                                selectedId: gateSelection.id,
+                                selectedName: gateSelection.name,
+                                selectedSource: gateSelection.source,
+                                confidence,
+                                poolSize: filtered.length,
+                            });
+                        } else if (sortedFiltered.length > 0) {
                             // Fallback to top scorer ONLY if above minimum threshold
                             const MIN_FALLBACK_CONFIDENCE = 0.80;
                             if (sortedFiltered[0].score >= MIN_FALLBACK_CONFIDENCE) {


### PR DESCRIPTION
Two commits: the ranking change, and the instrument that judges it.

## The change

`confidenceGate` short-circuited `simpleRerank` outright. Its judge, `assessConfidence`, is **pure recall** — `overlap / queryTokens` plus a containment bonus. It never penalises tokens the *candidate* carries that the query never used, and it reads `candidate.name` only, so `brandName` is invisible to it. An over-specific record wins for free: `subway cold cut combo` → *"Cold Cut Combo Salad"*, 15.7 kcal/100g against the sandwich's 69.5.

`simpleRerank` is the only stage on this path carrying precision terms, and it was the stage being skipped. `skipAiRerank` is a fossil name — nothing on this path awaits an LLM and `simpleRerank` is pure at p50 116µs.

Measured on a frozen candidate pool, noise floor 0.0%: the gate fires on **10.6%** of logged lines and disagrees with `simpleRerank` on **60.8%** of them. All 296 unique disagreements adjudicated row by row (not sampled and scaled): **115 IMPROVE / 50 REGRESS / 110 lateral / 12 both-wrong / 9 undetermined**. Class drift: **53 rows where only the gate's winner** carries a food-class noun the query never used, against **2** for the reranker.

The 50 regressions are pre-existing `simpleRerank` defects the gate was *masking*. Two are miscounted and worth naming: `popeyes red beans and rice` is both-wrong (both panels broken, opposite directions), and `dr pepper` is a **retrieval** defect — the normalized query is `dr black pepper`, so the pool contains no plain Dr Pepper record and no ranking change can fix it.

## One mitigation kept, one reverted

**Kept:** on agreement *and* `high_confidence_clear_winner`, confidence is the higher of the two. `confidence` is the cache-admission signal, so taking the rerank number unconditionally demoted lines **whose answer did not change** — `restaurant hibachi chicken` kept its record and went 0.917 → 0.707, under both the 0.85 gate and the 0.75 floor. Scoped to that one exit because the other two don't return confidences: `basic_produce_bypass` returns a clamped raw engine score that saturates at 1.000 for any OFF candidate.

**Reverted, and this is the more useful record:** appending the gate pick so it survives `filtered.slice(0,10)`. The defect is real — on 17 of 441 gate lines the pick sits past index 10 of the *gather*-ordered array, making those lines a deletion rather than an adjudication. But scored against the project's own adjudication it bought nothing: restored 5, of which **2 were adjudicated rerank-better**. It composed with the kept mitigation to take `buffalo wild wings boneless wings` from 0.710 (not cached) to **1.000 — a displacing upsert of an adjudicated-wrong record**. And it flattered its own measurement: restored rows become `SAME` in a baseline-vs-change diff and drop out of the screen population.

The real defect is truncation over gather order — same mechanism as composite→component drift. It needs its own fix and its own gate.

## The harness

Every ranking judgement here has been made with a throwaway script; the one behind the 60.8% figure existed in seven scratchpad copies and was never committed.

Three properties matter more than the diff:

- **The drift guard decides fit by HASH, not variant name.** Three hashes map to `gate-backstop` and only one is transcribed. A name comparison green-lights shapes the harness no longer reproduces — in a repo Syncthing-mirrored across three machines with divergent histories, that's live.
- **`verify` compares confidence as well as `foodId`.** Not decoration: with Mitigation A reverted, *nothing* separating this variant from baseline moves a `foodId` when the reranker names a winner — so a foodId-only verify was **structurally incapable of failing for any population**. It would have printed green over a broken transcription. Both stubs now go red on the confidence axis.
- **The golden screen reports `grams`/`total` as UNKNOWN, not satisfied.** The first version printed "no golden case changed verdict" while three cases moved 45→24, 330→240 and 660→480 grams. 148 of 243 nlp cases assert grams.

## Verification

`tsc --noEmit` clean; `lint:ci` 0 errors; 66/66 harness tests; noise floor 0/0 both variants; verify 65 MATCH / 0 unexplained on both axes, proven falsifiable by two stub runs with byte-identical restores. Golden: all 10 cases reaching the gate pass, including five hard grams bands.

One pre-existing jest failure (`does NOT fast-path "canned tuna in water"`) is **not** from this change — A/B'd against the pre-demotion baseline on the full file, identical failure both ways, working file restored byte-identical.

No production writes: the eval and sweep both resolve through the mapper, which saves to `FoodMapping`, so neither was run.

## Known and not fixed here

The 17 `slice(0,10)` deletions; `1 cup broccoli` moving 120 g → 44 g with `funnel=saved` and no golden band watching it; `n-supp-13`'s new winner carrying `carbs100 = 0` and `fat100 = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx
