### PR TITLE
feat: cache-lookup reject telemetry + winner-gate.sh (make the gate cheap to run)

### DIFF
--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# winner-gate.sh — one command for the winner-diff gate.
+#
+# WHY THIS EXISTS
+# ---------------
+# scripts/eval/winner-diff.ts is the gate the playbook demands before any
+# admission or ranking change may be called safe. It is a good harness. It was
+# also run for ZERO of the six mapping investigations on 2026-07-26, and the
+# reason is visible in its own header: doing it right is six commands, one of
+# which is the prose instruction "copy the tree, edit the copy". Under any time
+# pressure that loses to writing a plausible argument instead — which is how
+# "admit-only by inspection is not a safety argument" became a four-time repeat
+# finding in this repo.
+#
+# So this driver makes the correct sequence the cheap one. It:
+#   1. REFUSES to run without a cold-seed file (winner-diff blind spot (D): a
+#      population of already-asked queries cannot contain the cases a fix is
+#      supposed to CREATE — that blind spot has invalidated a gate before);
+#   2. ABORTS when the branch touches retrieval, because a frozen-pool diff is
+#      meaningless then (blind spot (A));
+#   3. builds the BASE tree as a git worktree instead of `git checkout -- <file>`,
+#      which is how uncommitted work gets destroyed;
+#   4. takes ONE snapshot shared by both sides, so retrieval nondeterminism
+#      cannot enter the diff;
+#   5. enforces the noise-floor receipt (must be 0) before it will diff.
+#
+# The underlying harness is strictly read-only and enforces that with a Prisma
+# write-guard middleware. This driver adds no writes of its own.
+#
+# USAGE
+#   scripts/eval/winner-gate.sh --cold-seeds <file> [options]
+#
+#   --cold-seeds <file>   REQUIRED. One raw ingredient line per line: the queries
+#                         your change is supposed to FIX. These must include keys
+#                         that have never been asked. Blank lines and #-comments
+#                         are ignored.
+#   --base <ref>          Base to compare against (default: origin/master).
+#   --regression <n>      Also sample n already-asked lines from the event log as
+#                         a regression population (default 250, 0 to disable).
+#   --label <name>        Names the artifact directory (default: the branch name).
+#   --keep                Keep the base worktree for inspection.
+#
+# EXAMPLE
+#   scripts/eval/winner-gate.sh --cold-seeds /tmp/mac-and-cheese-seeds.txt
+#
+set -euo pipefail
+
+BASE_REF="origin/master"
+COLD_SEEDS=""
+REGRESSION_N=250
+LABEL=""
+KEEP=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cold-seeds) COLD_SEEDS="$2"; shift 2 ;;
+        --base)       BASE_REF="$2";   shift 2 ;;
+        --regression) REGRESSION_N="$2"; shift 2 ;;
+        --label)      LABEL="$2";      shift 2 ;;
+        --keep)       KEEP=1;          shift ;;
+        -h|--help)    sed -n '2,45p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+[[ -f scripts/eval/winner-diff.ts ]] || { echo "must run from the backend repo root" >&2; exit 2; }
+
+# ---------------------------------------------------------------- blind spot D
+if [[ -z "$COLD_SEEDS" ]]; then
+    cat >&2 <<'EOF'
+REFUSING TO RUN: --cold-seeds is required.
+
+winner-diff's populations (--from-events, --from-cache) contain ONLY queries that
+have already been asked. If your change's value proposition is "queries that
+returned nothing now work", those queries are by construction absent, the diff
+reports SAME on 100% of rows, and the gate passes vacuously. That has already
+invalidated one gate in this repo.
+
+Write the queries your change is supposed to fix into a file, one per line,
+including ones nobody has ever typed, and pass it here. If your change genuinely
+creates no new answers, say so in the PR and pass a file containing the cases you
+expect to stay UNCHANGED — but pass a file.
+EOF
+    exit 2
+fi
+[[ -f "$COLD_SEEDS" ]] || { echo "cold-seeds file not found: $COLD_SEEDS" >&2; exit 2; }
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+LABEL="${LABEL:-${BRANCH//\//-}}"
+STAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+OUT="/tmp/winner-gate-${LABEL}-${STAMP}"
+mkdir -p "$OUT"
+
+echo "=== winner-gate ==="
+echo "branch:    $BRANCH"
+echo "base:      $BASE_REF"
+echo "cold:      $COLD_SEEDS ($(grep -cvE '^\s*(#|$)' "$COLD_SEEDS") seeds)"
+echo "artifacts: $OUT"
+echo
+
+# ---------------------------------------------------------------- blind spot A
+# A frozen-pool diff replays a pool BOTH variants inherit. If the branch changes
+# retrieval, each side would have produced a different pool and the comparison is
+# void — not conservative, void.
+RETRIEVAL_PATHS='src/lib/mapping/gather-candidates.ts|src/lib/search/|query-builder|typesense|fatsecret-lane|embedding'
+if git diff --name-only "$BASE_REF"...HEAD | grep -qE "$RETRIEVAL_PATHS"; then
+    echo "ABORT: this branch touches RETRIEVAL:" >&2
+    git diff --name-only "$BASE_REF"...HEAD | grep -E "$RETRIEVAL_PATHS" | sed 's/^/  /' >&2
+    cat >&2 <<'EOF'
+
+winner-diff freezes the candidate pool at gatherCandidates' output and replays it
+through both variants. When retrieval itself changes, both sides replay a pool
+NEITHER would have produced, so the diff measures nothing. Re-snapshot per
+variant (--cross-snapshot) and accept that retrieval nondeterminism is then
+inside your signal — or gate this change a different way.
+EOF
+    exit 3
+fi
+
+RUN='npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/winner-diff.ts'
+
+# ------------------------------------------------------------ base worktree
+# A worktree, NOT `git checkout <ref> -- <file>`: that form silently discards
+# uncommitted edits when HEAD is the base commit (playbook section 9).
+BASE_TREE="/tmp/winner-gate-base-${STAMP}"
+cleanup() {
+    if [[ $KEEP -eq 0 ]]; then
+        git worktree remove "$BASE_TREE" --force >/dev/null 2>&1 || true
+    else
+        echo "base worktree kept at $BASE_TREE"
+    fi
+}
+trap cleanup EXIT
+
+echo "[1/5] materializing BASE tree from $BASE_REF"
+git worktree add -q --detach "$BASE_TREE" "$BASE_REF"
+ln -s "$(pwd)/node_modules" "$BASE_TREE/node_modules"
+[[ -f .env ]] && cp .env "$BASE_TREE/.env"
+
+# ------------------------------------------------------------ population
+POP="$OUT/population.txt"
+grep -vE '^\s*(#|$)' "$COLD_SEEDS" > "$POP"
+COLD_N=$(wc -l < "$POP" | tr -d ' ')
+if [[ "$REGRESSION_N" -gt 0 ]]; then
+    echo "[2/5] snapshot: $COLD_N cold seeds + up to $REGRESSION_N already-asked lines"
+else
+    echo "[2/5] snapshot: $COLD_N cold seeds (regression population disabled)"
+fi
+
+# One snapshot, taken from BASE, shared by both replays. Retrieval runs once.
+( cd "$BASE_TREE" && eval "$RUN" snapshot --from-file "$POP" --out "$OUT/snap.json" ) 2>&1 | tail -20
+
+if [[ "$REGRESSION_N" -gt 0 ]]; then
+    ( cd "$BASE_TREE" && eval "$RUN" snapshot --from-events --limit "$REGRESSION_N" \
+        --out "$OUT/snap-regression.json" ) 2>&1 | tail -8
+fi
+
+# ------------------------------------------------------------ noise floor
+# The receipt is keyed by TREE HASH, so `diff` requires one from EACH side. A
+# base-only receipt is not sufficient and diff will (correctly) refuse to report.
+echo "[3/5] noise floor on BOTH trees (must be 0 — writes the receipts diff requires)"
+if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$OUT/snap.json" ) 2>&1 | tail -8; then
+    echo "ABORT: noise floor is non-zero on BASE. The replay is not deterministic," >&2
+    echo "so any before/after claim below it is not a result." >&2
+    exit 4
+fi
+if ! eval "$RUN" noise-floor --snapshot "$OUT/snap.json" 2>&1 | tail -8; then
+    echo "ABORT: noise floor is non-zero on BRANCH. Your change introduced" >&2
+    echo "nondeterminism into replay — that is itself the finding." >&2
+    exit 4
+fi
+
+# ------------------------------------------------------------ replays
+echo "[4/5] replay BASE, then BRANCH, against the identical frozen pool"
+( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap.json" \
+    --out "$OUT/A-base.json" --label BASE ) 2>&1 | tail -6
+eval "$RUN" replay --snapshot "$OUT/snap.json" \
+    --out "$OUT/B-branch.json" --label BRANCH 2>&1 | tail -6
+
+if [[ "$REGRESSION_N" -gt 0 ]]; then
+    ( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
+        --out "$OUT/A-base-regression.json" --label BASE ) 2>&1 | tail -4
+    eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
+        --out "$OUT/B-branch-regression.json" --label BRANCH 2>&1 | tail -4
+fi
+
+# ------------------------------------------------------------ diff
+echo
+echo "[5/5] DIFF — cold population (the cases the change is supposed to create)"
+eval "$RUN" diff --a "$OUT/A-base.json" --b "$OUT/B-branch.json" --screens 2>&1 | tee "$OUT/diff-cold.txt"
+
+if [[ "$REGRESSION_N" -gt 0 ]]; then
+    echo
+    echo "=== DIFF — regression population (already-asked lines that must not move) ==="
+    eval "$RUN" diff --a "$OUT/A-base-regression.json" --b "$OUT/B-branch-regression.json" --screens \
+        2>&1 | tee "$OUT/diff-regression.txt"
+fi
+
+cat <<EOF
+
+=== winner-gate done ===
+artifacts: $OUT
+
+Read it in this order, and do not skip the second question:
+  1. Did the COLD population move in the intended direction? If it shows SAME on
+     everything, the change does not do what the PR says it does.
+  2. Did the REGRESSION population move at all? Every mover there is a cost you
+     are paying, and it must be enumerated in the PR body — not summarized.
+
+This harness cannot see: serving/gram resolution, the save gates, or warm
+behaviour (it forces skipCache). A SAME here does NOT prove the cached row is
+unchanged. The eval's grams bands are what see serving regressions.
+EOF

--- a/src/lib/mapping/__tests__/cache-lookup-rejection-telemetry.test.ts
+++ b/src/lib/mapping/__tests__/cache-lookup-rejection-telemetry.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Cache-lookup rejection telemetry.
+ *
+ * getValidatedMappingByNormalizedName has two very different ways to return
+ * null — no row existed, or a row existed and the identity checks rejected it —
+ * and callers could not tell them apart. Every helper-level rejection was
+ * therefore written to MappingEventLog as `cacheHit=NULL, cacheEscape=NULL`,
+ * byte-identical to a cold key, which hid a real failure class: rows the
+ * pipeline writes under a key it can then never serve, so they re-resolve on
+ * every request forever.
+ *
+ * The discriminating assertion in this file is the NEGATIVE one — "no row" and
+ * "served a row" must both leave `reason` null. A test that only checked the
+ * rejection paths would pass against an implementation that set the reason
+ * unconditionally, which would be worse than no telemetry at all.
+ *
+ * Mocks only the db (save-gates pattern); the real filter heuristics run.
+ */
+
+const mockFoodMappingFindUnique = jest.fn();
+const mockFoodMappingFindMany = jest.fn();
+const mockFoodMappingUpdate = jest.fn();
+const mockAiGeneratedFindFirst = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        foodMapping: {
+            findUnique: (...args: unknown[]) => mockFoodMappingFindUnique(...args),
+            findMany: (...args: unknown[]) => mockFoodMappingFindMany(...args),
+            update: (...args: unknown[]) => mockFoodMappingUpdate(...args),
+        },
+        aiGeneratedFood: {
+            findFirst: (...args: unknown[]) => mockAiGeneratedFindFirst(...args),
+        },
+    },
+}));
+
+import {
+    getValidatedMappingByNormalizedName,
+    type CacheLookupRejection,
+} from '../validated-mapping-helpers';
+
+const BARCODE = '0011110000001';
+
+function row(overrides: Record<string, unknown> = {}) {
+    return {
+        normalizedForm: 'mayonnaise',
+        foodName: 'Light Mayonnaise',
+        brandName: null,
+        source: 'openfoodfacts',
+        offBarcode: BARCODE,
+        fdcId: null,
+        fsId: null,
+        aiConfidence: 0.95,
+        validatedBy: 'ai',
+        ...overrides,
+    };
+}
+
+const ORIGINAL_TRUST = process.env.HUMAN_ROW_TRUST;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFoodMappingFindUnique.mockResolvedValue(null);
+    mockFoodMappingFindMany.mockResolvedValue([]);
+    mockFoodMappingUpdate.mockResolvedValue({});
+    mockAiGeneratedFindFirst.mockResolvedValue(null);
+    delete process.env.HUMAN_ROW_TRUST;
+});
+
+afterAll(() => {
+    if (ORIGINAL_TRUST === undefined) delete process.env.HUMAN_ROW_TRUST;
+    else process.env.HUMAN_ROW_TRUST = ORIGINAL_TRUST;
+});
+
+describe('CacheLookupRejection out-param', () => {
+    it('records nutritional_modifier when a row is found and rejected on a modifier', async () => {
+        // 'Light Mayonnaise' cached under key 'mayonnaise': the query never says
+        // "light", so the row is a different product and is correctly rejected.
+        mockFoodMappingFindUnique.mockResolvedValue(row());
+        const rejection: CacheLookupRejection = { reason: null };
+
+        const result = await getValidatedMappingByNormalizedName(
+            'mayonnaise', 'openfoodfacts', undefined, rejection,
+        );
+
+        expect(result).toBeNull();
+        expect(rejection.reason).toBe('nutritional_modifier:light');
+        expect(rejection.foodName).toBe('Light Mayonnaise');
+        expect(rejection.normalizedForm).toBe('mayonnaise');
+    });
+
+    it('records core_token_mismatch when the cached row is a different food', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue(row({
+            normalizedForm: 'mayonnaise',
+            foodName: 'Chocolate Fudge Brownie',
+        }));
+        const rejection: CacheLookupRejection = { reason: null };
+
+        const result = await getValidatedMappingByNormalizedName(
+            'mayonnaise', 'openfoodfacts', undefined, rejection,
+        );
+
+        expect(result).toBeNull();
+        expect(rejection.reason).toBe('core_token_mismatch');
+    });
+
+    // ---- The negative assertions. These are what make the telemetry meaningful. ----
+
+    it('leaves reason NULL when no row exists (the cold-key case)', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue(null);
+        mockFoodMappingFindMany.mockResolvedValue([]);
+        const rejection: CacheLookupRejection = { reason: null };
+
+        const result = await getValidatedMappingByNormalizedName(
+            'nothing cached here', 'openfoodfacts', undefined, rejection,
+        );
+
+        expect(result).toBeNull();
+        // A cold key and a rejected row must stay distinguishable — this is the
+        // entire point of the out-param.
+        expect(rejection.reason).toBeNull();
+    });
+
+    it('leaves reason NULL when the row is served', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue(row({ foodName: 'Mayonnaise' }));
+        const rejection: CacheLookupRejection = { reason: null };
+
+        const result = await getValidatedMappingByNormalizedName(
+            'mayonnaise', 'openfoodfacts', undefined, rejection,
+        );
+
+        expect(result).not.toBeNull();
+        expect(rejection.reason).toBeNull();
+    });
+
+    it('leaves reason NULL when read-time trust serves a human-triage row', async () => {
+        // Trusted rows skip the NAME-heuristic rejections and ARE served, so
+        // nothing was bypassed. Counting these would inflate the population —
+        // the exact error that made an earlier hand count read 74 instead of 58.
+        mockFoodMappingFindUnique.mockResolvedValue(row({ validatedBy: 'human-triage' }));
+        const rejection: CacheLookupRejection = { reason: null };
+
+        const result = await getValidatedMappingByNormalizedName(
+            'mayonnaise', 'openfoodfacts', undefined, rejection,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.foodName).toBe('Light Mayonnaise');
+        expect(rejection.reason).toBeNull();
+    });
+
+    it('is optional — omitting it changes nothing', async () => {
+        mockFoodMappingFindUnique.mockResolvedValue(row());
+
+        await expect(
+            getValidatedMappingByNormalizedName('mayonnaise', 'openfoodfacts'),
+        ).resolves.toBeNull();
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -30,7 +30,7 @@ import {
     pieceNounInName, labelPieceMatchesItem, countedPieceNoun, servingLabelCountsPiece,
     inferDiscreteUnit,
 } from './count-label';
-import { getValidatedMappingByNormalizedName, saveValidatedMapping, getAiNormalizeCache, isTrustedHumanRow, isHumanTrustSkippableEscape } from './validated-mapping-helpers';
+import { getValidatedMappingByNormalizedName, saveValidatedMapping, getAiNormalizeCache, isTrustedHumanRow, isHumanTrustSkippableEscape, type CacheLookupRejection } from './validated-mapping-helpers';
 import { logMappingAnalysis } from './mapping-logger';
 import { logger } from '../logger';
 import type { FatSecretFoodDetails, FatSecretServing } from './client';
@@ -85,15 +85,16 @@ async function lookupValidatedMappingWithLegacyFallback(
     parsed: import('../parse/ingredient-line').ParsedIngredient | null | undefined,
     brandDetection: BrandKeyInput,
     rawLine: string,
+    rejection?: CacheLookupRejection,
 ): Promise<CachedMappedIngredient | null> {
     const symmetricKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection, rawLine);
-    const hit = await getValidatedMappingByNormalizedName(symmetricKey, 'fatsecret', rawLine);
+    const hit = await getValidatedMappingByNormalizedName(symmetricKey, 'fatsecret', rawLine, rejection);
     if (hit) return hit;
 
     const legacyKey = deriveCacheKeyName(normalizedName, parsed);
     if (legacyKey === symmetricKey || isMalformedCacheKey(legacyKey)) return null;
 
-    const legacyHit = await getValidatedMappingByNormalizedName(legacyKey, 'fatsecret', rawLine);
+    const legacyHit = await getValidatedMappingByNormalizedName(legacyKey, 'fatsecret', rawLine, rejection);
     if (legacyHit) {
         // Branded-query guard: the legacy key (deriveCacheKeyName) is BRANDLESS,
         // so when a brand was detected and stripped it can wrongly match a
@@ -112,8 +113,16 @@ async function lookupValidatedMappingWithLegacyFallback(
                 matchedBrand: brandDetection.matchedBrand,
                 cachedFood: legacyHit.foodName,
             });
+            if (rejection) {
+                rejection.reason = 'legacy_brand_mismatch';
+                rejection.normalizedForm = legacyKey;
+                rejection.foodName = legacyHit.foodName;
+            }
             return null;
         }
+        // A legacy hit that IS accepted clears any rejection the symmetric-key
+        // lookup recorded above — the caller got a row, so nothing was bypassed.
+        if (rejection) rejection.reason = null;
         logger.debug('mapping.legacy_cache_key_fallback_hit', {
             rawLine,
             symmetricKey,
@@ -867,7 +876,14 @@ export async function mapIngredientWithFallback(
         // sites: it's the only brand signal that exists this early. A miss
         // additionally falls back to the legacy (pre-Track-1c) key so rows
         // written under the old scheme stay reachable.
-        const earlyCacheHit = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed);
+        const earlyLookupRejection: CacheLookupRejection = { reason: null };
+        const earlyCacheHit = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, earlyLookupRejection);
+        if (!earlyCacheHit && earlyLookupRejection.reason && telemetry) {
+            // A row existed under this key and the read path rejected it. Without
+            // this the event is indistinguishable from a cold key, which is how
+            // rows that are written and then never servable stayed invisible.
+            telemetry.cacheEscape = 'lookup_early:' + earlyLookupRejection.reason;
+        }
         if (earlyCacheHit) {
             logger.info('mapping.early_cache_hit', { rawLine: trimmed, normalizedName, foodName: earlyCacheHit.foodName });
 
@@ -1281,7 +1297,11 @@ export async function mapIngredientWithFallback(
             // normalize may have replaced normalizedName. brandDetection is
             // request-stable, so this key matches the save key exactly. A
             // miss falls back to the legacy (pre-Track-1c) key.
-            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed);
+            const normalizedLookupRejection: CacheLookupRejection = { reason: null };
+            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, normalizedLookupRejection);
+            if (!normalizedCache && normalizedLookupRejection.reason && telemetry) {
+                telemetry.cacheEscape = 'lookup_normalized:' + normalizedLookupRejection.reason;
+            }
             if (normalizedCache) {
                 logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
                 const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -145,6 +145,40 @@ export function isHumanTrustSkippableEscape(reason: string): boolean {
 }
 
 /**
+ * Out-parameter for getValidatedMappingByNormalizedName.
+ *
+ * The read path has two very different ways to return null: no row existed under
+ * this key, or a row existed and the identity checks below REJECTED it. Callers
+ * could not tell them apart, so every helper-level rejection was written to
+ * MappingEventLog as `cacheHit=NULL, cacheEscape=NULL` — byte-identical to a cold
+ * key. That made a real, recurring failure class (a row the pipeline writes and
+ * then can never serve, so it re-resolves forever) statistically invisible.
+ *
+ * Pass an object here to find out which happened: a non-null `reason` after the
+ * call means a row was found and rejected. Purely diagnostic — populating it
+ * changes no control flow.
+ */
+export interface CacheLookupRejection {
+    /** Rejection class, or null when no row was found at all. */
+    reason: string | null;
+    /** Key the rejected row was stored under — for key-fork diagnosis. */
+    normalizedForm?: string;
+    /** Name of the rejected row, so the reason can be read without a second query. */
+    foodName?: string;
+}
+
+function noteRejection(
+    rejection: CacheLookupRejection | undefined,
+    reason: string,
+    cached: { normalizedForm: string; foodName: string },
+): void {
+    if (!rejection) return;
+    rejection.reason = reason;
+    rejection.normalizedForm = cached.normalizedForm;
+    rejection.foodName = cached.foodName;
+}
+
+/**
  * Retrieve a validated mapping from cache by RAW ingredient line
  * @deprecated Use getValidatedMappingByNormalizedName for new code
  */
@@ -168,11 +202,14 @@ export async function getValidatedMapping(
  * @param normalizedName - The normalized ingredient name to look up
  * @param source - Data source ('fatsecret' or 'fdc' or 'openfoodfacts')
  * @param rawLine - Optional raw ingredient line for cooking state/modifier validation
+ * @param rejection - Optional out-param; receives the reason when a row was found
+ *                    and rejected. See CacheLookupRejection.
  */
 export async function getValidatedMappingByNormalizedName(
     normalizedName: string,
     source: 'fatsecret' | 'fdc' | 'openfoodfacts' = 'fatsecret',
-    rawLine?: string
+    rawLine?: string,
+    rejection?: CacheLookupRejection
 ): Promise<CachedMappedIngredient | null> {
     try {
         // Canonicalize the lookup key (lowercase + singularize + sort tokens)
@@ -222,6 +259,7 @@ export async function getValidatedMappingByNormalizedName(
                     query: normalizedName,
                     cachedFood: cached.foodName,
                 });
+                noteRejection(rejection, 'core_token_mismatch', cached);
                 return null;  // Reject cache hit, force fresh search
             }
             trustSkippedRejection = 'core_token_mismatch';
@@ -244,6 +282,7 @@ export async function getValidatedMappingByNormalizedName(
                         cachedFood: cached.foodName,
                         modifier: mod,
                     });
+                    noteRejection(rejection, `nutritional_modifier:${mod}`, cached);
                     return null;  // Reject cache hit, force fresh search
                 }
                 trustSkippedRejection = trustSkippedRejection ?? `nutritional_modifier:${mod}`;
@@ -260,6 +299,7 @@ export async function getValidatedMappingByNormalizedName(
                         rawLine,
                         cachedFood: cached.foodName,
                     });
+                    noteRejection(rejection, 'context_mismatch', cached);
                     return null;  // Reject cache hit, force fresh search
                 }
                 trustSkippedRejection = trustSkippedRejection ?? 'context_mismatch';


### PR DESCRIPTION
Two changes that exist to make the *next* mapping fix cheaper and less error-prone, rather than to fix a mapping defect themselves.

## 1. Cache-lookup reject telemetry

`getValidatedMappingByNormalizedName` has two very different ways to return null — no row existed, or a row existed and the identity checks rejected it — and callers could not tell them apart. Every helper-level rejection was therefore written to `MappingEventLog` as `cacheHit=NULL, cacheEscape=NULL`, **byte-identical to a cold key**.

That hid a real, recurring class: rows the pipeline writes under a key it can then never serve, so they re-resolve on every request forever. `whole wheat toast` has a row with `usedCount 109` that the read path returns NULL for, because a multi-word modifier (`whole wheat`) is tested against the alphabetically-sorted key (`wheat` < `whole`).

Adds an optional `CacheLookupRejection` out-param populated at the four silent sites:

| site | reason |
|---|---|
| `validated-mapping-helpers.ts` core-token check | `core_token_mismatch` |
| `NUTRITIONAL_MODIFIERS` loop | `nutritional_modifier:<mod>` |
| cooking-state / critical-modifier check | `context_mismatch` |
| `map-ingredient-with-fallback.ts` legacy-key brand guard | `legacy_brand_mismatch` |

Surfaced as `telemetry.cacheEscape = 'lookup_early:<reason>'` / `'lookup_normalized:<reason>'`, matching the existing `early:` / `normalized:` convention. **No control flow changes** — the out-param is optional and every existing call site is untouched.

### Expect two metrics to move, deliberately

- The nightly escape histogram gains `lookup_*` classes and its total rises. Those events are not new behaviour; they were always happening and were invisible.
- **`stuck-keys.ts` filters `cacheEscape IS NULL`, so these keys leave the stuck-key population.** That is semantically right — they are escaping the cache, not sitting under the confidence gate, and those are different defects with different fixes — but the nightly stuck-key count will step down. Conflating the two is part of what this change exists to stop.

## 2. `scripts/eval/winner-gate.sh`

`winner-diff.ts` is the gate the playbook demands before any admission or ranking change may be called safe. It is a good harness. It was also run for **zero of the six** mapping investigations on 2026-07-26, and the reason is in its own header: doing it right is six commands, one of which is the prose instruction "copy the tree, edit the copy".

One command now. It refuses the two ways this gate has actually been run wrong:

- **No `--cold-seeds` → exit 2.** `--from-events`/`--from-cache` contain only already-asked queries, so a fix whose value proposition is "queries that returned nothing now work" gets SAME on 100% of rows and passes vacuously. That blind spot has already invalidated one gate here.
- **Branch touches retrieval → exit 3.** A frozen-pool diff replays a pool *neither* variant would have produced, so it measures nothing.

It also uses a git worktree for BASE rather than `git checkout <ref> -- <file>` (which silently discards uncommitted edits), and takes noise-floor receipts from **both** trees — `diff` keys receipts by tree hash, so a base-only receipt makes it refuse to report.

## Verification

**Falsifiability run** (the tests must fail without the change — playbook: "break the instrument on purpose before you quote its green"):

```
git checkout origin/master -- src/lib/mapping/validated-mapping-helpers.ts
npx jest cache-lookup-rejection-telemetry
  ✕ records nutritional_modifier when a row is found and rejected
  ✕ records core_token_mismatch when the cached row is a different food
  ✓ (4 negative guards — these pass on both trees by design)
Tests: 2 failed, 4 passed
```

The 4 negative guards assert `reason` stays NULL for a cold key, a served row, and a trusted human-triage row. They pass on master too — they guard against an over-firing implementation, they are not evidence the feature exists. The 2 failures are.

The human-triage guard is deliberate: an earlier hand count of this population read 74 keys instead of 58 precisely because it omitted `isTrustedHumanRow`.

**winner-gate on its own change** — a pure telemetry addition should move nothing, and now that is measured rather than asserted:

```
SAME 5 · WINNER-CHANGED 0 · rows with ANY movement: 0 / 5
noise floor: 0 on both trees
suppressed writes: 107 (read-only guard held)
```

**CI locally**: `typecheck` clean · `lint:ci` 0 errors · `next build` clean · full jest 2,127 passed / 1 failed.

That one failure is `src/ops/curated/__tests__/seed-curated.test.ts`, which needs a real Postgres. Reproduced identically on a clean `origin/master` worktree, so it is pre-existing and not from this change.

## Not in scope

`findByTokenSet` has its own internal validation and can also return null after finding candidates. It is closer to "no row" than "row rejected" so it is left uninstrumented; worth revisiting if the `lookup_*` classes turn out to under-count.