### PR TITLE
fix(eval): master is red, and CI has never run a single test

### DIFF
--- a/scripts/eval/__tests__/winner-diff.test.ts
+++ b/scripts/eval/__tests__/winner-diff.test.ts
@@ -475,9 +475,9 @@ describe('parseGoldenSet', () => {
         const n = (pred: (c: GoldenCase) => boolean) => all.filter(pred).length;
         expect(n(c => c.expectName.length > 0)).toBe(243);
         expect(n(c => !!c.grams)).toBe(148);              // the majority assertion
-        expect(n(c => !!c.macros)).toBe(59);
+        expect(n(c => !!c.macros)).toBe(65);
         expect(n(c => typeof c.expectItems === 'number')).toBe(47);
-        expect(n(c => !!c.total)).toBe(18);
+        expect(n(c => !!c.total)).toBe(35);
         // documented in _readme, no live case uses them — parsed anyway so the screen
         // does not go blind the moment one is added back
         expect(n(c => !!c.forbidName)).toBe(0);
@@ -485,16 +485,18 @@ describe('parseGoldenSet', () => {
         expect(n(c => typeof c.maxConfidence === 'number')).toBe(0);
         // no case asserts nothing at all
         expect(n(c => assertedBands(c).length === 0)).toBe(0);
-        // 47 assert a name and no numeric band — the population the _readme names
-        expect(n(c => !c.grams && !c.total && !c.macros)).toBe(47);
+        // 37 assert a name and no numeric band — the population the _readme names.
+        // Was 47 before PR #167 added calorie bands; those 10 are the whole point of
+        // that PR, and this line is the receipt that they landed.
+        expect(n(c => !c.grams && !c.total && !c.macros)).toBe(37);
 
         // split by shape: `--golden` replays item-shaped cases unless --include-multi-item
         const item = all.filter(c => c.shape === 'item');
         const text = all.filter(c => c.shape === 'text');
         expect([item.length, text.length]).toEqual([160, 83]);
         expect(item.filter(c => c.grams).length).toBe(117);
-        expect(item.filter(c => c.macros).length).toBe(43);
-        expect(item.filter(c => c.total).length).toBe(7);
+        expect(item.filter(c => c.macros).length).toBe(47);
+        expect(item.filter(c => c.total).length).toBe(16);
         expect(text.filter(c => c.grams).length).toBe(31);
         expect(text.filter(c => typeof c.expectItems === 'number').length).toBe(47);
 
@@ -714,7 +716,7 @@ describe('structurallyBlindBands / goldenCoverage over the REAL corpus', () => {
         const kind = (k: string) => cov.byKind.find(b => b.kind === k)!;
         expect(cov.cases).toBe(243);
         expect(kind('grams')).toEqual({ kind: 'grams', asserted: 148, blind: 148 });
-        expect(kind('total')).toEqual({ kind: 'total', asserted: 18, blind: 18 });
+        expect(kind('total')).toEqual({ kind: 'total', asserted: 35, blind: 35 });
         expect(kind('expectItems')).toEqual({ kind: 'expectItems', asserted: 47, blind: 47 });
         // expectName is judgeable except on the segmenter-bound text lines
         const en = kind('expectName');
@@ -732,7 +734,10 @@ describe('structurallyBlindBands / goldenCoverage over the REAL corpus', () => {
         const cov = goldenCoverage(all.filter(c => c.shape === 'item'));
         expect(cov.cases).toBe(160);
         expect(cov.byKind.find(b => b.kind === 'grams')).toEqual({ kind: 'grams', asserted: 117, blind: 117 });
-        expect(cov.casesWithBlindBand).toBe(117 + 7 - all.filter(c => c.shape === 'item' && c.grams && c.total).length);
+        // 117 item cases assert grams + 16 assert a total, less the 9 that assert both.
+        // The `total` term was 7 before PR #167 added calorie bands.
+        expect(all.filter(c => c.shape === 'item' && c.grams && c.total).length).toBe(9);
+        expect(cov.casesWithBlindBand).toBe(117 + 16 - 9);
     });
 
     it('an item case with only a name and a measurable macro band is fully judgeable', () => {

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -1313,8 +1313,17 @@ function replaySelection(e: SnapshotEntry, debug: boolean, variant: SelectionVar
                 // RECORD wins, but `confidence` is also the cache-admission signal
                 // (`admitToCache = confidence >= 0.85 || subThreshold`), and the two
                 // stages report on different scales: the gate exits at >= 0.85 by
-                // construction, simpleRerank returns min(0.5 + score*0.5, 0.95) with a
-                // 0.70 floor. Taking the rerank number unconditionally therefore
+                // construction, simpleRerank starts at min(0.5 + score*0.5, 0.95) and
+                // then adds up to +0.1 for `exact_match`, capped at 0.98
+                // (simple-rerank.ts:2077, :2086), with a 0.70 floor
+                // (MIN_RERANK_CONFIDENCE, :2169). CORRECTED 2026-07-26: this comment
+                // used to say the rerank scale TOPS OUT at 0.95, which is wrong. 0.98
+                // is reachable and is the single most common stored value — 1,370 of
+                // 3,246 FoodMapping rows sit at exactly 0.98 (measured 2026-07-26).
+                // That false ceiling was the stated premise for this mitigation. The
+                // mitigation is still right (0.85 vs the rerank scale is the real gap),
+                // but do not re-derive anything from the old number.
+                // Taking the rerank number unconditionally therefore
                 // DEMOTED lines whose answer did not change at all — 37 of the 441
                 // gate lines fall under the save gate, 9 with an UNCHANGED winner, 2
                 // of those under SUB_THRESHOLD_SAVE_FLOOR (0.75) so they stop being
@@ -1906,8 +1915,13 @@ function runCounterfactual(replayPath: string, top: number) {
     if (s.medianCounterMicros != null) {
         say('');
         say(`median wall time of the Step 4 the gate skipped: ${s.medianCounterMicros.toFixed(0)} us`);
-        say('   (simpleRerank is a pure function — there is no LLM in src/lib/mapping — so');
-        say('    this is the entire cost the gate avoids. Measure it; do not assert it.)');
+        say('   (simpleRerank is pure and synchronous — `grep -c "await " simple-rerank.ts`');
+        say('    is 0 — so this is the entire cost the gate avoids. Measure it; do not');
+        say('    assert it. CORRECTED 2026-07-26: this line used to claim "there is no LLM');
+        say('    in src/lib/mapping", which is false. ai-rerank.ts IS a full');
+        say('    OpenAI-compatible client, and map-ingredient-with-fallback.ts awaits');
+        say('    aiSimplifyIngredient in the same file that carried the denial. The true');
+        say('    claim is narrower: nothing on the gate/rerank path awaits an LLM.)');
     }
     sayAll(formatScreens(runScreens(s.pairs, 'GATE', 'RERANK'), top));
     say('');

--- a/src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts
+++ b/src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts
@@ -30,6 +30,30 @@ jest.mock('../../db', () => ({
     ingredient: {
       findMany: jest.fn().mockResolvedValue([]),
     },
+    // Serving stores reached via hydrateAndSelectServing -> ambiguous-unit-backfill.
+    // Omitting these did not make a test fail loudly — it made
+    // `does NOT fast-path "canned tuna in water"` die inside the mapper with
+    // "Cannot read properties of undefined (reading 'findUnique')", which reads
+    // like a production bug and is not one. Keep every model that
+    // ambiguous-unit-backfill.ts touches present here.
+    aiGeneratedServing: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn().mockResolvedValue(null),
+    },
+    fdcServing: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn().mockResolvedValue(null),
+    },
+    offServing: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn().mockResolvedValue(null),
+    },
+    userPortionOverride: {
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
   },
 }));
 


### PR DESCRIPTION
## The finding that matters most

`build` — the required status check that gates every merge — runs `lint:ci`, `typecheck`, `next build`. **It does not run jest.** There are 2,107 tests in this repo and none of them has ever gated a merge.

That is why the next item was possible.

## 1. Master is red right now

PR #167 added calorie bands to the golden set. PR #168's tests pin the pre-#167 counts. Each was green alone; #168 was even rebased onto #167 and re-ran green — because nothing in CI executes the tests. Merged in sequence they leave `master` red on three assertions.

Re-derived from the corpus and updated:

| assertion | was | now |
|---|---|---|
| `macros` | 59 | 65 |
| `total` | 18 | 35 |
| name-only, no numeric band | 47 | **37** |
| item `macros` | 43 | 47 |
| item `total` | 7 | 16 |

The name-only drop 47 → 37 is the receipt that #167's ten new bands landed.

## 2. A prisma mock gap that impersonated a production bug

The mapping test's mock omitted `aiGeneratedServing`, `fdcServing`, `offServing`, `userPortionOverride` — all reached via `hydrateAndSelectServing` → `ambiguous-unit-backfill`. `canned tuna in water` died *inside the mapper* with `Cannot read properties of undefined (reading 'findUnique')`, which reads like a mapping defect and is not one.

With the mock complete the test still fails — but now on a real assertion, and it fails **identically at `e227f368`** (pre-demotion), so it is pre-existing and not from the `confidenceGate` change.

**Worth stating plainly:** I had previously checked that same test against the baseline and called it pre-existing. That check was made while *both sides crashed on the missing mock* — identical silence, which proves nothing. The conclusion happened to be right; the evidence for it was worthless. Re-run properly with a worktree at `e227f368` and the same mock fix applied.

## 3. Two false claims shipped in committed comments, both load-bearing

- **"there is no LLM in `src/lib/mapping`"** — false. `ai-rerank.ts:84` is a full OpenAI-compatible client, and `map-ingredient-with-fallback.ts:2171` awaits `aiSimplifyIngredient`. The true claim is narrower and is the one the measurement supports: *nothing on the gate/rerank path awaits an LLM* (`grep -c "await " simple-rerank.ts` = 0). The caller copy was fixed in `cee10fd`; this harness copy was missed.
- **"`simpleRerank` returns `min(0.5 + score*0.5, 0.95)`"** — understates the ceiling. `simple-rerank.ts:2086` adds +0.1 for `exact_match` capped at **0.98**, and 0.98 is the single most common stored confidence: **1,370 of 3,246** `FoodMapping` rows (measured 2026-07-26). That false ceiling was the *stated premise* for Mitigation B. The mitigation is still correct — 0.85 vs the rerank scale is the real gap — but the reasoning as written was wrong.

While writing the first correction I nearly committed a third false number from memory (`2,454 of 3,475 pure-rerank rows`). It does not reproduce against the database. Replaced with the figure that does.

## Deliberately NOT in this PR

- **`does NOT fast-path "canned tuna in water"` still fails.** It is a real pre-existing decline — returns `null`, not `water_default` — and it needs its own diagnosis and gate, not a fix smuggled into a test-hygiene PR. Under investigation now.
- **Wiring jest into `ci.yml` waits on that**, so CI does not go red the moment it is switched on. When it lands it needs a `test:ci` script excluding `src/ops/curated/__tests__/seed-curated.test.ts`, which requires a live database.

## Verification

- `tsc --noEmit` — 0 errors
- `npm run lint:ci` — 0 errors (442 pre-existing warnings)
- `npx jest scripts/eval/__tests__/winner-diff.test.ts` — **66/66**
- Full suite with a dummy `DATABASE_URL`: **2,104 passed**, 2 failed (the tuna decline + the live-DB integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx