### PR TITLE
test(eval): fail-injection for every instrument that can silently pass

### DIFF
--- a/scripts/eval/__tests__/fail-closed.test.ts
+++ b/scripts/eval/__tests__/fail-closed.test.ts
@@ -1,0 +1,446 @@
+/**
+ * fail-closed.test.ts — FAIL INJECTION for every eval instrument that consults an
+ * external or fallible source.
+ *
+ * WHY THIS FILE EXISTS
+ * Three separate instruments under scripts/eval shipped a confidently wrong number
+ * while their own suites were 100% green. The recurring shape is not "the logic is
+ * wrong" — it is that an ABSENCE OF SIGNAL was encoded as the PASSING verdict:
+ *
+ *   the LLM call failed          -> the row read as ACCEPT -> KEEP        (PR #176)
+ *   the mapper returned no pick  -> foodName echoed the query -> PASS     (PR #152)
+ *   the row pull returned []     -> nEvict 0 -> exit 0 "clean batch"
+ *   --grep matched nothing       -> "0 real failures" -> exit 0
+ *   the noise-floor snapshot was empty -> "0 diffs" -> a passing receipt
+ *
+ * Every test below FORCES the underlying call to fail and asserts the verdict is
+ * NOT the passing one. Each block also carries a POSITIVE CONTROL: without one,
+ * "the verdict is not PASS" is satisfiable by an instrument that never passes
+ * anything, which is a tautology, not a test (playbook §5).
+ *
+ * NO NETWORK, NO DATABASE. `fetch` is replaced per-test; the production mapper is
+ * jest.mock'd with a factory so the real module (which builds a PrismaClient at
+ * import time) is never loaded.
+ */
+
+import {
+    driftedKnownIssues,
+    evalExitCode,
+    scoreNlpCase,
+    scoreSearchCase,
+    type BaselineEntry,
+} from '../assertions';
+import {
+    callLlm,
+    decide,
+    realServing,
+    resolveRealServings,
+    runLlm,
+    screenBatch,
+    screenExitCode,
+    tierD,
+    type LlmConfig,
+    type LlmVerdict,
+    type Policy,
+    type ScreenRow,
+} from '../correctness-screen';
+import { noiseGate, type NoiseFloorLedger, type ReplayFile } from '../winner-diff-screens';
+
+// The screen requires this lazily, inside resolveRealServings. A FACTORY mock means
+// the real module is never evaluated, so no PrismaClient is constructed.
+jest.mock('../../../src/lib/mapping/map-ingredient-with-fallback', () => ({
+    hydrateAndSelectServing: jest.fn(),
+}));
+const { hydrateAndSelectServing } = require('../../../src/lib/mapping/map-ingredient-with-fallback');
+
+const ALL_POLICIES: Policy[] = ['lenient', 'balanced', 'strict'];
+
+/** A GOOD-shaped row: real panel, brand present, head noun present, seed attributed. */
+function baseRow(over: Partial<ScreenRow> = {}): ScreenRow {
+    return {
+        key: 'almond great value',
+        src: 'openfoodfacts',
+        conf: 0.9,
+        validatedby: 'ai',
+        mapfoodname: 'Great value, almonds',
+        mapbrand: 'Great Value',
+        recname: 'Great value, almonds, smoke',
+        recbrand: 'Great Value',
+        per100g: { calories: 600, protein: 21, carbs: 20, fat: 53 },
+        off_serving_grams: 28,
+        off_serving_size: '28 g',
+        pkg_qty: null,
+        pkg_unit: '',
+        corruptreason: '',
+        dupof: '',
+        fs_serving_desc: '',
+        fs_serving_grams: null,
+        fs_serving_nutrients: null,
+        recid: '0000000000001',
+        n_off_servings: 1,
+        off_serv_min_g: null,
+        off_serv_max_g: null,
+        fdc_serving_size: null,
+        fdc_serving_unit: '',
+        fdc_serv_min_g: null,
+        seed: 'great value almonds',
+        ...over,
+    };
+}
+
+/** The exact wire shape the no-pick branch returns (api/nlp/parse/route.ts). */
+function abstentionFor(query: string) {
+    return {
+        rawText: query, foodName: query, brandName: null, foodId: undefined,
+        source: 'ai_estimated', matchConfidence: 0.0, servingConfidence: 0.0, grams: 0,
+        nutrition: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+        nutritionPer100g: { kcal100: 0, protein100: 0, carbs100: 0, fat100: 0 },
+        servingOptions: [],
+    };
+}
+
+// ===========================================================================
+// 1. The golden-set harness — a no-pick must never score PASS
+// ===========================================================================
+
+describe('golden-set harness: abstention is not a pass', () => {
+    // 37 of the 243 nlp cases assert a name with no numeric band. The abstain branch
+    // returns `foodName: parsed?.name ?? rawText` — THE QUERY TEXT — so substring
+    // containment matched trivially and the mapper answering "I have nothing" scored
+    // a pass on every one of them.
+    //
+    // isAbstention() was already unit-tested. What was NOT tested is the code that
+    // COMPOSES it into a verdict, which is where the guard actually has to live and
+    // where it can be deleted by a refactor without any test noticing.
+    const nameOnlyCase = { expectName: [['burrito']] };
+
+    it('a total abstention FAILS a name-only case', () => {
+        const failures = scoreNlpCase(nameOnlyCase, [abstentionFor('chipotle chicken burrito')]);
+        expect(failures.length).toBeGreaterThan(0);
+        expect(failures.join(' ')).toContain('NO PICK (abstained)');
+    });
+
+    it('POSITIVE CONTROL — a genuine pick still passes the same case', () => {
+        const pick = { foodName: 'Chicken Queso Burrito', brandName: 'Qdoba', foodId: 'fs_1', matchConfidence: 0.95, grams: 320 };
+        expect(scoreNlpCase(nameOnlyCase, [pick])).toEqual([]);
+    });
+
+    it('a segmentation case still passes when ONE real item matches', () => {
+        const pick = { foodName: 'Chicken Burrito', foodId: 'fs_1', matchConfidence: 0.9 };
+        expect(scoreNlpCase({ expectName: [['burrito']], expectItems: 2 }, [abstentionFor('zzz'), pick])).toEqual([]);
+    });
+
+    it('an abstention cannot trip a NEGATIVE assertion either', () => {
+        // Symmetry: the echoed query text must not count as a forbidden match, or
+        // forbidName would fire on the mapper doing the right thing.
+        expect(scoreNlpCase({ forbidName: [['tequila lime']] },
+            [abstentionFor('qdoba tequila lime chicken burrito')])).toEqual([]);
+    });
+
+    it('an EMPTY item list is a failure, not a vacuous pass', () => {
+        // A 500, a `{"error": ...}` body and a dead segmenter all look like this.
+        expect(scoreNlpCase(nameOnlyCase, []).length).toBeGreaterThan(0);
+        expect(scoreNlpCase(nameOnlyCase, null).length).toBeGreaterThan(0);
+        expect(scoreNlpCase(nameOnlyCase, { error: 'boom' }).length).toBeGreaterThan(0);
+        // ...and it fails even for a case that asserts NOTHING, because "no response"
+        // is a failure of the run, not of the assertions.
+        expect(scoreNlpCase({}, []).length).toBeGreaterThan(0);
+    });
+
+    it('search: an empty hit list FAILS instead of having nothing to disagree with', () => {
+        const c = { match: [['almond']] };
+        expect(scoreSearchCase(c, []).pass).toBe(false);
+        expect(scoreSearchCase(c, { error: 'typesense unreachable' }).pass).toBe(false);
+        expect(scoreSearchCase(c, []).detail).toContain('EMPTY');
+        // POSITIVE CONTROL
+        expect(scoreSearchCase(c, [{ name: 'Almonds', kcal100: 600 }]).pass).toBe(true);
+    });
+
+    it('a run that executed ZERO cases exits 2, not 0', () => {
+        expect(evalExitCode([])).toBe(2);
+        // POSITIVE CONTROLS — the ordinary codes are unchanged.
+        expect(evalExitCode([{ pass: true }])).toBe(0);
+        expect(evalExitCode([{ pass: false }])).toBe(1);
+        expect(evalExitCode([{ pass: false, knownIssue: true }])).toBe(0);
+    });
+});
+
+// ===========================================================================
+// 2. knownIssue suppression cannot hide a VALUE regression
+// ===========================================================================
+
+describe('knownIssue suppresses the FAILURE, never the DRIFT', () => {
+    const baseline: Record<string, BaselineEntry> = {
+        'n-cook-06': { foodId: 'off_1', foodName: 'Rolled Oats', grams: 234, kcal100: 361, abstained: false },
+    };
+
+    it('a suppressed case whose kcal collapsed 361 -> 0 still reports', () => {
+        // Both values fail the same band and both are knownIssue, so the pass/fail
+        // boolean is identical either way. Only a value comparison can see it.
+        const drift = driftedKnownIssues(
+            [{ id: 'n-cook-06', knownIssue: true, observed: { foodId: 'off_2', foodName: 'oats', grams: 234, kcal100: 0 } }],
+            baseline);
+        expect(drift).toHaveLength(1);
+        expect(drift[0].what).toContain('kcal100 361 -> 0');
+        expect(drift[0].what).toContain('record off_1 -> off_2');
+    });
+
+    it('a suppressed case that started ABSTAINING reports', () => {
+        const drift = driftedKnownIssues(
+            [{ id: 'n-cook-06', knownIssue: true, observed: { foodId: null, grams: 0, kcal100: 0, abstained: true } }],
+            baseline);
+        expect(drift[0].what).toContain('abstained false -> true');
+    });
+
+    it('a suppressed case that stopped answering ENTIRELY reports', () => {
+        // The doubly-invisible case: the transport failure is exempted by the pin AND
+        // there is no observation to diff, so `if (!r.observed) continue` erased it
+        // from the only output still watching that case.
+        const drift = driftedKnownIssues([{ id: 'n-cook-06', knownIssue: true }], baseline);
+        expect(drift).toHaveLength(1);
+        expect(drift[0].what).toContain('errored false -> true');
+    });
+
+    it('POSITIVE CONTROL — a case failing exactly as recorded reports nothing', () => {
+        expect(driftedKnownIssues(
+            [{ id: 'n-cook-06', knownIssue: true, observed: { ...baseline['n-cook-06'] } }],
+            baseline)).toEqual([]);
+    });
+
+    it('noise inside 10% is still not a report', () => {
+        expect(driftedKnownIssues(
+            [{ id: 'n-cook-06', knownIssue: true, observed: { ...baseline['n-cook-06'], kcal100: 380 } }],
+            baseline)).toEqual([]);
+    });
+});
+
+// ===========================================================================
+// 3. Tier L — the LLM call itself, not a hand-written verdict
+// ===========================================================================
+
+describe('callLlm: a failed or unreadable reply is UNSURE, never ACCEPT', () => {
+    const CFG: LlmConfig = { model: 'test-model', baseUrl: 'http://llm.invalid/v1', apiKey: 'k', concurrency: 1 };
+    let fetchSpy: jest.SpyInstance;
+
+    afterEach(() => { fetchSpy?.mockRestore(); });
+
+    const reply = (content: string) => ({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content } }] }),
+    }) as unknown as Response;
+
+    // The existing "Tier-L failure is fail-SAFE" test hand-builds the failed verdict
+    // and checks decide(). That leaves callLlm's OWN mapping untested: flipping its
+    // catch branch back to ACCEPT keeps every other test in the suite green.
+
+    it('a network exception -> UNSURE + error', async () => {
+        fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+        const v = await callLlm(baseRow(), CFG);
+        expect(v.verdict).toBe('UNSURE');
+        expect(v.error).toBe('call-failed');
+        expect(v.verdict).not.toBe('ACCEPT');
+    }, 20000);
+
+    it('a persistent HTTP 500 -> UNSURE + error, not a silent ACCEPT', async () => {
+        fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 500 } as Response);
+        const v = await callLlm(baseRow(), CFG);
+        expect(v.verdict).toBe('UNSURE');
+        expect(v.error).toBe('call-failed');
+    }, 20000);
+
+    it('a reply TRUNCATED mid-JSON -> UNSURE (the claude-sonnet-5 shape)', async () => {
+        // Measured: swapping --model to a reasoning model truncated 16 of 81 replies
+        // mid-object. Under the old default all 16 landed in KEEP.
+        fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(reply('{"verdict":"REJ'));
+        const v = await callLlm(baseRow(), CFG);
+        expect(v.verdict).toBe('UNSURE');
+        expect(v.error).toBe('call-failed');
+    }, 20000);
+
+    it('an UNRECOGNISED verdict string -> UNSURE, not ACCEPT by fallthrough', async () => {
+        // `=== 'REJECT' ? : === 'UNSURE' ? : 'ACCEPT'` made every unknown token an
+        // approval, so a model that answered anything the rubric did not literally
+        // spell had its row silently KEPT.
+        for (const body of ['{"verdict":"probably fine"}', '{}', '{"axis":"identity"}', '{"verdict":null}']) {
+            fetchSpy?.mockRestore();
+            fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(reply(body));
+            const v = await callLlm(baseRow(), CFG);
+            expect(v.verdict).toBe('UNSURE');
+            expect(v.error).toBe('unparseable-verdict');
+        }
+    }, 20000);
+
+    it('a CASE-DIFFERENT verdict is honoured, not silently inverted to ACCEPT', async () => {
+        // `"reject"` used to fall through the === chain and KEEP the row — the worst
+        // possible reading of the reply, since the model had said the opposite.
+        fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(reply('{"verdict":"reject","reason":"different food"}'));
+        const v = await callLlm(baseRow(), CFG);
+        expect(v.verdict).toBe('REJECT');
+        expect(v.error).toBeUndefined();
+    }, 20000);
+
+    it('POSITIVE CONTROL — a well-formed reply is honoured on all three verdicts', async () => {
+        for (const want of ['ACCEPT', 'UNSURE', 'REJECT'] as const) {
+            fetchSpy?.mockRestore();
+            fetchSpy = jest.spyOn(globalThis, 'fetch')
+                .mockResolvedValue(reply(`{"verdict":"${want}","axis":"identity","confidence":0.9,"reason":"ok"}`));
+            const v = await callLlm(baseRow(), CFG);
+            expect(v.verdict).toBe(want);
+            expect(v.error).toBeUndefined();
+        }
+    }, 20000);
+});
+
+describe('a TOTAL Tier-L outage produces REVIEW, never KEEP and never EVICT', () => {
+    it('every otherwise-clean row is withheld for a human', async () => {
+        const spy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('LLM down'));
+        try {
+            const rows = [baseRow(), baseRow({ key: 'cashew kirkland signature', seed: 'kirkland signature cashews', recname: 'Kirkland Signature Cashews', recbrand: 'Kirkland Signature', mapbrand: 'Kirkland Signature' })];
+            const llm = await runLlm(rows, { model: 'm', baseUrl: 'http://llm.invalid/v1', apiKey: 'k', concurrency: 2 });
+            expect([...llm.values()].every(v => v.error === 'call-failed')).toBe(true);
+
+            for (const p of ALL_POLICIES) {
+                const decisions = screenBatch(rows, p, llm).map(v => v.decision);
+                // Not KEEP: an unadjudicated row must not read as clean.
+                expect(decisions).not.toContain('KEEP');
+                // Not EVICT: an outage must not throw the cache away either. The
+                // fail-safe has to hold in BOTH directions.
+                expect(decisions).not.toContain('EVICT');
+                expect(new Set(decisions)).toEqual(new Set(['REVIEW']));
+            }
+        } finally { spy.mockRestore(); }
+    }, 30000);
+});
+
+// ===========================================================================
+// 4. resolveRealServings — a row whose anchor threw is UNJUDGED, never EVICT
+// ===========================================================================
+
+describe('resolveRealServings: a serving-resolution failure downgrades D5/D6 to INFO', () => {
+    beforeEach(() => { (hydrateAndSelectServing as jest.Mock).mockReset(); });
+
+    /** A row whose ONLY defect can be the serving anchor. */
+    const cleanBut = (over: Partial<ScreenRow> = {}) => baseRow({ off_serving_grams: null, ...over });
+
+    it('hydrateAndSelectServing THROWING marks the row errored, not resolved', async () => {
+        (hydrateAndSelectServing as jest.Mock).mockRejectedValue(new Error('FDC API 503'));
+        const rows = [cleanBut()];
+        await resolveRealServings(rows, 2);
+
+        expect(rows[0].real?.error).toBe('FDC API 503');
+        expect(realServing(rows[0]).judged).toBe(false);
+    });
+
+    it('...and that row can NEVER be evicted on D5 or D6, under any policy', async () => {
+        (hydrateAndSelectServing as jest.Mock).mockRejectedValue(new Error('FDC API 503'));
+        const rows = [cleanBut(), cleanBut({ fs_serving_grams: 1.0 })];  // the second would be D6
+        await resolveRealServings(rows, 2);
+
+        for (const p of ALL_POLICIES) {
+            for (const r of rows) {
+                const servingHits = tierD(r, p).filter(h => h.rule === 'D5' || h.rule === 'D6');
+                expect(servingHits.length).toBeGreaterThan(0);          // it still REPORTS
+                expect(servingHits.every(h => h.severity === 'INFO')).toBe(true);
+                expect(servingHits.every(h => h.detail.includes('UNJUDGED'))).toBe(true);
+            }
+            expect(screenBatch(rows, p).map(v => v.decision)).not.toContain('EVICT');
+        }
+    });
+
+    it('a null return (no serving selected) is also UNJUDGED, not "no anchor exists"', async () => {
+        (hydrateAndSelectServing as jest.Mock).mockResolvedValue(null);
+        const rows = [cleanBut()];
+        await resolveRealServings(rows, 1);
+        expect(rows[0].real).toBeNull();
+        expect(realServing(rows[0]).judged).toBe(false);
+        expect(tierD(rows[0], 'strict').find(h => h.rule === 'D5')?.severity).toBe('INFO');
+    });
+
+    it('a row the screen cannot even address is errored, not silently skipped', async () => {
+        // No record id => candidateId() returns null => the anchor never ran. That has
+        // to be recorded as an error, or the row falls through to the reconstruction
+        // wearing a `judged` flag it did not earn.
+        const rows = [cleanBut({ recid: '' })];
+        await resolveRealServings(rows, 1);
+        expect(rows[0].real?.error).toContain('no record id');
+        expect(realServing(rows[0]).judged).toBe(false);
+        expect(hydrateAndSelectServing).not.toHaveBeenCalled();
+    });
+
+    it('POSITIVE CONTROL — a resolved anchor IS judged and CAN evict', async () => {
+        // Without this the block above is satisfiable by a screen that never judges
+        // anything, which would be a tautology rather than a test.
+        (hydrateAndSelectServing as jest.Mock).mockResolvedValue({ grams: 1.0, servingTier: 'label_serving_default', kcal: 6 });
+        const rows = [cleanBut()];
+        await resolveRealServings(rows, 1);
+
+        expect(realServing(rows[0]).judged).toBe(true);
+        const d6 = tierD(rows[0], 'balanced').find(h => h.rule === 'D6');
+        expect(d6?.severity).toBe('EVICT');
+        expect(d6?.detail).not.toContain('UNJUDGED');
+        expect(screenBatch(rows, 'balanced')[0].decision).toBe('EVICT');
+    });
+});
+
+// ===========================================================================
+// 5. The screen's own exit code — zero rows is not a clean batch
+// ===========================================================================
+
+describe('screenExitCode: screening nothing is RED, not green', () => {
+    it('zero rows screened exits 2 regardless of the eviction count', () => {
+        // `json_agg` over no matching rows is SQL NULL -> `?? []`; an empty added.txt
+        // and a `--rows` file of `[]` produce the same. All three used to print
+        // "EVICT 0 · REVIEW 0 · KEEP 0" and exit 0.
+        expect(screenExitCode(0, 0)).toBe(2);
+    });
+
+    it('POSITIVE CONTROLS — the ordinary codes are unchanged', () => {
+        expect(screenExitCode(81, 0)).toBe(0);
+        expect(screenExitCode(81, 19)).toBe(1);
+    });
+});
+
+// ===========================================================================
+// 6. winner-diff's noise floor — a receipt over zero rows is not a floor
+// ===========================================================================
+
+describe('noiseGate: an EMPTY noise-floor receipt does not certify determinism', () => {
+    const replay = (over: Partial<ReplayFile> = {}): ReplayFile => ({
+        variant: 'A', snapshotTakenAt: '2026-07-27T00:00:00Z', gitDirty: 'clean',
+        withServing: false, rows: [],
+        ...over,
+    } as ReplayFile);
+
+    const ledgerWith = (rows: number): NoiseFloorLedger => ({
+        kind: 'winner-diff/noise-floor-ledger', version: 1,
+        receipts: (['A', 'B'] as const).map(variant => ({
+            kind: 'winner-diff/noise-floor', version: 1,
+            snapshotTakenAt: '2026-07-27T00:00:00Z', gitDirty: 'clean', gitHead: 'abc1234', variant,
+            rows, winnerDiffs: 0, pathDiffs: 0, servingDiffs: 0, withServing: false,
+            ranAt: '2026-07-27T01:00:00Z',
+        })),
+    } as unknown as NoiseFloorLedger);
+
+    it('rejects a 0-row receipt — "0 differences" over nothing is not a measurement', () => {
+        const v = noiseGate(ledgerWith(0), replay(), replay({ variant: 'B' }), { crossSnapshot: false });
+        expect(v.ok).toBe(false);
+        expect(v.problems.join(' ')).toContain('ZERO rows');
+    });
+
+    it('POSITIVE CONTROL — a real 0-diff receipt over real rows still passes', () => {
+        expect(noiseGate(ledgerWith(420), replay(), replay({ variant: 'B' }), { crossSnapshot: false }).ok).toBe(true);
+    });
+});
+
+// ===========================================================================
+// 7. decide() — the shape every block above depends on
+// ===========================================================================
+
+describe('decide(): an unadjudicated verdict is never a pass and never a purge', () => {
+    const failed: LlmVerdict = { verdict: 'UNSURE', axis: 'none', confidence: 0, reason: 'x', error: 'call-failed' };
+    it('holds for every policy', () => {
+        for (const p of ALL_POLICIES) {
+            expect(decide([], failed, p)).toBe('REVIEW');
+        }
+    });
+});

--- a/scripts/eval/__tests__/fixtures/prod-shapes.json
+++ b/scripts/eval/__tests__/fixtures/prod-shapes.json
@@ -1,0 +1,26 @@
+{
+  "_readme": "Shapes the LIVE cache actually contains. __tests__/prod-shape-coverage.test.ts fails when the committed test fixtures stop covering one of them. This file is the only thing that knows about a shape the fixture is MISSING — batch 01 contained zero fdc rows, which is why a missing FdcFood join in ROW_SQL survived 73 green tests and false-evicted 78 of 78 fdc rows in the live cache. A fixture cannot be trusted to notice what it does not contain. Regenerate with scripts/eval/refresh-prod-shapes.ts (needs a live DB; never run in CI).",
+  "measuredAt": "2026-07-27",
+  "refreshWith": "npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/refresh-prod-shapes.ts",
+  "population": { "table": "FoodMapping", "rows": 3248 },
+  "shapes": {
+    "source": [
+      { "value": "openfoodfacts", "count": 2728 },
+      { "value": "fatsecret", "count": 442 },
+      { "value": "fdc", "count": 78 }
+    ],
+    "servingTier": [
+      { "value": "label_serving_default", "count": 2036 },
+      { "value": "flat_100g_default", "count": 679 },
+      { "value": "fs_default_serving", "count": 309 },
+      { "value": "fdc_size_estimate", "count": 78 },
+      { "value": "fs_serving_macros_only", "count": 76 },
+      { "value": "fs_label_count", "count": 57 }
+    ]
+  },
+  "notes": [
+    "source counts were re-read live from FoodMapping on 2026-07-27 and sum to the full 3,248-row population.",
+    "servingTier counts come from a whole-cache --with-serving screen run on 2026-07-27 and sum to 3,235. The ~13-row remainder is rows whose real anchor could not be resolved at all; that state is an ERROR, not a shape, and the fixture is not required to carry an exemplar of it. It is covered instead by __tests__/fail-closed.test.ts, which forces hydrateAndSelectServing to throw and asserts the row is UNJUDGED.",
+    "Every fdc row in the cache resolves on fdc_size_estimate, which AI_SERVING_TIER_RE matches ('estimat'). The entire fdc population is therefore UNJUDGED by D5/D6 — the one production source with no fixture coverage was also the one whose serving anchor the screen may never gate on."
+  ]
+}

--- a/scripts/eval/__tests__/fixtures/screen-shape-exemplars.json
+++ b/scripts/eval/__tests__/fixtures/screen-shape-exemplars.json
@@ -1,0 +1,134 @@
+{
+ "_readme": "Exemplar rows for production shapes that the hand-audited batch-01 ground truth does NOT contain. Batch 01 is a frozen 81-row audit with a pinned confusion matrix, so rows cannot be added to it without lying about what was audited; this file carries the missing shapes instead. prod-shape-coverage.test.ts screens the UNION of both files against fixtures/prod-shapes.json. Rows are REAL, pulled from the live cache on 2026-07-27 via ROW_SQL with row.real filled by the actual hydrateAndSelectServing pass. They carry no BAD/GOOD label: they exist to prove the screen can SEE the shape, not to move the measured recall.",
+ "rows": [
+  {
+   "shape": "src=fdc, servingTier=fdc_size_estimate",
+   "row": {
+    "key": "avocado",
+    "src": "fdc",
+    "conf": 0.99,
+    "validatedby": "human-triage",
+    "mapfoodname": "Avocados, raw, all commercial varieties",
+    "mapbrand": "",
+    "recname": "Avocados, raw, all commercial varieties",
+    "recbrand": "",
+    "per100g": {
+     "fat": 14.7,
+     "carbs": 8.53,
+     "fiber": 6.7,
+     "sugar": 0.66,
+     "protein": 2,
+     "calories": 160
+    },
+    "off_serving_grams": null,
+    "off_serving_size": "",
+    "pkg_qty": null,
+    "pkg_unit": "",
+    "corruptreason": "",
+    "dupof": "",
+    "fs_serving_desc": "",
+    "fs_serving_grams": null,
+    "fs_serving_nutrients": null,
+    "recid": "171705",
+    "n_off_servings": 0,
+    "off_serv_min_g": null,
+    "off_serv_max_g": null,
+    "fdc_serving_size": null,
+    "fdc_serving_unit": "",
+    "fdc_serv_min_g": 50,
+    "real": {
+     "grams": 150,
+     "tier": "fdc_size_estimate",
+     "kcal": 240
+    },
+    "seed": "avocado"
+   }
+  },
+  {
+   "shape": "src=fdc, servingTier=fdc_size_estimate",
+   "row": {
+    "key": "bagel plain",
+    "src": "fdc",
+    "conf": 0.99,
+    "validatedby": "human-triage",
+    "mapfoodname": "Bagels, plain, unenriched, without calcium propionate(includes onion, poppy, sesame)",
+    "mapbrand": "",
+    "recname": "Bagels, plain, unenriched, without calcium propionate(includes onion, poppy, sesame)",
+    "recbrand": "",
+    "per100g": {
+     "fat": 1.6,
+     "carbs": 53.4,
+     "fiber": 2.3,
+     "sugar": 0,
+     "protein": 10.5,
+     "calories": 275
+    },
+    "off_serving_grams": null,
+    "off_serving_size": "",
+    "pkg_qty": null,
+    "pkg_unit": "",
+    "corruptreason": "",
+    "dupof": "",
+    "fs_serving_desc": "",
+    "fs_serving_grams": null,
+    "fs_serving_nutrients": null,
+    "recid": "175051",
+    "n_off_servings": 0,
+    "off_serv_min_g": null,
+    "off_serv_max_g": null,
+    "fdc_serving_size": null,
+    "fdc_serving_unit": "",
+    "fdc_serv_min_g": 26,
+    "real": {
+     "grams": 105,
+     "tier": "fdc_size_estimate",
+     "kcal": 288.75
+    },
+    "seed": "plain bagel"
+   }
+  },
+  {
+   "shape": "src=fdc, servingTier=fdc_size_estimate",
+   "row": {
+    "key": "banana",
+    "src": "fdc",
+    "conf": 0.98,
+    "validatedby": "ai",
+    "mapfoodname": "raw bananas",
+    "mapbrand": "",
+    "recname": "Bananas, raw",
+    "recbrand": "",
+    "per100g": {
+     "fat": 0.33,
+     "carbs": 22.8,
+     "fiber": 2.6,
+     "sugar": 12.2,
+     "protein": 1.09,
+     "calories": 89
+    },
+    "off_serving_grams": null,
+    "off_serving_size": "",
+    "pkg_qty": null,
+    "pkg_unit": "",
+    "corruptreason": "",
+    "dupof": "",
+    "fs_serving_desc": "",
+    "fs_serving_grams": null,
+    "fs_serving_nutrients": null,
+    "recid": "173944",
+    "n_off_servings": 0,
+    "off_serv_min_g": null,
+    "off_serv_max_g": null,
+    "fdc_serving_size": null,
+    "fdc_serving_unit": "",
+    "fdc_serv_min_g": 81,
+    "real": {
+     "grams": 118,
+     "tier": "fdc_size_estimate",
+     "kcal": 105.02
+    },
+    "seed": "banana"
+   }
+  }
+ ]
+}

--- a/scripts/eval/__tests__/prod-shape-coverage.test.ts
+++ b/scripts/eval/__tests__/prod-shape-coverage.test.ts
@@ -1,0 +1,150 @@
+/**
+ * prod-shape-coverage.test.ts — the fixture must contain every shape production does.
+ *
+ * THE CLASS OF BUG THIS CLOSES
+ * `ROW_SQL` joined `OffFood` and `FatSecretFood` but not `FdcFood`, so every
+ * fdc-sourced FoodMapping row arrived with `recname=''` and `per100g=null`. D8 ("no
+ * usable per-100g basis") fired on all of them and the screen false-evicted 78 of
+ * 78 fdc rows in the live cache. Seventy-three tests were green throughout —
+ * including a confusion matrix pinned row-by-row — because BATCH 01 CONTAINS NO FDC
+ * ROWS. The suite was not wrong about what it measured; the corpus simply did not
+ * have the shape, so a whole source was invisible.
+ *
+ * A fixture cannot be trusted to notice what it does not contain. fixtures/
+ * prod-shapes.json is the EXTERNAL record of what the live cache actually holds,
+ * and this file fails when the committed rows stop covering it.
+ *
+ * OFFLINE BY CONSTRUCTION. CI has no prod DB, so the manifest is a committed
+ * snapshot rather than a live query. It goes stale the moment production grows a
+ * shape — which is the point of naming the refresh script in every failure message.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { AI_SERVING_TIER_RE, realServing, tierD, type ScreenRow } from '../correctness-screen';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+interface ShapeCount { value: string; count: number }
+interface Manifest {
+    measuredAt: string;
+    refreshWith: string;
+    population: { table: string; rows: number };
+    shapes: { source: ShapeCount[]; servingTier: ShapeCount[] };
+}
+
+const MANIFEST = JSON.parse(fs.readFileSync(path.join(FIXTURES, 'prod-shapes.json'), 'utf8')) as Manifest;
+
+/**
+ * The whole committed test corpus, not one file.
+ *
+ * Batch 01 is a FROZEN hand audit — 81 rows, 23 BAD / 10 SUSPECT / 48 GOOD, with a
+ * confusion matrix pinned to exact counts. Rows cannot be added to it without
+ * misrepresenting what a human actually labelled, so the shapes it lacks live in
+ * screen-shape-exemplars.json and coverage is measured over the UNION.
+ */
+const BATCH01: ScreenRow[] = (JSON.parse(
+    fs.readFileSync(path.join(FIXTURES, 'correctness-screen-batch01.json'), 'utf8'),
+) as { rows: Array<{ row: ScreenRow }> }).rows.map(r => r.row);
+
+const EXEMPLARS: ScreenRow[] = (JSON.parse(
+    fs.readFileSync(path.join(FIXTURES, 'screen-shape-exemplars.json'), 'utf8'),
+) as { rows: Array<{ row: ScreenRow }> }).rows.map(r => r.row);
+
+const CORPUS: ScreenRow[] = [...BATCH01, ...EXEMPLARS];
+
+const HOW_TO_FIX = (dimension: string, missing: string[]) =>
+    `The committed fixtures cover no row with ${dimension} in [${missing.join(', ')}], `
+    + 'but the live cache does. A rule branch that never runs against a shape cannot be '
+    + 'wrong in a way any test can see — that is exactly how ROW_SQL lost its FdcFood '
+    + 'join for 78 of 78 fdc rows.\n'
+    + '  TO FIX: add a real exemplar row (pulled via ROW_SQL, with row.real filled by the '
+    + 'real serving pass) to scripts/eval/__tests__/fixtures/screen-shape-exemplars.json. '
+    + 'Do NOT add it to correctness-screen-batch01.json — that fixture is a frozen human audit.\n'
+    + `  IF THE MANIFEST IS STALE instead, refresh it from prod with:\n    ${MANIFEST.refreshWith}`;
+
+describe('the manifest itself', () => {
+    it('describes a real, non-empty population', () => {
+        // A manifest of nothing would make every coverage assertion below pass
+        // vacuously — the same "absence read as agreement" shape the whole PR is about.
+        expect(MANIFEST.population.rows).toBeGreaterThan(0);
+        expect(MANIFEST.shapes.source.length).toBeGreaterThan(0);
+        expect(MANIFEST.shapes.servingTier.length).toBeGreaterThan(0);
+        expect(MANIFEST.refreshWith).toContain('refresh-prod-shapes.ts');
+    });
+
+    it('reads the DB nowhere — CI has no prod database', () => {
+        const spy = jest.spyOn(globalThis, 'fetch');
+        expect(CORPUS.length).toBeGreaterThan(80);
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});
+
+describe('fixture coverage of production shapes', () => {
+    it('covers every FoodMapping.source the cache contains', () => {
+        const have = new Set(CORPUS.map(r => r.src));
+        const missing = MANIFEST.shapes.source.filter(s => s.count > 0 && !have.has(s.value)).map(s => s.value);
+        if (missing.length) throw new Error(HOW_TO_FIX('src', missing));
+        expect(missing).toEqual([]);
+    });
+
+    it('covers every serving tier the real anchor produces', () => {
+        const have = new Set(CORPUS.map(r => r.real?.tier).filter((t): t is string => !!t));
+        const missing = MANIFEST.shapes.servingTier.filter(s => s.count > 0 && !have.has(s.value)).map(s => s.value);
+        if (missing.length) throw new Error(HOW_TO_FIX('row.real.tier', missing));
+        expect(missing).toEqual([]);
+    });
+
+    it('DEMONSTRATES it can fail — a shape absent from the corpus is reported', () => {
+        // A coverage test that cannot fail is decoration. This runs the same check
+        // against a manifest entry that deliberately does not exist.
+        const have = new Set(CORPUS.map(r => r.src));
+        const missing = [...MANIFEST.shapes.source, { value: 'usda_branded_v2', count: 12 }]
+            .filter(s => s.count > 0 && !have.has(s.value)).map(s => s.value);
+        expect(missing).toEqual(['usda_branded_v2']);
+        expect(HOW_TO_FIX('src', missing)).toContain('refresh-prod-shapes.ts');
+    });
+});
+
+describe('the shapes batch 01 was missing are actually SCREENED, not merely present', () => {
+    const fdcRows = CORPUS.filter(r => r.src === 'fdc');
+
+    it('the corpus carries real fdc rows with a joined FdcFood record', () => {
+        expect(fdcRows.length).toBeGreaterThan(0);
+        for (const r of fdcRows) {
+            // These two fields are precisely what the missing join blanked out.
+            expect(r.recname).not.toBe('');
+            expect(r.per100g).toBeTruthy();
+        }
+    });
+
+    it('an fdc row with a real panel does NOT trip D8 — the rule that false-evicted 78/78', () => {
+        for (const r of fdcRows) {
+            expect(tierD(r, 'balanced').map(h => h.rule)).not.toContain('D8');
+        }
+    });
+
+    it('every fdc row resolves on an AI-ESTIMATED tier, so D5/D6 may never gate on it', () => {
+        // Measured over the whole cache: all 78 fdc rows come back on
+        // `fdc_size_estimate`, which AI_SERVING_TIER_RE matches on 'estimat'. The one
+        // source the fixture had no coverage of is also the one whose serving anchor
+        // is a fresh model guess — a number that can differ on the next request and
+        // therefore cannot ground a decision to throw a cache row away.
+        for (const r of fdcRows) {
+            expect(AI_SERVING_TIER_RE.test(r.real?.tier ?? '')).toBe(true);
+            expect(realServing(r).judged).toBe(false);
+            const serving = tierD(r, 'strict').filter(h => h.rule === 'D5' || h.rule === 'D6');
+            expect(serving.map(h => h.severity)).not.toContain('EVICT');
+        }
+    });
+
+    it('the exemplars do not disturb the pinned batch-01 matrix', () => {
+        // They live in a separate file for exactly this reason. If this ever fails,
+        // someone has merged the two corpora and the audited recall figures are no
+        // longer about the rows a human labelled.
+        expect(BATCH01).toHaveLength(81);
+        expect(BATCH01.filter(r => r.src === 'fdc')).toHaveLength(0);
+        expect(EXEMPLARS.length).toBeGreaterThan(0);
+    });
+});

--- a/scripts/eval/__tests__/serving-divergence.test.ts
+++ b/scripts/eval/__tests__/serving-divergence.test.ts
@@ -1,0 +1,213 @@
+/**
+ * serving-divergence.test.ts — pins how far the screen's serving RECONSTRUCTION is
+ * from the anchor the request path actually bills.
+ *
+ * THE CLASS OF BUG THIS CLOSES
+ * `resolveServingGrams(row)` REIMPLEMENTS the billing anchor: it walks
+ * OffFood.servingGrams -> FatSecretServing.grams -> OffServing.grams ->
+ * FdcFood.servingSize -> FdcServing.grams -> flat 100 g. It never calls
+ * `hydrateAndSelectServing`, so count-label serving, dose-anchored serving and the
+ * FatSecret weight oracle are invisible to it. D5/D6 judged that reconstruction and
+ * evicted cache rows on it. The screen carried the caveat "a row D5 calls 'no
+ * serving weight' MAY IN FACT BILL CORRECTLY — **this was not measured**" from the
+ * day it shipped, which is the whole failure mode: a reimplementation is not a
+ * measurement until something compares it to the original, and nothing did.
+ *
+ * `realServing(row)` reads the anchor `hydrateAndSelectServing` actually produced,
+ * baked into the fixture as `row.real`. This file compares the two OFFLINE — no DB,
+ * no FDC API, no model call — because the fixture already carries the real numbers.
+ * `measure-serving-divergence.ts` is the same method as a one-shot script; this is
+ * the same method as a gate.
+ *
+ * MEASURED 2026-07-27 over the 81 batch-01 rows: 78/81 = 96.3% agreement.
+ * The floor below is 95%, not 96.3%, so ordinary data movement in the fixture does
+ * not fail CI — but a refactor that quietly re-points D5/D6 at the reconstruction,
+ * or breaks one of the five resolution branches, drops well through it.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    realServing,
+    resolveServingGrams,
+    screenBatch,
+    tierD,
+    type Policy,
+    type ScreenRow,
+} from '../correctness-screen';
+
+const FIXTURE = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'fixtures', 'correctness-screen-batch01.json'), 'utf8'),
+) as { rows: Array<{ verdict: string; row: ScreenRow }> };
+
+const BATCH01: ScreenRow[] = FIXTURE.rows.map(r => r.row);
+
+/** Below 95% the reconstruction is not a stand-in for the anchor at all. */
+const AGREEMENT_FLOOR = 0.95;
+/** What it actually measured when the fixture was baked. Reported, never asserted as equality. */
+const MEASURED_AGREEMENT = 78 / 81;
+
+const ALL_POLICIES: Policy[] = ['lenient', 'balanced', 'strict'];
+
+/** The same comparison measure-serving-divergence.ts prints, as a function. */
+function compare(rows: ScreenRow[]) {
+    let agree = 0, errored = 0;
+    const moved: Array<{ key: string; from: number | null; to: number | null; tier: string | null }> = [];
+    for (const r of rows) {
+        if (r.real?.error) { errored++; continue; }
+        const a = resolveServingGrams(r).grams;
+        // Compare what D5/D6 actually CONSUME, i.e. after flat-100g normalisation.
+        // Comparing raw grams would count the flat-100g fallback as a disagreement
+        // when both sides are saying "there is no anchor here".
+        const b = realServing(r).grams;
+        if (a == null && b == null) { agree++; continue; }
+        if (a != null && b != null && Math.abs(a - b) < 0.01) { agree++; continue; }
+        moved.push({ key: r.key, from: a, to: b, tier: r.real?.tier ?? null });
+    }
+    return { agree, errored, moved, judged: Math.max(1, rows.length - errored) };
+}
+
+/** The D5/D6 bucket a gram weight lands in — the only thing the disagreement can cost. */
+function d56(g: number | null): 'D5' | 'D6' | '-' {
+    if (g == null) return 'D5';
+    if (g < 5 || g > 500) return 'D6';
+    return '-';
+}
+
+describe('the fixture carries the REAL anchor, so this can be measured offline', () => {
+    it('every row has a baked-in row.real — otherwise the comparison is vacuous', () => {
+        // Without this the whole file degenerates: realServing() falls back to
+        // resolveServingGrams() when `row.real` is undefined, so the two would agree
+        // 81/81 by construction and the test would pass by measuring nothing.
+        expect(BATCH01).toHaveLength(81);
+        expect(BATCH01.filter(r => r.real === undefined)).toHaveLength(0);
+    });
+
+    it('does not touch the network', () => {
+        const spy = jest.spyOn(globalThis, 'fetch');
+        compare(BATCH01);
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});
+
+describe('reconstruction vs real billing anchor — pinned floor', () => {
+    it(`agrees on at least ${(AGREEMENT_FLOOR * 100).toFixed(0)}% of rows (measured ${(MEASURED_AGREEMENT * 100).toFixed(1)}%)`, () => {
+        const { agree, judged, moved } = compare(BATCH01);
+        const rate = agree / judged;
+        if (rate < AGREEMENT_FLOOR) {
+            throw new Error(
+                `serving reconstruction agreement fell to ${(rate * 100).toFixed(1)}% (${agree}/${judged}); `
+                + `floor is ${(AGREEMENT_FLOOR * 100).toFixed(0)}%, measured baseline ${(MEASURED_AGREEMENT * 100).toFixed(1)}%. `
+                + `Rows that moved: ${JSON.stringify(moved)}. `
+                + 'Re-measure with: npx ts-node --project tsconfig.scripts.json --transpile-only '
+                + '-r tsconfig-paths/register scripts/eval/measure-serving-divergence.ts');
+        }
+        expect(rate).toBeGreaterThanOrEqual(AGREEMENT_FLOOR);
+    });
+
+    it('the divergence is REAL — a handful of rows genuinely disagree', () => {
+        // The counter-assertion to the floor. If `moved` were empty the floor above
+        // would be satisfied by a reconstruction that had been silently aliased to
+        // the real anchor, i.e. by deleting the thing being measured.
+        const { moved } = compare(BATCH01);
+        expect(moved.length).toBeGreaterThan(0);
+        expect(moved.length).toBeLessThanOrEqual(Math.ceil(81 * (1 - AGREEMENT_FLOOR)));
+    });
+
+    it('names the rows where the screen would have judged a number nobody is billed', () => {
+        // Pinned by key so the divergence stays legible rather than being a bare
+        // percentage. These three are the entire measured gap:
+        //   simple truth emerge protein bar — reconstruction found 55 g on the OFF
+        //     record; the real path fell through to flat_100g_default (no anchor).
+        //   kirkland cashews / publix sub  — reconstruction found NOTHING; the real
+        //     path recovered a weight through the FatSecret serving-macros branch,
+        //     which the reconstruction cannot see at all.
+        const { moved } = compare(BATCH01);
+        expect(moved.map(m => m.key).sort()).toEqual([
+            'bar emerge protein simple truth',
+            'cashew kirkland signature',
+            'publix sandwich sub',
+        ]);
+    });
+
+    it('all three disagreements change the D5/D6 verdict — this gap is not cosmetic', () => {
+        const flips = BATCH01.filter(r =>
+            d56(resolveServingGrams(r).grams) !== d56(realServing(r).grams));
+        expect(flips).toHaveLength(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The invariant that made shipping the real anchor SAFE
+// ---------------------------------------------------------------------------
+
+describe('a row whose real anchor did not run can NEVER produce an EVICT-severity D5/D6', () => {
+    /** Every shape that makes `judged` false. */
+    const unjudged: Array<[string, Partial<ScreenRow>]> = [
+        ['the --with-serving pass never ran', { real: undefined }],
+        ['hydrateAndSelectServing returned nothing', { real: null }],
+        ['hydration threw', { real: { grams: null, tier: null, kcal: null, error: 'FDC API 503' } }],
+        ['the anchor is a fresh AI guess', { real: { grams: 1.2, tier: 'ai_estimated_serving', kcal: 7 } }],
+        ['the anchor is an fdc size ESTIMATE', { real: { grams: 900, tier: 'fdc_size_estimate', kcal: 1400 } }],
+    ];
+
+    /** Rows engineered so the ONLY rule that can fire is a serving rule. */
+    const servingOnlyRow = (over: Partial<ScreenRow>): ScreenRow => ({
+        key: 'almond great value', src: 'openfoodfacts', conf: 0.9, validatedby: 'ai',
+        mapfoodname: 'Great value, almonds', mapbrand: 'Great Value',
+        recname: 'Great value, almonds, smoke', recbrand: 'Great Value',
+        per100g: { calories: 600, protein: 21, carbs: 20, fat: 53 },
+        off_serving_grams: null, off_serving_size: '', pkg_qty: null, pkg_unit: '',
+        corruptreason: '', dupof: '', fs_serving_desc: '', fs_serving_grams: null,
+        fs_serving_nutrients: null, recid: '0000000000001', n_off_servings: 1,
+        off_serv_min_g: null, off_serv_max_g: null,
+        fdc_serving_size: null, fdc_serving_unit: '', fdc_serv_min_g: null,
+        seed: 'great value almonds',
+        ...over,
+    });
+
+    it.each(unjudged)('%s -> D5/D6 are INFO under every policy', (_why, over) => {
+        // Both the "no anchor" shape and the "absurd anchor" shape, because D5 and D6
+        // are separate rules and only one of them fires per row.
+        for (const shape of [{}, { fs_serving_grams: 1.0 }]) {
+            const row = servingOnlyRow({ ...shape, ...over });
+            expect(realServing(row).judged).toBe(false);
+            for (const p of ALL_POLICIES) {
+                const hits = tierD(row, p).filter(h => h.rule === 'D5' || h.rule === 'D6');
+                expect(hits.length).toBeGreaterThan(0);                       // still REPORTS
+                expect(hits.map(h => h.severity)).not.toContain('EVICT');     // never GATES
+                expect(hits.every(h => h.detail.includes('UNJUDGED'))).toBe(true);
+            }
+        }
+    });
+
+    it('the whole batch run WITHOUT the real anchor yields zero D5/D6 evictions, even under --policy strict', () => {
+        // This is the `--no-serving` run. `strict` lists BOTH D5 and D6 in its evict
+        // set, so before the downgrade this configuration evicted rows on an
+        // unmeasured reconstruction — the exact mistake PR #174 closed for the
+        // serving gate.
+        const stripped = BATCH01.map(r => ({ ...r, real: undefined }));
+        const evicting = stripped.flatMap(r =>
+            tierD(r, 'strict').filter(h => (h.rule === 'D5' || h.rule === 'D6') && h.severity === 'EVICT'));
+        expect(evicting).toEqual([]);
+    });
+
+    it('POSITIVE CONTROL — with the real anchor present, D5/D6 DO evict under strict', () => {
+        // Without this, "no EVICT" is satisfiable by rules that never fire, which is
+        // a tautology rather than an invariant.
+        const judgedRows = BATCH01.filter(r => realServing(r).judged);
+        expect(judgedRows.length).toBeGreaterThan(70);
+        const evicting = judgedRows.flatMap(r =>
+            tierD(r, 'strict').filter(h => (h.rule === 'D5' || h.rule === 'D6') && h.severity === 'EVICT'));
+        expect(evicting.length).toBeGreaterThan(0);
+    });
+
+    it('an unjudged serving row is never EVICTed by the combined decision either', () => {
+        // The severity downgrade is only half the property — what ships is decide().
+        const row = servingOnlyRow({ real: { grams: null, tier: null, kcal: null, error: 'boom' } });
+        for (const p of ALL_POLICIES) {
+            expect(screenBatch([row], p)[0].decision).not.toBe('EVICT');
+        }
+    });
+});

--- a/scripts/eval/assertions.ts
+++ b/scripts/eval/assertions.ts
@@ -42,6 +42,180 @@ export function isAbstention(it: any): boolean {
     return noId && noConfidence;
 }
 
+// ---------------------------------------------------------------------------
+// Case scoring — the VERDICT, not just the predicates it is built from
+// ---------------------------------------------------------------------------
+
+/**
+ * The assertion block of one golden-set case. Every field is optional; a case
+ * asserts whichever of them it declares.
+ */
+export interface NlpCaseSpec {
+    expectItems?: number;
+    expectName?: string[][];
+    forbidName?: string[][];
+    expectAbstain?: boolean;
+    maxConfidence?: number;
+    macros?: Record<string, [number, number]>;
+    grams?: [number, number];
+    total?: Record<string, [number, number]>;
+    item?: { unit?: string };
+}
+
+/**
+ * Every way `items` fails `c`. Empty array == PASS.
+ *
+ * EXTRACTED FROM run-eval.ts DELIBERATELY. The predicates below (isAbstention,
+ * matchesAlt) were already unit-tested while the code that COMPOSES them into a
+ * pass/fail verdict was not, because run-eval.ts calls main() at module scope and
+ * importing it starts a real eval run. A tested predicate wired into an untested
+ * verdict is how a total abstention scored PASS on 37 name-only cases: the guard
+ * that stops it is one `!isAbstention(it) &&`, and nothing asserted it was there.
+ *
+ * FAIL-CLOSED CONTRACT: no input may produce an empty (== passing) result by
+ * ACCIDENT. A non-array, an empty array and an all-abstention response are each an
+ * ABSENCE of signal, and absence is never a pass.
+ */
+export function scoreNlpCase(c: NlpCaseSpec, items: unknown): string[] {
+    // Absence of a response is a failure, never a vacuous pass. run-eval reports the
+    // HTTP status separately; this guard makes the pure scorer independently safe.
+    if (!Array.isArray(items) || items.length === 0) {
+        return [`no items returned (${Array.isArray(items) ? 'empty array' : typeof items})`];
+    }
+
+    const failures: string[] = [];
+
+    if (c.expectItems && items.length < c.expectItems) {
+        failures.push(`expected >=${c.expectItems} items, got ${items.length}`);
+    }
+
+    // Name check: for single-item cases the one item must match; for segmentation
+    // cases at least one item must match.
+    //
+    // An abstention can NEVER satisfy a positive name assertion — it echoes the
+    // query text back as foodName, so it would otherwise match trivially. See
+    // isAbstention().
+    if (c.expectName) {
+        const anyNameMatch = items.some(it => !isAbstention(it) && matchesAlt(textOf(it), c.expectName!));
+        if (!anyNameMatch) {
+            const shown = items.map(it => isAbstention(it) ? 'NO PICK (abstained)' : `"${it.foodName}"`);
+            failures.push(`name mismatch: [${shown.join(', ')}]`);
+        }
+    }
+
+    // Negative name assertion — no returned item may match. This pins a
+    // wrong-record class without needing to know the right answer, which is what
+    // the composite->component drift cases need: "qdoba chicken burrito must not
+    // resolve to Tequila Lime Chicken" is assertable even while the correct
+    // billing figure is still being argued about.
+    if (c.forbidName) {
+        const offender = items.find(it => !isAbstention(it) && matchesAlt(textOf(it), c.forbidName!));
+        if (offender) {
+            failures.push(`forbidden name matched: "${offender.foodName}" [${offender.brandName ?? ''}]`);
+        }
+    }
+
+    // The mapper is REQUIRED to produce no confident pick. For a query whose
+    // honest answer is "not in the corpus", billing a component at 0.95 is worse
+    // than abstaining, and only this can express that.
+    if (c.expectAbstain) {
+        const confident = items.find(it => !isAbstention(it));
+        if (confident) {
+            failures.push(`expected abstention, got "${confident.foodName}" conf=${confident.matchConfidence} grams=${confident.grams}`);
+        }
+    }
+
+    // Weak form: it may guess, but must not look authoritative enough to cache.
+    if (typeof c.maxConfidence === 'number') {
+        const conf = items[0]?.matchConfidence;
+        if (typeof conf !== 'number' || conf > c.maxConfidence) {
+            failures.push(`confidence=${conf} exceeds maxConfidence ${c.maxConfidence} (mapped: "${items[0]?.foodName}")`);
+        }
+    }
+
+    if (c.macros) {
+        const per100 = items[0]?.nutritionPer100g ?? {};
+        for (const [key, range] of Object.entries(c.macros)) {
+            const v = per100[key];
+            if (typeof v !== 'number' || v < range[0] || v > range[1]) {
+                failures.push(`${key}=${typeof v === 'number' ? v.toFixed(1) : v} outside [${range[0]}, ${range[1]}] (mapped: "${items[0]?.foodName}")`);
+            }
+        }
+    }
+
+    // Resolved serving weight: asserts the total grams for the requested unit/quantity.
+    // This is what catches serving-estimation defects (e.g. "1 slice bread" → 100g).
+    if (c.grams) {
+        const g = items[0]?.grams;
+        if (typeof g !== 'number' || g < c.grams[0] || g > c.grams[1]) {
+            failures.push(`grams=${typeof g === 'number' ? g : String(g)} outside [${c.grams[0]}, ${c.grams[1]}] (unit "${c.item?.unit ?? ''}", mapped "${items[0]?.foodName}")`);
+        }
+    }
+
+    // Billed totals for the requested quantity — the grams-scaled `nutrition`
+    // block the app actually logs. This is the end-to-end assertion a per-100g
+    // band can't provide: a wrong record, wrong serving, or wrong scaling all
+    // surface as a wrong billed total ("1 tbsp olive oil" must bill ~119 kcal,
+    // whether the failure was density, record choice, or grams math).
+    // Keys: calories | protein | carbs | fat (also fiber/sugar/sodium).
+    if (c.total) {
+        const tot = items[0]?.nutrition ?? {};
+        for (const [key, range] of Object.entries(c.total)) {
+            const v = tot[key];
+            if (typeof v !== 'number' || v < range[0] || v > range[1]) {
+                failures.push(`total.${key}=${typeof v === 'number' ? v.toFixed(1) : v} outside [${range[0]}, ${range[1]}] (grams=${items[0]?.grams}, mapped: "${items[0]?.foodName}")`);
+            }
+        }
+    }
+
+    return failures;
+}
+
+/** The assertion block of one golden-set SEARCH case. */
+export interface SearchCaseSpec {
+    match: string[][];
+    rank?: number;
+    requireNutrition?: boolean;
+}
+
+const MACRO_KEYS = ['kcal100', 'protein100', 'carbs100', 'fat100'];
+function hasNum(v: unknown): boolean {
+    return typeof v === 'number' && Number.isFinite(v);
+}
+/** A search hit with NO finite macro at all — the null-nutrition rows the OFF filter should drop. */
+export function nutritionMissing(h: any): boolean {
+    return !MACRO_KEYS.some(k => hasNum(h?.[k]));
+}
+
+/**
+ * Score one search case against the hit list the API returned.
+ *
+ * Same fail-closed contract as scoreNlpCase: an EMPTY hit list is what a 500, a
+ * `{error: ...}` body or a dead Typesense all look like on the wire, and
+ * `[].some(...)` is `false`, so it must stay a FAIL. Pinned by test rather than by
+ * hope — this is one boolean flip away from "no hits, nothing to disagree with, pass".
+ */
+export function scoreSearchCase(c: SearchCaseSpec, hits: unknown): { pass: boolean; detail: string } {
+    const list: any[] = Array.isArray(hits) ? hits : [];
+    const topN = list.slice(0, c.rank ?? 3);
+    const hit = list.find(h => matchesAlt(textOf(h), c.match));
+    let pass = topN.some(h => matchesAlt(textOf(h), c.match));
+    let detail = pass
+        ? `hit: "${hit?.name}"`
+        : `top${c.rank ?? 3}: [${topN.map(h => `"${h.name}"`).join(', ') || 'EMPTY'}]`;
+    // Invariant (unless opted out): no returned hit may lack all nutrition — verifies
+    // the OFF null-nutrition filter keeps junk rows out of manual search results.
+    if (c.requireNutrition !== false && topN.length) {
+        const bad = topN.find(nutritionMissing);
+        if (bad) { pass = false; detail = `NULL-NUTRITION "${bad.name}" | ${detail}`; }
+    }
+    return { pass, detail };
+}
+
+// ---------------------------------------------------------------------------
+// knownIssue drift
+// ---------------------------------------------------------------------------
+
 /** Recorded state of a knownIssue case, so a change in HOW it fails is visible. */
 export interface BaselineEntry {
     foodId?: string | null;
@@ -49,6 +223,13 @@ export interface BaselineEntry {
     grams?: number | null;
     kcal100?: number | null;
     abstained?: boolean;
+    /**
+     * The case did not produce a reading at all — transport error, non-array body,
+     * zero items. Recorded because `knownIssue` otherwise swallows it completely:
+     * the failure is expected (not gating) AND there are no values to diff, so a
+     * pinned case that stops answering entirely would leave no trace anywhere.
+     */
+    errored?: boolean;
 }
 
 /**
@@ -70,6 +251,9 @@ export function numberDrifted(was: number | null | undefined, now: number | null
 /** Human-readable description of every way `now` differs from the baseline, or []. */
 export function describeDrift(was: BaselineEntry, now: BaselineEntry): string[] {
     const changes: string[] = [];
+    if ((was.errored ?? false) !== (now.errored ?? false)) {
+        changes.push(`errored ${was.errored ?? false} -> ${now.errored ?? false}`);
+    }
     if ((was.foodId ?? null) !== (now.foodId ?? null)) {
         changes.push(`record ${was.foodId ?? 'none'} -> ${now.foodId ?? 'none'} ("${was.foodName}" -> "${now.foodName}")`);
     }
@@ -79,4 +263,60 @@ export function describeDrift(was: BaselineEntry, now: BaselineEntry): string[] 
     if (numberDrifted(was.grams, now.grams)) changes.push(`grams ${was.grams} -> ${now.grams}`);
     if (numberDrifted(was.kcal100, now.kcal100)) changes.push(`kcal100 ${was.kcal100} -> ${now.kcal100}`);
     return changes;
+}
+
+/**
+ * The eval's process exit code — 0 = every case passed, 1 = real failures,
+ * 2 = the run is not a result.
+ *
+ * RUNNING ZERO CASES IS NOT A GREEN RUN. `--grep` matching nothing, `--only` with a
+ * typo, or a golden-set file that failed to parse into the expected shape all
+ * produce `results = []`, which printed "✅ 0 real failures" and exited 0 — byte-
+ * identical to a full green suite. Exit 2 so a CI step or a shell `&&` chain can
+ * tell "nothing failed" from "nothing ran".
+ */
+export function evalExitCode(results: Array<{ pass: boolean; knownIssue?: boolean }>): 0 | 1 | 2 {
+    if (results.length === 0) return 2;
+    return results.some(r => !r.pass && !r.knownIssue) ? 1 : 0;
+}
+
+/** The minimum a result must carry for the drift check to be able to see it. */
+export interface DriftableResult {
+    id: string;
+    knownIssue?: boolean;
+    observed?: BaselineEntry;
+}
+
+/**
+ * Every knownIssue case whose recorded values moved since the baseline was written.
+ *
+ * `knownIssue` is a whole-case, all-reasons, unbounded exemption from the pass/fail
+ * gate. This is the ONLY thing that still watches those cases, which is why it must
+ * be a pure function with its own tests rather than a private helper inside a script
+ * that cannot be imported. n-cook-06 slid from kcal100=361 (wrong record) to
+ * kcal100=0 (no nutrition at all) while the gate reported "0 real failures".
+ *
+ * Cases with no baseline entry yet are skipped — nothing to compare — and that
+ * exemption is deliberately NARROW: it applies to unknown ids only, never to a
+ * pinned case whose reading disappeared. A pinned case that stops answering records
+ * `errored: true` and drifts.
+ */
+export function driftedKnownIssues(
+    results: DriftableResult[],
+    baseline: Record<string, BaselineEntry>,
+): Array<{ id: string; what: string }> {
+    const out: Array<{ id: string; what: string }> = [];
+    for (const r of results) {
+        if (!r.knownIssue) continue;
+        const b = baseline[r.id];
+        if (!b) continue;  // new pin: nothing to compare until the baseline is refreshed
+        // A pinned case with a baseline but NO observation is not "unchanged" — the
+        // run produced no reading for a case it was watching. Report it as such
+        // rather than falling through to `continue`, which is what made a transport
+        // failure on a knownIssue case invisible in both the gate and the drift list.
+        const now = r.observed ?? { errored: true };
+        const changes = describeDrift(b, now);
+        if (changes.length) out.push({ id: r.id, what: changes.join('; ') });
+    }
+    return out;
 }

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -668,8 +668,22 @@ export async function callLlm(r: ScreenRow, cfg: LlmConfig): Promise<LlmVerdict>
             const j = await res.json() as { choices?: { message?: { content?: string } }[] };
             const txt = j?.choices?.[0]?.message?.content ?? '';
             const parsed = JSON.parse(txt.replace(/^```(?:json)?/i, '').replace(/```$/, '').trim());
+            // An UNRECOGNISED verdict string is a reply we could not read, not an
+            // approval. The old form was `=== 'REJECT' ? ... : === 'UNSURE' ? ... :
+            // 'ACCEPT'`, so `"reject"`, `"Reject"`, `"probably fine"`, a missing key and
+            // `{}` ALL landed on ACCEPT and the row was kept — the same fail-open shape
+            // PR #176 closed for a truncated reply, still open one branch over. Only the
+            // three known tokens are honoured; anything else is UNSURE (-> REVIEW).
+            const raw = String(parsed?.verdict ?? '').trim().toUpperCase();
+            if (raw !== 'ACCEPT' && raw !== 'UNSURE' && raw !== 'REJECT') {
+                return {
+                    verdict: 'UNSURE', axis: 'none', confidence: 0,
+                    reason: `unreadable verdict ${JSON.stringify(parsed?.verdict ?? null)}`,
+                    error: 'unparseable-verdict',
+                };
+            }
             return {
-                verdict: parsed.verdict === 'REJECT' ? 'REJECT' : parsed.verdict === 'UNSURE' ? 'UNSURE' : 'ACCEPT',
+                verdict: raw,
                 axis: String(parsed.axis ?? 'none'),
                 confidence: Number(parsed.confidence ?? 0),
                 reason: String(parsed.reason ?? ''),
@@ -721,6 +735,22 @@ export function decide(hits: Hit[], l: LlmVerdict | null | undefined, policy: Po
     if (lReject && POLICIES[policy].evict.includes('L')) return 'EVICT';
     if (hits.some(h => h.severity === 'REVIEW') || lReject || lUnsure) return 'REVIEW';
     return 'KEEP';
+}
+
+/**
+ * The process exit code for a completed run — 0 = nothing to evict, 1 = rows
+ * flagged, 2 = the run is not a result.
+ *
+ * SCREENING ZERO ROWS IS NOT A CLEAN BATCH. `loadRows` returns `[]` for an empty
+ * `added.txt`, for a `--rows` file containing `[]`, and for a key list that matches
+ * nothing in FoodMapping (`json_agg` over no rows is SQL NULL, coalesced to `[]`).
+ * All three then produced `nEvict = 0` and exit 0 — the same output as a batch that
+ * was screened and found clean. The truncation WARN could not catch it either: it
+ * only fires when `keys.length !== rows.length`, and 0 === 0.
+ */
+export function screenExitCode(rowsScreened: number, nEvict: number): 0 | 1 | 2 {
+    if (rowsScreened === 0) return 2;
+    return nEvict > 0 ? 1 : 0;
 }
 
 /** Tier D over every row, plus (optionally) the Tier-L verdicts already gathered. */
@@ -1040,7 +1070,8 @@ const USAGE = [
     '  --seeds accepts bare phrases OR explicit "key<TAB>phrase" pins. Use pins for any',
     '  run wider than one batch: nearest-match attribution guesses wrong at cache scale.',
     '',
-    'Exit 0 = nothing to evict, 1 = rows flagged for withholding, >1 = crash (treat as RED).',
+    'Exit 0 = nothing to evict, 1 = rows flagged for withholding, >1 = crash OR zero rows',
+'screened (treat as RED — a run that judged nothing is not a clean batch).',
 ].join('\n');
 
 async function main(): Promise<number> {
@@ -1252,7 +1283,12 @@ async function main(): Promise<number> {
         }
     }
 
-    return nEvict > 0 ? 1 : 0;
+    if (rows.length === 0) {
+        console.error('\nFATAL screened 0 rows. Nothing was judged, so this run is NOT a clean batch — '
+            + 'check that --bdir/added.txt is non-empty, that --rows is not [], and that the keys exist '
+            + 'in FoodMapping. Exiting 2.');
+    }
+    return screenExitCode(rows.length, nEvict);
 }
 
 if (require.main === module) {

--- a/scripts/eval/refresh-prod-shapes.ts
+++ b/scripts/eval/refresh-prod-shapes.ts
@@ -1,0 +1,145 @@
+/**
+ * refresh-prod-shapes.ts — regenerate __tests__/fixtures/prod-shapes.json from the
+ * live cache.
+ *
+ * WHY THIS EXISTS
+ * `correctness-screen.test.ts` was 73 tests green while `ROW_SQL` was missing its
+ * `FdcFood` join. Every fdc-sourced row therefore arrived with `recname=''` and
+ * `per100g=null`, D8 fired on all of them, and the screen false-evicted 78 of 78
+ * fdc rows in the live cache. Nothing caught it because BATCH 01 CONTAINS NO FDC
+ * ROWS — the test corpus simply did not have the shape, so the whole class of bug
+ * was invisible to a suite that could otherwise pin a confusion matrix to the row.
+ *
+ * A fixture cannot be trusted to notice what it does not contain. prod-shapes.json
+ * is the external record of what production ACTUALLY holds, and
+ * `prod-shape-coverage.test.ts` fails when the fixture corpus stops covering it.
+ * The manifest is committed and read offline; CI has no prod DB. This script is the
+ * MANUAL refresh, run from a machine that can reach the server.
+ *
+ * COST: the serving-tier tally calls `hydrateAndSelectServing` — the production
+ * path — once per cached row. It can hit the USDA FDC API and it can invoke the
+ * ambiguous-serving AI estimator. Over ~3,200 rows that is minutes of wall clock
+ * and a few hundred model calls. It is not free and it is not pure.
+ *
+ * Run:
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/refresh-prod-shapes.ts [--dry-run] [--limit N]
+ *
+ *   --dry-run   print the tally, write nothing
+ *   --limit N   sample N rows. IMPLIES --dry-run and REFUSES to write: a sampled
+ *               manifest silently drops the rare shapes, which are precisely the
+ *               ones the fixture is most likely to be missing. Use it to smoke-test
+ *               the script, never to produce the file.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    ROW_SQL,
+    resolveRealServings,
+    type PrismaLike,
+    type ScreenRow,
+} from './correctness-screen';
+
+const OUT = path.join(__dirname, '__tests__', 'fixtures', 'prod-shapes.json');
+const CHUNK = 400;
+
+interface ShapeCount { value: string; count: number }
+
+function tally(values: Array<string | null | undefined>): ShapeCount[] {
+    const m = new Map<string, number>();
+    for (const v of values) {
+        const key = v == null || v === '' ? '(none)' : v;
+        m.set(key, (m.get(key) ?? 0) + 1);
+    }
+    return [...m.entries()].map(([value, count]) => ({ value, count })).sort((a, b) => b.count - a.count);
+}
+
+function openPrisma(): PrismaLike {
+    require('dotenv/config');
+    const { PrismaClient } = require('@prisma/client');
+    return new PrismaClient() as PrismaLike;
+}
+
+async function main(): Promise<number> {
+    const args = process.argv.slice(2);
+    const limitRaw = args.includes('--limit') ? args[args.indexOf('--limit') + 1] : undefined;
+    const limit = limitRaw === undefined ? undefined : Number(limitRaw);
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+        console.error(`--limit must be a positive integer, got "${limitRaw}".`);
+        return 2;
+    }
+    const dryRun = args.includes('--dry-run') || limit !== undefined;
+
+    const prisma = openPrisma();
+    let rows: ScreenRow[] = [];
+    let population = 0;
+    try {
+        const keyRows = await prisma.$queryRawUnsafe(
+            `SELECT "normalizedForm" AS k FROM "FoodMapping" ORDER BY "normalizedForm"`,
+        ) as Array<{ k: string }>;
+        population = keyRows.length;
+        if (population === 0) {
+            console.error('FATAL FoodMapping is empty. Refusing to write a manifest that claims '
+                + 'production contains no shapes — that would make the coverage test pass vacuously.');
+            return 2;
+        }
+        const keys = (limit ? keyRows.slice(0, limit) : keyRows).map(r => r.k);
+        console.log(`pulling ${keys.length} of ${population} cached rows...`);
+        for (let i = 0; i < keys.length; i += CHUNK) {
+            const res = await prisma.$queryRawUnsafe(ROW_SQL, keys.slice(i, i + CHUNK)) as { json_agg: ScreenRow[] | null }[];
+            rows = rows.concat(res?.[0]?.json_agg ?? []);
+            process.stderr.write(`  rows ${rows.length}/${keys.length}\n`);
+        }
+    } finally { await prisma.$disconnect(); }
+
+    console.log(`resolving the REAL serving anchor for ${rows.length} rows `
+        + '(production path — FDC API + AI estimator, minutes)...');
+    await resolveRealServings(rows);
+
+    const sources = tally(rows.map(r => r.src));
+    const servingTiers = tally(rows.map(r => (r.real?.error ? '(unresolved)' : r.real?.tier)));
+
+    const manifest = {
+        _readme:
+            'Shapes the LIVE cache actually contains. __tests__/prod-shape-coverage.test.ts fails '
+            + 'when the committed test fixtures stop covering one of them. This file is the only '
+            + 'thing that knows about a shape the fixture is missing — batch 01 had zero fdc rows, '
+            + 'which is why a missing FdcFood join in ROW_SQL survived 73 green tests and '
+            + 'false-evicted 78 of 78 fdc rows. Regenerate with scripts/eval/refresh-prod-shapes.ts '
+            + '(needs a live DB; never run in CI).',
+        measuredAt: new Date().toISOString().slice(0, 10),
+        refreshWith: 'npx ts-node --project tsconfig.scripts.json --transpile-only '
+            + '-r tsconfig-paths/register scripts/eval/refresh-prod-shapes.ts',
+        population: { table: 'FoodMapping', rows: population, screened: rows.length },
+        shapes: {
+            // FoodMapping.source — which corpus the cached record lives in. Each one
+            // takes a DIFFERENT branch through ROW_SQL, tierD and hydrateAndSelectServing.
+            source: sources,
+            // The tier hydrateAndSelectServing resolved for a unitless `1 x`. This is
+            // what D5/D6 judge, so a tier absent from the fixture is a rule branch that
+            // has never been exercised.
+            servingTier: servingTiers,
+        },
+    };
+
+    console.log('\nsource:      ' + sources.map(s => `${s.value}=${s.count}`).join('  '));
+    console.log('servingTier: ' + servingTiers.map(s => `${s.value}=${s.count}`).join('  '));
+
+    if (dryRun) {
+        console.log(`\n${limit ? `--limit ${limit} sampled only — ` : ''}NOT written. `
+            + (limit ? 'A sampled manifest drops the rare shapes, which are exactly the ones the '
+                + 'fixture is most likely to be missing. Re-run without --limit to write.' : '(--dry-run)'));
+        return 0;
+    }
+    fs.writeFileSync(OUT, JSON.stringify(manifest, null, 2) + '\n');
+    console.log(`\nWritten to ${path.relative(process.cwd(), OUT)}. `
+        + 'Commit it, then run `npx jest scripts/eval/__tests__/prod-shape-coverage.test.ts` — '
+        + 'a FAILURE means production grew a shape no fixture covers, and the fix is to add an '
+        + 'exemplar row to fixtures/screen-shape-exemplars.json, not to edit the manifest.');
+    return 0;
+}
+
+if (require.main === module) {
+    main().then(c => process.exit(c)).catch(e => { console.error(e); process.exit(2); });
+}

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -19,7 +19,14 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { textOf, matchesAlt, isAbstention, describeDrift, type BaselineEntry } from './assertions';
+import {
+    isAbstention,
+    driftedKnownIssues,
+    evalExitCode,
+    scoreNlpCase,
+    scoreSearchCase,
+    type BaselineEntry,
+} from './assertions';
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
@@ -56,6 +63,8 @@ interface Observed {
     confidence?: number | null;
     itemCount?: number;
     abstained?: boolean;
+    /** No reading at all — transport error, non-array body, zero items. */
+    errored?: boolean;
 }
 
 interface CaseResult {
@@ -73,17 +82,6 @@ interface CaseResult {
 }
 
 const results: CaseResult[] = [];
-
-const MACRO_KEYS = ['kcal100', 'protein100', 'carbs100', 'fat100'];
-function hasNum(v: unknown): boolean {
-    return typeof v === 'number' && Number.isFinite(v);
-}
-/** A search hit with NO finite macro at all — the null-nutrition rows the OFF filter should drop. */
-function nutritionMissing(h: any): boolean {
-    return !MACRO_KEYS.some(k => hasNum(h?.[k]));
-}
-
-
 
 function percentile(sorted: number[], p: number): number {
     if (sorted.length === 0) return 0;
@@ -116,6 +114,7 @@ function writeKnownIssueBaseline(rs: CaseResult[]): void {
             grams: r.observed.grams ?? null,
             kcal100: r.observed.kcal100 ?? null,
             abstained: r.observed.abstained ?? false,
+            errored: r.observed.errored ?? false,
         };
     }
     fs.writeFileSync(baselinePath, JSON.stringify({
@@ -130,23 +129,11 @@ function writeKnownIssueBaseline(rs: CaseResult[]): void {
 
 /** Every knownIssue case whose recorded values moved since the baseline was written. */
 function compareKnownIssueBaseline(rs: CaseResult[]): Array<{ id: string; what: string }> {
-    const base = loadKnownIssueBaseline();
-    const out: Array<{ id: string; what: string }> = [];
-    for (const r of rs) {
-        if (!r.knownIssue || !r.observed) continue;
-        const b = base[r.id];
-        if (!b) continue;  // new pin: nothing to compare until the baseline is refreshed
-        const changes = describeDrift(b, r.observed);
-        if (changes.length) out.push({ id: r.id, what: changes.join('; ') });
-    }
-    return out;
+    return driftedKnownIssues(rs, loadKnownIssueBaseline());
 }
 
 async function runSearchCase(c: any): Promise<CaseResult> {
     const t0 = Date.now();
-    let detail = '';
-    let pass = false;
-    let confidence: number | undefined;
     try {
         const res = await fetch(`${BASE}/api/foods/search?s=${encodeURIComponent(c.query)}&local=true`, {
             headers: { 'x-api-key': API_KEY },
@@ -154,18 +141,8 @@ async function runSearchCase(c: any): Promise<CaseResult> {
         const ms = Date.now() - t0;
         const body: any = await res.json();
         const hits: any[] = Array.isArray(body) ? body : (body.data ?? body.results ?? []);
-        const topN = hits.slice(0, c.rank ?? 3);
-        pass = topN.some(h => matchesAlt(textOf(h), c.match));
-        confidence = hits[0]?.confidence;
-        detail = pass
-            ? `hit: "${hits.find((h: any) => matchesAlt(textOf(h), c.match))?.name}"`
-            : `top${c.rank ?? 3}: [${topN.map(h => `"${h.name}"`).join(', ') || 'EMPTY'}]`;
-        // Invariant (unless opted out): no returned hit may lack all nutrition — verifies
-        // the OFF null-nutrition filter keeps junk rows out of manual search results.
-        if (c.requireNutrition !== false && topN.length) {
-            const bad = topN.find(nutritionMissing);
-            if (bad) { pass = false; detail = `NULL-NUTRITION "${bad.name}" | ${detail}`; }
-        }
+        const { pass, detail } = scoreSearchCase(c, hits);
+        const confidence = hits[0]?.confidence;
         return {
             id: c.id, kind: 'search', category: c.category, query: c.query, pass, ms, detail, confidence,
             knownIssue: c.knownIssue,
@@ -178,7 +155,15 @@ async function runSearchCase(c: any): Promise<CaseResult> {
             },
         };
     } catch (err) {
-        return { id: c.id, kind: 'search', category: c.category, query: c.query, pass: false, ms: Date.now() - t0, detail: `ERROR: ${(err as Error).message}`, knownIssue: c.knownIssue };
+        // `observed` is recorded even here. Without it a knownIssue case that starts
+        // throwing is invisible twice over: the failure is exempted by the pin AND the
+        // drift check has nothing to diff, so a pinned case that stopped answering
+        // altogether left no trace in any output.
+        return {
+            id: c.id, kind: 'search', category: c.category, query: c.query, pass: false,
+            ms: Date.now() - t0, detail: `ERROR: ${(err as Error).message}`, knownIssue: c.knownIssue,
+            observed: { itemCount: 0, errored: true },
+        };
     }
 }
 
@@ -203,94 +188,11 @@ async function runNlpCase(c: any): Promise<CaseResult> {
                 id: c.id, kind: 'nlp', category: c.category, query, pass: false, ms,
                 detail: `TRANSPORT: no items returned (HTTP ${res.status})`,
                 knownIssue: c.knownIssue,
-                observed: { itemCount: 0 },
+                observed: { itemCount: 0, errored: true },
             };
         }
 
-        const failures: string[] = [];
-
-        if (c.expectItems && items.length < c.expectItems) {
-            failures.push(`expected >=${c.expectItems} items, got ${items.length}`);
-        }
-
-        // Name check: for single-item cases the one item must match; for
-        // segmentation cases at least one item must match.
-        //
-        // An abstention can NEVER satisfy a positive name assertion — it echoes the
-        // query text back as foodName, so it would otherwise match trivially. See
-        // isAbstention().
-        if (c.expectName) {
-            const anyNameMatch = items.some(it => !isAbstention(it) && matchesAlt(textOf(it), c.expectName));
-            if (!anyNameMatch) {
-                const shown = items.map(it => isAbstention(it) ? 'NO PICK (abstained)' : `"${it.foodName}"`);
-                failures.push(`name mismatch: [${shown.join(', ')}]`);
-            }
-        }
-
-        // Negative name assertion — no returned item may match. This pins a
-        // wrong-record class without needing to know the right answer, which is what
-        // the composite->component drift cases need: "qdoba chicken burrito must not
-        // resolve to Tequila Lime Chicken" is assertable even while the correct
-        // billing figure is still being argued about.
-        if (c.forbidName) {
-            const offender = items.find(it => !isAbstention(it) && matchesAlt(textOf(it), c.forbidName));
-            if (offender) {
-                failures.push(`forbidden name matched: "${offender.foodName}" [${offender.brandName ?? ''}]`);
-            }
-        }
-
-        // The mapper is REQUIRED to produce no confident pick. For a query whose
-        // honest answer is "not in the corpus", billing a component at 0.95 is worse
-        // than abstaining, and only this can express that.
-        if (c.expectAbstain) {
-            const confident = items.find(it => !isAbstention(it));
-            if (confident) {
-                failures.push(`expected abstention, got "${confident.foodName}" conf=${confident.matchConfidence} grams=${confident.grams}`);
-            }
-        }
-
-        // Weak form: it may guess, but must not look authoritative enough to cache.
-        if (typeof c.maxConfidence === 'number') {
-            const conf = items[0]?.matchConfidence;
-            if (typeof conf !== 'number' || conf > c.maxConfidence) {
-                failures.push(`confidence=${conf} exceeds maxConfidence ${c.maxConfidence} (mapped: "${items[0]?.foodName}")`);
-            }
-        }
-
-        if (c.macros) {
-            const per100 = items[0]?.nutritionPer100g ?? {};
-            for (const [key, range] of Object.entries(c.macros) as [string, [number, number]][]) {
-                const v = per100[key];
-                if (typeof v !== 'number' || v < range[0] || v > range[1]) {
-                    failures.push(`${key}=${typeof v === 'number' ? v.toFixed(1) : v} outside [${range[0]}, ${range[1]}] (mapped: "${items[0]?.foodName}")`);
-                }
-            }
-        }
-
-        // Resolved serving weight: asserts the total grams for the requested unit/quantity.
-        // This is what catches serving-estimation defects (e.g. "1 slice bread" → 100g).
-        if (c.grams) {
-            const g = items[0]?.grams;
-            if (typeof g !== 'number' || g < c.grams[0] || g > c.grams[1]) {
-                failures.push(`grams=${typeof g === 'number' ? g : String(g)} outside [${c.grams[0]}, ${c.grams[1]}] (unit "${c.item?.unit ?? ''}", mapped "${items[0]?.foodName}")`);
-            }
-        }
-
-        // Billed totals for the requested quantity — the grams-scaled `nutrition`
-        // block the app actually logs. This is the end-to-end assertion a per-100g
-        // band can't provide: a wrong record, wrong serving, or wrong scaling all
-        // surface as a wrong billed total ("1 tbsp olive oil" must bill ~119 kcal,
-        // whether the failure was density, record choice, or grams math).
-        // Keys: calories | protein | carbs | fat (also fiber/sugar/sodium).
-        if (c.total) {
-            const tot = items[0]?.nutrition ?? {};
-            for (const [key, range] of Object.entries(c.total) as [string, [number, number]][]) {
-                const v = tot[key];
-                if (typeof v !== 'number' || v < range[0] || v > range[1]) {
-                    failures.push(`total.${key}=${typeof v === 'number' ? v.toFixed(1) : v} outside [${range[0]}, ${range[1]}] (grams=${items[0]?.grams}, mapped: "${items[0]?.foodName}")`);
-                }
-            }
-        }
+        const failures = scoreNlpCase(c, items);
 
         const confidence = items[0]?.matchConfidence;
         return {
@@ -311,7 +213,13 @@ async function runNlpCase(c: any): Promise<CaseResult> {
             },
         };
     } catch (err) {
-        return { id: c.id, kind: 'nlp', category: c.category, query, pass: false, ms: Date.now() - t0, detail: `ERROR: ${(err as Error).message}`, knownIssue: c.knownIssue };
+        // See runSearchCase: `observed` is recorded on the error path too, so a pinned
+        // case that stops answering drifts instead of disappearing entirely.
+        return {
+            id: c.id, kind: 'nlp', category: c.category, query, pass: false,
+            ms: Date.now() - t0, detail: `ERROR: ${(err as Error).message}`, knownIssue: c.knownIssue,
+            observed: { itemCount: 0, errored: true },
+        };
     }
 }
 
@@ -412,10 +320,15 @@ async function main() {
     const outPath = path.join(outDir, `eval-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
     fs.writeFileSync(outPath, JSON.stringify({ summary, results }, null, 2));
     console.log(`\nResults written to ${path.relative(process.cwd(), outPath)}`);
-    console.log(`\n${realFails.length ? '❌' : '✅'} ${realFails.length} real failures, 🟡 ${knownFails.length} known issues (expected).`);
+    if (results.length === 0) {
+        console.error('\n❗ ZERO cases ran. Check --only / --grep and the golden-set file. '
+            + 'A run that executed nothing is not a green run — exiting 2.');
+    } else {
+        console.log(`\n${realFails.length ? '❌' : '✅'} ${realFails.length} real failures, 🟡 ${knownFails.length} known issues (expected).`);
+    }
 
-    // Only genuine (non-known-issue) failures fail the suite.
-    process.exit(realFails.length > 0 ? 1 : 0);
+    // Only genuine (non-known-issue) failures fail the suite — but zero cases is a 2.
+    process.exit(evalExitCode(results));
 }
 
 main().catch(err => { console.error(err); process.exit(2); });

--- a/scripts/eval/winner-diff-screens.ts
+++ b/scripts/eval/winner-diff-screens.ts
@@ -783,6 +783,16 @@ export function noiseGate(
                 `no noise-floor receipt for side ${side} (snapshot ${f.snapshotTakenAt}, ` +
                 `tree ${f.gitDirty}, variant ${f.variant}). Run: winner-diff noise-floor ` +
                 `--snapshot <snap.json> --variant ${f.variant}   FROM THAT TREE.`);
+        } else if (r.rows === 0) {
+            // A receipt over ZERO rows says nothing replayed, not that everything
+            // replayed identically — `winnerDiffs !== 0 || pathDiffs !== 0` is
+            // trivially false when no row was ever compared. An empty snapshot
+            // (`--from-events` matching no MappingEventLog rows) therefore wrote a
+            // PASSING receipt and licensed a diff run with no floor under it.
+            problems.push(
+                `side ${side} noise-floor receipt covers ZERO rows (snapshot ${f.snapshotTakenAt}, ` +
+                `variant ${f.variant}). Nothing was replayed, so "0 differences" is an absence of ` +
+                'measurement, not determinism. Re-take the floor against a non-empty snapshot.');
         } else if (r.winnerDiffs !== 0 || r.pathDiffs !== 0) {
             problems.push(
                 `side ${side} noise floor is NON-ZERO (${r.winnerDiffs} winner / ${r.pathDiffs} path ` +


### PR DESCRIPTION
Three measurement instruments under `scripts/eval/` shipped confidently wrong numbers while their own suites were 100% green. The recurring shape is not "the logic is wrong" — it is that an **absence of signal was encoded as the passing verdict**. This makes each class fail a test.

`scripts/eval/**` only. No `src/**` changes.

## A — reconstruction drift is now pinned
`scripts/eval/__tests__/serving-divergence.test.ts`

`resolveServingGrams(row)` REIMPLEMENTS the billing anchor; `realServing(row)` reads the one `hydrateAndSelectServing` actually produced. The screen carried the caveat *"a row D5 calls 'no serving weight' MAY IN FACT BILL CORRECTLY — this was not measured"* from the day it shipped: a reimplementation is not a measurement until something compares it to the original, and nothing did.

- Agreement pinned with a **95% floor** (measured 78/81 = 96.3%), computed offline from the fixture's baked-in `row.real` — no DB, no FDC API, no model call.
- A **counter-assertion** pins the 3 rows that genuinely disagree, so the floor cannot be satisfied by silently aliasing the reconstruction to the real anchor, and asserts all 3 flip the D5/D6 verdict.
- The invariant that made the change safe: **a row whose real anchor did not run (`judged === false`) can never produce an EVICT-severity D5/D6 hit** — 5 unjudged shapes × 3 policies, plus the whole batch stripped of `row.real` under `--policy strict`, plus a positive control that D5/D6 *do* still evict when the anchor ran.

## B — fail injection: absence is never a pass
`scripts/eval/__tests__/fail-closed.test.ts` (29 tests, every block carries a positive control)

- **`callLlm`** — network exception, persistent HTTP 500, a reply truncated mid-JSON, and an unrecognised verdict string all resolve to `UNSURE` + `error`, never `ACCEPT`. The existing `Tier-L failure is fail-SAFE` test hand-builds the failed verdict and only exercises `decide()`, so `callLlm`'s own mapping was untested: flipping its catch branch back to `ACCEPT` kept the entire suite green.
- **A total Tier-L outage** → every row `REVIEW`. Never `KEEP` (unscreened row reading as clean) and never `EVICT` (a blip must not throw the cache away).
- **`resolveRealServings`** — `hydrateAndSelectServing` throwing, returning `null`, or a row with no addressable record id all leave the row UNJUDGED; D5/D6 downgrade to INFO and can never EVICT under any policy. Positive control: a resolved 1.0 g anchor *is* judged and *does* EVICT on D6.
- **The golden-set harness** — a total abstention FAILS a name-only case (the real shipped bug: the no-pick branch echoes the query text back as `foodName`, so substring containment matched trivially). An empty or non-array response fails even a case that asserts nothing. `isAbstention()` was already unit-tested; the code that *composes* it into a verdict was not, which is where the guard actually has to live.
- **`knownIssue` suppression** — a pinned case whose `kcal100` moved 361 → 0, one that started abstaining, and one that stopped answering entirely all still REPORT.

## C — fixture shape coverage
`scripts/eval/__tests__/prod-shape-coverage.test.ts` + `fixtures/prod-shapes.json` + `scripts/eval/refresh-prod-shapes.ts`

`ROW_SQL`'s missing `FdcFood` join survived 73 green tests and false-evicted 78 of 78 fdc rows, because **batch 01 contains zero fdc rows**. A fixture cannot be trusted to notice what it does not contain.

- `fixtures/prod-shapes.json` records what the live cache actually holds: 3 sources (openfoodfacts 2728 / fatsecret 442 / fdc 78, re-read live) and 6 serving tiers over 3,248 rows.
- The test **fails, naming `refresh-prod-shapes.ts`**, when the committed corpus stops covering a shape. It reads no DB — CI has no prod database — and one test proves it can fail by running the same check against a shape that deliberately does not exist.
- Batch 01 is a frozen human audit with a pinned confusion matrix, so rows cannot be added to it. The missing shapes live in `fixtures/screen-shape-exemplars.json`: three **real** fdc rows pulled via `ROW_SQL` with `row.real` from the real serving pass. They are screened, not merely present — asserted not to trip D8, and asserted to resolve on an AI-estimated tier so D5/D6 may never gate on the whole fdc population.
- `refresh-prod-shapes.ts` refuses to write a sampled manifest (`--limit` implies `--dry-run`): a sample drops the rare shapes, which are exactly the ones the fixture is most likely to be missing.

## Instrument fixes the tests would otherwise have had to encode as correct
| where | was | now |
|---|---|---|
| `callLlm` | unrecognised verdict → `ACCEPT` by fallthrough, so `{"verdict":"reject"}` KEPT the row the model had just rejected | unknown → `UNSURE` + `unparseable-verdict`; case-different tokens honoured |
| `correctness-screen` | screening **zero rows** exited 0 — byte-identical to a clean batch | `screenExitCode()` → 2 |
| `run-eval` | `--grep` matching nothing printed "✅ 0 real failures" and exited 0 | `evalExitCode()` → 2 |
| `noiseGate` | a receipt over **0 rows** passed, since `winnerDiffs !== 0 \|\| pathDiffs !== 0` is trivially false when nothing was compared | rejected; licenses no diff run |
| `run-eval` | a `knownIssue` case that started throwing was invisible twice (exempted by the pin, and no `observed` to diff) | `observed: { errored: true }` on the error paths → it drifts |

`scoreNlpCase` / `scoreSearchCase` / `driftedKnownIssues` / `evalExitCode` were extracted from `run-eval.ts` into `assertions.ts` unchanged, because `run-eval.ts` calls `main()` at module scope and importing it starts a real eval run — the reason the abstention hole went unnoticed for as long as it did.

## Verification
- `npx jest scripts/eval` — 11 suites, 677 tests, green
- `npm run test:ci` — 108 suites, 2266 tests, green
- `npm run lint:ci` — 0 errors, 447 warnings (ceiling 700)
- `run-eval.ts` smoke-run against the live API: `--grep n-cook` reproduces the pinned known issue with no drift; `--grep zzz` now exits 2
- `refresh-prod-shapes.ts --limit 12` smoke-run against the live DB
- The coverage test was verified to FAIL (with the actionable message) when the fdc exemplars are removed
- `correctness-screen-batch01.json` is byte-untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx