### PR TITLE
fix(screen): a truncated Tier-L reply was reading as a clean row

### DIFF
--- a/scripts/eval/__tests__/correctness-screen.test.ts
+++ b/scripts/eval/__tests__/correctness-screen.test.ts
@@ -744,3 +744,28 @@ describe('parseSeedFile() + pinned attribution', () => {
         expect(rows[0].seed).toBe('great value almonds');
     });
 });
+
+describe('Tier-L failure is fail-SAFE, not fail-open', () => {
+    const failed = (): LlmVerdict =>
+        ({ verdict: 'UNSURE', axis: 'none', confidence: 0, reason: 'Unexpected end of JSON input', error: 'call-failed' });
+
+    it('an unadjudicated row goes to REVIEW, never KEEP', () => {
+        // It used to default to ACCEPT. Measured 2026-07-27: swapping --model to
+        // claude-sonnet-5 truncated 16 of 81 responses mid-JSON, and under ACCEPT all
+        // 16 landed in KEEP with only a WARN line to say so — a silently
+        // unscreened row reading as clean is the defect class this file exists for.
+        expect(decide([], failed(), 'balanced')).toBe('REVIEW');
+    });
+
+    it('still cannot mass-EVICT on an outage — that was the reason ACCEPT was chosen', () => {
+        // The fail-safe has to preserve the original property: a network blip must not
+        // throw the cache away. UNSURE reaches REVIEW and stops there under every policy.
+        for (const p of ['lenient', 'balanced', 'strict'] as Policy[]) {
+            expect(decide([], failed(), p)).not.toBe('EVICT');
+        }
+    });
+
+    it('a real ACCEPT still keeps the row, so the change costs no precision', () => {
+        expect(decide([], { verdict: 'ACCEPT', axis: 'none', confidence: 0.9, reason: '' }, 'balanced')).toBe('KEEP');
+    });
+});

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -649,7 +649,14 @@ export async function callLlm(r: ScreenRow, cfg: LlmConfig): Promise<LlmVerdict>
                 body: JSON.stringify({
                     model: cfg.model,
                     temperature: 0,
-                    max_tokens: 200,
+                    // 200 was enough for gpt-4o-mini and ONLY for gpt-4o-mini. A
+                    // reasoning model spends its thinking inside the same completion
+                    // budget: claude-sonnet-5 burns ~57 reasoning tokens before the
+                    // JSON and truncated 16 of 81 rows mid-object ("Unexpected end of
+                    // JSON input"). `--model` invites exactly that swap, so the budget
+                    // has to fit a reasoning model rather than the cheapest one. Costs
+                    // nothing when unused — billing is on tokens emitted, not reserved.
+                    max_tokens: 700,
                     response_format: { type: 'json_object' },
                     messages: [
                         { role: 'system', content: LLM_SYSTEM },
@@ -669,15 +676,17 @@ export async function callLlm(r: ScreenRow, cfg: LlmConfig): Promise<LlmVerdict>
             };
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
-            // A failed call defaults to ACCEPT so a network blip cannot mass-evict a
-            // batch — but every failure is counted and reported, because an
-            // unadjudicated row silently reading as clean is the whole defect class
-            // this file exists to close.
-            if (attempt === 2) return { verdict: 'ACCEPT', axis: 'none', confidence: 0, reason: msg, error: 'call-failed' };
+            // A failed call is UNSURE, not ACCEPT. Both avoid the mass-eviction a
+            // network blip could otherwise cause — UNSURE routes to REVIEW, EVICT is
+            // never reached — but ACCEPT let an unadjudicated row read as CLEAN, which
+            // is the exact defect class this file exists to close. Measured: swapping
+            // --model to claude-sonnet-5 truncated 16 of 81 rows, and under the old
+            // default all 16 landed in KEEP with nothing but a WARN line to say so.
+            if (attempt === 2) return { verdict: 'UNSURE', axis: 'none', confidence: 0, reason: msg, error: 'call-failed' };
             await new Promise(s => setTimeout(s, 800 * (attempt + 1)));
         }
     }
-    return { verdict: 'ACCEPT', axis: 'none', confidence: 0, reason: 'exhausted', error: 'call-failed' };
+    return { verdict: 'UNSURE', axis: 'none', confidence: 0, reason: 'exhausted', error: 'call-failed' };
 }
 
 export async function runLlm(rows: ScreenRow[], cfg: LlmConfig): Promise<Map<string, LlmVerdict>> {
@@ -1156,7 +1165,10 @@ async function main(): Promise<number> {
         console.log(`tier L: ${llmTargets.length} rows (of ${rows.length}) -> ${llmCfg.model}`);
         llm = await runLlm(llmTargets, llmCfg);
         const failed = [...llm.values()].filter(v => v.error).length;
-        if (failed) console.log(`WARN ${failed} Tier-L call(s) failed and defaulted to ACCEPT — those rows were NOT adjudicated.`);
+        if (failed) {
+            console.log(`WARN ${failed} Tier-L call(s) failed and were recorded UNSURE (-> REVIEW), NOT adjudicated. `
+                + 'A truncated response is the usual cause: raise max_tokens if you changed --model.');
+        }
     }
 
     const verdicts = screenBatch(rows, policy, llm);


### PR DESCRIPTION
Both bugs were found by actually running `--model anthropic/claude-sonnet-5` against the 81 hand-labelled rows, rather than reasoning about whether a model swap would work.

## 1. `max_tokens: 200` was a gpt-4o-mini number sitting behind a `--model` flag

A reasoning model spends its thinking inside the same completion budget. `claude-sonnet-5` burns ~57 reasoning tokens before emitting JSON and truncated **16 of 81 rows** mid-object — `Unexpected end of JSON input` ×13, `Unterminated string` ×3.

Raised to 700. Billing is on tokens *emitted*, not reserved, so this costs nothing when unused. **16 failures → 1.**

## 2. A failed call defaulted to ACCEPT — the row read as CLEAN

The original reasoning was sound (a network blip must not mass-evict the cache), but `UNSURE` satisfies it too: it routes to REVIEW and **never reaches EVICT under any policy**, which the tests now pin.

Under the old default those 16 truncated rows landed in **KEEP**, with a single WARN line as the only evidence. A silently unscreened row reading as clean is the exact defect class this file exists to close.

## Measured — both models at max_tokens 700

81 hand-labelled rows. EMPTY seeds, so Tier D's token rules abstain and this leans harder on Tier L than a real run would.

| model | EVICT | BAD evicted | GOOD wrongly evicted | **BAD missed entirely** |
|---|---|---|---|---|
| `openai/gpt-4o-mini` | 28 | 21/23 (91%) | 3/48 (6.3%) | 2 |
| `anthropic/claude-sonnet-5` | 20 | 19/23 (83%) | **0/48 (0.0%)** | **1** |

Sonnet evicts less but routes 3 BAD to REVIEW rather than KEEP, so it misses one BAD outright instead of two and destroys no GOOD rows.

**The shipped rubric was partly fitted to these same rows, which biases the comparison toward gpt-4o-mini** — so Sonnet doing better here is the stronger reading, not the weaker one.

Cost, taken from the response bodies: **$0.00484/row** for sonnet-5 vs **~$0.00028** for gpt-4o-mini — 17×, or **$15.70 vs $0.90** for the full 3,248-row cache.

This PR does **not** change the default model. gpt-4o-mini remains the measured operating point; the numbers above are here so the choice is an informed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx