### PR TITLE
fix(servings): the gate can see the billed number, and the billed number was wrong

### DIFF
--- a/scripts/eval/__tests__/serving-verdict.test.ts
+++ b/scripts/eval/__tests__/serving-verdict.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The SERVING verdict — winner-diff blind spot (B), closed 2026-07-27.
+ *
+ * These tests exist because of a specific shipped failure. PR #173 moved
+ * `mac and cheese` off an AI backfill onto the record literally named "Mac and
+ * Cheese" — the winner diff showed 5 NOWINNER->WINNER and 0 losses, the eval
+ * stayed at 0 real failures, and the gate was green. The billed number went
+ * 90.4 -> 39.5 kcal against a true ~400, because the 28g serving anchor never
+ * moved and the newly-admitted record has a lower kcal/100g.
+ *
+ * Nothing in the harness could see that. The verdict below is what sees it, so
+ * the cases that matter most here are the ones asserting that ABSENCE OF DATA
+ * is reported as UNJUDGED and never as agreement.
+ */
+
+import {
+    ReplayRow,
+    ServingInfo,
+    billedKcalDeltaPct,
+    classifyServing,
+    summariseServing,
+    formatServingSummary,
+} from '../winner-diff-screens';
+
+function row(query: string, serving?: ServingInfo | null): ReplayRow {
+    return {
+        query,
+        path: 'rerank',
+        relaxedRecovery: false,
+        pool: {
+            gather: 10, afterTokenFilter: 8, afterCoreToken: 6, afterZeroMacro: 6,
+            afterPlausibility: 5, afterDenylist: 5, admitted: 5, rerankWindow: 5,
+        },
+        rerankWindowIds: [], admittedIds: [], rerankRan: true,
+        gate: { skipAiRerank: false, reason: 'ok', confidence: 0.8 },
+        winner: null,
+        notes: [],
+        ...(serving === undefined ? {} : { serving }),
+    };
+}
+
+const s = (grams: number | null, tier: string | null, kcal: number | null, aiTouched = false): ServingInfo =>
+    ({ grams, servingTier: tier, servingDescription: null, totalKcal: kcal, aiTouched });
+
+describe('classifyServing', () => {
+    it('reports GRAMS-CHANGED when the billed grams move', () => {
+        expect(classifyServing(
+            row('rxbar chocolate sea salt', s(2.5, 'bare_category_default', 9.6)),
+            row('rxbar chocolate sea salt', s(52, 'bare_label_serving', 210)),
+        )).toBe('GRAMS-CHANGED');
+    });
+
+    it('reports TIER-CHANGED when grams hold but provenance moves', () => {
+        expect(classifyServing(
+            row('bagel', s(98, 'bare_sibling_serving', 260)),
+            row('bagel', s(98, 'bare_label_serving', 260)),
+        )).toBe('TIER-CHANGED');
+    });
+
+    it('treats sub-epsilon float drift as SAME', () => {
+        expect(classifyServing(row('q', s(28.0, 't', 90)), row('q', s(28.004, 't', 90)))).toBe('SERVING-SAME');
+    });
+
+    it('reports gained and lost servings in the right direction', () => {
+        expect(classifyServing(row('q', s(null, null, null)), row('q', s(50, 't', 100)))).toBe('NOSERVING->SERVING');
+        expect(classifyServing(row('q', s(50, 't', 100)), row('q', s(null, null, null)))).toBe('SERVING->NOSERVING');
+    });
+
+    // ---- the cases the whole file exists for: silence is never agreement ----
+
+    it('a replay taken WITHOUT the serving stage is UNJUDGED, not SERVING-SAME', () => {
+        // `serving === undefined` means the stage never ran. Calling that
+        // agreement is precisely the blind spot that cleared PR #173.
+        expect(classifyServing(row('mac and cheese'), row('mac and cheese'))).toBe('UNJUDGED');
+        expect(classifyServing(row('q'), row('q', s(28, 't', 39.5)))).toBe('UNJUDGED');
+        expect(classifyServing(row('q', s(28, 't', 90.4)), row('q'))).toBe('UNJUDGED');
+    });
+
+    it('a serving-stage error is UNJUDGED, not unchanged', () => {
+        const errored: ServingInfo = { ...s(null, null, null), error: 'winner not found in frozen pool' };
+        expect(classifyServing(row('q', errored), row('q', s(null, null, null)))).toBe('UNJUDGED');
+    });
+
+    it('an AI-estimated tier gets its own verdict rather than counting as movement', () => {
+        // AI estimators do not replay deterministically. Counting them as movement
+        // would make every gate look noisy; counting them as SAME would hide real
+        // regressions behind a model call. Neither — they are named.
+        expect(classifyServing(
+            row('q', s(30, 'ai_generated_serving', 100, true)),
+            row('q', s(45, 'ai_generated_serving', 150, true)),
+        )).toBe('AI-NONDETERMINISTIC');
+    });
+
+    it('null-vs-null with the stage RUN is genuine agreement', () => {
+        expect(classifyServing(row('q', null), row('q', null))).toBe('SERVING-SAME');
+    });
+});
+
+describe('billedKcalDeltaPct', () => {
+    it('is negative when the change makes the user under-billed', () => {
+        // The literal PR #173 numbers. A gate that prints this cannot report the
+        // change as a closed under-bill.
+        const d = billedKcalDeltaPct(
+            row('mac and cheese', s(28, 'flat', 90.4)),
+            row('mac and cheese', s(28, 'bare_category_default', 39.5)),
+        );
+        expect(d).not.toBeNull();
+        expect(d!).toBeCloseTo(-56.3, 1);
+    });
+
+    it('is null rather than Infinity when the A side billed zero', () => {
+        expect(billedKcalDeltaPct(row('q', s(10, 't', 0)), row('q', s(10, 't', 50)))).toBeNull();
+    });
+
+    it('is null when either side lacks a total', () => {
+        expect(billedKcalDeltaPct(row('q'), row('q', s(10, 't', 50)))).toBeNull();
+    });
+});
+
+describe('summariseServing', () => {
+    const A = [
+        row('mac and cheese', s(28, 'bare_category_default', 39.5)),
+        row('rxbar chocolate sea salt', s(2.5, 'bare_category_default', 9.6)),
+        row('black pepper', s(2.5, 'bare_category_default', 9.1)),
+        row('ghost cinnamon roll', s(30, 'ai_generated_serving', 120, true)),
+        row('unrun'),
+    ];
+    const B = [
+        row('mac and cheese', s(200, 'bare_sibling_serving', 282)),
+        row('rxbar chocolate sea salt', s(52, 'bare_label_serving', 210)),
+        row('black pepper', s(2.5, 'bare_category_default', 9.1)),
+        row('ghost cinnamon roll', s(31, 'ai_generated_serving', 124, true)),
+        row('unrun'),
+    ];
+
+    it('counts every verdict and ranks movers by kcal magnitude', () => {
+        const sum = summariseServing(A, B);
+        expect(sum.counts['GRAMS-CHANGED']).toBe(2);
+        expect(sum.counts['SERVING-SAME']).toBe(1);
+        expect(sum.counts['AI-NONDETERMINISTIC']).toBe(1);
+        expect(sum.counts['UNJUDGED']).toBe(1);
+        // rxbar is +2088%, mac and cheese +614% — biggest first.
+        expect(sum.moved.map(m => m.query)).toEqual(['rxbar chocolate sea salt', 'mac and cheese']);
+    });
+
+    it('lists the unjudged rows instead of only counting them', () => {
+        const sum = summariseServing(A, B);
+        expect(sum.unjudged).toContain('unrun');
+        expect(sum.unjudged).toContain('ghost cinnamon roll');
+    });
+
+    it('formats the unjudged rows into the report so a count cannot read as clearance', () => {
+        const text = formatServingSummary(summariseServing(A, B)).join('\n');
+        expect(text).toContain('UNJUDGED');
+        expect(text).toContain('NOT evidence of no change');
+        expect(text).toContain('unrun');
+        expect(text).toContain('BILLED-NUMBER MOVERS');
+    });
+
+    it('does not crash on an empty population', () => {
+        const sum = summariseServing([], []);
+        expect(formatServingSummary(sum).join('\n')).toContain('no comparable rows');
+    });
+});

--- a/scripts/eval/probe-bare-serving.ts
+++ b/scripts/eval/probe-bare-serving.ts
@@ -1,0 +1,96 @@
+/**
+ * probe-bare-serving.ts — what the bare-query serving guard OVERRODE, per query.
+ *
+ * Answers one question the event log cannot: for a key billed at
+ * `bare_category_default`, what did the tier cascade produce BEFORE the guard
+ * fired? MappingEventLog records only the final grams/tier, so "the guard
+ * replaced a fabricated 100g floor" and "the guard destroyed a genuine 52g bar
+ * label" are indistinguishable in it — and they need opposite fixes.
+ *
+ * The guard logs previousTier/previousGrams at
+ * map-ingredient-with-fallback.ts:5439; this captures that line per query
+ * instead of grepping a shared service journal.
+ *
+ * READ-ONLY: every Prisma mutation is intercepted and no-oped, same guard as
+ * winner-diff. Nothing is written to FoodMapping. skipCache is forced so each
+ * query resolves cold.
+ *
+ * Run ON THE BOX, from the repo root:
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/probe-bare-serving.ts <<'EOF'
+ *   mac and cheese
+ *   rxbar chocolate sea salt
+ *   EOF
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = process.cwd();
+for (const f of ['.env', '.env.local']) {
+    const p = path.join(REPO_ROOT, f);
+    if (!fs.existsSync(p)) continue;
+    for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+        const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*"?([^"\n]*)"?\s*$/);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { prisma } = require('../../src/lib/db');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const logger = require('../../src/lib/logger').logger;
+
+const MUTATING = new Set([
+    'create', 'createMany', 'createManyAndReturn', 'update', 'updateMany',
+    'upsert', 'delete', 'deleteMany', 'executeRaw', 'executeRawUnsafe',
+]);
+prisma.$use(async (params: any, next: any) => {
+    if (MUTATING.has(params.action)) return null;
+    return next(params);
+});
+
+/** Capture the guard's own log line rather than re-deriving what it did. */
+let captured: Record<string, any> | null = null;
+const realInfo = logger.info.bind(logger);
+logger.info = (msg: string, meta?: any) => {
+    if (typeof msg === 'string' && msg.endsWith('.bare_category_default')) captured = { msg, ...meta };
+    return realInfo(msg, meta);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { mapIngredientWithFallback } = require('../../src/lib/mapping/map-ingredient-with-fallback');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getBareQueryDefault } = require('../../src/lib/ai/ambiguous-serving-estimator');
+
+async function main() {
+    const lines = fs.readFileSync(0, 'utf8').split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('#'));
+    console.log(`probing ${lines.length} queries — READ-ONLY, skipCache forced\n`);
+
+    for (const line of lines) {
+        captured = null;
+        let r: any = null;
+        let err: string | null = null;
+        try {
+            r = await mapIngredientWithFallback(line, { skipCache: true });
+        } catch (e: any) {
+            err = e?.message ?? String(e);
+        }
+        const lex = getBareQueryDefault(line);
+        console.log(`── ${line}`);
+        if (err) { console.log(`   ERROR ${err}`); continue; }
+        if (!r) { console.log('   (no mapping)'); continue; }
+        console.log(`   record   ${r.foodId} "${r.foodName}"${r.brandName ? ` [${r.brandName}]` : ''}`);
+        console.log(`   BILLED   ${r.grams}g  ${Math.round(r.kcal)}kcal  tier=${r.servingTier ?? '-'}  desc=${r.servingDescription ?? '-'}`);
+        console.log(`   lexicon  ${lex ? `${lex.grams}g "${lex.description}"  (cap threshold ${lex.grams * 2}g)` : '(no category match)'}`);
+        if (captured) {
+            console.log(`   GUARD    ${captured.previousTier ?? '-'} ${captured.previousGrams}g  ->  ${captured.grams}g`);
+        } else {
+            console.log('   GUARD    did not fire');
+        }
+        console.log('');
+    }
+    await prisma.$disconnect();
+}
+
+main().catch(async e => { console.error(e); try { await prisma.$disconnect(); } catch { /* noop */ } process.exit(1); });

--- a/scripts/eval/winner-diff-screens.ts
+++ b/scripts/eval/winner-diff-screens.ts
@@ -174,6 +174,13 @@ export interface ReplayFile {
     gitDirty: string;
     snapshotTakenAt: string;
     snapshotPopulation: string;
+    /**
+     * The snapshot file this replay was produced from. Recorded so `diff` can find
+     * the noise-floor ledger by construction instead of guessing at it — the guess
+     * only worked when a directory held exactly one snapshot, so every gate run
+     * with both a cold and a regression population misresolved it.
+     */
+    snapshotPath?: string;
     callerHash: string;
     helpersHash: string;
     /** true when `--with-serving` ran the serving stage and populated row.serving */

--- a/scripts/eval/winner-diff-screens.ts
+++ b/scripts/eval/winner-diff-screens.ts
@@ -97,6 +97,34 @@ export interface CounterfactualInfo {
     notes: string[];
 }
 
+/**
+ * What the SERVING stage billed, once a winner exists.
+ *
+ * Populated only under `replay --with-serving`. It exists because the harness
+ * used to stop at winner selection, and that blind spot passed a green gate on a
+ * change that made the user's number WORSE: PR #173 moved `mac and cheese` onto
+ * the correct record and the billed total went 90.4 -> 39.5 kcal against a true
+ * ~400, because the 28g serving anchor never moved. A winner diff cannot see
+ * that. This can.
+ */
+export interface ServingInfo {
+    /** grams billed for the parsed quantity, or null when the stage produced nothing */
+    grams: number | null;
+    /** cascade branch that billed the grams — 'bare_category_default', 'fs_label_count', … */
+    servingTier: string | null;
+    servingDescription: string | null;
+    /** kcal the user is actually shown — the number every under-bill report quotes */
+    totalKcal: number | null;
+    /**
+     * True when the grams came from an AI estimator. Those tiers are not
+     * deterministic across replays, so the diff reports them in their own bucket
+     * rather than counting them as movement your change caused.
+     */
+    aiTouched: boolean;
+    /** the serving stage threw — the row is UNJUDGEABLE, which is not the same as unchanged */
+    error?: string;
+}
+
 export interface ReplayRow {
     query: string;
     /** population tag, so a report can separate real user lines from warmer keys */
@@ -114,6 +142,14 @@ export interface ReplayRow {
     gate: { skipAiRerank: boolean; reason: string; confidence: number };
     rerankReason?: string;
     winner: WinnerInfo | null;
+    /**
+     * The grams/kcal the winner was actually billed at.
+     *   undefined ⇒ the serving stage was never run (no --with-serving)
+     *   null      ⇒ it ran and produced no result (no winner, or the builder returned null)
+     * The distinction matters: a diff must refuse to compare a stage that never
+     * ran, and must NOT read that as "serving unchanged".
+     */
+    serving?: ServingInfo | null;
     /** present only when the gate pre-empted: what simpleRerank would have picked */
     counter?: CounterfactualInfo;
     counterMicros?: number;
@@ -140,6 +176,8 @@ export interface ReplayFile {
     snapshotPopulation: string;
     callerHash: string;
     helpersHash: string;
+    /** true when `--with-serving` ran the serving stage and populated row.serving */
+    withServing?: boolean;
     rows: ReplayRow[];
 }
 
@@ -177,6 +215,144 @@ export function classifyVerdict(a: ReplayRow, b: ReplayRow): Verdict {
     if (a.path !== b.path || a.relaxedRecovery !== b.relaxedRecovery) return 'PATH-CHANGED';
     return 'SAME';
 }
+
+// ============================================================
+// 3b. THE SERVING VERDICT  (blind spot (B), closed 2026-07-27)
+// ============================================================
+
+export type ServingVerdict =
+    /** both sides billed the same grams (within FP tolerance) */
+    | 'SERVING-SAME'
+    /** grams moved — the only verdict that changes what the user is billed */
+    | 'GRAMS-CHANGED'
+    /** same grams, different cascade branch: no user-visible change TODAY, but the
+     *  provenance moved, and a tier is what the next fix will target */
+    | 'TIER-CHANGED'
+    | 'NOSERVING->SERVING'
+    | 'SERVING->NOSERVING'
+    /** at least one side came from an AI estimator — not deterministic, not judgeable */
+    | 'AI-NONDETERMINISTIC'
+    /** the stage did not run on one or both sides, or it threw */
+    | 'UNJUDGED';
+
+export const SERVING_VERDICTS: readonly ServingVerdict[] = [
+    'SERVING-SAME', 'GRAMS-CHANGED', 'TIER-CHANGED',
+    'NOSERVING->SERVING', 'SERVING->NOSERVING', 'AI-NONDETERMINISTIC', 'UNJUDGED',
+];
+
+/** Grams are floats off a cascade of multiplications; 0.01g is not a change. */
+const GRAMS_EPSILON = 0.01;
+
+/**
+ * Did the number the USER IS BILLED move?
+ *
+ * `UNJUDGED` is returned whenever the stage did not run on both sides, and that
+ * is load-bearing: the failure this verdict exists to prevent is reading silence
+ * as safety. A replay taken without --with-serving has `serving === undefined`,
+ * and calling that SERVING-SAME would reproduce the exact blind spot that let a
+ * green gate ship a worse billed number.
+ */
+export function classifyServing(a: ReplayRow, b: ReplayRow): ServingVerdict {
+    const sa = a.serving;
+    const sb = b.serving;
+    if (sa === undefined || sb === undefined) return 'UNJUDGED';
+    if (sa?.error || sb?.error) return 'UNJUDGED';
+    if (sa?.aiTouched || sb?.aiTouched) return 'AI-NONDETERMINISTIC';
+
+    const ga = sa?.grams ?? null;
+    const gb = sb?.grams ?? null;
+    if (ga == null && gb == null) return 'SERVING-SAME';
+    if (ga == null) return 'NOSERVING->SERVING';
+    if (gb == null) return 'SERVING->NOSERVING';
+    if (Math.abs(ga - gb) > GRAMS_EPSILON) return 'GRAMS-CHANGED';
+    if ((sa?.servingTier ?? null) !== (sb?.servingTier ?? null)) return 'TIER-CHANGED';
+    return 'SERVING-SAME';
+}
+
+/**
+ * Percent change in the billed total. Signed: negative means the change made the
+ * user's number SMALLER, which for an under-bill fix is the wrong direction and
+ * is the single fact PR #173's report should have led with.
+ */
+export function billedKcalDeltaPct(a: ReplayRow, b: ReplayRow): number | null {
+    const ka = a.serving?.totalKcal ?? null;
+    const kb = b.serving?.totalKcal ?? null;
+    if (ka == null || kb == null || ka === 0) return null;
+    return (100 * (kb - ka)) / ka;
+}
+
+export interface ServingSummary {
+    counts: Record<ServingVerdict, number>;
+    /** rows whose billed grams moved, worst-magnitude first */
+    moved: Array<{
+        query: string;
+        aGrams: number | null; bGrams: number | null;
+        aTier: string | null; bTier: string | null;
+        aKcal: number | null; bKcal: number | null;
+        kcalDeltaPct: number | null;
+    }>;
+    /** rows the gate could not adjudicate — must be printed, never summarised away */
+    unjudged: string[];
+}
+
+export function summariseServing(aRows: ReplayRow[], bRows: ReplayRow[]): ServingSummary {
+    const byQ = new Map(bRows.map(r => [r.query, r]));
+    const counts = Object.fromEntries(SERVING_VERDICTS.map(v => [v, 0])) as Record<ServingVerdict, number>;
+    const moved: ServingSummary['moved'] = [];
+    const unjudged: string[] = [];
+
+    for (const a of aRows) {
+        const b = byQ.get(a.query);
+        if (!b) continue;
+        const v = classifyServing(a, b);
+        counts[v]++;
+        if (v === 'UNJUDGED' || v === 'AI-NONDETERMINISTIC') unjudged.push(a.query);
+        if (v === 'GRAMS-CHANGED' || v === 'NOSERVING->SERVING' || v === 'SERVING->NOSERVING') {
+            moved.push({
+                query: a.query,
+                aGrams: a.serving?.grams ?? null, bGrams: b.serving?.grams ?? null,
+                aTier: a.serving?.servingTier ?? null, bTier: b.serving?.servingTier ?? null,
+                aKcal: a.serving?.totalKcal ?? null, bKcal: b.serving?.totalKcal ?? null,
+                kcalDeltaPct: billedKcalDeltaPct(a, b),
+            });
+        }
+    }
+    moved.sort((x, y) => Math.abs(y.kcalDeltaPct ?? 0) - Math.abs(x.kcalDeltaPct ?? 0));
+    return { counts, moved, unjudged };
+}
+
+export function formatServingSummary(s: ServingSummary, top = 30): string[] {
+    const out: string[] = [];
+    const total = Object.values(s.counts).reduce((a, b) => a + b, 0);
+    out.push('');
+    out.push('=== SERVING DIFF — what the user is BILLED (winner-diff blind spot (B)) ===');
+    if (total === 0) { out.push('  no comparable rows'); return out; }
+    for (const v of SERVING_VERDICTS) {
+        if (!s.counts[v]) continue;
+        out.push(`  ${v.padEnd(22)} ${String(s.counts[v]).padStart(5)}  (${((100 * s.counts[v]) / total).toFixed(1)}%)`);
+    }
+    if (s.moved.length) {
+        out.push('');
+        out.push('  BILLED-NUMBER MOVERS  (worst kcal delta first)');
+        for (const m of s.moved.slice(0, top)) {
+            const d = m.kcalDeltaPct == null ? '   n/a' : `${m.kcalDeltaPct >= 0 ? '+' : ''}${m.kcalDeltaPct.toFixed(1)}%`;
+            out.push(`    ${m.query}`);
+            out.push(`      ${fmtG(m.aGrams)} ${m.aTier ?? '-'} ${fmtK(m.aKcal)}  ->  ${fmtG(m.bGrams)} ${m.bTier ?? '-'} ${fmtK(m.bKcal)}   kcal ${d}`);
+        }
+        if (s.moved.length > top) out.push(`    … and ${s.moved.length - top} more`);
+    }
+    if (s.unjudged.length) {
+        out.push('');
+        out.push(`  ${s.unjudged.length} row(s) UNJUDGED (stage not run, threw, or AI-estimated).`);
+        out.push('  These are NOT evidence of no change. Listed so the count cannot be read as clearance:');
+        for (const q of s.unjudged.slice(0, top)) out.push(`    ${q}`);
+        if (s.unjudged.length > top) out.push(`    … and ${s.unjudged.length - top} more`);
+    }
+    return out;
+}
+
+function fmtG(g: number | null): string { return g == null ? '(none)' : `${g.toFixed(1)}g`; }
+function fmtK(k: number | null): string { return k == null ? '(none)' : `${k.toFixed(0)}kcal`; }
 
 /** Window ids present in A but not B, and vice versa. */
 export function windowChurn(a: ReplayRow, b: ReplayRow): { evicted: string[]; added: string[] } {
@@ -524,6 +700,14 @@ export interface NoiseFloorReceipt {
     rows: number;
     winnerDiffs: number;
     pathDiffs: number;
+    /**
+     * Set only when the noise-floor run itself used --with-serving. A receipt
+     * without it proves nothing about serving determinism, which is why
+     * `noiseGate` refuses a serving-bearing diff that can only find one of these.
+     */
+    withServing?: boolean;
+    /** grams/tier differences between two replays of the SAME tree — must also be 0 */
+    servingDiffs?: number;
 }
 
 export interface NoiseFloorLedger {
@@ -597,6 +781,20 @@ export function noiseGate(
                 `side ${side} noise floor is NON-ZERO (${r.winnerDiffs} winner / ${r.pathDiffs} path ` +
                 `differences over ${r.rows} rows). The replay is not deterministic on this tree; ` +
                 'any diff number below would be noise plus signal with no way to separate them.');
+        } else if (f.withServing && !r.withServing) {
+            // A winner-only receipt says nothing about whether the SERVING stage
+            // replays deterministically. Accepting it would let a serving diff be
+            // reported with no floor under it — the same "silence read as safety"
+            // failure the serving stage was added to prevent.
+            problems.push(
+                `side ${side} replayed WITH the serving stage but its noise-floor receipt was ` +
+                'taken WITHOUT it. Re-run: winner-diff noise-floor --snapshot <snap.json> ' +
+                '--with-serving   FROM THAT TREE.');
+        } else if (f.withServing && r.servingDiffs !== 0) {
+            problems.push(
+                `side ${side} SERVING noise floor is NON-ZERO (${r.servingDiffs} grams/tier ` +
+                `differences over ${r.rows} rows). Serving resolution is not deterministic on ` +
+                'this tree, so no billed-number claim below it is a result.');
         }
     }
 

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -1993,12 +1993,19 @@ function runDiff(aPath: string, bPath: string, opts: {
     say('');
     say('REMINDER — a SAME verdict does NOT clear the change. This gate is blind to:');
     say('  (a) retrieval effects (the gather output is frozen);');
-    say('  (b) everything after winner selection — hydration, serving resolution, AI');
-    say('      backfill, the save-time plausibility and brand-mismatch gates, the write;');
+    if (A.withServing && B.withServing) {
+        say('  (b) PARTLY CLOSED this run — hydration and serving resolution DID run and are');
+        say('      reported in the SERVING DIFF above. Still unseen: AI backfill determinism,');
+        say('      the save-time plausibility and brand-mismatch gates, and the write itself.');
+    } else {
+        say('  (b) everything after winner selection — hydration, serving resolution, AI');
+        say('      backfill, the save-time plausibility and brand-mismatch gates, the write.');
+        say('      Re-run with --with-serving to close the serving half of this.');
+    }
     say('  (c) warm-key behaviour (skipCache is forced, so this is COLD resolution);');
-    say('  (d) any case the change is supposed to CREATE — this population contains only');
-    say('      queries that were already asked. Pair this with a hand-written positive');
-    say('      case list that asserts the RIGHT answer.');
+    say('  (d) any case the change is supposed to CREATE — a --from-events or --from-cache');
+    say('      population contains only queries that were already asked. Pair this with a');
+    say('      hand-written positive case list that asserts the RIGHT answer.');
     say('');
 
     if (opts.jsonOut) {

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -1630,7 +1630,7 @@ async function resolveServings(snap: SnapshotFile, rows: ReplayRow[]): Promise<v
 
 async function buildReplay(
     snap: SnapshotFile, label: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean,
-    withServing = false,
+    withServing = false, snapshotPath?: string,
 ): Promise<{ file: ReplayFile; enriched: number }> {
     const drift = checkDrift(allowDrift);
     announceVariantFit(drift, variant);
@@ -1679,6 +1679,7 @@ async function buildReplay(
         gitDirty: gitDirtyHash(),
         snapshotTakenAt: snap.takenAt,
         snapshotPopulation: snap.population,
+        ...(snapshotPath ? { snapshotPath } : {}),
         callerHash: drift.caller,
         helpersHash: drift.helpers,
         rows,
@@ -2016,11 +2017,22 @@ function runDiff(aPath: string, bPath: string, opts: {
 }
 
 /** Where the snapshot that produced this replay lives, for the receipt lookup. */
+/**
+ * Where the receipt ledger for this replay lives.
+ *
+ * A replay now RECORDS the snapshot it was replayed from, so in the normal case
+ * there is nothing to guess. The guessing below is the pre-2026-07-27 fallback and
+ * it had a bug worth remembering: it only resolved when the directory held EXACTLY
+ * ONE .noise-floor.json. A gate run with both a cold and a regression population
+ * writes two, so it silently fell through to "snapshot.json" — a file that never
+ * exists — and `diff` refused to report with a message pointing at a path nothing
+ * had ever written. That failure looks exactly like a missing noise floor, which
+ * is the one message in this harness you least want to be spurious.
+ */
 function guessSnapshotPath(f: ReplayFile, replayPath: string): string {
     const explicit = argStr('snapshot');
     if (explicit) return explicit;
-    // Replays are conventionally written next to their snapshot; fall back to the
-    // population string only for the message.
+    if (f.snapshotPath && fs.existsSync(receiptPath(f.snapshotPath))) return f.snapshotPath;
     const dir = path.dirname(replayPath);
     const guesses = fs.existsSync(dir) ? fs.readdirSync(dir).filter(n => n.endsWith('.noise-floor.json')) : [];
     if (guesses.length === 1) return path.join(dir, guesses[0].replace(/\.noise-floor\.json$/, '.json'));
@@ -2436,13 +2448,39 @@ function gitHead(): string {
  * nothing. Hashing src/lib/mapping/*.ts means two replays with the same value provably
  * ran the same mapping code, which is exactly the property the noise floor needs.
  */
+/**
+ * Directories whose contents decide what a replay produces. `gitDirtyHash` is the
+ * harness's answer to "did the two sides run the same code", and a directory left
+ * out of it is a change the gate cannot tell apart from no change at all.
+ *
+ * src/lib/servings and the serving estimator joined the list on 2026-07-27, with
+ * the serving stage. Before that, a fix living entirely in bare-query-guard.ts
+ * produced an IDENTICAL tree hash on both sides: the BASE noise-floor receipt
+ * satisfied the BRANCH, and the diff header announced "identical tree AND
+ * identical variant — this run is itself a noise-floor check" about a run that
+ * was nothing of the sort.
+ */
+const HASHED_SOURCE_PATHS = [
+    'src/lib/mapping',
+    'src/lib/servings',
+    // The bare-query lexicon getBareQueryDefault() lives here; it decides grams.
+    'src/lib/ai/ambiguous-serving-estimator.ts',
+];
+
 function gitDirtyHash(): string {
     try {
-        const dir = path.join(REPO_ROOT, 'src/lib/mapping');
         const parts: string[] = [];
-        for (const f of fs.readdirSync(dir).sort()) {
-            if (!f.endsWith('.ts')) continue;
-            parts.push(f + ':' + sha(fs.readFileSync(path.join(dir, f), 'utf8')));
+        for (const rel of HASHED_SOURCE_PATHS) {
+            const p = path.join(REPO_ROOT, rel);
+            if (!fs.existsSync(p)) continue;
+            if (fs.statSync(p).isDirectory()) {
+                for (const f of fs.readdirSync(p).sort()) {
+                    if (!f.endsWith('.ts')) continue;
+                    parts.push(rel + '/' + f + ':' + sha(fs.readFileSync(path.join(p, f), 'utf8')));
+                }
+            } else {
+                parts.push(rel + ':' + sha(fs.readFileSync(p, 'utf8')));
+            }
         }
         return sha(parts.join('\n')).slice(0, 8);
     } catch { return 'unknown'; }
@@ -2577,7 +2615,7 @@ async function main() {
         const out = argStr('out');
         if (!snapPath || !out) throw new Error('replay needs --snapshot <file> --out <file> [--label X]');
         const snap = readSnapshot(snapPath);
-        const { file, enriched } = await buildReplay(snap, argStr('label') ?? 'unlabelled', resolveVariant(), debug, allowDrift, withServing);
+        const { file, enriched } = await buildReplay(snap, argStr('label') ?? 'unlabelled', resolveVariant(), debug, allowDrift, withServing, path.resolve(snapPath));
         writeJsonAtomic(out, file);
         printReplaySummary(file, enriched, verbose);
         say('');

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -108,6 +108,17 @@
  *   $RUN replay --snapshot /tmp/wd-snap.json --out /tmp/wd-B.json --label BRANCH
  *   $RUN diff --a /tmp/wd-A.json --b /tmp/wd-B.json --screens
  *
+ *   Prefer scripts/eval/winner-gate.sh, which runs all of the above in one command.
+ *
+ * --with-serving  (add to BOTH replays AND the noise-floor run)
+ *   Runs the real serving layer for every row that has a winner and records the
+ *   grams / tier / kcal the user would be billed. Without it this harness stops at
+ *   winner selection — limit (B) below — and a change can move the winner onto the
+ *   CORRECT record while making the billed number worse. That is not hypothetical:
+ *   PR #173 did exactly that (mac and cheese, 90.4 -> 39.5 kcal against a true
+ *   ~400) and passed a green winner gate. Any change that could touch grams must
+ *   be gated with this flag.
+ *
  * NEVER switch variants with `git checkout <sha> -- <file>`. That is how
  * uncommitted work gets destroyed. Copy the tree and edit the copy.
  */
@@ -127,16 +138,20 @@ import {
     PopulationLine,
     QueryOrigin,
     ScreenPair,
+    ServingInfo,
     Verdict,
     VERDICTS,
     classifyOrigin,
+    classifyServing,
     classifyVerdict,
     counterfactualSummary,
     emptyLedger,
     formatScreens,
+    formatServingSummary,
     gateReasonHistogram,
     kcalDeltaPct,
     noiseGate,
+    summariseServing,
     originSplit,
     parseGoldenSet,
     parseQueryFile,
@@ -511,6 +526,11 @@ const { simpleRerank, toRerankCandidate, stripPrepModifiers } = rerankMod;
 const {
     computeFloorHitIds, dropDenylistedCandidates, makeSortedFilteredComparator, candidateHasVolumeServing,
 } = mapperMod;
+/**
+ * The whole serving layer behind one exported entry point. Used by the optional
+ * --with-serving stage; it is the SAME function the route calls, not a transcription.
+ */
+const { hydrateAndSelectServing } = mapperMod;
 const { countedPieceNoun, extractLabelServingUnit, GENERIC_PIECE_WORDS, servingLabelCountsPiece } = countLabelMod;
 const { assessMacroPlausibility } = plausibilityMod;
 
@@ -1536,11 +1556,81 @@ async function preEnrichAiGenerated(entries: SnapshotEntry[]): Promise<number> {
 }
 
 // ============================================================
+// 9b. THE SERVING STAGE  (optional; closes blind spot (B))
+// ============================================================
+
+/**
+ * Tiers whose grams came from a model rather than from data. They do not replay
+ * deterministically, so they are flagged and reported in their own bucket rather
+ * than counted as movement the change under test caused.
+ */
+const AI_SERVING_TIER_RE = /(^|_)ai(_|$)|estimate/i;
+
+/**
+ * Run the REAL serving layer for every row that has a winner, and record what the
+ * user would be billed.
+ *
+ * WHY THIS IS A SEPARATE PASS. `replaySelection` is synchronous and pure over the
+ * frozen pool; serving resolution is async and reads the DB (sibling medians,
+ * package quantities, OffServing rows). Keeping it after the fact preserves that
+ * property — the selection half of a replay is still reproducible with no I/O.
+ *
+ * WHY THE WRITE GUARD IS ENOUGH. `hydrateOffCandidate` is cache-first: for records
+ * already in OffFood — which is every record Typesense can return, since it indexes
+ * our own Postgres — it is a pure read. Its upserts only fire for a record we do
+ * not have, and the guard no-ops those without throwing.
+ *
+ * The honest limit: this measures the serving stage under REPLAY, where the cache
+ * is bypassed. It still cannot see the save gates or what a warm read would serve.
+ */
+async function resolveServings(snap: SnapshotFile, rows: ReplayRow[]): Promise<void> {
+    const byQuery = new Map(snap.entries.map(e => [e.query, e]));
+
+    for (const row of rows) {
+        const e = byQuery.get(row.query);
+        if (!e || !row.winner) { row.serving = null; continue; }
+
+        // The winner is recorded as an id; the builder needs the candidate OBJECT.
+        // Deep-copy it: buildOffResult mutates candidate.nutrition in place, and a
+        // mutated pool would make the second replay of a noise-floor pair differ
+        // from the first for reasons that have nothing to do with the code.
+        const src = e.candidates.find(c => c.id === row.winner!.foodId);
+        if (!src) {
+            row.serving = { grams: null, servingTier: null, servingDescription: null, totalKcal: null, aiTouched: false, error: 'winner not found in frozen pool' };
+            continue;
+        }
+        const cand: UnifiedCandidate = JSON.parse(JSON.stringify(src));
+
+        try {
+            const r = await hydrateAndSelectServing(cand, e.parsed, row.winner.confidence, e.gatherRawLine);
+            if (!r) { row.serving = null; continue; }
+            const tier: string | null = r.servingTier ?? null;
+            row.serving = {
+                grams: typeof r.grams === 'number' ? r.grams : null,
+                servingTier: tier,
+                servingDescription: r.servingDescription ?? null,
+                // `kcal` on FatsecretMappedIngredient is the TOTAL for the resolved
+                // grams, not a per-100g figure — it is verbatim what route.ts:296
+                // records as MappingEventLog.totalKcal, i.e. the number on screen.
+                totalKcal: typeof r.kcal === 'number' ? r.kcal : null,
+                aiTouched: tier != null && AI_SERVING_TIER_RE.test(tier),
+            };
+        } catch (err: any) {
+            row.serving = {
+                grams: null, servingTier: null, servingDescription: null, totalKcal: null,
+                aiTouched: false, error: err?.message ?? String(err),
+            };
+        }
+    }
+}
+
+// ============================================================
 // 10. REPLAY mode
 // ============================================================
 
 async function buildReplay(
     snap: SnapshotFile, label: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean,
+    withServing = false,
 ): Promise<{ file: ReplayFile; enriched: number }> {
     const drift = checkDrift(allowDrift);
     announceVariantFit(drift, variant);
@@ -1572,6 +1662,10 @@ async function buildReplay(
             });
         }
     }
+
+    if (withServing) {
+        await resolveServings(snap, rows);
+    }
     muzzle(false);
 
     const file: ReplayFile = {
@@ -1579,6 +1673,7 @@ async function buildReplay(
         version: 1,
         label,
         variant,
+        withServing,
         ranAt: new Date().toISOString(),
         gitHead: gitHead(),
         gitDirty: gitDirtyHash(),
@@ -1646,6 +1741,15 @@ function fmtWinner(w: WinnerInfo | null): string {
     return `${w.source}:${w.foodId} "${w.foodName}"${brand}  ${pan}  conf=${w.confidence.toFixed(3)} reason=${w.selectionReason} idx=${w.indexInFiltered}`;
 }
 
+function fmtServing(s: ServingInfo | null | undefined): string {
+    if (s === undefined) return '(stage not run)';
+    if (s === null) return '(no serving)';
+    if (s.error) return `(ERROR: ${s.error})`;
+    const g = s.grams == null ? '?g' : `${s.grams.toFixed(1)}g`;
+    const k = s.totalKcal == null ? '?kcal' : `${s.totalKcal.toFixed(0)}kcal`;
+    return `${g} ${k} ${s.servingTier ?? '-'}${s.aiTouched ? ' (AI)' : ''}`;
+}
+
 // ============================================================
 // 11. NOISE FLOOR
 // ============================================================
@@ -1670,14 +1774,17 @@ function readLedger(p: string): NoiseFloorLedger | null {
  * 0 changed rows" and reported 2 changes; both statements cannot be true, and the
  * label was the wrong one.
  */
-async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean) {
+async function runNoiseFloor(
+    snapPath: string, variant: SelectionVariant, debug: boolean, allowDrift: boolean, withServing = false,
+) {
     const snap: SnapshotFile = readSnapshot(snapPath);
-    const a = await buildReplay(snap, 'noise-1', variant, debug, allowDrift);
-    const b = await buildReplay(snap, 'noise-2', variant, debug, allowDrift);
+    const a = await buildReplay(snap, 'noise-1', variant, debug, allowDrift, withServing);
+    const b = await buildReplay(snap, 'noise-2', variant, debug, allowDrift, withServing);
 
     const byQ = new Map(b.file.rows.map(r => [r.query, r]));
     let winnerDiffs = 0;
     let pathDiffs = 0;
+    let servingDiffs = 0;
     const offenders: string[] = [];
     for (const ra of a.file.rows) {
         const rb = byQ.get(ra.query);
@@ -1686,6 +1793,17 @@ async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug:
         const wb = rb.winner?.foodId ?? null;
         if (wa !== wb) { winnerDiffs++; offenders.push(`${ra.query}: winner ${wa} -> ${wb}`); }
         if (ra.path !== rb.path) { pathDiffs++; offenders.push(`${ra.query}: path ${ra.path} -> ${rb.path}`); }
+        if (withServing) {
+            // AI-estimated tiers are nondeterministic BY DESIGN; counting them here
+            // would make the floor permanently non-zero and the gate unusable. They
+            // are excluded from the floor and reported as UNJUDGED in every diff, so
+            // the exclusion can never be mistaken for clearance.
+            const v = classifyServing(ra, rb);
+            if (v !== 'SERVING-SAME' && v !== 'AI-NONDETERMINISTIC' && v !== 'UNJUDGED') {
+                servingDiffs++;
+                offenders.push(`${ra.query}: serving ${ra.serving?.grams ?? '-'}g/${ra.serving?.servingTier ?? '-'} -> ${rb.serving?.grams ?? '-'}g/${rb.serving?.servingTier ?? '-'}`);
+            }
+        }
     }
 
     const receipt: NoiseFloorReceipt = {
@@ -1699,6 +1817,7 @@ async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug:
         rows: a.file.rows.length,
         winnerDiffs,
         pathDiffs,
+        ...(withServing ? { withServing: true, servingDiffs } : {}),
     };
 
     const rp = receiptPath(snapPath);
@@ -1712,8 +1831,9 @@ async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug:
     say('================================================================================');
     say('NOISE FLOOR  (replayNoise: same snapshot, same tree, same variant — MUST be 0)');
     say(`  snapshot ${snap.takenAt}   tree ${receipt.gitDirty}   variant ${variant}`);
-    say(`  rows ${receipt.rows}   winner-diffs ${receipt.winnerDiffs}   path-diffs ${receipt.pathDiffs}`);
-    if (winnerDiffs === 0 && pathDiffs === 0) {
+    say(`  rows ${receipt.rows}   winner-diffs ${receipt.winnerDiffs}   path-diffs ${receipt.pathDiffs}`
+        + (withServing ? `   serving-diffs ${servingDiffs}` : '   (serving stage NOT run)'));
+    if (winnerDiffs === 0 && pathDiffs === 0 && servingDiffs === 0) {
         say('  RESULT: 0 — the replay is deterministic on this tree. A diff run may proceed.');
     } else {
         say('  RESULT: NON-ZERO. !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
@@ -1730,7 +1850,7 @@ async function runNoiseFloor(snapPath: string, variant: SelectionVariant, debug:
     say('        is a different, genuinely non-zero number.');
     say('================================================================================');
 
-    if (winnerDiffs !== 0 || pathDiffs !== 0) process.exitCode = 1;
+    if (winnerDiffs !== 0 || pathDiffs !== 0 || servingDiffs !== 0) process.exitCode = 1;
 }
 
 // ============================================================
@@ -1817,6 +1937,12 @@ function runDiff(aPath: string, bPath: string, opts: {
         if (d != null && a.winner && b.winner && a.winner.foodId !== b.winner.foodId) {
             say(`     kcal/100g ${a.winner.panel!.kcal} -> ${b.winner.panel!.kcal}  (${d >= 0 ? '+' : ''}${d.toFixed(1)}%)`);
         }
+        // The BILLED number, printed next to the winner change that caused it. A
+        // winner can move to the correct record and still bill worse — that is not
+        // a hypothetical, it is what PR #173 shipped.
+        if (A.withServing && B.withServing) {
+            say(`     BILLED ${fmtServing(a.serving)}  ->  ${fmtServing(b.serving)}   [${classifyServing(a, b)}]`);
+        }
     }
     if (changedRows.length > opts.top) {
         say('');
@@ -1829,6 +1955,22 @@ function runDiff(aPath: string, bPath: string, opts: {
     for (const k of VERDICTS) say(`  ${k.padEnd(18)} ${counts[k]}`);
     say(`  rows with ANY movement (winner, pool or rerank window): ${movement} / ${A.rows.length}`);
     say('--------------------------------------------------------------------------------');
+
+    // The serving section is printed for EVERY run, including the ones where the
+    // stage did not run. When it did not, it says so in one line instead of being
+    // absent — an absent section reads as "nothing to report", which is the exact
+    // misreading that let a winner-only gate clear a worse billed number.
+    if (A.withServing && B.withServing) {
+        sayAll(formatServingSummary(summariseServing(A.rows, B.rows), opts.top));
+    } else {
+        say('');
+        say('=== SERVING DIFF — NOT RUN ===');
+        say('  Neither replay carried the serving stage, so this run says NOTHING about');
+        say('  what the user is billed. A winner can move onto the CORRECT record and the');
+        say('  billed number can still get worse (PR #173: mac and cheese, 90.4 -> 39.5 kcal');
+        say('  against a true ~400, because the 28g anchor never moved).');
+        say('  Re-run both replays with --with-serving to gate the billed number.');
+    }
 
     if (opts.screens) sayAll(formatScreens(runScreens(pairs, A.label, B.label), opts.top));
 
@@ -2409,6 +2551,10 @@ async function main() {
     const allowDrift = has('--allow-drift');
     const verbose = has('--verbose');
     const top = argInt('top') ?? 30;
+    // Opt-in because it costs a DB round trip per row and, on rows that reach an
+    // AI estimator, a model call. Opt-in is NOT "optional": a replay without it
+    // cannot adjudicate the number the user sees, and the diff now says so.
+    const withServing = has('--with-serving');
 
     if (!mode || mode === 'help' || mode === '--help' || mode === '-h') { say(HELP); return; }
 
@@ -2431,7 +2577,7 @@ async function main() {
         const out = argStr('out');
         if (!snapPath || !out) throw new Error('replay needs --snapshot <file> --out <file> [--label X]');
         const snap = readSnapshot(snapPath);
-        const { file, enriched } = await buildReplay(snap, argStr('label') ?? 'unlabelled', resolveVariant(), debug, allowDrift);
+        const { file, enriched } = await buildReplay(snap, argStr('label') ?? 'unlabelled', resolveVariant(), debug, allowDrift, withServing);
         writeJsonAtomic(out, file);
         printReplaySummary(file, enriched, verbose);
         say('');
@@ -2440,7 +2586,7 @@ async function main() {
     } else if (mode === 'noise-floor' || mode === 'noise') {
         const snapPath = argStr('snapshot');
         if (!snapPath) throw new Error('noise-floor needs --snapshot <file>');
-        await runNoiseFloor(snapPath, resolveVariant(), debug, allowDrift);
+        await runNoiseFloor(snapPath, resolveVariant(), debug, allowDrift, withServing);
 
     } else if (mode === 'diff') {
         const a = argStr('a');

--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -188,14 +188,12 @@ noise_floor_both_trees() {
         echo "introduced nondeterminism into replay — that is itself the finding." >&2
         exit 4
     fi
-    # UPSTREAM BUG WORKAROUND (winner-diff.ts, found 2026-07-26): `diff` derives
-    # the receipt-ledger path from the replay files and resolves it to
-    # "snapshot.noise-floor.json" rather than "<snapshot-basename>.noise-floor.json".
-    # The ledger written above holds exactly the receipts diff asks for, under the
-    # right name, and diff still REFUSES TO REPORT because it reads the wrong path.
-    # Mirror it so a correct run is not blocked by a filename. Remove once fixed.
-    local ledger="${snap%.json}.noise-floor.json"
-    [[ -f "$ledger" ]] && cp "$ledger" "$(dirname "$snap")/snapshot.noise-floor.json"
+    # The ledger-path bug this used to work around is FIXED upstream: a replay now
+    # records its own snapshot path, so `diff` finds the ledger by construction.
+    # The old workaround mirrored the ledger to a shared "snapshot.noise-floor.json",
+    # which was actively harmful once this driver grew a second population — the
+    # regression mirror overwrote the cold one and `diff` refused to report a run
+    # whose receipts were all present and all zero.
 }
 
 echo "[3/5] noise floor: every snapshot x both trees (must be 0)"

--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -40,6 +40,18 @@
 #                         a regression population (default 250, 0 to disable).
 #   --label <name>        Names the artifact directory (default: the branch name).
 #   --keep                Keep the base worktree for inspection.
+#   --no-serving          Skip the serving stage. Do NOT pass this for any change
+#                         that could touch grams — see below.
+#
+# THE SERVING STAGE IS ON BY DEFAULT
+#   winner-diff stops at winner selection (its own limit (B)). That blind spot
+#   passed a green gate on PR #173, which moved `mac and cheese` onto the correct
+#   record while the billed number went 90.4 -> 39.5 kcal against a true ~400 --
+#   the 28g serving anchor never moved and the new record has a lower kcal/100g.
+#   So this driver runs `--with-serving` on both replays and both noise floors,
+#   and the diff prints a SERVING section reporting what the USER IS BILLED.
+#   Rows it cannot adjudicate (AI-estimated tiers) are listed as UNJUDGED, never
+#   folded into the SAME count.
 #
 # EXAMPLE
 #   scripts/eval/winner-gate.sh --cold-seeds /tmp/mac-and-cheese-seeds.txt
@@ -51,6 +63,7 @@ COLD_SEEDS=""
 REGRESSION_N=250
 LABEL=""
 KEEP=0
+SERVING="--with-serving"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -59,7 +72,8 @@ while [[ $# -gt 0 ]]; do
         --regression) REGRESSION_N="$2"; shift 2 ;;
         --label)      LABEL="$2";      shift 2 ;;
         --keep)       KEEP=1;          shift ;;
-        -h|--help)    sed -n '2,45p' "$0"; exit 0 ;;
+        --no-serving) SERVING="";      shift ;;
+        -h|--help)    sed -n '2,58p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
@@ -164,12 +178,12 @@ fi
 # bugs were caught.
 noise_floor_both_trees() {
     local snap="$1" name="$2"
-    if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$snap" ) 2>&1 | tail -6; then
+    if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$snap" $SERVING ) 2>&1 | tail -6; then
         echo "ABORT: noise floor non-zero on BASE for $name. The replay is not" >&2
         echo "deterministic, so any before/after claim below it is not a result." >&2
         exit 4
     fi
-    if ! eval "$RUN" noise-floor --snapshot "$snap" 2>&1 | tail -6; then
+    if ! eval "$RUN" noise-floor --snapshot "$snap" $SERVING 2>&1 | tail -6; then
         echo "ABORT: noise floor non-zero on BRANCH for $name. Your change" >&2
         echo "introduced nondeterminism into replay — that is itself the finding." >&2
         exit 4
@@ -193,15 +207,15 @@ fi
 # ------------------------------------------------------------ replays
 echo "[4/5] replay BASE, then BRANCH, against the identical frozen pool"
 ( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap.json" \
-    --out "$OUT/A-base.json" --label BASE ) 2>&1 | tail -6
+    --out "$OUT/A-base.json" --label BASE $SERVING ) 2>&1 | tail -6
 eval "$RUN" replay --snapshot "$OUT/snap.json" \
-    --out "$OUT/B-branch.json" --label BRANCH 2>&1 | tail -6
+    --out "$OUT/B-branch.json" --label BRANCH $SERVING 2>&1 | tail -6
 
 if [[ "$REGRESSION_N" -gt 0 ]]; then
     ( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
-        --out "$OUT/A-base-regression.json" --label BASE ) 2>&1 | tail -4
+        --out "$OUT/A-base-regression.json" --label BASE $SERVING ) 2>&1 | tail -4
     eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
-        --out "$OUT/B-branch-regression.json" --label BRANCH 2>&1 | tail -4
+        --out "$OUT/B-branch-regression.json" --label BRANCH $SERVING 2>&1 | tail -4
 fi
 
 # ------------------------------------------------------------ diff
@@ -221,13 +235,17 @@ cat <<EOF
 === winner-gate done ===
 artifacts: $OUT
 
-Read it in this order, and do not skip the second question:
+Read it in this order, and do not skip questions 2 or 3:
   1. Did the COLD population move in the intended direction? If it shows SAME on
      everything, the change does not do what the PR says it does.
   2. Did the REGRESSION population move at all? Every mover there is a cost you
      are paying, and it must be enumerated in the PR body — not summarized.
+  3. In the SERVING DIFF: which way did the BILLED number go? A winner can move
+     onto the right record and bill worse. If the PR claims an under-bill is
+     fixed, a GRAMS-CHANGED row going the wrong way refutes that claim outright,
+     and UNJUDGED rows are not evidence of safety.
 
-This harness cannot see: serving/gram resolution, the save gates, or warm
-behaviour (it forces skipCache). A SAME here does NOT prove the cached row is
-unchanged. The eval's grams bands are what see serving regressions.
+Still invisible to this harness: the save gates, and warm behaviour (replay forces
+skipCache). A SAME here does NOT prove the CACHED row is unchanged — for that,
+run the eval and check the stored FoodMapping row directly.
 EOF

--- a/src/lib/servings/__tests__/cap-product-query-guard.test.ts
+++ b/src/lib/servings/__tests__/cap-product-query-guard.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The category CAP must not overwrite a PRODUCT's declared label serving.
+ *
+ * `getBareQueryDefault` matches a lexicon token anywhere in the query, and the
+ * CAP fires whenever the billed grams exceed `categoryDefault x 2`. For the 2.5g
+ * spice/salt category that threshold is FIVE GRAMS — below every real packaged
+ * food — so any product whose name happens to contain salt / cinnamon / spice /
+ * pepper had its manufacturer serving replaced by one teaspoon.
+ *
+ * All six rows below were measured live on the box (2026-07-27) with
+ * scripts/eval/probe-bare-serving.ts, which captures the guard's own
+ * previousTier/previousGrams. They are not hypotheses:
+ *
+ *   mac and cheese                            bare_label_serving    113.4g -> 28g
+ *   rxbar chocolate sea salt                  label_serving_default    52g -> 2.5g
+ *   quaker instant rolled oats apple cinnamon label_serving_default    43g -> 2.5g
+ *   ryse loaded protein cinnamon              label_serving_default  34.2g -> 2.5g
+ *   pumpkin spice granola                     fs_default_serving       29g -> 2.5g
+ *   talenti sea salt caramel                  fs_default_serving      128g -> 2.5g
+ *
+ * `mac and cheese` is the case that shows head-anchoring is not enough on its
+ * own: its literal head token IS "cheese", so the head-gated branch let a 113.4g
+ * label serving be capped to the 28g one-ounce cheese default — 40 kcal billed
+ * for a ~400 kcal dish.
+ */
+
+import {
+    applyOffBareQueryGuard,
+    capMayOverrideLabelServing,
+    isDoseAnchoredBareQuery,
+} from '../bare-query-guard';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+const bare = (name: string): ParsedIngredient =>
+    ({ qty: 1, unit: null, multiplier: 1, name } as unknown as ParsedIngredient);
+
+/** The CAP path, driven exactly as build-off-result / build-fatsecret-result drive it. */
+function cap(queryName: string, grams: number, servingTier = 'label_serving_default') {
+    return applyOffBareQueryGuard({
+        grams,
+        servingTier,
+        parsed: bare(queryName),
+        rawLine: queryName,
+        queryName,
+        foodName: 'irrelevant to the CAP path',
+    });
+}
+
+describe('capMayOverrideLabelServing', () => {
+    it.each([
+        ['salt'], ['doritos'], ['honey'], ['mayonnaise'],
+        ['olive oil'], ['black pepper'], ['peanut butter'], ['brown sugar'],
+        ['table salt'], ['coca cola'], ['greek yogurt'],
+    ])('allows the cap for the bare ingredient %p', (q) => {
+        expect(capMayOverrideLabelServing(q)).toBe(true);
+    });
+
+    it('allows a THREE-token dose-anchored query through ("ghost pre workout")', () => {
+        // The scoop dose is the whole point for these, and the phrase needs its
+        // final token to trigger the category (eval n-serv-43).
+        expect(isDoseAnchoredBareQuery('ghost pre workout')).toBe(true);
+        expect(capMayOverrideLabelServing('ghost pre workout')).toBe(true);
+    });
+
+    it.each([
+        ['mac and cheese'],
+        ['rxbar chocolate sea salt'],
+        ['quaker instant rolled oats apple cinnamon'],
+        ['ryse loaded protein cinnamon'],
+        ['pumpkin spice granola'],
+        ['talenti sea salt caramel'],
+    ])('blocks the cap for the product query %p', (q) => {
+        expect(capMayOverrideLabelServing(q)).toBe(false);
+    });
+
+    it('does not let the dose-anchor carve-out readmit a long product query', () => {
+        // "rxbar chocolate sea salt" IS dose-anchored by the letter of the rule —
+        // its head token is "salt" — which is exactly why the carve-out carries a
+        // token limit of its own instead of being an unconditional escape hatch.
+        expect(isDoseAnchoredBareQuery('rxbar chocolate sea salt')).toBe(true);
+        expect(capMayOverrideLabelServing('rxbar chocolate sea salt')).toBe(false);
+    });
+
+    it('is not fooled by punctuation or extra whitespace', () => {
+        expect(capMayOverrideLabelServing('  olive   oil  ')).toBe(true);
+        expect(capMayOverrideLabelServing("trader joe's everything bagel seasoning")).toBe(false);
+    });
+
+    it('treats an empty query as capable (it cannot be a product name)', () => {
+        expect(capMayOverrideLabelServing('')).toBe(true);
+    });
+});
+
+describe('the CAP path — what the fix must CREATE', () => {
+    it('keeps the 52g RXBAR label instead of billing one teaspoon of sea salt', () => {
+        expect(cap('rxbar chocolate sea salt', 52)).toBeNull();
+    });
+
+    it('keeps the 113.4g mac-and-cheese label the head-gated branch used to cap', () => {
+        expect(cap('mac and cheese', 113.398, 'bare_label_serving')).toBeNull();
+    });
+
+    it.each([
+        ['quaker instant rolled oats apple cinnamon', 43, 'label_serving_default'],
+        ['ryse loaded protein cinnamon', 34.2, 'label_serving_default'],
+        ['pumpkin spice granola', 29, 'label_serving_default'],
+        ['talenti sea salt caramel', 128, 'label_serving_default'],
+    ])('keeps the declared label for %p', (q, g, tier) => {
+        expect(cap(q as string, g as number, tier as string)).toBeNull();
+    });
+});
+
+describe('the CAP path — what the fix must NOT break', () => {
+    it('still caps a 250g whole-bottle olive oil serving to 14g', () => {
+        expect(cap('olive oil', 250)).toMatchObject({ grams: 14, servingTier: 'bare_category_default' });
+    });
+
+    it('still caps the 164g bell-pepper seed hijack on bare "black pepper" (n-serv-38)', () => {
+        expect(cap('black pepper', 164, 'seed_count_default'))
+            .toMatchObject({ grams: 2.5, servingTier: 'bare_category_default' });
+    });
+
+    it('still caps a 130g doritos package to the salty-snack default (n-serv-42)', () => {
+        expect(cap('doritos', 130)).not.toBeNull();
+    });
+
+    it('still caps the 104g cup-measure on bare sugar (n-serv-37)', () => {
+        expect(cap('sugar', 104)).toMatchObject({ grams: 4 });
+    });
+
+    it('stays inert on peanut butter, whose own 32g entry sets a 64g threshold (n-serv-50)', () => {
+        expect(cap('peanut butter', 32)).toBeNull();
+    });
+
+    // ---- REPLACE tiers are deliberately untouched ----
+    //
+    // There the grams are FABRICATED — a flat-100g placeholder or a count floor —
+    // so a category default is strictly better in both directions and no label
+    // data is at risk. Asserted rather than assumed, because "the change only
+    // narrows a cap" is the kind of by-inspection claim this repo has been wrong
+    // about five times.
+
+    it('a long product query still gets its flat-100g floor REPLACED', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 100,
+            servingTier: 'flat_100g_default',
+            parsed: bare('quest protein bar birthday cake'),
+            rawLine: 'quest protein bar birthday cake',
+            queryName: 'quest protein bar birthday cake',
+            foodName: 'Quest Protein Bar Birthday Cake',
+        });
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBeGreaterThan(5);
+    });
+
+    it('a long product query still replaces the flat floor via its lexicon category', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 100,
+            servingTier: 'flat_100g_default',
+            parsed: bare('trader joes everything bagel seasoning'),
+            rawLine: 'trader joes everything bagel seasoning',
+            queryName: 'trader joes everything bagel seasoning',
+            foodName: 'Everything Bagel Seasoning',
+        });
+        expect(r).toMatchObject({ grams: 2.5 });
+    });
+
+    // ---- eligibility is unchanged ----
+
+    it('a non-bare request is still ignored entirely', () => {
+        expect(applyOffBareQueryGuard({
+            grams: 250,
+            servingTier: 'label_serving_default',
+            parsed: { qty: 2, unit: null, multiplier: 1, name: 'olive oil' } as unknown as ParsedIngredient,
+            rawLine: '2 olive oil',
+            queryName: 'olive oil',
+            foodName: 'Olive Oil',
+        })).toBeNull();
+    });
+});

--- a/src/lib/servings/__tests__/cap-product-query-guard.test.ts
+++ b/src/lib/servings/__tests__/cap-product-query-guard.test.ts
@@ -70,7 +70,7 @@ describe('capMayOverrideLabelServing', () => {
         ['pumpkin spice granola'],
         ['talenti sea salt caramel'],
     ])('blocks the cap for the product query %p', (q) => {
-        expect(capMayOverrideLabelServing(q)).toBe(false);
+        expect(capMayOverrideLabelServing(q, 'label_serving_default')).toBe(false);
     });
 
     it('does not let the dose-anchor carve-out readmit a long product query', () => {
@@ -78,16 +78,43 @@ describe('capMayOverrideLabelServing', () => {
         // its head token is "salt" — which is exactly why the carve-out carries a
         // token limit of its own instead of being an unconditional escape hatch.
         expect(isDoseAnchoredBareQuery('rxbar chocolate sea salt')).toBe(true);
-        expect(capMayOverrideLabelServing('rxbar chocolate sea salt')).toBe(false);
+        expect(capMayOverrideLabelServing('rxbar chocolate sea salt', 'label_serving_default')).toBe(false);
+    });
+
+    it('protects DECLARED label tiers only — package-scale grams stay cappable', () => {
+        // The winner-gate caught this as a live regression on the first draft,
+        // which protected every CAP tier by token count: `orgain organic protein
+        // powder` went 35g -> 325.3g via package_count_sibling, billing 1,168 kcal
+        // for one scoop. A package COUNT is not a declared serving.
+        const q = 'orgain organic protein powder';
+        expect(capMayOverrideLabelServing(q, 'package_count_sibling')).toBe(true);
+        expect(capMayOverrideLabelServing(q, 'package_quantity_own')).toBe(true);
+        expect(capMayOverrideLabelServing(q, 'seed_count_default')).toBe(true);
+        expect(capMayOverrideLabelServing(q, 'label_serving_default')).toBe(false);
     });
 
     it('is not fooled by punctuation or extra whitespace', () => {
-        expect(capMayOverrideLabelServing('  olive   oil  ')).toBe(true);
-        expect(capMayOverrideLabelServing("trader joe's everything bagel seasoning")).toBe(false);
+        expect(capMayOverrideLabelServing('  olive   oil  ', 'label_serving_default')).toBe(true);
+        expect(capMayOverrideLabelServing("trader joe's everything bagel seasoning", 'label_serving_default')).toBe(false);
     });
 
     it('treats an empty query as capable (it cannot be a product name)', () => {
-        expect(capMayOverrideLabelServing('')).toBe(true);
+        expect(capMayOverrideLabelServing('', 'label_serving_default')).toBe(true);
+    });
+});
+
+describe('the package-scale regression the gate caught', () => {
+    it('still caps a 325g whole-tub package count to the one-scoop default', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 325.3,
+            servingTier: 'package_count_sibling',
+            parsed: bare('orgain organic protein powder'),
+            rawLine: 'orgain organic protein powder',
+            queryName: 'orgain organic protein powder',
+            foodName: 'Organic Protein Protein Powder',
+        });
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBeLessThan(100);
     });
 });
 

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -160,14 +160,32 @@ const CAP_MAX_QUERY_TOKENS = 2;
 const CAP_MAX_DOSE_ANCHORED_TOKENS = 3;
 
 /**
- * May a lexicon category default overwrite grams that came from the record's own
- * declared label?
+ * Tiers whose grams are the manufacturer's DECLARED SERVING for this record.
+ * Only these are protected by the query-token rule.
  *
- * This governs the CAP paths only. The REPLACE paths are untouched: there the
- * grams are fabricated (a flat 100g placeholder or a count floor), so a category
+ * The distinction is the whole point. A declared serving is data about one
+ * serving; a PACKAGE-scale tier (package_count_*, package_quantity_*) is a count
+ * of the whole container, and capping those is exactly what the guard is for. The
+ * first draft of this fix protected every CAP tier by token count, and the
+ * winner-gate caught the cost immediately: `orgain organic protein powder`
+ * (4 tokens) went 35g -> 325.3g via package_count_sibling, billing 1,168 kcal for
+ * one scoop of protein powder. The 35g cap there was correct and stays.
+ */
+const DECLARED_LABEL_TIERS = new Set([
+    'label_serving_default',   // also the alias for fs_default_serving
+    'bare_label_serving',
+]);
+
+/**
+ * May a lexicon category default overwrite these grams?
+ *
+ * Governs the CAP paths only. The REPLACE paths are untouched: there the grams
+ * are fabricated (a flat 100g placeholder or a count floor), so a category
  * default is strictly better and no label data is at risk.
  */
-export function capMayOverrideLabelServing(queryName: string): boolean {
+export function capMayOverrideLabelServing(queryName: string, servingTier?: string): boolean {
+    // Package-scale grams are not a declared serving; cap them as before.
+    if (servingTier !== undefined && !DECLARED_LABEL_TIERS.has(servingTier)) return true;
     const n = queryTokens(queryName).length;
     if (n <= CAP_MAX_QUERY_TOKENS) return true;
     return isDoseAnchoredBareQuery(queryName) && n <= CAP_MAX_DOSE_ANCHORED_TOKENS;
@@ -258,12 +276,12 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
 
     const queryDefault = getBareQueryDefault(queryName);
 
-    // A multi-word PRODUCT query keeps its record's declared label serving: the
+    // A multi-word PRODUCT query keeps its record's DECLARED label serving: the
     // manufacturer's number outranks a category guess made from one token inside
-    // the product's name. Applies to both CAP paths; the REPLACE path below is
-    // deliberately untouched, since there the grams are fabricated and nothing
-    // real is being overwritten.
-    const capAllowed = capMayOverrideLabelServing(queryName);
+    // the product's name. Package-scale tiers are unaffected — capping those is
+    // what the guard is for. The REPLACE path below is untouched entirely, since
+    // there the grams are fabricated and nothing real is being overwritten.
+    const capAllowed = capMayOverrideLabelServing(queryName, servingTier);
 
     if (CAP_TIERS.has(servingTier)) {
         // CAP consults ONLY the query-side lexicon. A foodName fallback here

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -115,10 +115,62 @@ export function usableBareLabelServing(
     return servingGrams;
 }
 
+function queryTokens(queryName: string): string[] {
+    return (queryName || '').toLowerCase().split(/[^a-z]+/).filter(t => t.length > 0);
+}
+
 /** Last alphabetic token of a query name ("pumpkin spice latte" → "latte"). */
 function queryHeadToken(queryName: string): string {
-    const toks = (queryName || '').toLowerCase().split(/[^a-z]+/).filter(t => t.length > 0);
+    const toks = queryTokens(queryName);
     return toks[toks.length - 1] ?? '';
+}
+
+/**
+ * How many words a query may have before its own matched record's DECLARED label
+ * serving outranks a lexicon category default.
+ *
+ * A lexicon category describes a bare ingredient, and a bare ingredient is named
+ * in one or two words: "salt", "black pepper", "olive oil", "brown sugar". Three
+ * or more words means the user named a PRODUCT, and a product's manufacturer
+ * serving beats a category guess about one token inside its name.
+ *
+ * Measured on the box 2026-07-27 — every one of these had real label data that
+ * the CAP destroyed, because the cap threshold is `categoryDefault x 2` and for
+ * the 2.5g spice category that is FIVE GRAMS, i.e. below every real packaged food:
+ *
+ *   mac and cheese              bare_label_serving   113.4g -> 28g   (cheese, 28g)
+ *   rxbar chocolate sea salt    label_serving_default   52g -> 2.5g  (salt, 2.5g)
+ *   quaker instant rolled oats apple cinnamon         43g -> 2.5g   (cinnamon)
+ *   ryse loaded protein cinnamon                    34.2g -> 2.5g   (cinnamon)
+ *   pumpkin spice granola       fs_default_serving      29g -> 2.5g  (spice)
+ *   talenti sea salt caramel    fs_default_serving     128g -> 2.5g  (salt)
+ *
+ * In every case the lexicon token names the FLAVOUR, not the food. A 2x band on
+ * a 2.5g anchor is not a band; it clamps everything.
+ */
+const CAP_MAX_QUERY_TOKENS = 2;
+
+/**
+ * Dose-anchored queries get one extra token ("ghost pre workout"), because the
+ * dose default is the whole point for them and the phrase needs its final token
+ * to trigger. Beyond that the same product logic applies: "rxbar chocolate sea
+ * salt" is dose-anchored by the letter of `isDoseAnchoredBareQuery` — its head
+ * token IS "salt" — and is obviously not a teaspoon of salt.
+ */
+const CAP_MAX_DOSE_ANCHORED_TOKENS = 3;
+
+/**
+ * May a lexicon category default overwrite grams that came from the record's own
+ * declared label?
+ *
+ * This governs the CAP paths only. The REPLACE paths are untouched: there the
+ * grams are fabricated (a flat 100g placeholder or a count floor), so a category
+ * default is strictly better and no label data is at risk.
+ */
+export function capMayOverrideLabelServing(queryName: string): boolean {
+    const n = queryTokens(queryName).length;
+    if (n <= CAP_MAX_QUERY_TOKENS) return true;
+    return isDoseAnchoredBareQuery(queryName) && n <= CAP_MAX_DOSE_ANCHORED_TOKENS;
 }
 
 /**
@@ -206,11 +258,18 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
 
     const queryDefault = getBareQueryDefault(queryName);
 
+    // A multi-word PRODUCT query keeps its record's declared label serving: the
+    // manufacturer's number outranks a category guess made from one token inside
+    // the product's name. Applies to both CAP paths; the REPLACE path below is
+    // deliberately untouched, since there the grams are fabricated and nothing
+    // real is being overwritten.
+    const capAllowed = capMayOverrideLabelServing(queryName);
+
     if (CAP_TIERS.has(servingTier)) {
         // CAP consults ONLY the query-side lexicon. A foodName fallback here
         // would make any OFF name containing a lexicon token ("Chocolate Chip
         // …", "… Crisps") cap a genuine label serving the user never named.
-        if (queryDefault && grams > queryDefault.grams * 2) {
+        if (capAllowed && queryDefault && grams > queryDefault.grams * 2) {
             return buildOverride(queryDefault.grams);
         }
         return null;
@@ -222,7 +281,13 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
         // query HEAD ("olive oil" → oil: a 250g whole-bottle "serving" still
         // caps to 14g). Contained-token hijacks (pepper jack, butter chicken)
         // keep the label.
-        if (queryDefault
+        //
+        // Head-anchoring alone is NOT sufficient, which is why the token rule is
+        // and'ed in: "mac and cheese" has "cheese" as its literal head token, so
+        // this branch capped a genuine 113.4g label serving to the 28g one-ounce
+        // cheese default and billed 40 kcal for a ~400 kcal dish.
+        if (capAllowed
+            && queryDefault
             && getBareQueryDefault(queryHeadToken(queryName)) != null
             && grams > queryDefault.grams * 2) {
             return buildOverride(queryDefault.grams);


### PR DESCRIPTION
Two things, and the second was found by the first.

## 1. The gate could not see what the user is billed

`winner-diff` stops at winner selection — limit (B) in its own header. That blind
spot passed a **green gate on PR #173**: `mac and cheese` moved onto the record
literally named "Mac and Cheese" (5 NOWINNER→WINNER, 0 losses, eval unchanged),
while the billed total went **90.4 → 39.5 kcal against a true ~400**. The serving
anchor never moved and the new record has a lower kcal/100g.

`replay --with-serving` now runs `hydrateAndSelectServing` — the same function the
route calls, not a transcription — for every row with a winner, and records
grams / tier / totalKcal. `diff` prints a SERVING section. `winner-gate.sh` passes
it by default.

Design points worth reviewing:

- Separate async pass after the sync replay, so the selection half stays pure over
  the frozen pool. The winner candidate is **deep-copied**, because `buildOffResult`
  mutates `candidate.nutrition` in place and would otherwise make the second replay
  of a noise-floor pair differ for reasons unrelated to the code under test.
- The write guard suffices: `hydrateOffCandidate` is cache-first, and every record
  Typesense can return is already in `OffFood`.
- AI-estimated tiers are **excluded from the noise floor** (nondeterministic by
  design; including them would make the floor permanently non-zero) and reported as
  UNJUDGED in every diff, so the exclusion can never read as clearance.
- `serving === undefined` (stage never ran) classifies **UNJUDGED, never
  SERVING-SAME**. That one distinction is the whole point, and the tests lean on it.
- A diff with no serving data prints "SERVING DIFF — NOT RUN" with the PR #173
  numbers rather than omitting the section; an absent section reads as nothing to report.

### Two harness bugs it exposed immediately

- **`gitDirtyHash` hashed only `src/lib/mapping`.** A fix living entirely in
  `src/lib/servings` produced an *identical tree hash on both sides*: the BASE
  noise-floor receipt satisfied the BRANCH, and the header announced "identical tree
  AND identical variant — this run is itself a noise-floor check" about a run that
  was nothing of the sort. Now hashes mapping + servings + the bare-query lexicon.
- **`guessSnapshotPath` only resolved with exactly one `.noise-floor.json` present.**
  `winner-gate.sh` writes two (cold + regression), so it fell through to a path
  nothing ever writes and `diff` refused to report. A spurious "the noise floor is
  not established" is the worst false alarm this harness can raise, because the
  correct response to a real one is to stop. A replay now records its snapshot path.
  The old mirror workaround is removed — with two populations it was *causing* the
  refusal it was written to prevent.

## 2. A product's declared label serving outranks a category guess

`getBareQueryDefault` matches a lexicon token **anywhere** in the query, and the CAP
fires at `categoryDefault × 2`. For the 2.5 g spice/salt category that threshold is
**five grams** — below every real packaged food. Measured live with the new
`probe-bare-serving.ts`, which captures the guard's own `previousTier`/`previousGrams`:

| query | tier the guard overrode | grams destroyed |
|---|---|---|
| `mac and cheese` | `bare_label_serving` | **113.4 g → 28 g** |
| `rxbar chocolate sea salt` | `label_serving_default` | **52 g → 2.5 g** |
| `quaker instant rolled oats apple cinnamon` | `label_serving_default` | 43 g → 2.5 g |
| `ryse loaded protein cinnamon` | `label_serving_default` | 34.2 g → 2.5 g |
| `pumpkin spice granola` | `fs_default_serving` | 29 g → 2.5 g |
| `talenti sea salt caramel` | `fs_default_serving` | 128 g → 2.5 g |

In every case the lexicon token names the **flavour**, not the food.

Note: the comment above `HEAD_GATED_CAP_TIERS` claims `pumpkin spice latte` already
keeps its genuine label serving. Live, it bills 2.5 g / 1 kcal. The claim is true
only for the `bare_label_serving` tier and false for `label_serving_default`, which
carries no head gate at all.

**The rule.** A lexicon category describes a bare ingredient, and a bare ingredient is
named in one or two words. Three or more means the user named a *product*, and the
manufacturer's declared serving beats a guess about one token inside its name.
Dose-anchored queries get a third token (`ghost pre workout`, n-serv-43).

Three things worth knowing:

- **Declared-label tiers only.** `package_count_*`, `package_quantity_*` and
  `seed_count_default` stay fully cappable. The first draft protected every CAP tier
  and **the gate caught the cost on the regression population**: `orgain organic
  protein powder` went 35 g → **325.3 g** via `package_count_sibling`, billing 1,168
  kcal for one scoop. A package count is not a serving. That commit is kept separate
  so the correction is visible.
- **Head-anchoring alone does not solve it.** `mac and cheese` has `cheese` as its
  literal head token, so the existing head-gated branch capped a 113.4 g label to 28 g.
- **The dose-anchor carve-out needs its own token limit.** `rxbar chocolate sea salt`
  IS dose-anchored by the letter of `isDoseAnchoredBareQuery` (head token `salt`), so
  an unconditional carve-out would have readmitted the worst case in the set.

REPLACE paths are untouched and asserted so — there the grams are fabricated, so a
category default is strictly better in both directions. Asserted rather than argued,
because "the change only narrows a cap" is the by-inspection safety claim this repo
has been wrong about five times.

## Gate results

Isolated tree on the box; BASE and BRANCH differ **only** by the servings fix
(verified two-dot). All **4/4 noise-floor receipts 0** (2 snapshots × 2 trees, serving included).

**Cold, 200 rows** (every `bare_category_default` key from 7 days + never-asked cases of the same class):
- winners `SAME 200/200`, 0 movement — record identity untouched
- serving: `SERVING-SAME 165`, **`GRAMS-CHANGED 33`, all upward**, `UNJUDGED 2` (`cheese`/`Cheese`, AI)

**Regression, 200 already-asked lines:**
- winners `SAME 200/200`, 0 movement
- serving: `SERVING-SAME 181`, `GRAMS-CHANGED 3`, `AI-NONDETERMINISTIC 16`

All three regression movers are intended: `rxbar chocolate sea salt` 2.5→52 g,
`mac and cheese` 28→113.4 g, `a bagel with cream cheese` 28→105 g.

Sample of the cold movers:

```
pumpkin spice latte                      2.5g  ->  240.0g   1 ->  130 kcal
lean cuisine spaghetti with meat sauce  14.0g  ->  326.0g  13 ->  310 kcal
boston market mac and cheese            28.0g  ->  397.0g  37 ->  520 kcal
sardines in olive oil                   14.0g  ->  120.0g  40 ->  340 kcal
culvers cheese curds                    28.0g  ->  150.0g  95 ->  510 kcal
good and gather almond butter           14.0g  ->   32.0g  83 ->  190 kcal
```

**Eval on the built branch: `0 real failures, 16 known issues`** — the exact deployed
baseline. Server identity verified before trusting it (`:3100` billed 113.4 g while
live `:3000` billed 28 g), because a health check is not an identity check.

### Known cost, not hidden

`nutzo seven nut butter` moves 32 g → 211 g. 211 g is likely a jar, not a serving.
That record's panel is also broken (188 kcal for 211 g of nut butter ≈ 89 kcal/100g,
where nut butter is ~600), so **both** the before and after numbers are wrong for it;
this change does not fix it and does not make the record any less broken. Flagging
rather than burying it.

## Tests

- `scripts/eval/__tests__/serving-verdict.test.ts` — 15, the serving verdict
- `src/lib/servings/__tests__/cap-product-query-guard.test.ts` — 37, including the
  package-scale regression the gate caught
- The 151 existing guard tests are unchanged and still pass.

The 13 DB-dependent suites that fail locally fail identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx