### PR TITLE
fix(filter): an "X and Y" query no longer annihilates its own dish

### DIFF
--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -174,6 +174,14 @@ noise_floor_both_trees() {
         echo "introduced nondeterminism into replay — that is itself the finding." >&2
         exit 4
     fi
+    # UPSTREAM BUG WORKAROUND (winner-diff.ts, found 2026-07-26): `diff` derives
+    # the receipt-ledger path from the replay files and resolves it to
+    # "snapshot.noise-floor.json" rather than "<snapshot-basename>.noise-floor.json".
+    # The ledger written above holds exactly the receipts diff asks for, under the
+    # right name, and diff still REFUSES TO REPORT because it reads the wrong path.
+    # Mirror it so a correct run is not blocked by a filename. Remove once fixed.
+    local ledger="${snap%.json}.noise-floor.json"
+    [[ -f "$ledger" ]] && cp "$ledger" "$(dirname "$snap")/snapshot.noise-floor.json"
 }
 
 echo "[3/5] noise floor: every snapshot x both trees (must be 0)"

--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -158,18 +158,28 @@ if [[ "$REGRESSION_N" -gt 0 ]]; then
 fi
 
 # ------------------------------------------------------------ noise floor
-# The receipt is keyed by TREE HASH, so `diff` requires one from EACH side. A
-# base-only receipt is not sufficient and diff will (correctly) refuse to report.
-echo "[3/5] noise floor on BOTH trees (must be 0 — writes the receipts diff requires)"
-if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$OUT/snap.json" ) 2>&1 | tail -8; then
-    echo "ABORT: noise floor is non-zero on BASE. The replay is not deterministic," >&2
-    echo "so any before/after claim below it is not a result." >&2
-    exit 4
-fi
-if ! eval "$RUN" noise-floor --snapshot "$OUT/snap.json" 2>&1 | tail -8; then
-    echo "ABORT: noise floor is non-zero on BRANCH. Your change introduced" >&2
-    echo "nondeterminism into replay — that is itself the finding." >&2
-    exit 4
+# The receipt is keyed by (SNAPSHOT, TREE HASH), so `diff` requires one per
+# snapshot per side — four runs when a regression population is in play. Missing
+# any one makes diff refuse to report, which is how both of this driver's own
+# bugs were caught.
+noise_floor_both_trees() {
+    local snap="$1" name="$2"
+    if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$snap" ) 2>&1 | tail -6; then
+        echo "ABORT: noise floor non-zero on BASE for $name. The replay is not" >&2
+        echo "deterministic, so any before/after claim below it is not a result." >&2
+        exit 4
+    fi
+    if ! eval "$RUN" noise-floor --snapshot "$snap" 2>&1 | tail -6; then
+        echo "ABORT: noise floor non-zero on BRANCH for $name. Your change" >&2
+        echo "introduced nondeterminism into replay — that is itself the finding." >&2
+        exit 4
+    fi
+}
+
+echo "[3/5] noise floor: every snapshot x both trees (must be 0)"
+noise_floor_both_trees "$OUT/snap.json" "cold"
+if [[ "$REGRESSION_N" -gt 0 ]]; then
+    noise_floor_both_trees "$OUT/snap-regression.json" "regression"
 fi
 
 # ------------------------------------------------------------ replays

--- a/src/lib/mapping/__tests__/multi-ingredient-self-match.test.ts
+++ b/src/lib/mapping/__tests__/multi-ingredient-self-match.test.ts
@@ -38,19 +38,34 @@ describe('isMultiIngredientMismatch — compound-query self-match', () => {
         expect(isMultiIngredientMismatch(query, candidate)).toBe(false);
     });
 
-    // ---- what the fix must NOT break: the reverse check still adjudicates ----
+    // ---- what the fix must NOT break ----
+    //
+    // MEASURED, not assumed. Both groups below return false on origin/master AND
+    // on this branch — they exit before reaching the branch this change touches,
+    // so the change provably cannot have moved them. Written down because the
+    // 2026-07-26 investigation reported that the canonical regression "lives in
+    // the SECOND branch and must be shown untouched"; it does not live in either
+    // branch, and a test asserting it did would have failed on master too.
 
-    it('still rejects a candidate matching only ONE side of a compound query', () => {
-        // The canonical regression this rule was written for.
-        expect(isMultiIngredientMismatch('tomato and green chili mix', 'green raw tomatoes')).toBe(true);
+    it('the canonical regression exits early on WORD COUNT, not on either branch', () => {
+        // 'tomato and green chili mix' has 5 significant words, so
+        // `if (queryWords.length > 3) return false` at filter-candidates.ts:2020
+        // fires first. This function never adjudicates it — whatever keeps
+        // 'green raw tomatoes' out is upstream (must-have tokens / core-token
+        // coverage), so the guard added here cannot reopen it.
+        expect(isMultiIngredientMismatch('tomato and green chili mix', 'green raw tomatoes')).toBe(false);
     });
 
     it.each([
         ['mac and cheese', 'Cheddar Cheese'],
         ['biscuits and gravy', 'Buttermilk Biscuits'],
         ['bacon and eggs', 'Scrambled Eggs'],
-    ])('%p still rejects the single-component candidate %p', (query, candidate) => {
-        expect(isMultiIngredientMismatch(query, candidate)).toBe(true);
+    ])('%p vs single-component %p exits at the no-connector guard', (query, candidate) => {
+        // The candidate carries no and/&/with, so `if (!multiMatch) return false`
+        // at :2024 fires. The REVERSE CHECK only ever runs when the CANDIDATE is
+        // compound — it is not a general single-component rejector, which is the
+        // opposite of what the investigation assumed.
+        expect(isMultiIngredientMismatch(query, candidate)).toBe(false);
     });
 
     // ---- the first branch must be UNCHANGED for single-ingredient queries ----

--- a/src/lib/mapping/__tests__/multi-ingredient-self-match.test.ts
+++ b/src/lib/mapping/__tests__/multi-ingredient-self-match.test.ts
@@ -1,0 +1,72 @@
+/**
+ * isMultiIngredientMismatch: an "X and Y" query must not annihilate its own dish.
+ *
+ * The first branch assumes the QUERY is a single ingredient that appears in the
+ * candidate only as the secondary component ("cheese" must not be answered by
+ * "Mac and Cheese"). When the query is ITSELF an "X and Y" compound that premise
+ * is false, and the function returned true for a candidate whose name is
+ * byte-identical to the query — so `mac and cheese` rejected every candidate
+ * including the record literally named "Mac and Cheese", left strict and relaxed
+ * pools both empty, and fell to AI backfill at 28g/90kcal against a real
+ * ~200g/~400kcal serving (measured live on the box, 2026-07-26).
+ *
+ * The regression this rule exists for lives in the REVERSE CHECK, not the first
+ * branch. It is asserted here by test rather than by inspection, because that
+ * distinction is exactly what the playbook's HARD RULE demands.
+ */
+
+import { isMultiIngredientMismatch } from '../filter-candidates';
+
+describe('isMultiIngredientMismatch — compound-query self-match', () => {
+    // ---- what the fix must CREATE ----
+
+    it('does not reject a candidate byte-identical to the query', () => {
+        expect(isMultiIngredientMismatch('mac and cheese', 'Mac and Cheese')).toBe(false);
+    });
+
+    it.each([
+        ['mac and cheese', 'Mac and Cheese (Cooked)'],
+        ['biscuits and gravy', 'Biscuits and Gravy'],
+        ['rice and beans', 'Rice and Beans'],
+        ['bacon and eggs', 'Bacon and Eggs'],
+        ['chips and queso', 'Chips and Queso'],
+        ['spaghetti and meatballs', 'Spaghetti and Meatballs'],
+        ['beef and broccoli', 'Beef and Broccoli'],
+        ['gin and tonic', 'Gin and Tonic'],
+        ['ackee and saltfish', 'Ackee and Saltfish'],
+    ])('admits the real dish for %p', (query, candidate) => {
+        expect(isMultiIngredientMismatch(query, candidate)).toBe(false);
+    });
+
+    // ---- what the fix must NOT break: the reverse check still adjudicates ----
+
+    it('still rejects a candidate matching only ONE side of a compound query', () => {
+        // The canonical regression this rule was written for.
+        expect(isMultiIngredientMismatch('tomato and green chili mix', 'green raw tomatoes')).toBe(true);
+    });
+
+    it.each([
+        ['mac and cheese', 'Cheddar Cheese'],
+        ['biscuits and gravy', 'Buttermilk Biscuits'],
+        ['bacon and eggs', 'Scrambled Eggs'],
+    ])('%p still rejects the single-component candidate %p', (query, candidate) => {
+        expect(isMultiIngredientMismatch(query, candidate)).toBe(true);
+    });
+
+    // ---- the first branch must be UNCHANGED for single-ingredient queries ----
+
+    it('a single-ingredient query is still rejected by a mixed product', () => {
+        // This is the behaviour the first branch exists for and the guard must
+        // not touch: "cheese" is only the secondary half of "Mac and Cheese".
+        expect(isMultiIngredientMismatch('cheese', 'Mac and Cheese')).toBe(true);
+        expect(isMultiIngredientMismatch('gravy', 'Biscuits and Gravy')).toBe(true);
+    });
+
+    it('a single-ingredient query matching the PRIMARY half is still admitted', () => {
+        expect(isMultiIngredientMismatch('mac', 'Mac and Cheese')).toBe(false);
+    });
+
+    it('a non-compound candidate is short-circuited regardless of query shape', () => {
+        expect(isMultiIngredientMismatch('mac and cheese', 'Macaroni')).toBe(false);
+    });
+});

--- a/src/lib/mapping/filter-candidates.ts
+++ b/src/lib/mapping/filter-candidates.ts
@@ -2026,16 +2026,37 @@ export function isMultiIngredientMismatch(normalizedName: string, candidateName:
     const beforeConnector = multiMatch[1];
     const afterConnector = multiMatch[3];
 
-    // Check if query matches the part AFTER the connector (secondary ingredient)
-    const queryMainToken = queryWords[queryWords.length - 1]; // Last word is usually the main ingredient
+    // This branch's premise is that the QUERY is a single ingredient appearing
+    // in the candidate only as the SECONDARY component — "cheese" must not be
+    // answered by "Mac and Cheese". That premise is false when the query is
+    // itself an "X and Y" compound: the user asked for the dish, and the dish's
+    // own last token naturally sits in the after-connector half.
+    //
+    // Without this guard the function returned true for a candidate whose name
+    // is byte-identical to the query. "mac and cheese" split the candidate into
+    // before="mac" / after="cheese", found queryMainToken "cheese" in the after
+    // half and not the before half, and rejected EVERY candidate — including
+    // the record literally named "Mac and Cheese" — leaving strict and relaxed
+    // pools both empty and dropping the line to AI backfill at 28g/90kcal
+    // against a real ~200g/~400kcal serving.
+    //
+    // The REVERSE CHECK below is what adjudicates compound queries, and it
+    // still rejects a candidate matching only ONE side ("tomato and green chili
+    // mix" vs "green raw tomatoes"), so narrowing here does not reopen that case.
+    const queryIsCompound = /^(.+?)\s+(&|and|with)\s+(.+)$/i.test(queryLower);
 
-    // If query's main token is in the "after" part but NOT in the "before" part,
-    // the query is a secondary ingredient in this mixed product
-    const inAfter = afterConnector.includes(queryMainToken);
-    const inBefore = beforeConnector.includes(queryMainToken);
+    if (!queryIsCompound) {
+        // Check if query matches the part AFTER the connector (secondary ingredient)
+        const queryMainToken = queryWords[queryWords.length - 1]; // Last word is usually the main ingredient
 
-    if (inAfter && !inBefore) {
-        return true; // Mismatch - query is secondary ingredient
+        // If query's main token is in the "after" part but NOT in the "before" part,
+        // the query is a secondary ingredient in this mixed product
+        const inAfter = afterConnector.includes(queryMainToken);
+        const inBefore = beforeConnector.includes(queryMainToken);
+
+        if (inAfter && !inBefore) {
+            return true; // Mismatch - query is secondary ingredient
+        }
     }
 
     // REVERSE CHECK: If the QUERY contains "and"/"&"/"with" (is itself multi-ingredient),


### PR DESCRIPTION
## The defect

`isMultiIngredientMismatch(q, candidate)` returned **true for a candidate whose name is byte-identical to the query**. On `mac and cheese`:

```
candidate "Mac and Cheese"  ->  before="mac"  after="cheese"
queryMainToken = "cheese"   (last word of the query)
inAfter = true   inBefore = false   ->  return true
```

Every candidate is rejected — strict *and* relaxed pools both empty — and the line falls to AI backfill.

**Measured live on the box before the fix:**

```
mac and cheese -> "Mac and Cheese (Cooked)"  grams=28  kcal=90.4  servingTier=(none)  funnelStage=(none)
```

A real serving is ~200 g / ~400 kcal, so this is a **~4.4x silent under-bill** on a dish with 115 events/wk. It also cannot cache (confidence 0.612, below the 0.85 save gate), so it re-runs the entire pipeline on every request.

## The fix

The first branch's premise is *"the QUERY is a single ingredient appearing in the candidate only as the secondary component"* — `cheese` must not be answered by `Mac and Cheese`. That premise is false when the query is itself an `X and Y` compound: the user asked for the dish, and the dish's own last token naturally sits in the after-connector half.

So the branch is skipped when the query is itself compound. This is more principled than the name-equality check originally proposed — it also fixes `biscuits and gravy`, `chicken and waffles`, etc., not just byte-identical matches.

## Two corrections to the investigation that motivated this

Both were caught by writing the tests as assertions about real behaviour and running them against `origin/master`.

1. **The canonical regression does NOT live in the second branch.** `tomato and green chili mix` has 5 significant words, so `if (queryWords.length > 3) return false` at `filter-candidates.ts:2020` fires first — this function never adjudicates it, on master or on this branch. Whatever keeps `green raw tomatoes` out is upstream.
2. **The REVERSE CHECK is not a general single-component rejector.** It sits below `if (!multiMatch) return false`, so it only ever runs when the *candidate* is compound. `mac and cheese` vs `Cheddar Cheese` returns false on master too.

Both are asserted in the test file with the reason, so the next reader does not re-derive them.

## Verification

**Falsifiability run** — the tests must be red without the change:

| tree | result |
|---|---|
| `origin/master` | **10 failed**, 7 passed |
| this branch | **17 passed** |

The 10 reds are exactly the "must CREATE" cases. The 7 that pass on both are the "must not break" cases — they exit before the modified branch, so the change provably cannot move them.

**winner-gate (`scripts/eval/winner-gate.sh`)** — the HARD RULE gate, noise floor 0 on both trees for both populations:

*Cold population* (28 A-and-B dishes, including never-asked ones — blind spot D):

```
WINNER-CHANGED    15
NOWINNER->WINNER   5
WINNER->NOWINNER   0
PATH-CHANGED       0
20 / 28 rows moved
```

*Regression population* (150 already-asked event-log lines):

```
SAME             149
WINNER-CHANGED     0
NOWINNER->WINNER   1     <- `mac and cheese` itself
WINNER->NOWINNER   0
1 / 150 rows moved · no-nutrition BASE 0 / BRANCH 0 · no Atwater drift · no class drift
```

`WINNER->NOWINNER 0` on both populations is admit-only **confirmed at pipeline level**, not by inspection — which is the distinction that has been wrong four times in this repo.

## One thing that is not a clean win

The cold run reports `no-nutrition winner: BASE 0, BRANCH 4`. Four of the newly-admitted cold winners carry no nutrition panel, so they will still reach AI backfill for their numbers. Not a regression (BASE had no winner at all for those), but not a full fix either — those four are a follow-up, not a claim this PR closes.

`fish and chips` also moved off a class-drifting pick (144 -> 490 kcal/100g, BASE-only drift).

## Also in this PR: two `winner-gate.sh` fixes, both found by the gate refusing to report

- Noise-floor receipts are keyed by **(snapshot, tree)**, so a regression population needs four runs, not two.
- **Upstream bug in `winner-diff.ts`**: `diff` derives the receipt-ledger path from the replay files and resolves it to `snapshot.noise-floor.json` instead of `<basename>.noise-floor.json`, so a correct run is blocked by a filename. The ledger is mirrored as a workaround, commented, and should be removed once `winner-diff.ts` is fixed.

## CI locally

`typecheck` clean · `lint:ci` 0 errors · `next build` clean · jest **2,144 passed** / 1 failed (`seed-curated`, needs a real Postgres and is in CI's `testPathIgnorePatterns`).