### PR TITLE
fix(parse): "100g candy" parses as qty 0, name "gdy" — live on /api/nlp/parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
       - run: npm run prisma:generate
       - run: npm run lint:ci
       - run: npm run typecheck
+      # Until 2026-07-26 this job was lint + typecheck + build only, so NONE of the
+      # 2,121 tests in this repo had ever gated a merge. That is how PR #167 and
+      # PR #168 both went green and still left master red on three assertions:
+      # #167 changed the golden-set band counts, #168's tests pinned the old ones,
+      # and nothing in CI executed either. Do not remove this step.
+      #
+      # test:ci excludes src/ops/curated/__tests__/seed-curated.test.ts, which needs
+      # a reachable Postgres. Everything else runs in ~6s.
+      - run: npm run test:ci
       - run: npm run build
     env:
       # Supabase Configuration (Required for build)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "prisma:migrate": "prisma migrate dev",
         "seed:foods": "node scripts/seed-foods.js",
         "test": "jest",
+        "test:ci": "jest --ci --testPathIgnorePatterns /node_modules/ src/ops/curated/__tests__/seed-curated.test.ts",
         "test:watch": "jest --watch",
         "prisma:seed": "prisma db seed",
         "usda:import": "ts-node --transpile-only scripts/usda-import.ts",

--- a/src/lib/parse/__tests__/ingredient-line.test.ts
+++ b/src/lib/parse/__tests__/ingredient-line.test.ts
@@ -346,4 +346,77 @@ describe('resolvePackageMultipliers package resolution rules', () => {
     expect(p.unit).toBe('oz');
     expect(p.name).toBe('tomatoes');
   });
+
+  /**
+   * NON-VACUITY: every case below returned a MANGLED name and qty 0 on master
+   * before this guard landed — verified by running this exact list against
+   * 1850a1c. They are not hypothetical.
+   *
+   *   '100g canned tuna in water' -> { qty: 0, unit: null, name: 'gned tuna in water' }
+   *   '150g cantaloupe'           -> { qty: 0, unit: null, name: 'gtaloupe' }
+   *   '340g bottled water'        -> { qty: 0, unit: null, name: 'gd water' }
+   *
+   * Two independent defects co-fired: the container alternation had no trailing
+   * \b (so `can` matched `canned`), and the qty1/qty2 separator was optional
+   * (so `100` split into 10 x 0 = 0).
+   */
+  describe.each([
+    ['100g canned tuna in water', 100, 'g', 'tuna in water'],
+    ['150g cantaloupe', 150, 'g', 'cantaloupe'],
+    ['100g candy', 100, 'g', 'candy'],
+    ['120g baguette', 120, 'g', 'baguette'],
+    ['100g canola oil', 100, 'g', 'canola oil'],
+    ['200g cane sugar', 200, 'g', 'cane sugar'],
+    ['340g bottled water', 340, 'g', 'bottled water'],
+    ['500g boxed pasta', 500, 'g', 'boxed pasta'],
+    ['200g jarred pesto', 200, 'g', 'jarred pesto'],
+    ['150g tube tomato paste', 150, 'g', 'tube tomato paste'],
+    ['250g packaged salad', 250, 'g', 'packaged salad'],
+    ['100g cannellini beans', 100, 'g', 'cannellini beans'],
+  ])('a container word must not match a longer word that starts with it', (line, qty, unit, name) => {
+    test(`${line} keeps its quantity and its name`, () => {
+      const p = parseIngredientLine(line as string)!;
+      expect(p.qty).toBeCloseTo(qty as number);
+      expect(p.unit).toBe(unit);
+      expect(p.name).toBe(name);
+    });
+  });
+
+  test('a single contiguous number is never split against itself', () => {
+    // "30g packet oatmeal" kept its unit on master but billed qty 0, because
+    // "30" was read as qty1=3 x qty2=0. The name survived, so this one was
+    // silent in a way the mangled-name cases were not.
+    const p = parseIngredientLine('30g packet oatmeal')!;
+    expect(p.qty).toBeCloseTo(30);
+    expect(p.unit).toBe('g');
+  });
+
+  test('a real container word still resolves after the \\b guard', () => {
+    // The \b must not break the genuine package form: `cans` is a whole token.
+    const p = parseIngredientLine('2 100g cans of tuna')!;
+    expect(p.qty).toBeCloseTo(200);
+    expect(p.unit).toBe('g');
+  });
+
+  test('qty1 === 1 still preserves the package structure', () => {
+    const p = parseIngredientLine('1 (14 oz) can beans')!;
+    expect(p.qty).toBeCloseTo(1);
+    expect(p.name).toContain('14 oz can beans');
+  });
+
+  /**
+   * KNOWN LIMIT, asserted so it cannot drift silently. "canned" is an adjective,
+   * not a package count, so the multiplier correctly no longer fires here.
+   * Master produced qty 30 with the mangled name "ozned tomatoes" — it got the
+   * quantity right by accident while destroying the name. Neither answer is
+   * right; this one is at least not corrupt. A real fix would need to treat
+   * "<n> <n> <unit> canned <food>" as "<n> cans of <n> <unit>", which is a
+   * parser feature, not a regex guard.
+   */
+  test('"2 15 oz canned tomatoes" no longer multiplies, and no longer mangles', () => {
+    const p = parseIngredientLine('2 15 oz canned tomatoes')!;
+    expect(p.name).not.toMatch(/ozned|gned/);
+    expect(p.name).toBe('15 oz tomatoes');
+    expect(p.qty).toBeCloseTo(2);
+  });
 });

--- a/src/lib/parse/ingredient-line.ts
+++ b/src/lib/parse/ingredient-line.ts
@@ -50,7 +50,27 @@ export type ParsedIngredient = {
 function resolvePackageMultipliers(line: string): string {
   // Pattern to match: qty1 [delimiter] ( qty2 unit ) [package_type]
   // e.g. 1/2 (12 oz) package, 2 x 15-ounce cans, 3 (4 oz) containers, 2 15 oz cans
-  const packageRegex = /\b(\d+(?:\s+(?:and\s+)?\d+\/\d+|\/\d+|\.\d+)?)\s*[-x×*(\s]?\s*(\d+(?:\/\d+|\.\d+)?)\s*-?(oz|ounce|ounces|g|gram|grams|ml|milliliter|milliliters|floz|fl\s*oz|fluid\s*oz|fluid\s*ounces?|lb|lbs|pound|pounds|kg|kilogram|kilograms)\b(?:\s*\))?\s*(?:cans|can|packages|package|containers|container|pouches|pouch|boxes|box|bags|bag|bottles|bottle|packets|packet|envelopes|envelope|sachets|sachet|jars|jar|tubs|tub|cartons|carton)/gi;
+  //
+  // TWO GUARDS, both load-bearing — removing either one reopens a live defect:
+  //
+  //   (a) `(?:\s*[-x×*(]\s*|\s+)` — the qty1/qty2 separator is REQUIRED. It used to
+  //       be `\s*[-x×*(\s]?\s*`, fully optional, so a single contiguous number was
+  //       split against itself: "100" became qty1="10" x qty2="0" = 0.
+  //
+  //   (b) the trailing `\b` after the container alternation. Without it, `can`
+  //       matched the first three letters of `canned`/`cantaloupe`/`candy`/`canola`,
+  //       `bag` matched `baguette`, `box` matched `boxed`, `bottle` matched
+  //       `bottled`, `tub` matched `tube`.
+  //
+  // Together they billed silently wrong. "100g canned tuna in water" parsed as
+  // { qty: 0, unit: null, name: "gned tuna in water" } — a garbage name that
+  // poisons deriveMustHaveTokens, plus qty 0 that starves serving selection.
+  // Live examples: "150g cantaloupe" -> "gtaloupe", "100g candy" -> "gdy",
+  // "340g bottled water" -> "gd water", "30g packet oatmeal" -> 0 g.
+  //
+  // Each guard alone is insufficient: (a) alone still corrupts "100g cans of tuna";
+  // (b) alone still corrupts "2 15 oz canned tomatoes". Keep both.
+  const packageRegex = /\b(\d+(?:\s+(?:and\s+)?\d+\/\d+|\/\d+|\.\d+)?)(?:\s*[-x×*(]\s*|\s+)(\d+(?:\/\d+|\.\d+)?)\s*-?(oz|ounce|ounces|g|gram|grams|ml|milliliter|milliliters|floz|fl\s*oz|fluid\s*oz|fluid\s*ounces?|lb|lbs|pound|pounds|kg|kilogram|kilograms)\b(?:\s*\))?\s*(?:cans|can|packages|package|containers|container|pouches|pouch|boxes|box|bags|bag|bottles|bottle|packets|packet|envelopes|envelope|sachets|sachet|jars|jar|tubs|tub|cartons|carton)\b/gi;
 
   return line.replace(packageRegex, (match, qty1Str, qty2Str, unit) => {
     const qty1 = parseFraction(qty1Str);


### PR DESCRIPTION
## The defect

`parseIngredientLine('100g canned tuna in water')` returns:

```
{ qty: 0, unit: null, name: 'gned tuna in water' }
```

Pure function, no mocks, no mapper, no database. It is live on `/api/nlp/parse` right now.

**Measured on master `1850a1c`** — these are real outputs, not hypotheticals:

| input | master | this PR |
|---|---|---|
| `150g cantaloupe` | qty 0, `"gtaloupe"` | 150 g, `"cantaloupe"` |
| `100g candy` | qty 0, `"gdy"` | 100 g, `"candy"` |
| `120g baguette` | qty 0, `"guette"` | 120 g, `"baguette"` |
| `100g canola oil` | qty 0, `"gola oil"` | 100 g, `"canola oil"` |
| `340g bottled water` | qty 0, `"gd water"` | 340 g, `"bottled water"` |
| `250g packaged salad` | qty 0, `"gd salad"` | 250 g, `"packaged salad"` |
| `100g cannellini beans` | qty 0, `"gnellini beans"` | 100 g, `"cannellini beans"` |
| `30g packet oatmeal` | **qty 0** g, `"oatmeal"` | 30 g, `"packet oatmeal"` |

The failure is silent in both directions: the garbage name poisons `deriveMustHaveTokens`, and `qty: 0` starves serving selection — so the line either returns `null` or bills **zero grams**. The last row is the nastiest: the name survives, so nothing looks wrong.

## Root cause — two defects in one regex, both required

1. **The container alternation had no trailing `\b`.** `can` matched the first three letters of `canned`, `cantaloupe`, `candy`, `cane`, `canola`, `cannellini`. Likewise `bag`⊂`baguette`, `box`⊂`boxed`, `bottle`⊂`bottled`, `tub`⊂`tube`, `jar`⊂`jarred`.
2. **The qty1/qty2 separator `\s*[-x×*(\s]?\s*` was fully optional**, so a single contiguous number split against itself: `100` → qty1 `10` × qty2 `0` = **0**.

Each guard alone is insufficient — `\b` alone still corrupts `100g cans of tuna`; the separator alone still corrupts `2 15 oz canned tomatoes` — so both ship together.

This is **not a ranking change and not a gate**. It restores a correct `qty`/`unit`/`name` *before* retrieval, so the existing ranking finally gets the input it was designed for. Notably the pool goes 1→0 in `filter-candidates` on `mustHaveTokens: ["gned","tuna"]` and is then restored by `relaxed_filter_recovery` — no `simple_rerank.result` is ever emitted for the failing line. Ranking was never implicated.

## Legitimate multipliers are byte-identical

`2 x 15 oz cans` → 30 oz · `2 15 oz cans` → 30 oz · `3 (4 oz) containers` → 12 oz · `1 (14 oz) can` → unchanged (qty1===1 guard) · `2 100g cans` → 200 g · `1/2 (12 oz) package` → 6 oz · `2x200g bags` → 400 g

## One known limit, asserted so it cannot drift silently

`2 15 oz canned tomatoes` no longer multiplies: it now yields `qty 2, name "15 oz tomatoes"`. Master produced `qty 30` with the name `"ozned tomatoes"` — the right quantity *by accident*, with the name destroyed.

Neither answer is correct. This one is at least not corrupt. A real fix would need the parser to read `"<n> <n> <unit> canned <food>"` as a package form, which is a parser feature, not a regex guard. There is a test pinning the new behaviour so it can't drift unnoticed.

*(The diagnosing agent's matrix listed this case as "fixed". It isn't — I re-ran both sides and it changes quantity semantics. Recorded as a limit rather than a win.)*

## Also in this PR: wire jest into CI

Until today `build` was `lint:ci` + `typecheck` + `next build`. **None of the 2,121 tests in this repo had ever gated a merge.** That is exactly how #167 and #168 both went green and still left `master` red on three assertions — #167 changed the golden-set band counts, #168's tests pinned the old ones, and nothing in CI executed either.

`test:ci` excludes `src/ops/curated/__tests__/seed-curated.test.ts` (needs a reachable Postgres). Everything else runs in ~6 seconds.

## Verification

- `tsc --noEmit` — 0 errors
- `npm run lint:ci` — 0 errors (442 pre-existing warnings)
- `npm run test:ci` — **101 suites, 2,121 passed**
- `does NOT fast-path "canned tuna in water"` now **passes** — the test was right all along and was failing for a reason unrelated to its own name
- Both sides of every table above run on the whole file, never a `-t` subset

## Follow-ups, deliberately not here

- `FoodMapping` rows keyed on the corrupted forms (`gned …`, `gtaloupe`, `gd water`) are now unreachable orphans. Needs a gated data-op audit.
- Container adjectives now survive into the name, so a few cache-key shapes move. This wants a golden eval + cache-parity replay before the next warm wave, not an assumption of zero migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx