### PR TITLE
fix(screen): the correctness screen graded fdc rows blind, guessed seeds, and judged a serving nobody is billed

### DIFF
--- a/scripts/eval/__tests__/correctness-screen.test.ts
+++ b/scripts/eval/__tests__/correctness-screen.test.ts
@@ -24,10 +24,16 @@
  *     temperature 0 agreed exactly on BAD and GOOD and disagreed by one SUSPECT
  *     row). The shipped operating point is Tier D + Tier L; this file defends only
  *     the deterministic half, which is 78% of the measured recall.
- *   - Whether a flagged row actually bills wrong. D5/D6 read a RECONSTRUCTION of the
- *     billing anchor, not hydrateAndSelectServing. Never measured.
  *   - D9 in the wild: it fired ZERO times across all 81 rows, so its only coverage
  *     anywhere is the synthetic case below.
+ *
+ * CLOSED 2026-07-27 — "whether a flagged row actually bills wrong" used to sit in
+ * the list above, because D5/D6 read a reconstruction rather than
+ * hydrateAndSelectServing. They now read the real anchor, and the fixture carries
+ * it (`row.real`), so this file is still offline and deterministic while pinning
+ * the number the USER IS BILLED. Measured agreement between the two on these 81
+ * rows: 78/81 = 96.3%. The remaining gap is why D5/D6 abstain to INFO rather than
+ * evict whenever the real anchor did not run.
  */
 
 import * as fs from 'fs';
@@ -39,6 +45,7 @@ import {
     MEASURED_BAD_RECALL_TIER_D_ONLY,
     MEASURED_BAD_RECALL_WITH_LLM,
     POLICIES,
+    ROW_SQL,
     TIER_D_RULE_IDS,
     attribute,
     atwater,
@@ -47,6 +54,8 @@ import {
     decide,
     parseIntFlag,
     parsePolicy,
+    parseSeedFile,
+    realServing,
     resolveServingGrams,
     screenBatch,
     stem,
@@ -164,13 +173,22 @@ describe('Tier D over batch 01 — pinned confusion matrix', () => {
      * BAD catches at ZERO cost in GOOD rows, D5 is a SUSPECT detector rather than a
      * BAD detector (which is why `balanced` sends it to REVIEW), and D9 fires on
      * nothing at all.
+     *
+     * UPDATED 2026-07-27 — D5/D6 now read the REAL billing anchor
+     * (hydrateAndSelectServing) instead of the column reconstruction, and the fixture
+     * carries it. Measured effect on these same 81 rows: reconstruction and real
+     * anchor agree on 78/81 (96.3%), and the 3 that differ move D5 STRICTLY in the
+     * right direction — it gains the BAD row `bar emerge protein simple truth`
+     * (billing flat-100g, which the 55 g column hid) and drops two SUSPECT rows that
+     * do resolve a real serving via `fs_serving_macros_only`. BAD recall is unchanged
+     * at every policy; the screen simply withholds one fewer row.
      */
     const PER_RULE: { rule: RuleId; fires: number; bad: number; good: number; suspect: number; note: string }[] = [
         { rule: 'D1', fires: 1, bad: 1, good: 0, suspect: 0, note: 'bare-brand key: `joe trader`' },
         { rule: 'D2', fires: 1, bad: 0, good: 0, suspect: 1, note: 'generic-key takeover (millville lost)' },
         { rule: 'D3', fires: 16, bad: 15, good: 0, suspect: 1, note: 'THE WORKHORSE — head noun absent' },
         { rule: 'D4', fires: 3, bad: 3, good: 0, suspect: 0, note: 'a subset of D3 in practice' },
-        { rule: 'D5', fires: 8, bad: 1, good: 0, suspect: 7, note: 'a SUSPECT detector, not a BAD detector' },
+        { rule: 'D5', fires: 7, bad: 2, good: 0, suspect: 5, note: 'a SUSPECT detector, not a BAD detector' },
         { rule: 'D6', fires: 3, bad: 3, good: 0, suspect: 0, note: '1.0 g chili oil, 1.9 g muffin, 1106 g banana' },
         { rule: 'D7', fires: 2, bad: 1, good: 0, suspect: 1, note: 'Atwater: inconsistency, not wrongness' },
         { rule: 'D8', fires: 1, bad: 0, good: 0, suspect: 1, note: 'empty panels are a restaurant-batch rule' },
@@ -205,7 +223,7 @@ describe('Tier D over batch 01 — pinned confusion matrix', () => {
         );
         const c = confusionOf(flagged, LABELS);
         expect({ flagged: flagged.size, bad: c.badCaught, good: c.goodFlagged, suspect: c.susFlagged })
-            .toEqual({ flagged: 27, bad: 19, good: 0, suspect: 8 });
+            .toEqual({ flagged: 26, bad: 19, good: 0, suspect: 7 });
         expect(c.recall).toBeCloseTo(19 / 23, 10);
     });
 
@@ -215,9 +233,9 @@ describe('Tier D over batch 01 — pinned confusion matrix', () => {
      * more; `lenient` is not a screen.
      */
     const PER_POLICY: { policy: Policy; evict: number; evictBad: number; review: number; reviewBad: number; keep: number }[] = [
-        { policy: 'lenient', evict: 5, evictBad: 4, review: 22, reviewBad: 15, keep: 54 },
-        { policy: 'balanced', evict: 19, evictBad: 18, review: 8, reviewBad: 1, keep: 54 },
-        { policy: 'strict', evict: 27, evictBad: 19, review: 0, reviewBad: 0, keep: 54 },
+        { policy: 'lenient', evict: 5, evictBad: 4, review: 21, reviewBad: 15, keep: 55 },
+        { policy: 'balanced', evict: 19, evictBad: 18, review: 7, reviewBad: 1, keep: 55 },
+        { policy: 'strict', evict: 26, evictBad: 19, review: 0, reviewBad: 0, keep: 55 },
     ];
 
     it.each(PER_POLICY)('policy $policy: EVICT $evict ($evictBad BAD) · REVIEW $review · KEEP $keep, and 0 GOOD ever evicted',
@@ -334,13 +352,48 @@ describe('D4 — zero seed/record content-token overlap', () => {
 });
 
 describe('D5 — no serving weight anywhere', () => {
-    it('fires when every gram column is empty (a unitless `1 x` bills a flat 100 g)', () => {
-        const r = baseRow({ off_serving_grams: null, fs_serving_grams: null, off_serv_min_g: null });
+    const noCols = { off_serving_grams: null, fs_serving_grams: null, off_serv_min_g: null };
+
+    it('fires when the REAL anchor resolves no serving', () => {
+        const r = baseRow({ ...noCols, real: { grams: null, tier: null, kcal: null } });
         expect(rules(tierD(r, 'balanced'))).toContain('D5');
-        // ...and under `balanced` it is a REVIEW, not an EVICT: 7 of its 8 fires on
-        // batch 01 were SUSPECT rows, and the anchor it reads is a reconstruction.
+        // ...and under `balanced` it is a REVIEW, not an EVICT: 5 of its 7 fires on
+        // batch 01 were SUSPECT rows.
         expect(tierD(r, 'balanced').find(h => h.rule === 'D5')?.severity).toBe('REVIEW');
     });
+
+    it('fires on flat_100g_default — 100 g there is the ABSENCE of an anchor', () => {
+        // The real function reports the flat-100g fallback as `100 g`, which sits
+        // squarely inside D6's plausible band. Reading it literally silenced D5 on 6
+        // batch-01 rows (one of them BAD) the first time this was wired up.
+        const r = baseRow({ ...noCols, real: { grams: 100, tier: 'flat_100g_default', kcal: 250 } });
+        expect(rules(tierD(r, 'balanced'))).toContain('D5');
+        expect(rules(tierD(r, 'balanced'))).not.toContain('D6');
+    });
+
+    it('does NOT fire when the real anchor found a serving the columns could not', () => {
+        // `cashew kirkland signature`: no gram column anywhere, but the FatSecret
+        // macros-only path resolves 56.7 g. The reconstruction called this D5; the
+        // real anchor clears it.
+        const r = baseRow({ ...noCols, real: { grams: 56.7, tier: 'fs_serving_macros_only', kcal: 320 } });
+        expect(rules(tierD(r, 'balanced'))).not.toContain('D5');
+    });
+
+    it('ABSTAINS to INFO when the real anchor never ran — an unmeasured reconstruction may not evict', () => {
+        // `real: undefined` is an offline --rows replay or --no-serving. D5/D6 must
+        // report, never gate: the reconstruction's agreement with the real anchor is
+        // 96.3%, not 100%, so on its own authority it may not throw a row away.
+        const r = baseRow(noCols);
+        const h = tierD(r, 'balanced').find(x => x.rule === 'D5');
+        expect(h?.severity).toBe('INFO');
+        expect(h?.detail).toContain('UNJUDGED');
+    });
+
+    it('D6 also abstains without the real anchor, at a weight that would otherwise EVICT', () => {
+        const h = tierD(baseRow({ off_serving_grams: 1.0 }), 'balanced').find(x => x.rule === 'D6');
+        expect(h?.severity).toBe('INFO');
+    });
+
     it('does not fire when any column anchors a weight', () => {
         const r = baseRow({ off_serving_grams: null, fs_serving_grams: 44, off_serv_min_g: null });
         expect(rules(tierD(r, 'balanced'))).not.toContain('D5');
@@ -582,5 +635,112 @@ describe('confusionOf()', () => {
         expect(c.precBad).toBeCloseTo(0.5, 10);
         expect(c.precBadSus).toBeCloseTo(1.0, 10);
         expect(c.recall).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The three blind spots closed 2026-07-27. Each of these tests exists because the
+// screen produced a confident, wrong number over the full 3,248-row cache.
+// ---------------------------------------------------------------------------
+
+describe('ROW_SQL joins every source a FoodMapping row can point at', () => {
+    it('joins FdcFood — its absence false-evicted 78 of 78 fdc rows', () => {
+        // FoodMapping.fdcId is a first-class source, but ROW_SQL joined only OffFood
+        // and FatSecretFood. Every fdc row therefore arrived with recname='' and
+        // per100g=null, so D8 ("no usable per-100g basis") fired on all of them and
+        // D3/D4 compared the seed against an empty string. Batch 01 had no fdc rows,
+        // which is exactly why the measured operating point never saw it.
+        expect(ROW_SQL).toContain('"FdcFood"');
+        expect(ROW_SQL).toMatch(/LEFT JOIN "FdcFood" \w+\s+ON \w+\."fdcId" = m\."fdcId"/);
+    });
+
+    it('coalesces the fdc record into name, brand and panel — not just the join', () => {
+        // A join nobody selects from is the same bug with extra steps.
+        expect(ROW_SQL).toMatch(/coalesce\(o\.name, f\.name, fd\.description/);
+        expect(ROW_SQL).toMatch(/coalesce\(o\."nutrientsPer100g", f\."nutrientsPer100g", fd\."nutrientsPer100g"\)/);
+    });
+
+    it('reads FdcFood.servingSize as grams ONLY when the unit says grams', () => {
+        const asGrams = baseRow({
+            off_serving_grams: null, fs_serving_grams: null, off_serv_min_g: null,
+            fdc_serving_size: 85, fdc_serving_unit: 'g',
+        });
+        expect(resolveServingGrams(asGrams)).toEqual({ grams: 85, from: 'FdcFood.servingSize' });
+
+        // `1 cup` in the servingSize column is a VOLUME. Reading 240 there as 240 g
+        // would invent a weight for every liquid in the FDC corpus.
+        const asVolume = baseRow({
+            off_serving_grams: null, fs_serving_grams: null, off_serv_min_g: null,
+            fdc_serving_size: 240, fdc_serving_unit: 'ml',
+        });
+        expect(resolveServingGrams(asVolume).grams).toBeNull();
+    });
+});
+
+describe('realServing() — the anchor D5/D6 judge', () => {
+    it('reports judged=false when the pass never ran, so the rules abstain', () => {
+        expect(realServing(baseRow()).judged).toBe(false);
+        expect(realServing(baseRow({ real: null })).judged).toBe(false);
+        expect(realServing(baseRow({ real: { grams: null, tier: null, kcal: null, error: 'boom' } })).judged).toBe(false);
+    });
+
+    it('normalises flat_100g_default to "no anchor" rather than a plausible 100 g', () => {
+        const r = realServing(baseRow({ real: { grams: 100, tier: 'flat_100g_default', kcal: 250 } }));
+        expect(r.judged).toBe(true);
+        expect(r.grams).toBeNull();
+        expect(r.from).toContain('flat_100g_default');
+    });
+
+    it('treats an AI-ESTIMATED tier as UNJUDGED — a fresh model guess cannot evict a row', () => {
+        // hydrateAndSelectServing invokes the ambiguous-serving estimator for rows the
+        // corpus cannot anchor. That number is not a property of the cached row; it can
+        // differ on the next request. Same rule as the serving gate's
+        // AI-NONDETERMINISTIC verdict (PR #174): report it, never gate on it.
+        for (const tier of ['ai_estimated_serving', 'fdc_size_estimated', 'count_ai_default']) {
+            const r = realServing(baseRow({ real: { grams: 28, tier, kcal: 90 } }));
+            expect(r.judged).toBe(false);
+            expect(r.from).toContain('ai-estimated');
+        }
+        const h = tierD(baseRow({ real: { grams: 1.0, tier: 'ai_estimated_serving', kcal: 5 } }), 'balanced')
+            .find(x => x.rule === 'D6');
+        expect(h?.severity).toBe('INFO');
+    });
+
+    it('passes a genuine anchor through untouched', () => {
+        const r = realServing(baseRow({ real: { grams: 56.7, tier: 'fs_serving_macros_only', kcal: 320 } }));
+        expect(r).toEqual({ grams: 56.7, from: 'hydrateAndSelectServing:fs_serving_macros_only', judged: true });
+    });
+});
+
+describe('parseSeedFile() + pinned attribution', () => {
+    it('parses bare phrases, key<TAB>phrase pins, comments and blanks', () => {
+        const s = parseSeedFile('# a comment\n\nplain seed phrase\nsome key\tthe observed phrase\n');
+        expect(s.phrases).toEqual(['plain seed phrase', 'the observed phrase']);
+        expect(s.byKey.get('some key')).toBe('the observed phrase');
+    });
+
+    it('a pin beats the Jaccard guess — the failure that made 332 evictions unquotable', () => {
+        // Measured 2026-07-27 over the whole cache: a TURKEY key drew the seed
+        // `85% lean 15% fat beef` because it was the nearest phrase in a 4,168-entry
+        // list, and D3 then reported "head noun 'beef' absent" on a correct row.
+        const rows = [baseRow({ key: '15% 85% fat lean turkey', recname: '85% lean ground turkey' })];
+        const seeds = parseSeedFile('85% lean 15% fat beef\n15% 85% fat lean turkey\t85% lean 15% fat turkey\n');
+
+        attribute(rows, seeds, null);
+        expect(rows[0].seed).toBe('85% lean 15% fat turkey');
+        expect(rules(tierD(rows[0], 'balanced'))).not.toContain('D3');
+    });
+
+    it('without the pin the same row draws the wrong seed and D3 misfires', () => {
+        const rows = [baseRow({ key: '15% 85% fat lean turkey', recname: '85% lean ground turkey' })];
+        attribute(rows, parseSeedFile('85% lean 15% fat beef\n'), null);
+        expect(rows[0].seed).toBe('85% lean 15% fat beef');
+        expect(rules(tierD(rows[0], 'balanced'))).toContain('D3');
+    });
+
+    it('still accepts a plain string[] so batch callers are unaffected', () => {
+        const rows = [baseRow({ key: 'almond great value' })];
+        attribute(rows, ['great value almonds'], null);
+        expect(rows[0].seed).toBe('great value almonds');
     });
 });

--- a/scripts/eval/__tests__/fixtures/correctness-screen-batch01.json
+++ b/scripts/eval/__tests__/fixtures/correctness-screen-batch01.json
@@ -53,7 +53,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "fit and active protein shake"
+    "seed": "fit and active protein shake",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 39.43661880493164
+    }
    }
   },
   {
@@ -93,7 +98,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "amazon fresh almond butter"
+    "seed": "amazon fresh almond butter",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 190.08
+    }
    }
   },
   {
@@ -133,7 +143,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "good and gather almond butter"
+    "seed": "good and gather almond butter",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 190.08
+    }
    }
   },
   {
@@ -173,7 +188,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "simply nature almond butter"
+    "seed": "simply nature almond butter",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 190
+    }
    }
   },
   {
@@ -215,7 +235,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "simple truth almond butter"
+    "seed": "simple truth almond butter",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 593.75
+    }
    }
   },
   {
@@ -257,7 +282,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "sprouts almond butter"
+    "seed": "sprouts almond butter",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 593.75
+    }
    }
   },
   {
@@ -297,7 +327,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 31,
     "off_serv_max_g": 31,
-    "seed": "great value almonds"
+    "seed": "great value almonds",
+    "real": {
+     "grams": 31,
+     "tier": "label_serving_default",
+     "kcal": 190.03
+    }
    }
   },
   {
@@ -350,7 +385,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature almonds"
+    "seed": "kirkland signature almonds",
+    "real": {
+     "grams": 30,
+     "tier": "fs_default_serving",
+     "kcal": 170
+    }
    }
   },
   {
@@ -390,7 +430,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 28,
     "off_serv_max_g": 28,
-    "seed": "members mark almonds"
+    "seed": "members mark almonds",
+    "real": {
+     "grams": 28,
+     "tier": "label_serving_default",
+     "kcal": 170.00000732421876
+    }
    }
   },
   {
@@ -432,7 +477,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 140,
     "off_serv_max_g": 140,
-    "seed": "trader joes vanilla almondmilk yogurt"
+    "seed": "trader joes vanilla almondmilk yogurt",
+    "real": {
+     "grams": 140,
+     "tier": "label_serving_default",
+     "kcal": 330.4
+    }
    }
   },
   {
@@ -472,7 +522,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 113.398,
     "off_serv_max_g": 113.398,
-    "seed": "amazon fresh chicken breast"
+    "seed": "amazon fresh chicken breast",
+    "real": {
+     "grams": 113.398,
+     "tier": "label_serving_default",
+     "kcal": 109.99606
+    }
    }
   },
   {
@@ -512,7 +567,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 170,
     "off_serv_max_g": 170,
-    "seed": "amazon fresh greek yogurt"
+    "seed": "amazon fresh greek yogurt",
+    "real": {
+     "grams": 170,
+     "tier": "label_serving_default",
+     "kcal": 180.2
+    }
    }
   },
   {
@@ -552,7 +612,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 28,
     "off_serv_max_g": 28,
-    "seed": "amazon fresh trail mix"
+    "seed": "amazon fresh trail mix",
+    "real": {
+     "grams": 28,
+     "tier": "label_serving_default",
+     "kcal": 160.0000048828125
+    }
    }
   },
   {
@@ -592,7 +657,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 112,
     "off_serv_max_g": 112,
-    "seed": "good and gather chicken breast"
+    "seed": "good and gather chicken breast",
+    "real": {
+     "grams": 112,
+     "tier": "label_serving_default",
+     "kcal": 140
+    }
    }
   },
   {
@@ -632,7 +702,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 70,
     "off_serv_max_g": 70,
-    "seed": "great value macaroni and cheese"
+    "seed": "great value macaroni and cheese",
+    "real": {
+     "grams": 70,
+     "tier": "label_serving_default",
+     "kcal": 249.89999999999998
+    }
    }
   },
   {
@@ -679,7 +754,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "good and gather rotisserie chicken"
+    "seed": "good and gather rotisserie chicken",
+    "real": {
+     "grams": 84,
+     "tier": "fs_default_serving",
+     "kcal": 130
+    }
    }
   },
   {
@@ -721,7 +801,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 41,
     "off_serv_max_g": 41,
-    "seed": "good and gather granola"
+    "seed": "good and gather granola",
+    "real": {
+     "grams": 41,
+     "tier": "label_serving_default",
+     "kcal": 170.00000366210938
+    }
    }
   },
   {
@@ -777,7 +862,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "good and gather sparkling water"
+    "seed": "good and gather sparkling water",
+    "real": {
+     "grams": 15,
+     "tier": "fs_label_count",
+     "kcal": 70
+    }
    }
   },
   {
@@ -829,7 +919,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature bacon"
+    "seed": "kirkland signature bacon",
+    "real": {
+     "grams": 18,
+     "tier": "fs_default_serving",
+     "kcal": 90
+    }
    }
   },
   {
@@ -871,7 +966,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 56,
     "off_serv_max_g": 56,
-    "seed": "kirkland signature turkey bacon"
+    "seed": "kirkland signature turkey bacon",
+    "real": {
+     "grams": 56,
+     "tier": "label_serving_default",
+     "kcal": 59.92000000000001
+    }
    }
   },
   {
@@ -914,7 +1014,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 143,
     "off_serv_max_g": 143,
-    "seed": "trader joes everything but the bagel seasoning"
+    "seed": "trader joes everything but the bagel seasoning",
+    "real": {
+     "grams": 143,
+     "tier": "label_serving_default",
+     "kcal": 379.99998168945314
+    }
    }
   },
   {
@@ -958,7 +1063,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 1106.7653828,
     "off_serv_max_g": 1106.7653828,
-    "seed": "trader joes gone bananas"
+    "seed": "trader joes gone bananas",
+    "real": {
+     "grams": 1106.7653828,
+     "tier": "label_serving_default",
+     "kcal": 129.49154767661258
+    }
    }
   },
   {
@@ -1001,7 +1111,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 55,
     "off_serv_max_g": 55,
-    "seed": "simple truth emerge protein bar"
+    "seed": "simple truth emerge protein bar",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 194.6903076171875
+    }
    }
   },
   {
@@ -1041,7 +1156,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 24,
     "off_serv_max_g": 24,
-    "seed": "millville granola bars"
+    "seed": "millville granola bars",
+    "real": {
+     "grams": 24,
+     "tier": "label_serving_default",
+     "kcal": 100.08
+    }
    }
   },
   {
@@ -1084,7 +1204,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature protein bars"
+    "seed": "kirkland signature protein bars",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 283.3333435058594
+    }
    }
   },
   {
@@ -1126,7 +1251,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "sprouts brand granola"
+    "seed": "sprouts brand granola",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 190.08
+    }
    }
   },
   {
@@ -1166,7 +1296,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 112,
     "off_serv_max_g": 112,
-    "seed": "great value frozen chicken breast"
+    "seed": "great value frozen chicken breast",
+    "real": {
+     "grams": 112,
+     "tier": "label_serving_default",
+     "kcal": 140
+    }
    }
   },
   {
@@ -1206,7 +1341,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 112,
     "off_serv_max_g": 112,
-    "seed": "kirkland signature organic chicken breast"
+    "seed": "kirkland signature organic chicken breast",
+    "real": {
+     "grams": 112,
+     "tier": "label_serving_default",
+     "kcal": 109.98399658203127
+    }
    }
   },
   {
@@ -1246,7 +1386,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 112,
     "off_serv_max_g": 112,
-    "seed": "members mark chicken breast"
+    "seed": "members mark chicken breast",
+    "real": {
+     "grams": 112,
+     "tier": "label_serving_default",
+     "kcal": 129.92000000000002
+    }
    }
   },
   {
@@ -1286,7 +1431,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 112,
     "off_serv_max_g": 112,
-    "seed": "simple truth organic chicken breast"
+    "seed": "simple truth organic chicken breast",
+    "real": {
+     "grams": 112,
+     "tier": "label_serving_default",
+     "kcal": 109.98399658203127
+    }
    }
   },
   {
@@ -1328,7 +1478,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 450,
     "off_serv_max_g": 450,
-    "seed": "trader joes cold brew"
+    "seed": "trader joes cold brew",
+    "real": {
+     "grams": 450,
+     "tier": "label_serving_default",
+     "kcal": 149.84999656677246
+    }
    }
   },
   {
@@ -1370,7 +1525,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 71,
     "off_serv_max_g": 71,
-    "seed": "trader joes turkey burgers"
+    "seed": "trader joes turkey burgers",
+    "real": {
+     "grams": 71,
+     "tier": "label_serving_default",
+     "kcal": 100.00000503540036
+    }
    }
   },
   {
@@ -1413,7 +1573,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 100,
     "off_serv_max_g": 100,
-    "seed": "trader joes kung pao chicken burrito"
+    "seed": "trader joes kung pao chicken burrito",
+    "real": {
+     "grams": 100,
+     "tier": "label_serving_default",
+     "kcal": 40
+    }
    }
   },
   {
@@ -1465,7 +1630,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes speculoos cookie butter"
+    "seed": "trader joes speculoos cookie butter",
+    "real": {
+     "grams": 15,
+     "tier": "fs_default_serving",
+     "kcal": 85
+    }
    }
   },
   {
@@ -1520,7 +1690,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "heb creamy peanut butter"
+    "seed": "heb creamy peanut butter",
+    "real": {
+     "grams": 32,
+     "tier": "fs_default_serving",
+     "kcal": 190
+    }
    }
   },
   {
@@ -1560,7 +1735,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "kroger peanut butter"
+    "seed": "kroger peanut butter",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 179.84
+    }
    }
   },
   {
@@ -1600,7 +1780,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "simply nature organic peanut butter"
+    "seed": "simply nature organic peanut butter",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 190
+    }
    }
   },
   {
@@ -1640,7 +1825,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 36,
     "off_serv_max_g": 36,
-    "seed": "sprouts organic peanut butter"
+    "seed": "sprouts organic peanut butter",
+    "real": {
+     "grams": 36,
+     "tier": "label_serving_default",
+     "kcal": 209.88
+    }
    }
   },
   {
@@ -1682,7 +1872,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "wegmans salted caramel gelato"
+    "seed": "wegmans salted caramel gelato",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 189.6551666259766
+    }
    }
   },
   {
@@ -1734,7 +1929,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature cashews"
+    "seed": "kirkland signature cashews",
+    "real": {
+     "grams": 56.6999484752573,
+     "tier": "fs_serving_macros_only",
+     "kcal": 330
+    }
    }
   },
   {
@@ -1776,7 +1976,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 85,
     "off_serv_max_g": 85,
-    "seed": "trader joes unexpected cheddar"
+    "seed": "trader joes unexpected cheddar",
+    "real": {
+     "grams": 85,
+     "tier": "label_serving_default",
+     "kcal": 159.79999999999998
+    }
    }
   },
   {
@@ -1831,7 +2036,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "great value string cheese"
+    "seed": "great value string cheese",
+    "real": {
+     "grams": 28,
+     "tier": "fs_default_serving",
+     "kcal": 80
+    }
    }
   },
   {
@@ -1884,7 +2094,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "publix deli fried chicken"
+    "seed": "publix deli fried chicken",
+    "real": {
+     "grams": 94,
+     "tier": "fs_label_count",
+     "kcal": 220
+    }
    }
   },
   {
@@ -1924,7 +2139,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 76,
     "off_serv_max_g": 76,
-    "seed": "kirkland signature chicken sausage"
+    "seed": "kirkland signature chicken sausage",
+    "real": {
+     "grams": 76,
+     "tier": "label_serving_default",
+     "kcal": 150.0000018310547
+    }
    }
   },
   {
@@ -1967,7 +2187,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "members mark rotisserie chicken"
+    "seed": "members mark rotisserie chicken",
+    "real": {
+     "grams": 100,
+     "tier": "flat_100g_default",
+     "kcal": 270
+    }
    }
   },
   {
@@ -2010,7 +2235,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 1,
     "off_serv_max_g": 1,
-    "seed": "trader joes chili onion crunch"
+    "seed": "trader joes chili onion crunch",
+    "real": {
+     "grams": 1,
+     "tier": "label_serving_default",
+     "kcal": 1.1
+    }
    }
   },
   {
@@ -2063,7 +2293,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "favorite day chocolate chip cookies"
+    "seed": "favorite day chocolate chip cookies",
+    "real": {
+     "grams": 40,
+     "tier": "fs_default_serving",
+     "kcal": 190
+    }
    }
   },
   {
@@ -2103,7 +2338,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 28.349,
     "off_serv_max_g": 28.349,
-    "seed": "clancys tortilla chips"
+    "seed": "clancys tortilla chips",
+    "real": {
+     "grams": 28.349,
+     "tier": "label_serving_default",
+     "kcal": 141.745
+    }
    }
   },
   {
@@ -2158,7 +2398,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes soy chorizo"
+    "seed": "trader joes soy chorizo",
+    "real": {
+     "grams": 56,
+     "tier": "fs_default_serving",
+     "kcal": 130
+    }
    }
   },
   {
@@ -2198,7 +2443,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 84,
     "off_serv_max_g": 84,
-    "seed": "trader joes hold the cone"
+    "seed": "trader joes hold the cone",
+    "real": {
+     "grams": 84,
+     "tier": "label_serving_default",
+     "kcal": 260.4
+    }
    }
   },
   {
@@ -2251,7 +2501,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes cornbread crunch"
+    "seed": "trader joes cornbread crunch",
+    "real": {
+     "grams": 47,
+     "tier": "fs_default_serving",
+     "kcal": 170
+    }
    }
   },
   {
@@ -2293,7 +2548,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 85,
     "off_serv_max_g": 85,
-    "seed": "favorite day ice cream sandwiches"
+    "seed": "favorite day ice cream sandwiches",
+    "real": {
+     "grams": 85,
+     "tier": "label_serving_default",
+     "kcal": 130.04999999999998
+    }
    }
   },
   {
@@ -2333,7 +2593,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 71,
     "off_serv_max_g": 71,
-    "seed": "kirkland signature croissants"
+    "seed": "kirkland signature croissants",
+    "real": {
+     "grams": 71,
+     "tier": "label_serving_default",
+     "kcal": 300.33
+    }
    }
   },
   {
@@ -2388,7 +2653,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "specially selected croissants"
+    "seed": "specially selected croissants",
+    "real": {
+     "grams": 57,
+     "tier": "fs_default_serving",
+     "kcal": 210
+    }
    }
   },
   {
@@ -2430,7 +2700,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 28,
     "off_serv_max_g": 28,
-    "seed": "trader joes elote dip"
+    "seed": "trader joes elote dip",
+    "real": {
+     "grams": 28,
+     "tier": "label_serving_default",
+     "kcal": 49.99999938964845
+    }
    }
   },
   {
@@ -2485,7 +2760,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature granola"
+    "seed": "kirkland signature granola",
+    "real": {
+     "grams": 55,
+     "tier": "fs_default_serving",
+     "kcal": 250
+    }
    }
   },
   {
@@ -2525,7 +2805,12 @@
     "n_off_servings": 4,
     "off_serv_min_g": 240,
     "off_serv_max_g": 300,
-    "seed": "great value orange juice"
+    "seed": "great value orange juice",
+    "real": {
+     "grams": 300,
+     "tier": "label_serving_default",
+     "kcal": 141
+    }
    }
   },
   {
@@ -2580,7 +2865,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature greek yogurt"
+    "seed": "kirkland signature greek yogurt",
+    "real": {
+     "grams": 227,
+     "tier": "fs_default_serving",
+     "kcal": 130
+    }
    }
   },
   {
@@ -2620,7 +2910,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 170,
     "off_serv_max_g": 170,
-    "seed": "members mark greek yogurt"
+    "seed": "members mark greek yogurt",
+    "real": {
+     "grams": 170,
+     "tier": "label_serving_default",
+     "kcal": 99.99999809265137
+    }
    }
   },
   {
@@ -2660,7 +2955,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 150,
     "off_serv_max_g": 150,
-    "seed": "wegmans organic greek yogurt"
+    "seed": "wegmans organic greek yogurt",
+    "real": {
+     "grams": 150,
+     "tier": "label_serving_default",
+     "kcal": 120
+    }
    }
   },
   {
@@ -2700,7 +3000,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 170,
     "off_serv_max_g": 170,
-    "seed": "signature select greek yogurt"
+    "seed": "signature select greek yogurt",
+    "real": {
+     "grams": 170,
+     "tier": "label_serving_default",
+     "kcal": 89.93000259399415
+    }
    }
   },
   {
@@ -2740,7 +3045,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 170,
     "off_serv_max_g": 170,
-    "seed": "simple truth greek yogurt"
+    "seed": "simple truth greek yogurt",
+    "real": {
+     "grams": 170,
+     "tier": "label_serving_default",
+     "kcal": 119.99999771118163
+    }
    }
   },
   {
@@ -2793,7 +3103,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes vegetable gyoza"
+    "seed": "trader joes vegetable gyoza",
+    "real": {
+     "grams": 85,
+     "tier": "fs_default_serving",
+     "kcal": 160
+    }
    }
   },
   {
@@ -2833,7 +3148,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 49,
     "off_serv_max_g": 49,
-    "seed": "heb tortillas"
+    "seed": "heb tortillas",
+    "real": {
+     "grams": 49,
+     "tier": "label_serving_default",
+     "kcal": 149.94
+    }
    }
   },
   {
@@ -2876,7 +3196,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 52,
     "off_serv_max_g": 52,
-    "seed": "millville honey nut toasted oats"
+    "seed": "millville honey nut toasted oats",
+    "real": {
+     "grams": 52,
+     "tier": "label_serving_default",
+     "kcal": 189.8
+    }
    }
   },
   {
@@ -2918,7 +3243,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 40,
     "off_serv_max_g": 40,
-    "seed": "trader joes protein pasta"
+    "seed": "trader joes protein pasta",
+    "real": {
+     "grams": 40,
+     "tier": "label_serving_default",
+     "kcal": 140
+    }
    }
   },
   {
@@ -2960,7 +3290,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 36,
     "off_serv_max_g": 36,
-    "seed": "trader joes scandinavian swimmers"
+    "seed": "trader joes scandinavian swimmers",
+    "real": {
+     "grams": 36,
+     "tier": "label_serving_default",
+     "kcal": 159.84
+    }
    }
   },
   {
@@ -3015,7 +3350,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes joe joes"
+    "seed": "trader joes joe joes",
+    "real": {
+     "grams": 29,
+     "tier": "fs_default_serving",
+     "kcal": 140
+    }
    }
   },
   {
@@ -3064,7 +3404,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "trader joes tzatziki"
+    "seed": "trader joes tzatziki",
+    "real": {
+     "grams": 30,
+     "tier": "fs_default_serving",
+     "kcal": 35
+    }
    }
   },
   {
@@ -3115,7 +3460,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "publix key lime pie"
+    "seed": "publix key lime pie",
+    "real": {
+     "grams": 132,
+     "tier": "fs_label_count",
+     "kcal": 420
+    }
    }
   },
   {
@@ -3168,7 +3518,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature dried mango"
+    "seed": "kirkland signature dried mango",
+    "real": {
+     "grams": 41,
+     "tier": "fs_default_serving",
+     "kcal": 130
+    }
    }
   },
   {
@@ -3220,7 +3575,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature trail mix"
+    "seed": "kirkland signature trail mix",
+    "real": {
+     "grams": 57,
+     "tier": "fs_default_serving",
+     "kcal": 320
+    }
    }
   },
   {
@@ -3263,7 +3623,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 1.9,
     "off_serv_max_g": 1.9,
-    "seed": "kirkland signature muffins"
+    "seed": "kirkland signature muffins",
+    "real": {
+     "grams": 1.9,
+     "tier": "label_serving_default",
+     "kcal": 4.999999999999999
+    }
    }
   },
   {
@@ -3320,7 +3685,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "kirkland signature protein shake"
+    "seed": "kirkland signature protein shake",
+    "real": {
+     "grams": 34,
+     "tier": "fs_default_serving",
+     "kcal": 170
+    }
    }
   },
   {
@@ -3363,7 +3733,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 100,
     "off_serv_max_g": 100,
-    "seed": "kirkland signature quinoa"
+    "seed": "kirkland signature quinoa",
+    "real": {
+     "grams": 100,
+     "tier": "label_serving_default",
+     "kcal": 112
+    }
    }
   },
   {
@@ -3403,7 +3778,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 32,
     "off_serv_max_g": 32,
-    "seed": "signature select trail mix"
+    "seed": "signature select trail mix",
+    "real": {
+     "grams": 32,
+     "tier": "label_serving_default",
+     "kcal": 169.92000000000002
+    }
    }
   },
   {
@@ -3443,7 +3823,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 30,
     "off_serv_max_g": 30,
-    "seed": "sprouts trail mix"
+    "seed": "sprouts trail mix",
+    "real": {
+     "grams": 30,
+     "tier": "label_serving_default",
+     "kcal": 170.00000610351563
+    }
    }
   },
   {
@@ -3483,7 +3868,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 30,
     "off_serv_max_g": 30,
-    "seed": "wegmans trail mix"
+    "seed": "wegmans trail mix",
+    "real": {
+     "grams": 30,
+     "tier": "label_serving_default",
+     "kcal": 150
+    }
    }
   },
   {
@@ -3526,7 +3916,12 @@
     "n_off_servings": 1,
     "off_serv_min_g": 28,
     "off_serv_max_g": 28,
-    "seed": "publix pecan pie"
+    "seed": "publix pecan pie",
+    "real": {
+     "grams": 28,
+     "tier": "label_serving_default",
+     "kcal": 190.12
+    }
    }
   },
   {
@@ -3569,7 +3964,12 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "publix sub sandwich"
+    "seed": "publix sub sandwich",
+    "real": {
+     "grams": 175,
+     "tier": "fs_serving_macros_only",
+     "kcal": 350
+    }
    }
   },
   {
@@ -3625,8 +4025,14 @@
     "n_off_servings": 0,
     "off_serv_min_g": null,
     "off_serv_max_g": null,
-    "seed": "signature select sparkling water"
+    "seed": "signature select sparkling water",
+    "real": {
+     "grams": 30,
+     "tier": "fs_label_count",
+     "kcal": 120
+    }
    }
   }
- ]
+ ],
+ "_realAnchor": "Each row.real is what hydrateAndSelectServing returns for that record — captured 2026-07-27 against the live corpus. It exists so the pinned matrix measures the anchor the USER IS BILLED, offline and deterministically. Reconstruction vs real agreed on 78/81 (96.3%); the 3 that differ are recorded in the PR that added this field."
 }

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -1179,8 +1179,8 @@ async function main(): Promise<number> {
             + 'the 4 rows Tier D misses are exactly the 4 Tier L catches.');
     }
     console.log('NOTE this screen grades the rows the batch ADDED. It says "this is wrong"; it never says "here is '
-        + 'the right one", and it does not call hydrateAndSelectServing, so D5/D6 are a reconstruction of the billing '
-        + 'anchor whose agreement with the real one was never measured.');
+        + 'the right one". D5/D6 read the real billing anchor when --with-serving ran (reconstruction/real agreement '
+        + 'measured at 96.3% on batch 01) and abstain to INFO when it did not.');
 
     if (outPath) {
         fs.writeFileSync(outPath, JSON.stringify({

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -80,18 +80,24 @@
  *    future "the LLM catches everything, drop Tier D" simplification would silently
  *    drop those 3. (Symmetrically, the 4 BAD rows Tier D misses are exactly the 4
  *    Tier L catches. Neither tier alone reaches 100%.)
- * 2. **The serving check is a RECONSTRUCTION.** `resolveServingGrams` reimplements
- *    the billing anchor and never calls `hydrateAndSelectServing`, so count-label
- *    serving, dose-anchored serving and the FatSecret weight oracle are invisible
- *    to it. A row D5 calls "no serving weight" MAY IN FACT BILL CORRECTLY.
- *    **This was not measured.**
+ * 2. ~~**The serving check is a RECONSTRUCTION.**~~ CLOSED 2026-07-27. D5/D6 read the
+ *    real anchor through `hydrateAndSelectServing` (on by default; `--no-serving`
+ *    opts out). `resolveServingGrams` survives only as the fallback for offline
+ *    `--rows` replays, and when the real anchor did not run D5/D6 report INFO and
+ *    never EVICT — an unmeasured reconstruction may not throw a cache row away.
  * 3. **D9 fired zero times on the 81 rows.** It is unexercised, not validated.
+ *    (Update 2026-07-27: it fires 13 times across the full 3,248-row cache, and all
+ *    13 reproduce as a plain SQL join against corruptReason/duplicateOfBarcode.)
  * 4. **Determinism is partial.** Four Tier-L runs at temperature 0 gave identical
  *    BAD and GOOD columns; the SUSPECT column moved by one row. Quote review-queue
  *    sizes as a range, not a number.
  * 5. **One batch, one domain.** Batch 01 is store brands. Hand-label the first 20
  *    added rows of the next domain and re-run with `--labels` before trusting any
  *    of these numbers there.
+ * 6. **The measured numbers are a BATCH instrument's.** Screening the whole cache at
+ *    once changes seed attribution from a lookup into a nearest-match guess unless
+ *    `--seeds` carries explicit `key<TAB>phrase` pins — see `attribute()`. Without
+ *    pins, the seed-dependent rules produce false positives at cache width.
  *
  * ---------------------------------------------------------------------------
  * USAGE (from repo root)
@@ -158,8 +164,32 @@ export interface ScreenRow {
     n_off_servings: number;
     off_serv_min_g: number | null;
     off_serv_max_g: number | null;
+    /**
+     * FDC columns. ROW_SQL joined OffFood and FatSecretFood ONLY until 2026-07-27,
+     * so every fdc-sourced row arrived with recname='' and per100g=null and D8
+     * fired on all of them — 78 of 78 fdc rows in the live cache, a 100% false
+     * positive rate on that source. Batch 01 contained no fdc rows, which is why
+     * the measured operating point never saw it.
+     */
+    fdc_serving_size: number | null;
+    fdc_serving_unit: string;
+    fdc_serv_min_g: number | null;
     /** Filled in by attribute(); '' means "could not be attributed to a seed". */
     seed?: string;
+    /**
+     * Filled in by the --with-serving pass from the REAL billing anchor
+     * (hydrateAndSelectServing), not from resolveServingGrams. `undefined` means
+     * the pass never ran for this row, which is UNJUDGED — never agreement.
+     */
+    real?: RealServing | null;
+}
+
+/** What the request path would actually bill for a unitless `1 x` of this row. */
+export interface RealServing {
+    grams: number | null;
+    tier: string | null;
+    kcal: number | null;
+    error?: string;
 }
 
 export interface LlmVerdict {
@@ -288,19 +318,73 @@ export function contentStems(seed: string, brand: Set<string>): string[] {
  *
  * !! THIS IS A RECONSTRUCTION, NOT THE PIPELINE. !!
  * It walks OffFood.servingGrams -> FatSecretServing.grams -> OffServing.grams ->
- * flat 100 g. It does NOT call hydrateAndSelectServing, so count-label serving,
- * dose-anchored serving and funnel fix 5's FatSecret weight oracle are invisible
- * here. A row D5 flags as "no serving weight" MAY IN FACT BILL CORRECTLY via one of
- * those. The divergence between this reconstruction and the real anchor was NEVER
- * MEASURED — read D5/D6 as "this row's anchor looks wrong from the columns", not as
- * "this row bills wrong".
+ * FdcFood.servingSize -> FdcServing.grams -> flat 100 g. It does NOT call
+ * hydrateAndSelectServing, so count-label serving, dose-anchored serving and funnel
+ * fix 5's FatSecret weight oracle are invisible here.
+ *
+ * PREFER `realServing()`. Since 2026-07-27 the screen runs the real anchor by
+ * default (`--with-serving`) and D5/D6 judge THAT; this function is the fallback
+ * used only for the LLM card and for rows the real pass could not resolve. Where
+ * the two disagree, the real one is right by construction — it is the function the
+ * request path calls.
  */
 export function resolveServingGrams(r: ScreenRow): { grams: number | null; from: string } {
     if (r.off_serving_grams != null && r.off_serving_grams > 0) return { grams: r.off_serving_grams, from: 'OffFood.servingGrams' };
     if (r.fs_serving_grams != null && r.fs_serving_grams > 0) return { grams: r.fs_serving_grams, from: 'FatSecretServing.grams' };
     if (r.off_serv_min_g != null && r.off_serv_min_g > 0) return { grams: r.off_serv_min_g, from: 'OffServing.grams' };
+    // FDC: servingSize is only a weight when its unit says so — `1 cup` in the
+    // servingSize column is a volume and must not be read as grams.
+    if (r.fdc_serving_size != null && r.fdc_serving_size > 0 && /^g(ram)?s?$/i.test(r.fdc_serving_unit || '')) {
+        return { grams: r.fdc_serving_size, from: 'FdcFood.servingSize' };
+    }
+    if (r.fdc_serv_min_g != null && r.fdc_serv_min_g > 0) return { grams: r.fdc_serv_min_g, from: 'FdcServing.grams' };
     return { grams: null, from: 'none (flat-100g default)' };
 }
+
+/**
+ * The anchor D5/D6 actually judge, and whether it can be judged at all.
+ *
+ * `judged: false` means the real pass did not produce a number for this row — the
+ * flag was off, the row is an offline `--rows` replay, or hydration threw. In that
+ * state D5/D6 MUST NOT evict: the reconstruction alone was never measured against
+ * the real anchor, and evicting a cache row on an unvalidated number is the same
+ * mistake the serving gate closed in PR #174. Absence of a verdict is UNJUDGED,
+ * never agreement — the screen goes quiet, not loud.
+ */
+export function realServing(r: ScreenRow): { grams: number | null; from: string; judged: boolean } {
+    if (r.real === undefined) return { ...resolveServingGrams(r), judged: false };
+    if (r.real === null || r.real.error) return { grams: null, from: 'real anchor unresolved', judged: false };
+    // `flat_100g_default` is the ABSENCE of an anchor wearing a number. The real
+    // function reports it as 100 g; the reconstruction reports it as null. They mean
+    // the same thing, and D5 exists to say it — so normalise to null or D5 falls
+    // silent on exactly the rows it was written for. Measured on batch 01: 6 of the
+    // 9 reconstruction/real "disagreements" were only this, and reading the 100 g
+    // literally would have silenced 6 correct D5 warnings (one of them a BAD row).
+    if (NO_ANCHOR_TIERS.has(r.real.tier ?? '')) {
+        return { grams: null, from: `hydrateAndSelectServing:${r.real.tier}`, judged: true };
+    }
+    // An AI-ESTIMATED anchor is not a property of this cache row — it is a fresh model
+    // guess that can differ on the next request, so it cannot ground a decision to
+    // throw the row away. Same rule the serving gate uses (PR #174's
+    // AI-NONDETERMINISTIC verdict): name it, never silently read it as agreement.
+    if (AI_SERVING_TIER_RE.test(r.real.tier ?? '')) {
+        return { grams: r.real.grams, from: `ai-estimated:${r.real.tier}`, judged: false };
+    }
+    return { grams: r.real.grams, from: `hydrateAndSelectServing:${r.real.tier ?? 'no-tier'}`, judged: true };
+}
+
+/**
+ * Tiers produced by a model call rather than by corpus data. Matching one means the
+ * screen spent an LLM call resolving that row — see the cost note on
+ * `resolveRealServings`.
+ */
+export const AI_SERVING_TIER_RE = /(^|_)ai(_|$)|estimat/i;
+
+/**
+ * Serving tiers that are a FALLBACK, not a measured portion. A row on one of these
+ * has no real anchor no matter what number it carries, which is what D5 reports.
+ */
+export const NO_ANCHOR_TIERS = new Set<string>(['flat_100g_default']);
 
 export function atwater(p: Record<string, number> | null): { declared: number; computed: number; ratio: number } | null {
     if (!p) return null;
@@ -407,15 +491,20 @@ export function tierD(r: ScreenRow, policy: Policy): Hit[] {
     // D5 — no gram anchor anywhere, so a unitless `1 x` bills the flat-100g default.
     // 1/23 BAD but 7/10 SUSPECT: a SUSPECT detector, not a BAD detector, which is why
     // `balanced` routes it to REVIEW rather than EVICT.
-    // CAVEAT: resolveServingGrams is a RECONSTRUCTION (see its docstring). A row
-    // flagged here may still bill correctly via hydrateAndSelectServing. NOT MEASURED.
-    const sg = resolveServingGrams(r);
+    //
+    // Since 2026-07-27 this reads the REAL anchor (hydrateAndSelectServing) when the
+    // --with-serving pass ran. When it did not, both rules DOWNGRADE to INFO instead
+    // of firing: the reconstruction's agreement with the real anchor has never been
+    // measured, so it may not evict a row on its own authority.
+    const sg = realServing(r);
+    const dsev = (rule: RuleId): Severity => (sg.judged ? sev(rule) : 'INFO');
+    const unjudged = sg.judged ? '' : ' [UNJUDGED: real anchor not computed, reconstruction only]';
     if (sg.grams == null) {
-        hits.push({ rule: 'D5', severity: sev('D5'), detail: 'no serving weight in any column -> flat-100g default' });
+        hits.push({ rule: 'D5', severity: dsev('D5'), detail: `no serving weight -> flat-100g default (${sg.from})${unjudged}` });
     } else if (sg.grams < 5 || sg.grams > 500) {
         // D6 — an absurd gram weight: 1.0 g of chili oil, 1.9 g of muffin, 1106 g of
-        // banana. 3/23 BAD, 0/48 GOOD. Same reconstruction caveat as D5.
-        hits.push({ rule: 'D6', severity: sev('D6'), detail: `serving weight ${sg.grams} g implausible (from ${sg.from})` });
+        // banana. 3/23 BAD, 0/48 GOOD.
+        hits.push({ rule: 'D6', severity: dsev('D6'), detail: `serving weight ${sg.grams} g implausible (from ${sg.from})${unjudged}` });
     }
 
     // D7 — Atwater inconsistency on the per-100g panel. Detects arithmetic
@@ -524,9 +613,15 @@ Use UNSURE when you cannot tell whether it is the same product from the informat
 
 /** The compact record card Tier L judges. Deterministic given the row. */
 export function llmUserPrompt(r: ScreenRow): string {
-    const sg = resolveServingGrams(r);
+    const sg = realServing(r);
     const aw = atwater(r.per100g);
     const p = r.per100g ?? {};
+    // When the real anchor ran, quote ITS kcal — hydrateAndSelectServing can bill a
+    // food whose per-100g panel is empty (the FatSecret serving-nutrient path), and
+    // per100g * grams / 100 would print 0 kcal for a real 1,980 kcal entree.
+    const billed = r.real && !r.real.error && r.real.kcal != null
+        ? `${r.real.kcal.toFixed(0)} kcal`
+        : `${((Number(p.calories ?? 0) * (sg.grams ?? 100)) / 100).toFixed(0)} kcal`;
     const lines = [
         `shopper phrase: ${r.seed}`,
         `cache key stored: ${r.key}`,
@@ -536,8 +631,8 @@ export function llmUserPrompt(r: ScreenRow): string {
         `per 100 g: ${isFinite(Number(p.calories)) ? `${Number(p.calories).toFixed(1)} kcal` : 'NO CALORIES'}, protein ${Number(p.protein ?? 0).toFixed(1)} g, carbs ${Number(p.carbs ?? 0).toFixed(1)} g, fat ${Number(p.fat ?? 0).toFixed(1)} g` + (Object.keys(p).length === 0 ? '  [PANEL IS EMPTY {}]' : ''),
         aw ? `Atwater check: declared/computed = ${aw.ratio.toFixed(2)}` : 'Atwater check: not computable',
         sg.grams != null
-            ? `default serving: ${sg.grams} g  (label: ${r.off_serving_size || r.fs_serving_desc || 'n/a'})  -> a "1 x" log bills ${((Number(p.calories ?? 0) * sg.grams) / 100).toFixed(0)} kcal`
-            : `default serving: NONE in any column -> a "1 x" log bills a flat 100 g = ${Number(p.calories ?? 0).toFixed(0)} kcal`,
+            ? `default serving: ${sg.grams} g  (label: ${r.off_serving_size || r.fs_serving_desc || 'n/a'}, via ${sg.from})  -> a "1 x" log bills ${billed}`
+            : `default serving: NONE resolved (${sg.from}) -> a "1 x" log bills a flat 100 g = ${billed}`,
         r.pkg_qty ? `package quantity: ${r.pkg_qty} ${r.pkg_unit}` : '',
     ].filter(Boolean);
     return lines.join('\n');
@@ -643,9 +738,9 @@ SELECT json_agg(t) FROM (
 SELECT m."normalizedForm" AS key, m.source AS src, m."aiConfidence" AS conf,
        coalesce(m."validatedBy",'') AS validatedby,
        m."foodName" AS mapfoodname, coalesce(m."brandName",'') AS mapbrand,
-       coalesce(o.name, f.name, '') AS recname,
-       coalesce(o."brandName", f."brandName", '') AS recbrand,
-       coalesce(o."nutrientsPer100g", f."nutrientsPer100g") AS per100g,
+       coalesce(o.name, f.name, fd.description, '') AS recname,
+       coalesce(o."brandName", f."brandName", fd."brandName", '') AS recbrand,
+       coalesce(o."nutrientsPer100g", f."nutrientsPer100g", fd."nutrientsPer100g") AS per100g,
        o."servingGrams" AS off_serving_grams,
        coalesce(o."servingSize",'') AS off_serving_size,
        o."packageQuantity" AS pkg_qty,
@@ -658,11 +753,15 @@ SELECT m."normalizedForm" AS key, m.source AS src, m."aiConfidence" AS conf,
        coalesce(m."offBarcode", m."fsId", m."fdcId"::text,'') AS recid,
        (SELECT count(*) FROM "OffServing" os WHERE os.barcode = o.barcode) AS n_off_servings,
        (SELECT min(os.grams) FROM "OffServing" os WHERE os.barcode = o.barcode AND os.grams IS NOT NULL) AS off_serv_min_g,
-       (SELECT max(os.grams) FROM "OffServing" os WHERE os.barcode = o.barcode AND os.grams IS NOT NULL) AS off_serv_max_g
+       (SELECT max(os.grams) FROM "OffServing" os WHERE os.barcode = o.barcode AND os.grams IS NOT NULL) AS off_serv_max_g,
+       fd."servingSize" AS fdc_serving_size,
+       coalesce(fd."servingSizeUnit",'') AS fdc_serving_unit,
+       (SELECT min(fs2.grams) FROM "FdcServing" fs2 WHERE fs2."fdcId" = fd."fdcId" AND fs2.grams > 0) AS fdc_serv_min_g
 FROM "FoodMapping" m
 LEFT JOIN "OffFood" o        ON o.barcode  = m."offBarcode"
 LEFT JOIN "FatSecretFood" f  ON f."fsId"   = m."fsId"
 LEFT JOIN "FatSecretServing" fs ON fs."fsId" = f."fsId" AND fs."servingId" = f."defaultServingId"
+LEFT JOIN "FdcFood" fd       ON fd."fdcId" = m."fdcId"
 WHERE m."normalizedForm" = ANY($1::text[])
 ORDER BY 1) t;`;
 
@@ -682,15 +781,92 @@ function openPrisma(): PrismaLike {
     return new PrismaClient() as PrismaLike;
 }
 
-async function loadRows(keys: string[], rowsIn?: string, rowsOut?: string): Promise<ScreenRow[]> {
+async function loadRows(keys: string[], rowsIn?: string): Promise<ScreenRow[]> {
     if (rowsIn) return JSON.parse(fs.readFileSync(rowsIn, 'utf8')) as ScreenRow[];
     const prisma = openPrisma();
     try {
         const res = await prisma.$queryRawUnsafe(ROW_SQL, keys) as { json_agg: ScreenRow[] | null }[];
-        const rows: ScreenRow[] = res?.[0]?.json_agg ?? [];
-        if (rowsOut) fs.writeFileSync(rowsOut, JSON.stringify(rows, null, 1));
-        return rows;
+        return res?.[0]?.json_agg ?? [];
     } finally { await prisma.$disconnect(); }
+}
+
+/** `off_` / `fs_` / `fdc_` — the id prefixes hydrateAndSelectServing branches on. */
+function candidateId(r: ScreenRow): string | null {
+    if (!r.recid) return null;
+    if (r.src === 'openfoodfacts') return `off_${r.recid}`;
+    if (r.src === 'fatsecret') return `fs_${r.recid}`;
+    if (r.src === 'fdc') return `fdc_${r.recid}`;
+    return null;
+}
+
+/**
+ * Fill `row.real` with what the REQUEST PATH would bill for a unitless `1 x`.
+ *
+ * This calls `hydrateAndSelectServing` — the same function route.ts calls — rather
+ * than reimplementing it, which is the whole point: the previous reconstruction
+ * could not see count-label serving, dose-anchored serving or the FatSecret weight
+ * oracle, and PR #174 moved the real anchor further from it still. A screen that
+ * evicts cache rows on a number the user is not billed is grading the wrong thing.
+ *
+ * Rows it cannot resolve get `error` set, which makes D5/D6 abstain. Failure is
+ * never silently converted into agreement.
+ *
+ * !! THIS IS NOT FREE AND NOT PURE. !!
+ * `hydrateAndSelectServing` is the production path, so it does what production does:
+ * it can call the USDA FDC API and it can invoke the ambiguous-serving AI estimator
+ * (one gpt-4o-mini call per ambiguous row). Over the full 3,248-row cache that is
+ * minutes of wall clock and a few hundred model calls, NOT the offline pure-function
+ * cost of Tier D. Rows it resolves through the estimator come back on an
+ * `AI_SERVING_TIER_RE` tier and D5/D6 abstain on them, so the model spend buys
+ * information about the row but never a verdict. Budget for it, or pass
+ * `--no-serving` and accept that D5/D6 report instead of gate.
+ */
+export async function resolveRealServings(rows: ScreenRow[], concurrency = 8): Promise<void> {
+    // Required lazily: this module builds a Prisma client and pulls in the whole
+    // mapper at import time, which unit tests must never do.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { hydrateAndSelectServing } = require('../../src/lib/mapping/map-ingredient-with-fallback');
+    let next = 0;
+    const worker = async (): Promise<void> => {
+        for (;;) {
+            const i = next++;
+            if (i >= rows.length) return;
+            const r = rows[i];
+            const id = candidateId(r);
+            if (!id) { r.real = { grams: null, tier: null, kcal: null, error: `no record id for source '${r.src}'` }; continue; }
+            const p = r.per100g ?? {};
+            const candidate = {
+                id,
+                source: r.src as 'fdc' | 'openfoodfacts' | 'ai_generated' | 'fatsecret',
+                name: r.recname || r.mapfoodname,
+                brandName: r.recbrand || r.mapbrand || null,
+                score: 1,
+                nutrition: {
+                    kcal: Number(p.calories ?? p.kcal ?? 0),
+                    protein: Number(p.protein ?? 0),
+                    carbs: Number(p.carbs ?? p.carbohydrate ?? 0),
+                    fat: Number(p.fat ?? 0),
+                    per100g: true,
+                },
+                rawData: {},
+            };
+            try {
+                const res = await hydrateAndSelectServing(candidate, null, r.conf ?? 0.9, r.seed || r.key);
+                if (!res) { r.real = null; continue; }
+                r.real = {
+                    grams: typeof res.grams === 'number' ? res.grams : null,
+                    tier: res.servingTier ?? null,
+                    // `kcal` is the TOTAL for the resolved grams — the same field
+                    // route.ts records as MappingEventLog.totalKcal.
+                    kcal: typeof res.kcal === 'number' ? res.kcal : null,
+                };
+            } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
+                r.real = { grams: null, tier: null, kcal: null, error: msg };
+            }
+        }
+    };
+    await Promise.all(Array.from({ length: Math.max(1, concurrency) }, worker));
 }
 
 /**
@@ -708,17 +884,63 @@ async function loadRows(keys: string[], rowsIn?: string, rowsOut?: string): Prom
  * A row with NO seed is reported and screened with an empty seed, which makes the
  * token rules ABSTAIN rather than fire — conservative in the right direction, but it
  * does mean an attribution failure makes the screen quiet, not loud.
+ *
+ * !! THE JACCARD FALLBACK DOES NOT SCALE PAST ONE BATCH. !!
+ * It picks the nearest seed in the list, and "nearest" stops meaning "correct" once
+ * the list spans many domains. Measured 2026-07-27 screening all 3,248 cache rows
+ * against 4,168 observed phrases: a TURKEY key was attributed to an `85% lean 15%
+ * fat beef` seed, and three distinct Chick-fil-A keys all matched one
+ * `chick fil a milkshake` seed — each producing a false D3 "head noun absent". 332
+ * of 516 evictions rested solely on seed-dependent rules. For any run wider than a
+ * single batch, pass EXPLICIT `key<TAB>phrase` pairs (see `parseSeedFile`) so
+ * attribution is a lookup instead of a guess.
  */
+/**
+ * A seed file's contents. `byKey` holds explicit `key<TAB>phrase` pins; `phrases`
+ * holds bare seed lines. A file may mix both — batch runs use bare lines, and a
+ * whole-cache run pins every key.
+ */
+export interface SeedInput { phrases: string[]; byKey: Map<string, string> }
+
+/**
+ * Parse a --seeds file. A line with a TAB is `key<TAB>observed phrase` and pins
+ * that key exactly; a line without one is a bare seed phrase matched by
+ * canonicalization then Jaccard. `#` comments and blanks are ignored.
+ */
+export function parseSeedFile(text: string): SeedInput {
+    const phrases: string[] = [];
+    const byKey = new Map<string, string>();
+    for (const raw of text.split('\n')) {
+        const line = raw.replace(/\r$/, '');
+        if (!line.trim() || line.trimStart().startsWith('#')) continue;
+        const tab = line.indexOf('\t');
+        if (tab >= 0) {
+            const key = line.slice(0, tab).trim();
+            const phrase = line.slice(tab + 1).trim();
+            if (key && phrase) { byKey.set(key, phrase); phrases.push(phrase); }
+            continue;
+        }
+        phrases.push(line.trim());
+    }
+    return { phrases, byKey };
+}
+
 export function attribute(
     rows: ScreenRow[],
-    seeds: string[],
+    seeds: string[] | SeedInput,
     canon?: ((s: string) => string) | null,
 ): { unattributed: string[] } {
+    const list = Array.isArray(seeds) ? seeds : seeds.phrases;
+    const pinned = Array.isArray(seeds) ? new Map<string, string>() : seeds.byKey;
     const byKey = new Map<string, string>();
-    const seedSets = seeds.map(s => ({ s, set: new Set(toks(s).map(stem)) }));
-    if (canon) for (const s of seeds) { const k = canon(s); if (!byKey.has(k)) byKey.set(k, s); }
+    const seedSets = list.map(s => ({ s, set: new Set(toks(s).map(stem)) }));
+    if (canon) for (const s of list) { const k = canon(s); if (!byKey.has(k)) byKey.set(k, s); }
     const unattributed: string[] = [];
     for (const r of rows) {
+        // An explicit key->phrase pin always wins: it is the phrase actually observed
+        // for this key, not the nearest one in a global list.
+        const exactPin = pinned.get(r.key);
+        if (exactPin) { r.seed = exactPin; continue; }
         const exact = byKey.get(r.key);
         if (exact) { r.seed = exact; continue; }
         const kt = new Set(toks(r.key).map(stem));
@@ -797,12 +1019,17 @@ function confusion(name: string, flagged: Set<string>, labels: Map<string, Label
 const USAGE = [
     'Usage: correctness-screen.ts (--bdir <batch dir> | --rows <rows.json>) [--seeds <seed file>]',
     '  [--policy strict|balanced|lenient] [--llm] [--llm-all] [--model <id>] [--concurrency N]',
-    '  [--out <screen.json>] [--dump-rows <rows.json>] [--labels <labels.json>]',
+    '  [--out <screen.json>] [--dump-rows <rows.json>] [--labels <labels.json>] [--no-serving]',
     '',
     '  --bdir        batch directory produced by gate.py; reads <bdir>/added.txt',
     '  --rows        replay a previously dumped row pull instead of reading the DB',
     '  --llm         add Tier L. WITHOUT it, measured BAD recall falls 100% -> 78%.',
     '  --labels      score against a hand-labelled ground truth (how the shipped numbers were made)',
+    '  --no-serving  skip the real billing anchor. D5/D6 then report INFO, never EVICT,',
+    '                because the reconstruction alone was never measured against it.',
+    '',
+    '  --seeds accepts bare phrases OR explicit "key<TAB>phrase" pins. Use pins for any',
+    '  run wider than one batch: nearest-match attribution guesses wrong at cache scale.',
     '',
     'Exit 0 = nothing to evict, 1 = rows flagged for withholding, >1 = crash (treat as RED).',
 ].join('\n');
@@ -827,6 +1054,10 @@ async function main(): Promise<number> {
     const useLlm = has('--llm') || llmAll;
     const policy = parsePolicy(val('--policy'));
     const concurrency = parseIntFlag('--concurrency', val('--concurrency'), 6, 1);
+    // Default ON, mirroring winner-gate.sh: the instrument should see the number the
+    // user is billed unless someone explicitly opts out. An offline --rows replay has
+    // no DB, so it cannot run the real anchor.
+    const withServing = !has('--no-serving') && !rowsIn;
 
     let llmCfg: LlmConfig | null = null;
     if (useLlm) {
@@ -855,7 +1086,7 @@ async function main(): Promise<number> {
         keys = fs.readFileSync(addedPath, 'utf8').split('\n')
             .map(l => l.split('\t')[0].trim()).filter(Boolean);
     }
-    let rows = await loadRows(keys, rowsIn, rowsOut);
+    let rows = await loadRows(keys, rowsIn);
     if (keys.length) {
         const wanted = new Set(keys);
         const pulled = rows.length;
@@ -867,18 +1098,51 @@ async function main(): Promise<number> {
         }
     }
 
-    const seeds = seedsPath
-        ? fs.readFileSync(seedsPath, 'utf8').split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('#'))
-        : [];
-    if (!seeds.length) {
+    const seeds: SeedInput = seedsPath
+        ? parseSeedFile(fs.readFileSync(seedsPath, 'utf8'))
+        : { phrases: [], byKey: new Map() };
+    if (!seeds.phrases.length) {
         console.log('WARN no --seeds file: every row is screened with an EMPTY seed, so D1/D2/D3/D4/D10/D11 '
             + 'ABSTAIN. D3 alone carries 15 of 23 measured BAD catches — this run is not the measured screen.');
     }
     const { unattributed } = attribute(rows, seeds, loadCanonicalizer());
+    const guessed = rows.length - unattributed.length - seeds.byKey.size;
+    if (seeds.byKey.size) {
+        console.log(`seeds: ${seeds.byKey.size} key(s) pinned explicitly, ${Math.max(0, guessed)} matched by canonicalization/Jaccard.`);
+    }
     if (unattributed.length) {
         console.log(`WARN ${unattributed.length} row(s) could not be attributed to a seed and are screened with an `
             + `empty seed (token rules abstain): ${unattributed.slice(0, 5).join(', ')}`);
     }
+    // Jaccard picks the NEAREST seed, and nearest stops meaning correct once the seed
+    // list spans domains (turkey key <- beef seed, 2026-07-27). Say so rather than
+    // letting a wide run quietly inherit a per-batch instrument's reputation.
+    if (!seeds.byKey.size && seeds.phrases.length > 300) {
+        console.log(`WARN ${seeds.phrases.length} bare seed phrases and no key->phrase pins. Attribution is a `
+            + 'nearest-match GUESS at this width and the seed-dependent rules (D1/D2/D3/D4/D10/D11) '
+            + 'will produce false positives. Pass explicit "key<TAB>phrase" lines for a whole-cache run.');
+    }
+
+    // --- The real billing anchor, for D5/D6. Needs the DB; an offline --rows replay
+    // cannot run it, and in that case D5/D6 report INFO/UNJUDGED rather than evicting
+    // on a reconstruction whose agreement with the real anchor was never measured.
+    if (withServing) {
+        await resolveRealServings(rows);
+        const ok = rows.filter(r => r.real && !r.real.error).length;
+        const failed = rows.filter(r => r.real?.error).length;
+        const ai = rows.filter(r => r.real && !r.real.error && AI_SERVING_TIER_RE.test(r.real.tier ?? '')).length;
+        console.log(`serving: real anchor resolved for ${ok}/${rows.length} row(s)`
+            + (failed ? `, ${failed} errored (D5/D6 abstain on those)` : '')
+            + (ai ? `, ${ai} via an AI estimator (D5/D6 abstain on those too)` : ''));
+    } else {
+        console.log('NOTE --no-serving: D5/D6 are a RECONSTRUCTION this run and are reported as INFO, not EVICT. '
+            + 'Tier-D BAD recall is below the measured 18/23 without them.');
+    }
+
+    // Dump AFTER the serving pass, not during the row pull: the real anchor costs
+    // minutes and a few hundred model calls, and a dump taken before it produces a
+    // --rows file that can never judge D5/D6. Pay once, replay offline forever.
+    if (rowsOut) fs.writeFileSync(rowsOut, JSON.stringify(rows, null, 1));
 
     // --- Tier D (pure, offline)
     const dHits = new Map<string, Hit[]>();

--- a/scripts/eval/measure-serving-divergence.ts
+++ b/scripts/eval/measure-serving-divergence.ts
@@ -1,0 +1,87 @@
+/**
+ * measure-serving-divergence.ts — how far the screen's serving RECONSTRUCTION is
+ * from the anchor the request path actually bills.
+ *
+ * correctness-screen.ts carried this caveat from the day it shipped:
+ *
+ *   "The serving check is a RECONSTRUCTION. resolveServingGrams reimplements the
+ *    billing anchor and never calls hydrateAndSelectServing ... A row D5 calls
+ *    'no serving weight' MAY IN FACT BILL CORRECTLY. **This was not measured.**"
+ *
+ * This measures it, over the same 81 hand-labelled batch-01 rows the pinned
+ * confusion matrix is built from. Read-only: it resolves servings and prints; it
+ * writes nothing.
+ *
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/measure-serving-divergence.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ScreenRow, resolveServingGrams, resolveRealServings, realServing } from './correctness-screen';
+
+const FIXTURE = path.join(__dirname, '__tests__', 'fixtures', 'correctness-screen-batch01.json');
+
+async function main(): Promise<number> {
+    const fx = JSON.parse(fs.readFileSync(FIXTURE, 'utf8')) as {
+        rows: Array<{ verdict: string; row: ScreenRow }>;
+    };
+    const rows = fx.rows.map(e => e.row);
+    const verdicts = new Map(fx.rows.map(e => [e.row.key, e.verdict]));
+
+    const before = rows.map(r => resolveServingGrams(r));
+    await resolveRealServings(rows);
+
+    let agree = 0, differ = 0, errored = 0, nullBoth = 0;
+    const moved: Array<{ key: string; from: number | null; to: number | null; tier: string | null; verdict: string }> = [];
+
+    rows.forEach((r, i) => {
+        if (r.real?.error) { errored++; return; }
+        const a = before[i].grams;
+        // Compare what D5/D6 actually consume, i.e. AFTER flat-100g normalisation —
+        // comparing raw grams counts the flat-100g fallback as a disagreement when
+        // both sides are saying "there is no anchor here".
+        const b = realServing(r).grams;
+        if (a == null && b == null) { nullBoth++; agree++; return; }
+        if (a != null && b != null && Math.abs(a - b) < 0.01) { agree++; return; }
+        differ++;
+        moved.push({ key: r.key, from: a, to: b, tier: r.real?.tier ?? null, verdict: verdictOf(verdicts, r.key) });
+    });
+
+    console.log(`\nSERVING RECONSTRUCTION vs REAL ANCHOR — ${rows.length} batch-01 rows`);
+    console.log(`  agree            ${agree}   (of which both-null: ${nullBoth})`);
+    console.log(`  DIFFER           ${differ}`);
+    console.log(`  errored          ${errored}`);
+    console.log(`  agreement rate   ${((agree / Math.max(1, rows.length - errored)) * 100).toFixed(1)}%\n`);
+
+    if (moved.length) {
+        console.log('rows where the screen judged a number the user is NOT billed:');
+        for (const m of moved.slice(0, 40)) {
+            console.log(`  ${m.verdict.padEnd(8)} ${m.key.slice(0, 46).padEnd(46)} ${fmt(m.from)} -> ${fmt(m.to)}  ${m.tier ?? ''}`);
+        }
+        if (moved.length > 40) console.log(`  ... and ${moved.length - 40} more`);
+    }
+
+    // The number that matters for the pinned matrix: does a D5/D6 verdict flip?
+    const flips = rows.filter((r, i) => {
+        const a = before[i].grams, b = realServing(r).grams;
+        return d56(a) !== d56(b);
+    });
+    console.log(`\nD5/D6 verdict flips: ${flips.length} of ${rows.length}`);
+    for (const r of flips.slice(0, 20)) {
+        const i = rows.indexOf(r);
+        console.log(`  ${verdictOf(verdicts, r.key).padEnd(8)} ${r.key.slice(0, 46).padEnd(46)} `
+            + `${d56(before[i].grams)} -> ${d56(realServing(r).grams)}`);
+    }
+    return 0;
+}
+
+function d56(g: number | null): string {
+    if (g == null) return 'D5';
+    if (g < 5 || g > 500) return 'D6';
+    return '-';
+}
+function fmt(g: number | null): string { return g == null ? 'none'.padStart(8) : `${g.toFixed(1)}g`.padStart(8); }
+function verdictOf(m: Map<string, string>, k: string): string { return m.get(k) ?? '?'; }
+
+main().then(c => process.exit(c)).catch(e => { console.error(e); process.exit(2); });


### PR DESCRIPTION
Screening all **3,248 live cache rows** produced EVICT 516 / REVIEW 786 / KEEP 1946. Reading the rows instead of the counts, most of that was the **instrument**, not the cache.

## 1. `ROW_SQL` never joined `FdcFood`

`FoodMapping.fdcId` is a first-class source, but only `OffFood` and `FatSecretFood` were joined. Every fdc row arrived with `recname=''` and `per100g=null`, so D8 ("no usable per-100g basis") fired on **all 78 of them** — a 100% false-positive rate on that source, and D3/D4 compared the seed against an empty string.

Batch 01 contained no fdc rows, which is exactly why the measured operating point never saw it.

## 2. D5/D6 judged a number the user is not billed

The file carried this caveat from the day it shipped: *"the divergence between this reconstruction and the real anchor was **never measured**."*

It is now — **78/81 = 96.3%** on the batch-01 rows. D5/D6 call `hydrateAndSelectServing`, the function the request path calls, and the fixture carries the result so the pinned matrix stays offline and deterministic.

Where the two differ, the real anchor wins. D5 **gains** the BAD row `bar emerge protein simple truth` (billing flat-100g behind a 55 g column) and **drops** two SUSPECT rows that resolve a genuine serving via `fs_serving_macros_only`. **BAD recall is unchanged at every policy**; the screen withholds one fewer row.

Two traps hit on the way in, both now pinned by tests:

- **`flat_100g_default` is the absence of an anchor wearing a plausible number.** The real function reports it as `100 g`, which sits inside D6's plausible band. Reading it literally silenced D5 on **6** batch-01 rows, one of them BAD.
- **`hydrateAndSelectServing` invokes the ambiguous-serving AI estimator.** That number is a fresh model guess, not a property of the cached row, so it is UNJUDGED — the same rule the serving gate uses. The screen may spend a model call *learning* about a row; it may never *evict* on one.

## 3. `attribute()`'s Jaccard fallback does not scale past one batch

Over 4,168 observed phrases it matched a **turkey** key to an `85% lean 15% fat beef` seed, and three distinct Chick-fil-A keys to one `chick fil a milkshake` — then reported "head noun absent" on each. **332 of the 516 evictions rested solely on seed-dependent rules.**

`--seeds` now accepts explicit `key<TAB>phrase` pins, and a wide run without them says so instead of inheriting a per-batch instrument's reputation.

## Result — same cache, fixed instrument

| rule | before | after |
|---|---|---|
| D3 head-noun absent | 265 | **116** |
| D8 no per-100g basis | 126 | **48** |
| D1 bare-brand key | 94 | **43** |
| D4 zero token overlap | 56 | 43 |
| D6 implausible weight | 47 | **55** ↑ |
| D9 corpus-marked bad | 13 | 12 |
| **EVICT / REVIEW / KEEP** | **516 / 786 / 1946** | **265 / 812 / 2171** |

fdc evictions: **78 → 15**. D6 *rose* — the real anchor finds implausible weights the columns hid.

Also: `--dump-rows` now writes **after** the serving pass, so a `--rows` replay carries the anchor that cost minutes and a few hundred model calls to compute.

## Tests

84 in `correctness-screen.test.ts` (622 across `scripts/eval/`), all offline. New coverage pins the FdcFood join and its columns, the grams-vs-volume unit guard, `flat_100g_default` normalisation, AI-tier abstention, D5/D6 abstaining to INFO when the anchor did not run, and pinned-vs-Jaccard attribution on the exact turkey/beef row that misfired.

`scripts/eval/measure-serving-divergence.ts` is the read-only harness that produced the 96.3% figure and can re-derive it after any serving change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx