### PR TITLE
feat(eval): read-only detector for the panel-divided-by-serving-scale OFF corruption class

### DIFF
--- a/scripts/eval/__tests__/panel-scale-divided.test.ts
+++ b/scripts/eval/__tests__/panel-scale-divided.test.ts
@@ -1,0 +1,527 @@
+/**
+ * panel-scale-divided.test.ts — offline tests for detect-panel-scale-divided.ts.
+ *
+ * NO DATABASE, NO NETWORK. Every fixture family is built in code and fed to
+ * `runScan` through an in-memory RowStream, so what is under test is the
+ * detector's own logic rather than a snapshot of the corpus.
+ *
+ * The last block is a FAIL INJECTION in the style of fail-closed.test.ts
+ * (PR #177): a total query failure must exit non-zero and must NOT render as a
+ * clean "0 rows" summary. The anti-pattern it exists to prevent is
+ * cache-parity-sweep.ts printing "0 changed records" on total HTTP failure.
+ */
+
+import {
+    familyKey,
+    familyFlagged,
+    familyStats,
+    formatSummary,
+    guardRepair,
+    newFamily,
+    addMember,
+    repairPanel,
+    runScan,
+    scanExitCode,
+    stripSizeTokens,
+    MAX_REPAIRED_KCAL_100G,
+    MIN_FLAGGED_SERVING_G,
+    type Panel,
+    type PanelRow,
+    type RowStream,
+    type ScanReport,
+} from '../detect-panel-scale-divided';
+import { MAX_MACRO_SUM_100G } from '../../../src/lib/mapping/corrupt-mark';
+
+// ===========================================================================
+// Fixture helpers
+// ===========================================================================
+
+/** A row whose stored panel is the TRUE density divided by S/100 — i.e. one
+ *  actual instance of the defect, generated from the mechanism rather than
+ *  hand-typed, so the fixture cannot drift away from the hypothesis. */
+function corruptRow(over: {
+    barcode: string;
+    name: string;
+    brandName: string;
+    servingGrams: number;
+    trueDensity: Panel;
+}): PanelRow {
+    const f = 100 / over.servingGrams;
+    const d = over.trueDensity;
+    return {
+        barcode: over.barcode,
+        name: over.name,
+        brandName: over.brandName,
+        servingGrams: over.servingGrams,
+        nutrientsPer100g: {
+            calories: d.calories * f,
+            protein: (d.protein ?? 0) * f,
+            carbs: (d.carbs ?? 0) * f,
+            fat: (d.fat ?? 0) * f,
+            fiber: (d.fiber ?? 0) * f,
+            sugars: (d.sugars ?? 0) * f,
+            sodium: (d.sodium ?? 0) * f,
+        },
+    };
+}
+
+function healthyRow(over: {
+    barcode: string;
+    name: string;
+    brandName: string;
+    servingGrams: number;
+    panel: Panel;
+}): PanelRow {
+    return {
+        barcode: over.barcode, name: over.name, brandName: over.brandName,
+        servingGrams: over.servingGrams, nutrientsPer100g: { ...over.panel },
+    };
+}
+
+/** A stream over fixed rows. Re-iterable, because runScan makes TWO passes. */
+function streamOf(rows: PanelRow[]): RowStream {
+    return async function* () { yield rows; };
+}
+
+const SYNTH = (n: number) => `9${'0'.repeat(13)}${n}`;   // length 15 -> synthetic
+const EAN = (n: number) => `50${String(n).padStart(11, '0')}`; // length 13 -> real EAN
+
+const JM_NAME = "Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White";
+const JM_BRAND = "Jersey Mike's Subs";
+
+/**
+ * The two rows of the live proof, panels copied VERBATIM out of the corpus
+ * (2026-07-26) rather than synthesized — so this fixture is evidence, not a
+ * restatement of the hypothesis. Same product, two sizes, one true density.
+ */
+function jerseyMikesFamily(barcode: (n: number) => string): PanelRow[] {
+    return [
+        healthyRow({
+            barcode: barcode(1), name: `${JM_NAME} Regular`, brandName: JM_BRAND, servingGrams: 541,
+            panel: { calories: 32, protein: 1.66, carbs: 2.59, fat: 1.66, fiber: 0, sugars: 0.37, sodium: 0.124 },
+        }),
+        healthyRow({
+            barcode: barcode(2), name: `${JM_NAME} Giant`, brandName: JM_BRAND, servingGrams: 1060,
+            panel: { calories: 16.3, protein: 0.849, carbs: 1.32, fat: 0.849, fiber: 0, sugars: 0.189, sodium: 0.065 },
+        }),
+    ];
+}
+
+async function scan(rows: PanelRow[], opts: Parameters<typeof runScan>[1] = {}): Promise<ScanReport> {
+    return runScan(streamOf(rows), opts);
+}
+
+// ===========================================================================
+// 1. Family key — size tokens must collapse, identity tokens must not
+// ===========================================================================
+
+describe('family key: size words collapse, the product does not', () => {
+    it('Regular / Giant / 32 Oz variants of one sub land in ONE key', () => {
+        const keys = new Set([
+            "Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White Regular",
+            "Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White Giant",
+            "Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White, 32 Oz",
+            "Jersey Mike's Subs - #44 Buffalo Chicken Cheese Steak on White (Mini)",
+        ].map(n => familyKey(n, "Jersey Mike's Subs")));
+        expect(keys.size).toBe(1);
+        expect([...keys][0]).toBe("Jersey Mike's Subs|jersey mike s subs buffalo chicken cheese steak on white");
+    });
+
+    it('every listed size token is stripped, including bare integers', () => {
+        for (const t of ['mini', 'small', 'sm', 'regular', 'reg', 'medium', 'med', 'large', 'lg',
+            'giant', 'kid', 'kids', 'cub', 'junior', 'jr', 'whatameal', 'whatabox', 'combo',
+            'value', 'snack', 'single', 'double', 'triple', 'oz', 'fl', 'in', 'inch',
+            'footlong', 'half', 'full', 'meal', 'box', '12', '440']) {
+            expect(stripSizeTokens(`Burrito ${t}`)).toBe('burrito');
+        }
+    });
+
+    it('POSITIVE CONTROL — two genuinely different products do NOT collapse', () => {
+        // Without this the block above is satisfiable by a key that strips
+        // everything, which would merge the whole brand into one family.
+        expect(familyKey('Taco Bell, Crunchwrap Supreme', 'Taco Bell'))
+            .not.toBe(familyKey('Taco Bell, Cheesy Gordita Crunch', 'Taco Bell'));
+        expect(familyKey('Chips, Large', 'Chipotle')).not.toBe(familyKey('Queso, Large', 'Chipotle'));
+    });
+
+    it('the same product name under DIFFERENT brands stays separate', () => {
+        expect(familyKey('Iced Coffee, Large', 'Wawa')).not.toBe(familyKey('Iced Coffee, Large', 'Dunkin'));
+    });
+
+    it('a name that normalizes to nothing yields NO key (the pseudo-family guard)', () => {
+        // Live artifact: `Нз|` merged "Паста" (459 kcal/100g, S=50) with
+        // "Пържола" (107 kcal/100g, S=186) — unrelated foods that happen to fit
+        // a -1.11 slope at r2 1.00. A family key must name a product.
+        expect(familyKey('Пържола', 'Нз')).toBeNull();
+        expect(familyKey('Паста', 'Нз')).toBeNull();
+        expect(familyKey('Large', 'Wawa')).toBeNull();      // all-size-token name
+        expect(familyKey('Sub', null)).toBeNull();
+        expect(familyKey('Sub', '  ')).toBeNull();
+    });
+
+    it('...and those rows are COUNTED, not silently dropped', async () => {
+        const rows = [
+            healthyRow({ barcode: SYNTH(1), name: 'Паста', brandName: 'Нз', servingGrams: 50, panel: { calories: 459 } }),
+            healthyRow({ barcode: SYNTH(2), name: 'Пържола', brandName: 'Нз', servingGrams: 186, panel: { calories: 107 } }),
+            healthyRow({ barcode: SYNTH(3), name: 'Пържола', brandName: 'Нз', servingGrams: 186, panel: { calories: 107 } }),
+        ];
+        const r = await scan(rows, { arm: 'all' });
+        expect(r.baseFilterPassed).toBe(3);
+        expect(r.skippedEmptyNameKey).toBe(3);
+        expect(r.flaggedRowsAllArms).toBe(0);
+        // The exclusion is visible in the human summary, not just the JSON.
+        expect(formatSummary(r).join('\n')).toContain('empty family key');
+    });
+});
+
+// ===========================================================================
+// 2. The Jersey Mike's shape flags and repairs to a size-invariant density
+// ===========================================================================
+
+describe('a 2-size divided family is flagged and repairs to one density', () => {
+    it('slope is -1 at r2 1 and both sizes recover the SAME density', async () => {
+        const r = await scan(jerseyMikesFamily(SYNTH));
+
+        expect(r.flaggedFamilies).toBe(1);
+        expect(r.flaggedRows).toBe(2);
+        expect(r.repairs).toHaveLength(2);
+        expect(r.refusalCount).toBe(0);
+
+        for (const rep of r.repairs) {
+            // -1.0029 on the real rounded panels, not exactly -1: this is why
+            // the flag band is [-1.15, -0.85] and not an equality test.
+            expect(rep.familySlope).toBeCloseTo(-1, 2);
+            expect(rep.familyR2).toBeCloseTo(1, 6);
+            expect(rep.familySize).toBe(2);
+            expect(rep.familyDistinctServings).toBe(2);
+        }
+
+        // THE POINT: a per-100g density cannot depend on serving mass. Before
+        // repair the two sizes disagree ~2x; after repair they agree to 0.2%.
+        const byServing = [...r.repairs].sort((a, b) => a.servingGrams - b.servingGrams);
+        const stored = byServing.map(x => x.current.calories);
+        expect(stored[0] / stored[1]).toBeGreaterThan(1.9);
+
+        const recovered = byServing.map(x => x.repaired.calories);
+        expect(recovered[0]).toBeCloseTo(173.1, 1);
+        expect(recovered[1]).toBeCloseTo(172.8, 1);
+        expect(Math.abs(recovered[0] - recovered[1]) / recovered[0]).toBeLessThan(0.003);
+
+        // Every macro recovers to an equally size-invariant value. The 3%
+        // tolerance is the STORED rounding, not the method: the Giant's sodium
+        // is filed as 0.065 g/100g (two significant figures), and multiplying a
+        // 2-s.f. number by 10.6 carries that rounding straight through.
+        for (const k of ['protein', 'carbs', 'fat', 'sugars', 'sodium'] as const) {
+            const a = byServing[0].repaired[k]!;
+            const b = byServing[1].repaired[k]!;
+            expect(Math.abs(a - b) / a).toBeLessThan(0.03);
+        }
+
+        // ...and the two sizes stop billing the identical number they bill today.
+        expect(Math.round(byServing[0].currentServingKcal)).toBe(173);
+        expect(Math.round(byServing[1].currentServingKcal)).toBe(173);
+        expect(Math.round(byServing[0].repairedServingKcal)).toBe(937);
+        expect(Math.round(byServing[1].repairedServingKcal)).toBe(1831);
+        expect(byServing[0].understatementFactor).toBeCloseTo(5.4, 1);
+        expect(byServing[1].understatementFactor).toBeCloseTo(10.6, 1);
+    });
+
+    it('EVERY numeric field is repaired, not just calories', () => {
+        // The refuted kJ-slip hypothesis predicts calories-only. The macros
+        // moved too, which is why the corrupt rows are Atwater-PERFECT.
+        const stored: Panel = { calories: 32, protein: 1.66, carbs: 2.59, fat: 1.66, fiber: 0, sugars: 0.37, sodium: 0.124 };
+        const rep = repairPanel(stored, 541);
+        for (const k of ['calories', 'protein', 'carbs', 'fat', 'sugars', 'sodium'] as const) {
+            expect(rep[k]!).toBeCloseTo((stored[k] as number) * 5.41, 6);
+        }
+        // A MISSING field stays missing — never invented as a measured zero.
+        expect(repairPanel({ calories: 32, protein: null }, 541).protein).toBeNull();
+        expect(repairPanel({ calories: 32 }, 541).fiber).toBeNull();
+    });
+
+    it('the corrupt panel is Atwater-CONSISTENT, so Atwater cannot detect it', () => {
+        // Guards the refuted hypothesis: if someone reintroduces an Atwater
+        // cross-check as the detector, this documents why it sees nothing.
+        const row = jerseyMikesFamily(SYNTH)[0].nutrientsPer100g as Record<string, number>;
+        const atwater = 4 * row.protein + 4 * row.carbs + 9 * row.fat;
+        expect(Math.abs(atwater - row.calories) / row.calories).toBeLessThan(0.01);
+    });
+
+    it('a family whose sizes are too CLOSE together does not qualify', () => {
+        const acc = newFamily();
+        addMember(acc, 200, 100);
+        addMember(acc, 240, 83.33);   // spread 1.2 < 1.3
+        expect(familyStats(acc).sizeSpread).toBeCloseTo(1.2, 6);
+        expect(familyFlagged(familyStats(acc))).toBe(false);
+    });
+
+    it('a NOISY family (real recipe drift between sizes) fails the r2 gate', async () => {
+        const rows = [
+            healthyRow({ barcode: SYNTH(11), name: 'Combo Platter Regular', brandName: 'Diner', servingGrams: 300, panel: { calories: 200, protein: 10, carbs: 20, fat: 8 } }),
+            healthyRow({ barcode: SYNTH(12), name: 'Combo Platter Large', brandName: 'Diner', servingGrams: 500, panel: { calories: 260, protein: 12, carbs: 26, fat: 10 } }),
+            healthyRow({ barcode: SYNTH(13), name: 'Combo Platter Giant', brandName: 'Diner', servingGrams: 800, panel: { calories: 190, protein: 9, carbs: 19, fat: 7 } }),
+        ];
+        expect((await scan(rows)).flaggedRows).toBe(0);
+    });
+
+    it('members BELOW the serving guard are not flagged even in a flagged family', async () => {
+        const rows = [
+            ...jerseyMikesFamily(SYNTH),
+            corruptRow({ barcode: SYNTH(3), name: `${JM_NAME} Mini`, brandName: JM_BRAND, servingGrams: 120, trueDensity: { calories: 173.1, protein: 8.98, carbs: 14.01, fat: 8.98 } }),
+        ];
+        const r = await scan(rows);
+        expect(r.flaggedRows).toBe(2);
+        expect(r.repairs.every(x => x.servingGrams >= MIN_FLAGGED_SERVING_G)).toBe(true);
+        expect(r.repairs.map(x => x.barcode)).not.toContain(SYNTH(3));
+    });
+});
+
+// ===========================================================================
+// 3. Arms — the portion-standardized retail family is not a repair candidate
+// ===========================================================================
+
+describe('arms: a real-EAN retail family stays OUT of the synthetic arm', () => {
+    // Wegmans/M&S/Great Value shape: per-100g panels standardized by retail
+    // policy across pack sizes produce the same -1 slope HONESTLY. Every
+    // hand-checked false positive lived here (measured 10.0% FP, 3 of 30, on
+    // the unrestricted set), which is why the default arm excludes it.
+    const retail = [
+        corruptRow({ barcode: EAN(1), name: 'Muenster Cheese Slices, Small', brandName: 'Wegmans', servingGrams: 200, trueDensity: { calories: 100, protein: 7, carbs: 1, fat: 8 } }),
+        corruptRow({ barcode: EAN(2), name: 'Muenster Cheese Slices, Large', brandName: 'Wegmans', servingGrams: 400, trueDensity: { calories: 100, protein: 7, carbs: 1, fat: 8 } }),
+    ];
+
+    it('it is invisible in the default (synthetic) arm', async () => {
+        const r = await scan(retail);
+        expect(r.arm).toBe('synthetic');
+        expect(r.flaggedRows).toBe(0);
+        expect(r.repairs).toHaveLength(0);
+        // ...but the detector still ADMITS it flagged, so a 0 here is a
+        // deliberate arm exclusion and not a claim the corpus is clean.
+        expect(r.flaggedRowsAllArms).toBe(2);
+    });
+
+    it('--arm real-ean shows it, --arm all shows both, and the arms partition', async () => {
+        const rows = [...retail, ...jerseyMikesFamily(SYNTH)];
+        const synth = await scan(rows, { arm: 'synthetic' });
+        const ean = await scan(rows, { arm: 'real-ean' });
+        const all = await scan(rows, { arm: 'all' });
+
+        expect(synth.flaggedRows).toBe(2);
+        expect(synth.byBrand.map(b => b.brandName)).toEqual(["Jersey Mike's Subs"]);
+        expect(ean.flaggedRows).toBe(2);
+        expect(ean.byBrand.map(b => b.brandName)).toEqual(['Wegmans']);
+        expect(all.flaggedRows).toBe(4);
+        expect(synth.flaggedRows + ean.flaggedRows).toBe(all.flaggedRows);
+        // flaggedRowsAllArms is arm-independent — the denominator never moves.
+        for (const r of [synth, ean, all]) expect(r.flaggedRowsAllArms).toBe(4);
+    });
+});
+
+// ===========================================================================
+// 4. Single-size brands are STRUCTURALLY unexaminable, and the reason matters
+// ===========================================================================
+
+describe('White Claw shape: a single-size brand is never flagged, and the reason is "no family"', () => {
+    const whiteClaw: PanelRow[] = ['Black Cherry', 'Mango', 'Lime', 'Raspberry', 'Watermelon']
+        .map((flavour, i) => healthyRow({
+            barcode: SYNTH(20 + i),
+            name: `White Claw Hard Seltzer ${flavour}, 12 Fl Oz`,
+            brandName: 'White Claw',
+            servingGrams: 355,
+            panel: { calories: 2.8, protein: 0, carbs: 0.56, fat: 0 },
+        }));
+
+    it('zero rows flagged', async () => {
+        const r = await scan(whiteClaw, { arm: 'all' });
+        expect(r.flaggedRows).toBe(0);
+        expect(r.flaggedRowsAllArms).toBe(0);
+        expect(r.repairs).toHaveLength(0);
+    });
+
+    it('the REASON is that no multi-size family forms — its kcal is never examined', async () => {
+        // This is the load-bearing assertion. "0 flagged" for White Claw must
+        // not be read as "White Claw is clean": five distinct flavours are five
+        // one-member families at one serving size, so no family qualifies and
+        // no density comparison ever happens. Reading it as an all-clear is the
+        // fixture-blindness failure this project keeps rediscovering.
+        const r = await scan(whiteClaw, { arm: 'all' });
+        expect(r.baseFilterPassed).toBe(5);
+        expect(r.families).toBe(5);
+        expect(r.qualifyingFamilies).toBe(0);
+
+        // And it is the FAMILY test that excludes it, not any kcal threshold:
+        // at 0.028 kcal/g White Claw is far BELOW the corrupt Jersey Mike's sub
+        // (0.21 kcal/g), so any absolute energy floor hits the seltzer first.
+        for (const row of whiteClaw) {
+            const acc = newFamily();
+            addMember(acc, row.servingGrams!, (row.nutrientsPer100g as { calories: number }).calories);
+            const s = familyStats(acc);
+            expect(s.n).toBe(1);
+            expect(s.distinctServings).toBe(1);
+            expect(familyFlagged(s)).toBe(false);
+        }
+    });
+
+    it('POSITIVE CONTROL — give the same brand a SECOND size and it becomes examinable', async () => {
+        // Without this, "White Claw never flags" is satisfiable by a detector
+        // that flags nothing at all.
+        const surge = { calories: 40, protein: 0, carbs: 8, fat: 0 };
+        const twoSize = [
+            ...whiteClaw,
+            corruptRow({ barcode: SYNTH(30), name: 'White Claw Surge Blackberry, 16 Fl Oz', brandName: 'White Claw', servingGrams: 473, trueDensity: surge }),
+            corruptRow({ barcode: SYNTH(31), name: 'White Claw Surge Blackberry, 12 Fl Oz', brandName: 'White Claw', servingGrams: 355, trueDensity: surge }),
+        ];
+        const r = await scan(twoSize, { arm: 'all' });
+        expect(r.qualifyingFamilies).toBe(1);
+        expect(r.flaggedRows).toBe(2);
+    });
+});
+
+// ===========================================================================
+// 5. The post-repair plausibility guard
+// ===========================================================================
+
+describe('plausibility guard: an impossible repair is REFUSED and COUNTED', () => {
+    it('refuses a repaired energy density above the physical ceiling', () => {
+        expect(guardRepair({ calories: MAX_REPAIRED_KCAL_100G + 1 }).join(' ')).toContain('repaired-kcal-impossible');
+        expect(guardRepair({ calories: MAX_REPAIRED_KCAL_100G })).toEqual([]);
+    });
+
+    it('refuses a repaired macro sum above the existing MAX_MACRO_SUM_100G slack', () => {
+        // 105, not 100: corrupt-mark.ts grants that slack to label rounding
+        // deliberately. Reused, not reinvented — a second copy would fork it.
+        expect(MAX_MACRO_SUM_100G).toBe(105);
+        expect(guardRepair({ calories: 400, protein: 40, carbs: 40, fat: 26 }).join(' '))
+            .toContain('repaired-macro-sum-impossible');
+        expect(guardRepair({ calories: 400, protein: 40, carbs: 40, fat: 25 })).toEqual([]);
+    });
+
+    it('the refused row is reported with its reason, never dropped into silence', async () => {
+        // The live shape: Taco Bell "Crunchwrap Supreme" pairs a 100 g row at
+        // 537 kcal/100g with a 260 g row at 204 — a -1.01 slope at r2 1.00. But
+        // the 260 g row is ALREADY a correct density, so "repairing" it would
+        // invent a 108 g/100g macro sum. The guard is what catches it.
+        const rows = [
+            healthyRow({ barcode: SYNTH(40), name: 'Taco Bell, Crunchwrap Supreme', brandName: 'Taco Bell', servingGrams: 100, panel: { calories: 537, protein: 16, carbs: 71, fat: 21 } }),
+            healthyRow({ barcode: SYNTH(41), name: 'Taco Bell, Crunchwrap Supreme', brandName: 'Taco Bell', servingGrams: 260, panel: { calories: 204, protein: 5.77, carbs: 28.1, fat: 7.69 } }),
+        ];
+        const r = await scan(rows);
+
+        expect(r.flaggedRows).toBe(1);              // only the >=150 g member
+        expect(r.repairs).toHaveLength(0);          // ...and it was refused
+        expect(r.refusalCount).toBe(1);
+        expect(r.refusals).toHaveLength(1);
+        expect(r.refusals[0].barcode).toBe(SYNTH(41));
+        expect(r.refusals[0].reasons.join(' ')).toContain('repaired-macro-sum-impossible');
+
+        // A refusal must be legible in the human summary. If the only place a
+        // dropped row appears is a JSON field nobody opens, an emptied plan
+        // reads exactly like a clean corpus.
+        const text = formatSummary(r).join('\n');
+        expect(text).toContain('REFUSED');
+        expect(text).toContain('Repairs REFUSED by the post-repair plausibility guard: 1');
+        // The per-brand summary carries the refusal too.
+        expect(r.byBrand).toEqual([{ brandName: 'Taco Bell', rows: 1, families: 1, refusals: 1 }]);
+    });
+
+    it('POSITIVE CONTROL — a plausible repair in the same run is still emitted', async () => {
+        const rows = [
+            healthyRow({ barcode: SYNTH(40), name: 'Taco Bell, Crunchwrap Supreme', brandName: 'Taco Bell', servingGrams: 100, panel: { calories: 537, protein: 16, carbs: 71, fat: 21 } }),
+            healthyRow({ barcode: SYNTH(41), name: 'Taco Bell, Crunchwrap Supreme', brandName: 'Taco Bell', servingGrams: 260, panel: { calories: 204, protein: 5.77, carbs: 28.1, fat: 7.69 } }),
+            ...jerseyMikesFamily(SYNTH),
+        ];
+        const r = await scan(rows);
+        expect(r.repairs).toHaveLength(2);
+        expect(r.refusalCount).toBe(1);
+        expect(r.flaggedRows).toBe(3);
+        // repairs + refusals accounts for EVERY flagged row: nothing vanishes.
+        expect(r.repairs.length + r.refusalCount).toBe(r.flaggedRows);
+    });
+
+    it('--limit truncates the plan but never the counts, and says so', async () => {
+        const r = await scan(jerseyMikesFamily(SYNTH), { limit: 1 });
+        expect(r.repairs).toHaveLength(1);
+        expect(r.flaggedRows).toBe(2);
+        expect(r.truncated).toBe(true);
+        expect(formatSummary(r).join('\n')).toContain('TRUNCATED');
+    });
+});
+
+// ===========================================================================
+// 6. FAIL INJECTION — a dead query is not a clean corpus
+// ===========================================================================
+
+describe('fail-closed: a total query failure exits non-zero and prints no clean summary', () => {
+    const boom: RowStream = async function* () {
+        throw new Error('P1001: Can\'t reach database server at 192.168.1.133:5432');
+        // eslint-disable-next-line no-unreachable
+        yield [];
+    };
+
+    it('runScan PROPAGATES the failure instead of returning an empty report', async () => {
+        // The anti-pattern: cache-parity-sweep.ts catches, returns nothing, and
+        // prints "0 changed records" with exit 0 on a total outage. A scan that
+        // swallowed this would report "0 rows flagged" over a dead database.
+        await expect(runScan(boom, { arm: 'all' })).rejects.toThrow(/reach database server/);
+    });
+
+    it('a failure mid-stream propagates too, not just a failure on the first read', async () => {
+        const partial: RowStream = async function* () {
+            yield jerseyMikesFamily(SYNTH);
+            throw new Error('ECONNRESET');
+        };
+        await expect(runScan(partial, { arm: 'all' })).rejects.toThrow('ECONNRESET');
+    });
+
+    it('the CLI wrapper shape: a rejection means no summary is ever composed', async () => {
+        // Mirrors main(): runScan is NOT wrapped in a try/catch of its own, so a
+        // rejection reaches the top-level handler and exits 2. Assert that the
+        // only path to formatSummary is a report that actually exists.
+        const printed: string[] = [];
+        let exitCode = 0;
+        try {
+            const report = await runScan(boom, { arm: 'all' });
+            for (const line of formatSummary(report)) printed.push(line);
+            exitCode = scanExitCode(report);
+        } catch {
+            exitCode = 2;
+        }
+        expect(exitCode).toBe(2);
+        expect(printed).toHaveLength(0);
+        expect(printed.join('\n')).not.toMatch(/Flagged|0 rows|Repairs emitted/);
+    });
+
+    it('an EMPTY result set is exit 2 as well — nothing scanned is not a clean run', async () => {
+        const empty = await scan([], { arm: 'all' });
+        expect(empty.scanned).toBe(0);
+        expect(scanExitCode(empty)).toBe(2);
+        // ...and so is a scan where every row failed the base filter: a filter
+        // typo or a wrong-database pointer produces exactly this.
+        const allFiltered = await scan([
+            healthyRow({ barcode: SYNTH(50), name: 'Sub', brandName: 'X', servingGrams: 1, panel: { calories: 200 } }),
+        ], { arm: 'all' });
+        expect(allFiltered.scanned).toBe(1);
+        expect(allFiltered.baseFilterPassed).toBe(0);
+        expect(scanExitCode(allFiltered)).toBe(2);
+    });
+
+    it('POSITIVE CONTROL — a real scan exits 0 and DOES compose a summary', async () => {
+        // Without this, "exit code is not 0" is satisfiable by a script that
+        // never succeeds, which is a tautology rather than a test.
+        const ok = await scan(jerseyMikesFamily(SYNTH));
+        expect(scanExitCode(ok)).toBe(0);
+        expect(formatSummary(ok).join('\n')).toContain('Repairs emitted: 2');
+    });
+
+    it('a run that flags NOTHING still exits 0 — absence of the defect is a real answer', async () => {
+        // The converse guard: only a broken INSTRUMENT is red. A healthy corpus
+        // must not be reported as an error, or the exit code stops meaning
+        // anything.
+        const clean = await scan([
+            healthyRow({ barcode: SYNTH(60), name: 'Oat Milk, Large', brandName: 'Cafe', servingGrams: 500, panel: { calories: 45, protein: 1, carbs: 7, fat: 1.5 } }),
+            healthyRow({ barcode: SYNTH(61), name: 'Oat Milk, Small', brandName: 'Cafe', servingGrams: 250, panel: { calories: 45, protein: 1, carbs: 7, fat: 1.5 } }),
+        ], { arm: 'all' });
+        expect(clean.flaggedRows).toBe(0);
+        expect(scanExitCode(clean)).toBe(0);
+    });
+});

--- a/scripts/eval/detect-panel-scale-divided.ts
+++ b/scripts/eval/detect-panel-scale-divided.ts
@@ -1,0 +1,688 @@
+/**
+ * detect-panel-scale-divided.ts — corpus scan for the "panel divided by
+ * serving scale" OFF corruption family (READ-ONLY; there is no --execute path
+ * in this file and it writes nothing to the database, by construction).
+ *
+ * ===========================================================================
+ * THE MECHANISM
+ * ===========================================================================
+ * The OFF chain-restaurant import stores a per-100 g panel in OpenFoodFacts'
+ * `*_serving` slot. OFF's own derivation then computes
+ *
+ *     _100g = _serving / serving_quantity * 100
+ *
+ * and so divides an already-per-100 g panel AGAIN. Net effect: EVERY numeric
+ * field of `nutrientsPer100g` — calories AND all the macros — comes out
+ * divided by `servingGrams / 100`.
+ *
+ * Repair is therefore closed-form and applies to every numeric field:
+ *
+ *     true_per_100g_field = stored_field * servingGrams / 100
+ *
+ * ===========================================================================
+ * LIVE PROOF (verified against the corpus 2026-07-26)
+ * ===========================================================================
+ *   Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White Regular
+ *     servingGrams 541,  stored 32.00 kcal/100g
+ *   Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White Giant
+ *     servingGrams 1060, stored 16.30 kcal/100g
+ *
+ *   recovered `stored * S / 100` = 173.1 and 172.8 kcal/100g.
+ *
+ * A per-100 g DENSITY cannot depend on serving mass. That the two sizes
+ * disagree ~2x on the stored density and agree to 0.2% after multiplying by
+ * their own serving mass is the whole diagnosis: the stored number is the
+ * density divided by the size, and the divisor is recoverable per row.
+ *
+ * Today both sizes bill an identical 173 kcal. The true values are ~937 and
+ * ~1,831 kcal — 5.4x and 10.6x under.
+ *
+ * ===========================================================================
+ * REFUTED HYPOTHESES — do not retry these
+ * ===========================================================================
+ * - kJ/kcal unit slip: REFUTED. Stored kcal equals 4P + 4C + 9F to four
+ *   significant figures on the corrupt rows. A unit slip in the energy field
+ *   leaves the macros alone; here the macros moved by the same factor.
+ * - Atwater cross-check as the detector: REFUTED BY MEASUREMENT. The corrupt
+ *   rows are Atwater-PERFECT precisely because every macro was divided by the
+ *   same factor. detect-corrupt-nutrition.ts's `kj-as-kcal` rule is blind here
+ *   for exactly this reason.
+ * - Any absolute kcal or energy-density floor: REFUTED. The corrupt Jersey
+ *   Mike's sub sits at 0.21 kcal/g; a legitimate White Claw sits at 0.028
+ *   kcal/g. Any floor low enough to catch the sub hits the seltzer FIRST.
+ *   (This project has already shipped one absolute-threshold fix that
+ *   destroyed good data — see sync-docs/mapping_investigation_playbook.md.)
+ *
+ * WHY THE EXISTING DETECTORS CANNOT SEE THIS CLASS
+ * - scripts/eval/detect-corrupt-panel.ts rescales candidates by `x 100 / S`,
+ *   which is the OPPOSITE direction to this defect, and needs >= 4 same-name
+ *   siblings for a robust median.
+ * - scripts/eval/detect-corrupt-nutrition.ts is entirely UPPER bounds; these
+ *   rows are corrupt by being too SMALL, and every individual field is well
+ *   inside every ceiling.
+ *
+ * ===========================================================================
+ * THE DETECTOR
+ * ===========================================================================
+ * The signature is not a threshold on any value — it is the DEPENDENCE of the
+ * stored density on serving mass, which is physically impossible and can only
+ * be seen across a family of same-product different-size rows.
+ *
+ *   family key   `brandName | <name lowercased, non-alphanumerics -> spaces,
+ *                size tokens stripped>` (see SIZE_TOKENS)
+ *   base filter  servingGrams in [5, 5000], calories > 0, brandName NOT NULL
+ *   qualifies    >= 2 members AND >= 2 distinct servingGrams
+ *                AND max(S)/min(S) >= 1.3
+ *   FLAGGED      regr_slope(ln kcal100, ln S) in [-1.15, -0.85]
+ *                AND regr_r2 >= 0.95
+ *   member guard only members with servingGrams >= 150 are flagged
+ *
+ * A slope of exactly -1 is the algebraic fingerprint of `stored = D * 100 / S`
+ * for a size-invariant true density D. The r2 gate keeps families whose sizes
+ * genuinely differ in recipe (and therefore in density) out.
+ *
+ * ARMS. `--arm synthetic` (DEFAULT) restricts to `length(barcode) > 13`, the
+ * synthetic-barcode chain import where this defect was introduced.
+ * `--arm real-ean` (length <= 13) is reported for completeness but is NOT a
+ * repair candidate set: every hand-checked false positive lived there
+ * (M&S Greek Yogurt, Wegmans muenster variants standardized to 100 kcal,
+ * Great Value, Aldi, Tesco — retail lines whose per-100g panels are
+ * portion-standardized by policy, which produces the same slope honestly).
+ * Measured false-positive rate on the UNRESTRICTED set was 10.0% (3 of 30
+ * hand-checked).
+ *
+ * MEASURED POPULATIONS (live corpus, 2026-07-26; 629,341 rows past the base
+ * filter, 552,184 families, 8,953 multi-size qualifying):
+ *
+ *   all arms   3,640 rows / 1,089 families
+ *   synthetic  3,173 rows /   824 families /  55 brands   (guard refusals: 1)
+ *   real-EAN     467 rows /   288 families / 189 brands   (guard refusals: 31)
+ *
+ * The synthetic arm is 54 chain restaurants (Jersey Mike's 575, White Castle
+ * 289, Wawa 278, Firehouse 234, Zaxby's 144, KFC 128, Taco Bell 119, Dunkin'
+ * 113, Panda Express 109, ...) plus exactly ONE non-chain row:
+ * `Asda | Thai sticky rice`.
+ *
+ * These are 4 rows / 3 families BELOW the SQL sizing pass that first measured
+ * this class (3,644 / 1,092; synthetic 3,174 / 825 / 56). The entire
+ * difference is the empty-family-key guard below, and it reconciles exactly:
+ * the SQL had no such guard, so 4 rows across 3 pseudo-families (`Нз|`,
+ * `Братья Караваевы|`, `Своя линия|`) were counted as detections. They are
+ * artifacts of the key, not instances of the defect. The sizing pass also
+ * listed `Нз | Пържола` as a second non-chain brand; that row is one of the 4.
+ *
+ * STRUCTURAL BLIND SPOT, stated so nobody reads a 0 as an all-clear: brands
+ * sold in a single size (White Claw, Truly — one can size per SKU) can never
+ * form a multi-size family, so their kcal is never examined by this detector
+ * at all. "0 flagged" for such a brand means NOT LOOKED AT, not CLEAN.
+ *
+ * POST-REPAIR PLAUSIBILITY GUARD. Distinct from detection: this is a guard on
+ * the OUTPUT, so an absolute bound is legitimate here in a way it is not in
+ * the detector. A repair is REFUSED (never silently dropped — refusals are
+ * counted and reported with reasons) when the repaired panel would be
+ * physically impossible: repaired kcal/100g > MAX_REPAIRED_KCAL_100G, or
+ * repaired protein+carbs+fat > MAX_MACRO_SUM_100G.
+ *
+ * Run (from repo root, read-only):
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/detect-panel-scale-divided.ts \
+ *     [--arm synthetic|real-ean|all] [--out plan.json] [--limit N] [--json]
+ *
+ * THE DATA-OP IS NOT IN THIS FILE. This produces a repair PLAN for review.
+ * Applying it needs its own reviewed, approved script.
+ */
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PrismaClient } from '@prisma/client';
+import { MAX_MACRO_SUM_100G } from '../../src/lib/mapping/corrupt-mark';
+
+// ===========================================================================
+// Constants
+// ===========================================================================
+
+/** Size/portion words stripped from the name before forming the family key, so
+ *  "... On White Regular" and "... On White Giant" land in ONE family. Bare
+ *  integers go too ("12 Chocolate Chip Cookies", "32 Oz"). */
+export const SIZE_TOKENS: ReadonlySet<string> = new Set([
+    'mini', 'small', 'sm', 'regular', 'reg', 'medium', 'med', 'large', 'lg',
+    'giant', 'kid', 'kids', 'cub', 'junior', 'jr', 'whatameal', 'whatabox',
+    'combo', 'value', 'snack', 'single', 'double', 'triple', 'oz', 'fl', 'in',
+    'inch', 'footlong', 'half', 'full', 'meal', 'box',
+]);
+
+/** Base filter: serving masses outside this band are parse junk, not portions. */
+export const MIN_SERVING_G = 5;
+export const MAX_SERVING_G = 5000;
+
+/** Family qualification. */
+export const MIN_FAMILY_MEMBERS = 2;
+export const MIN_DISTINCT_SERVINGS = 2;
+export const MIN_SIZE_SPREAD = 1.3;
+
+/** Flag band. Exact -1 is the algebraic signature; the band absorbs rounding
+ *  in the stored panel and small genuine recipe drift between sizes. */
+export const MIN_SLOPE = -1.15;
+export const MAX_SLOPE = -0.85;
+export const MIN_R2 = 0.95;
+
+/** Member guard: only large servings are flagged. Below ~150 g the division
+ *  factor is near 1, so the repair moves little and the evidence is weakest. */
+export const MIN_FLAGGED_SERVING_G = 150;
+
+/** Synthetic-barcode arm boundary. Real EANs/UPCs are <= 13 digits; the chain
+ *  import minted longer synthetic ids. */
+export const MAX_REAL_EAN_LENGTH = 13;
+
+/** Post-repair guard ceiling for energy density. Deliberately 5 kcal STRICTER
+ *  than corrupt-mark's MAX_KCAL_100G (905): that 905 grants label-rounding
+ *  slack to a number a manufacturer actually printed, and a value this script
+ *  SYNTHESIZES has not earned that slack. Pure fat is ~900. */
+export const MAX_REPAIRED_KCAL_100G = 900;
+
+// MAX_MACRO_SUM_100G (= 105) is imported, not redefined. It is DELIBERATE
+// label-rounding slack over the physical 100 g/100g — see its comment in
+// src/lib/mapping/corrupt-mark.ts. Inventing a second number here would fork it.
+
+// ===========================================================================
+// Pure core (unit-tested offline in __tests__/panel-scale-divided.test.ts)
+// ===========================================================================
+
+/** Every numeric field of the stored panel. All of them were divided. */
+export interface Panel {
+    calories: number;
+    protein?: number | null;
+    carbs?: number | null;
+    fat?: number | null;
+    fiber?: number | null;
+    sugars?: number | null;
+    sodium?: number | null;
+}
+
+export interface PanelRow {
+    barcode: string;
+    name: string;
+    brandName: string | null;
+    servingGrams: number | null;
+    nutrientsPer100g: unknown;
+}
+
+export type Arm = 'synthetic' | 'real-ean' | 'all';
+
+/** Lowercase, non-alphanumerics -> spaces, collapse whitespace, drop size
+ *  tokens and bare integers. */
+export function stripSizeTokens(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+        .split(/\s+/)
+        .filter(t => t !== '' && !SIZE_TOKENS.has(t) && !/^[0-9]+$/.test(t))
+        .join(' ');
+}
+
+/**
+ * `brandName | <size-stripped name>`, or null when no honest key exists.
+ *
+ * EMPTY-NAME GUARD. `stripSizeTokens` is ASCII-alphanumeric (as is the
+ * Postgres `[^a-z0-9]` used to size this class), so a name written entirely in
+ * a non-Latin script normalizes to the EMPTY STRING. Without this guard those
+ * rows all collapse into a single pseudo-family `Brand|` — and a pseudo-family
+ * is not a family: the live corpus has `Нз|` merging "Паста" (459 kcal/100g,
+ * S=50) with "Пържола" (107 kcal/100g, S=186), two unrelated foods whose
+ * accidental pairing fits a -1.11 slope at r2 1.00 and flags. Four such rows
+ * across three pseudo-families (`Нз|`, `Братья Караваевы|`, `Своя линия|`)
+ * were flagged by the SQL sizing pass that did NOT have this guard; they are
+ * artifacts of the key, not instances of the defect.
+ *
+ * Skipped rows are COUNTED (`skippedEmptyNameKey`) and reported, never
+ * silently dropped.
+ */
+export function familyKey(name: string, brandName: string | null): string | null {
+    if (brandName == null || brandName.trim() === '') return null;
+    const stripped = stripSizeTokens(name);
+    if (!stripped) return null;
+    return `${brandName}|${stripped}`;
+}
+
+export function readPanel(nutrients: unknown): Panel | null {
+    if (nutrients == null || typeof nutrients !== 'object') return null;
+    const n = nutrients as Record<string, unknown>;
+    const num = (k: string): number | null => {
+        const v = n[k];
+        return typeof v === 'number' && isFinite(v) ? v : null;
+    };
+    const calories = num('calories') ?? num('kcal');
+    if (calories == null || !(calories > 0)) return null;
+    return {
+        calories,
+        protein: num('protein'), carbs: num('carbs'), fat: num('fat'),
+        fiber: num('fiber'), sugars: num('sugars'), sodium: num('sodium'),
+    };
+}
+
+/** THE repair: every numeric field x S/100. Nulls stay null (a missing field
+ *  must not be invented as 0 — that would look like a measured zero). */
+export function repairPanel(panel: Panel, servingGrams: number): Panel {
+    const f = servingGrams / 100;
+    const scale = (v: number | null | undefined) => (v == null ? v ?? null : v * f);
+    return {
+        calories: panel.calories * f,
+        protein: scale(panel.protein), carbs: scale(panel.carbs), fat: scale(panel.fat),
+        fiber: scale(panel.fiber), sugars: scale(panel.sugars), sodium: scale(panel.sodium),
+    };
+}
+
+export function macroSum(panel: Panel): number {
+    return (panel.protein ?? 0) + (panel.carbs ?? 0) + (panel.fat ?? 0);
+}
+
+/** Post-repair plausibility guard. Returns the reasons a repair is refused;
+ *  empty array = emit it. */
+export function guardRepair(repaired: Panel): string[] {
+    const reasons: string[] = [];
+    if (repaired.calories > MAX_REPAIRED_KCAL_100G) {
+        reasons.push(`repaired-kcal-impossible: ${repaired.calories.toFixed(1)} > ${MAX_REPAIRED_KCAL_100G} kcal/100g`);
+    }
+    const sum = macroSum(repaired);
+    if (sum > MAX_MACRO_SUM_100G) {
+        reasons.push(`repaired-macro-sum-impossible: ${sum.toFixed(1)} > ${MAX_MACRO_SUM_100G} g/100g`);
+    }
+    return reasons;
+}
+
+/** Streaming accumulator for one family's OLS fit of ln(kcal100) on ln(S). */
+export interface FamilyAccumulator {
+    n: number;
+    sx: number; sy: number; sxx: number; syy: number; sxy: number;
+    minServing: number; maxServing: number;
+    servings: Set<number>;
+}
+
+export function newFamily(): FamilyAccumulator {
+    return {
+        n: 0, sx: 0, sy: 0, sxx: 0, syy: 0, sxy: 0,
+        minServing: Infinity, maxServing: -Infinity, servings: new Set(),
+    };
+}
+
+export function addMember(acc: FamilyAccumulator, servingGrams: number, kcal100: number): void {
+    const x = Math.log(servingGrams);
+    const y = Math.log(kcal100);
+    acc.n += 1;
+    acc.sx += x; acc.sy += y;
+    acc.sxx += x * x; acc.syy += y * y; acc.sxy += x * y;
+    acc.minServing = Math.min(acc.minServing, servingGrams);
+    acc.maxServing = Math.max(acc.maxServing, servingGrams);
+    acc.servings.add(servingGrams);
+}
+
+export interface FamilyStats {
+    n: number;
+    distinctServings: number;
+    sizeSpread: number;
+    slope: number | null;
+    r2: number | null;
+}
+
+/** Mirrors Postgres regr_slope/regr_r2 (including their null/degenerate
+ *  behaviour) so the SQL used to size this class and the script agree. */
+export function familyStats(acc: FamilyAccumulator): FamilyStats {
+    const { n, sx, sy, sxx, syy, sxy } = acc;
+    const sizeSpread = acc.minServing > 0 ? acc.maxServing / acc.minServing : 0;
+    const base = { n, distinctServings: acc.servings.size, sizeSpread };
+    if (n < 2) return { ...base, slope: null, r2: null };
+    const dxx = n * sxx - sx * sx;
+    const dyy = n * syy - sy * sy;
+    const dxy = n * sxy - sx * sy;
+    if (dxx <= 0) return { ...base, slope: null, r2: null };   // no x variance
+    const slope = dxy / dxx;
+    const r2 = dyy <= 0 ? 1 : (dxy * dxy) / (dxx * dyy);        // PG: Syy=0 -> 1
+    return { ...base, slope, r2 };
+}
+
+export function familyQualifies(stats: FamilyStats): boolean {
+    return stats.n >= MIN_FAMILY_MEMBERS
+        && stats.distinctServings >= MIN_DISTINCT_SERVINGS
+        && stats.sizeSpread >= MIN_SIZE_SPREAD;
+}
+
+export function familyFlagged(stats: FamilyStats): boolean {
+    if (!familyQualifies(stats)) return false;
+    if (stats.slope == null || stats.r2 == null) return false;
+    return stats.slope >= MIN_SLOPE && stats.slope <= MAX_SLOPE && stats.r2 >= MIN_R2;
+}
+
+export function inArm(barcode: string, arm: Arm): boolean {
+    if (arm === 'all') return true;
+    const synthetic = barcode.length > MAX_REAL_EAN_LENGTH;
+    return arm === 'synthetic' ? synthetic : !synthetic;
+}
+
+/** Rows the base filter admits at all. */
+export function passesBaseFilter(row: PanelRow): boolean {
+    if (row.brandName == null || row.brandName.trim() === '') return false;
+    const s = row.servingGrams;
+    if (s == null || !isFinite(s) || s < MIN_SERVING_G || s > MAX_SERVING_G) return false;
+    return readPanel(row.nutrientsPer100g) != null;
+}
+
+// ===========================================================================
+// Scan
+// ===========================================================================
+
+export interface RepairEntry {
+    barcode: string;
+    name: string;
+    brandName: string;
+    servingGrams: number;
+    current: Panel;
+    repaired: Panel;
+    /** Serving-level energy today vs after repair — the user-visible delta. */
+    currentServingKcal: number;
+    repairedServingKcal: number;
+    understatementFactor: number;
+    familyKey: string;
+    familySlope: number;
+    familyR2: number;
+    familySize: number;
+    familyDistinctServings: number;
+}
+
+export interface RefusalEntry {
+    barcode: string;
+    name: string;
+    brandName: string;
+    servingGrams: number;
+    current: Panel;
+    repaired: Panel;
+    familyKey: string;
+    reasons: string[];
+}
+
+export interface ScanReport {
+    at: string;
+    arm: Arm;
+    scanned: number;
+    baseFilterPassed: number;
+    /** Base-filter rows with no honest family key (name normalizes to empty).
+     *  Reported so the exclusion is auditable — see familyKey's comment. */
+    skippedEmptyNameKey: number;
+    families: number;
+    qualifyingFamilies: number;
+    flaggedFamilies: number;
+    /** Flagged members in the selected arm, BEFORE the plausibility guard. */
+    flaggedRows: number;
+    /** Flagged members in the selected arm across ALL arms, for context. */
+    flaggedRowsAllArms: number;
+    flaggedFamiliesAllArms: number;
+    repairs: RepairEntry[];
+    refusals: RefusalEntry[];
+    refusalCount: number;
+    /** True when --limit truncated `repairs`; summary counts stay full. */
+    truncated: boolean;
+    byBrand: Array<{ brandName: string; rows: number; families: number; refusals: number }>;
+}
+
+export type RowStream = () => AsyncIterable<PanelRow[]>;
+
+export interface ScanOptions {
+    arm?: Arm;
+    limit?: number;
+}
+
+/**
+ * Two passes over the stream: pass 1 accumulates per-family regression sums
+ * (bounded memory), pass 2 re-reads and emits the flagged members.
+ *
+ * This function deliberately does NOT catch stream errors. A query failure has
+ * to propagate so the caller exits non-zero; swallowing it would turn a total
+ * outage into a confident "0 rows flagged" — the exact failure shape PR #177
+ * was written to stop (cache-parity-sweep.ts printing "0 changed records" on
+ * total HTTP failure).
+ */
+export async function runScan(stream: RowStream, opts: ScanOptions = {}): Promise<ScanReport> {
+    const arm: Arm = opts.arm ?? 'synthetic';
+    const limit = opts.limit != null && opts.limit > 0 ? opts.limit : Infinity;
+
+    // ---- Pass 1: family regression sums ----
+    const families = new Map<string, FamilyAccumulator>();
+    let scanned = 0;
+    let baseFilterPassed = 0;
+    let skippedEmptyNameKey = 0;
+    for await (const batch of stream()) {
+        for (const row of batch) {
+            scanned += 1;
+            if (!passesBaseFilter(row)) continue;
+            baseFilterPassed += 1;
+            const panel = readPanel(row.nutrientsPer100g)!;
+            const key = familyKey(row.name, row.brandName);
+            if (!key) { skippedEmptyNameKey += 1; continue; }
+            let acc = families.get(key);
+            if (!acc) { acc = newFamily(); families.set(key, acc); }
+            addMember(acc, row.servingGrams!, panel.calories);
+        }
+    }
+
+    const flaggedKeys = new Map<string, FamilyStats>();
+    let qualifyingFamilies = 0;
+    for (const [key, acc] of families) {
+        const stats = familyStats(acc);
+        if (familyQualifies(stats)) qualifyingFamilies += 1;
+        if (familyFlagged(stats)) flaggedKeys.set(key, stats);
+    }
+    const familyCount = families.size;
+    families.clear();
+
+    // ---- Pass 2: emit flagged members ----
+    const repairs: RepairEntry[] = [];
+    const refusals: RefusalEntry[] = [];
+    let refusalCount = 0;
+    let flaggedRows = 0;
+    let flaggedRowsAllArms = 0;
+    const armFamilies = new Set<string>();
+    const allArmFamilies = new Set<string>();
+    const brands = new Map<string, { rows: number; families: Set<string>; refusals: number }>();
+    let truncated = false;
+
+    for await (const batch of stream()) {
+        for (const row of batch) {
+            if (!passesBaseFilter(row)) continue;
+            const servingGrams = row.servingGrams!;
+            if (servingGrams < MIN_FLAGGED_SERVING_G) continue;
+            const key = familyKey(row.name, row.brandName);
+            if (!key) continue;
+            const stats = flaggedKeys.get(key);
+            if (!stats) continue;
+
+            flaggedRowsAllArms += 1;
+            allArmFamilies.add(key);
+            if (!inArm(row.barcode, arm)) continue;
+
+            flaggedRows += 1;
+            armFamilies.add(key);
+            const brandName = row.brandName!;
+            let b = brands.get(brandName);
+            if (!b) { b = { rows: 0, families: new Set(), refusals: 0 }; brands.set(brandName, b); }
+            b.rows += 1;
+            b.families.add(key);
+
+            const current = readPanel(row.nutrientsPer100g)!;
+            const repaired = repairPanel(current, servingGrams);
+            const reasons = guardRepair(repaired);
+            if (reasons.length > 0) {
+                refusalCount += 1;
+                b.refusals += 1;
+                // Refusals are always retained in full: a dropped row that
+                // nobody counts is indistinguishable from a clean run.
+                refusals.push({
+                    barcode: row.barcode, name: row.name, brandName,
+                    servingGrams, current, repaired, familyKey: key, reasons,
+                });
+                continue;
+            }
+            if (repairs.length >= limit) { truncated = true; continue; }
+            const currentServingKcal = (current.calories * servingGrams) / 100;
+            const repairedServingKcal = (repaired.calories * servingGrams) / 100;
+            repairs.push({
+                barcode: row.barcode, name: row.name, brandName, servingGrams,
+                current, repaired,
+                currentServingKcal, repairedServingKcal,
+                understatementFactor: currentServingKcal > 0 ? repairedServingKcal / currentServingKcal : 0,
+                familyKey: key,
+                familySlope: stats.slope!, familyR2: stats.r2!,
+                familySize: stats.n, familyDistinctServings: stats.distinctServings,
+            });
+        }
+    }
+
+    const byBrand = [...brands.entries()]
+        .map(([brandName, b]) => ({ brandName, rows: b.rows, families: b.families.size, refusals: b.refusals }))
+        .sort((a, b) => b.rows - a.rows || a.brandName.localeCompare(b.brandName));
+
+    return {
+        at: new Date().toISOString(),
+        arm, scanned, baseFilterPassed, skippedEmptyNameKey,
+        families: familyCount,
+        qualifyingFamilies,
+        flaggedFamilies: armFamilies.size,
+        flaggedRows,
+        flaggedRowsAllArms,
+        flaggedFamiliesAllArms: allArmFamilies.size,
+        repairs, refusals, refusalCount, truncated, byBrand,
+    };
+}
+
+/**
+ * 0 = the scan ran and produced a report; 2 = the scan saw NOTHING.
+ *
+ * A scan of zero rows is not a clean corpus, it is a broken instrument (an
+ * empty result set, a filter typo, a database pointed at the wrong host). It
+ * must never render as green.
+ */
+export function scanExitCode(report: Pick<ScanReport, 'scanned' | 'baseFilterPassed'>): number {
+    if (report.scanned === 0) return 2;
+    if (report.baseFilterPassed === 0) return 2;
+    return 0;
+}
+
+export function formatSummary(report: ScanReport): string[] {
+    const out: string[] = [];
+    out.push('');
+    out.push(`Scanned ${report.scanned} rows; ${report.baseFilterPassed} passed the base filter.`);
+    out.push(`Excluded for an empty family key (name normalizes to nothing): ${report.skippedEmptyNameKey}`);
+    out.push(`Families: ${report.families} total, ${report.qualifyingFamilies} multi-size qualifying.`);
+    out.push(`Flagged across ALL arms: ${report.flaggedRowsAllArms} rows / ${report.flaggedFamiliesAllArms} families.`);
+    out.push(`Arm "${report.arm}": ${report.flaggedRows} rows / ${report.flaggedFamilies} families / ${report.byBrand.length} brands.`);
+    out.push(`Repairs emitted: ${report.repairs.length}${report.truncated ? ' (TRUNCATED by --limit; counts above are full-population)' : ''}`);
+    out.push(`Repairs REFUSED by the post-repair plausibility guard: ${report.refusalCount}`);
+    if (report.refusals.length > 0) {
+        for (const r of report.refusals.slice(0, 20)) {
+            out.push(`  REFUSED ${r.barcode} "${r.name}" [${r.brandName}] S=${r.servingGrams}g: ${r.reasons.join('; ')}`);
+        }
+        if (report.refusals.length > 20) out.push(`  ... ${report.refusals.length - 20} more refusals in the report file`);
+    }
+    out.push('');
+    out.push('Per brand (rows / families / refused):');
+    for (const b of report.byBrand) {
+        out.push(`  ${b.brandName.padEnd(28)} ${String(b.rows).padStart(5)} / ${String(b.families).padStart(4)} / ${b.refusals}`);
+    }
+    const worst = [...report.repairs].sort((a, b) => b.understatementFactor - a.understatementFactor).slice(0, 15);
+    if (worst.length > 0) {
+        out.push('');
+        out.push('Worst understatements (bills today -> bills after repair):');
+        for (const r of worst) {
+            out.push(`  ${r.barcode} "${r.name}" [${r.brandName}] S=${r.servingGrams}g: `
+                + `${r.current.calories.toFixed(1)} -> ${r.repaired.calories.toFixed(1)} kcal/100g, `
+                + `${Math.round(r.currentServingKcal)} -> ${Math.round(r.repairedServingKcal)} kcal/serving `
+                + `(${r.understatementFactor.toFixed(1)}x under; family slope ${r.familySlope.toFixed(3)}, r2 ${r.familyR2.toFixed(3)}, n=${r.familySize})`);
+        }
+    }
+    out.push('');
+    out.push('READ-ONLY: nothing was written to the database. The data-op is a separate, unapproved PR.');
+    return out;
+}
+
+// ===========================================================================
+// CLI
+// ===========================================================================
+
+const BATCH = 20000;
+
+function parseArgs(argv: string[]) {
+    const value = (flag: string): string | undefined => {
+        const i = argv.indexOf(flag);
+        return i >= 0 ? argv[i + 1] : undefined;
+    };
+    const armRaw = value('--arm') ?? 'synthetic';
+    if (armRaw !== 'synthetic' && armRaw !== 'real-ean' && armRaw !== 'all') {
+        throw new Error(`--arm must be one of synthetic|real-ean|all (got "${armRaw}")`);
+    }
+    const limitRaw = value('--limit');
+    const limit = limitRaw != null ? Number(limitRaw) : undefined;
+    if (limit != null && (!isFinite(limit) || limit <= 0)) {
+        throw new Error(`--limit must be a positive number (got "${limitRaw}")`);
+    }
+    return {
+        arm: armRaw as Arm,
+        limit,
+        out: value('--out'),
+        json: argv.includes('--json'),
+    };
+}
+
+function prismaStream(prisma: PrismaClient): RowStream {
+    return async function* () {
+        let cursor: string | undefined;
+        for (;;) {
+            const batch: PanelRow[] = await prisma.offFood.findMany({
+                select: { barcode: true, name: true, brandName: true, servingGrams: true, nutrientsPer100g: true },
+                where: {
+                    brandName: { not: null },
+                    servingGrams: { gte: MIN_SERVING_G, lte: MAX_SERVING_G },
+                },
+                orderBy: { barcode: 'asc' },
+                take: BATCH,
+                ...(cursor ? { cursor: { barcode: cursor }, skip: 1 } : {}),
+            });
+            if (!batch.length) return;
+            yield batch;
+            cursor = batch[batch.length - 1].barcode;
+        }
+    };
+}
+
+async function main(): Promise<void> {
+    const opts = parseArgs(process.argv.slice(2));
+    const prisma = new PrismaClient();
+    try {
+        // No try/catch around runScan: a failure must reach the top-level
+        // handler and exit 2, never fall through to a summary.
+        const report = await runScan(prismaStream(prisma), { arm: opts.arm, limit: opts.limit });
+
+        const outDir = path.join(__dirname, 'results');
+        fs.mkdirSync(outDir, { recursive: true });
+        const ts = report.at.replace(/[:.]/g, '-');
+        const outPath = opts.out ?? path.join(outDir, `panel-scale-divided-${opts.arm}-${ts}.json`);
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 1));
+
+        if (opts.json) {
+            console.log(JSON.stringify(report, null, 1));
+        } else {
+            for (const line of formatSummary(report)) console.log(line);
+            console.log(`Repair plan written to ${path.relative(process.cwd(), outPath)}`);
+        }
+
+        const code = scanExitCode(report);
+        if (code !== 0) {
+            console.error(`FAIL: the scan saw ${report.scanned} rows / ${report.baseFilterPassed} after the base filter — that is a broken instrument, not a clean corpus.`);
+            process.exitCode = code;
+        }
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+if (require.main === module) {
+    main().catch(err => { console.error(err); process.exit(2); });
+}


### PR DESCRIPTION
## The defect

The OFF chain-restaurant import files a **per-100 g** panel in OpenFoodFacts' `*_serving` slot. OFF's own derivation

```
_100g = _serving / serving_quantity * 100
```

then divides that already-per-100 g panel **again**. Net effect: **every numeric field** of `nutrientsPer100g` — calories *and* all macros — is divided by `servingGrams / 100`.

Repair is closed-form and applies to every field:

```
true_per_100g_field = stored_field * servingGrams / 100
```

## Live proof (verified against the corpus, in the script header)

| row | S | stored kcal/100g | `stored * S/100` |
|---|---|---|---|
| Jersey Mike's Subs, #44 Buffalo Chicken Cheese Steak On White **Regular** | 541 g | 32.00 | **173.1** |
| …same product, **Giant** | 1060 g | 16.30 | **172.8** |

A per-100 g *density* cannot depend on serving mass. That the two sizes disagree ~2× on the stored density and agree **to 0.2%** after each is multiplied by its own serving mass is the entire diagnosis: the stored number is the density divided by the size, and the divisor is recoverable per row.

Today **both sizes bill an identical 173 kcal**. True values ≈ **937** and **1,831** kcal — 5.4× and 10.6× under. The plan file reproduces this exactly (`repairedServingKcal: 1831.47`, `understatementFactor: 10.6`).

## Refuted hypotheses — documented in the header so nobody retries them

- **kJ/kcal unit slip — REFUTED.** Stored kcal equals 4P + 4C + 9F to four significant figures. A unit slip in the energy field leaves macros alone; here the macros moved by the same factor.
- **Atwater cross-check as the detector — REFUTED BY MEASUREMENT.** The corrupt rows are Atwater-**perfect** precisely because every macro was divided by the same factor. A test in the suite asserts this, so the blindness is on record rather than rediscovered.
- **Any absolute kcal or energy-density floor — REFUTED.** The corrupt Jersey Mike's sub is 0.21 kcal/g; a legitimate White Claw is 0.028 kcal/g. Any floor low enough to catch the sub hits the seltzer **first**. (This project has already shipped one absolute-threshold fix that destroyed good data — `sync-docs/mapping_investigation_playbook.md`.)
- **Existing detectors are structurally blind.** `detect-corrupt-panel.ts` rescales by `×100/S` — the *opposite* direction — and needs ≥ 4 name-siblings. `detect-corrupt-nutrition.ts` is entirely **upper** bounds; these rows are corrupt by being too *small* and sit well inside every ceiling.

## The detector

Detection is the **slope**, never a threshold on a value. Within a family of same-product different-size rows:

- family key `brandName | <name lowercased, non-alphanumerics → spaces, size tokens stripped>`
- base filter `servingGrams ∈ [5, 5000]`, `calories > 0`, `brandName NOT NULL`
- qualifies: ≥ 2 members, ≥ 2 distinct `servingGrams`, `max(S)/min(S) ≥ 1.3`
- **flagged**: `regr_slope(ln kcal100, ln S) ∈ [-1.15, -0.85]` and `regr_r2 ≥ 0.95`
- member guard: only members with `servingGrams ≥ 150` are flagged
- default arm `--arm synthetic` = `length(barcode) > 13`, the synthetic-barcode chain import

Slope exactly −1 is the algebraic fingerprint of `stored = D × 100 / S` for a size-invariant true density `D`. `familyStats()` mirrors Postgres `regr_slope`/`regr_r2` (including their degenerate cases) so the SQL sizing pass and the script agree.

## Measured populations (live corpus, 2026-07-26)

629,341 rows past the base filter; 552,184 families; 8,953 multi-size qualifying.

| arm | rows | families | brands | guard refusals |
|---|---|---|---|---|
| all | 3,640 | 1,089 | 231 | 32 |
| **synthetic (default)** | **3,173** | **824** | **55** | **1** |
| real-EAN | 467 | 288 | 189 | 31 |

Synthetic arm = 54 chain restaurants (Jersey Mike's 575, White Castle 289, Wawa 278, Firehouse 234, Zaxby's 144, KFC 128, Taco Bell 119, Dunkin' 113, Panda Express 109, …) plus exactly **one** non-chain row, `Asda | Thai sticky rice`.

### Deviation from the SQL sizing pass — reported, not papered over

The sizing pass measured 3,644 / 1,092 (synthetic 3,174 / 825 / 56). This PR measures **4 rows / 3 families fewer**, and the difference reconciles exactly.

`stripSizeTokens` is ASCII-alphanumeric (as is the Postgres `[^a-z0-9]` the sizing SQL used), so a name written entirely in a non-Latin script normalizes to the **empty string**. The SQL had no guard for that, so those rows collapsed into pseudo-families `Brand|` and were counted as detections. The live corpus has `Нз|` merging **"Паста"** (459 kcal/100g, S=50) with **"Пържола"** (107 kcal/100g, S=186) — two unrelated foods whose accidental pairing fits a −1.11 slope at r² 1.00.

The 4 rows sit in 3 such pseudo-families (`Нз|`, `Братья Караваевы|`, `Своя линия|`): 1 row / 1 family in the synthetic arm (which is also why the brand count is 55, not 56 — the sizing pass's second "non-chain brand" `Нз | Пържола` **is** one of these 4), and 3 rows / 3 families in real-EAN. `familyKey()` now returns `null` for an empty stripped name, and the excluded rows are **counted and printed** (`skippedEmptyNameKey: 1731`) rather than silently dropped.

## False-positive evidence and the arm split

Measured FP on the **unrestricted** set was **10.0%** (3 of 30 hand-checked), and every hand-checked false positive lived in the **real-EAN** arm: M&S Greek Yogurt, Wegmans muenster variants standardized to 100 kcal, Great Value, Aldi, Tesco. These are retail lines whose per-100 g panels are portion-standardized by policy, which produces the same −1 slope *honestly*. That is why the default arm excludes them; `--arm real-ean` reports them but they are **not** a repair-candidate set.

## Post-repair plausibility guard

This is a guard on the **output**, not a detection threshold — which is what makes an absolute bound legitimate here in a way it is not in the detector. A repair is refused when the repaired panel would be physically impossible:

- repaired kcal/100g > 900 (`MAX_REPAIRED_KCAL_100G`, deliberately 5 kcal stricter than `MAX_KCAL_100G = 905`: that slack is granted to a number a manufacturer printed, and a value we *synthesize* has not earned it)
- repaired macro sum > `MAX_MACRO_SUM_100G` — **imported from `corrupt-mark.ts`, not reinvented**. It is 105, deliberate label-rounding slack over the physical 100; a second copy here would fork it.

Refusals are counted, printed with reasons, and retained in full in the plan. A silently dropped row must never look like a clean run — `repairs.length + refusalCount === flaggedRows` is asserted in the suite.

**The single synthetic-arm refusal is the guard earning its keep, and it is a real false positive.** `Taco Bell, Crunchwrap Supreme` pairs a 100 g row at 537 kcal/100g with a 260 g row at 204 — a −1.01 slope at r² 1.00. But the 260 g row is *already* a correct density (204 × 2.6 ≈ 530 kcal, the real product); "repairing" it would invent a 108.1 g/100g macro sum. The guard caught it. The 100 g row (whose `servingGrams` is the wrong field, not its panel) is below the 150 g member guard and was never a candidate.

## Structural blind spot, stated so a 0 is not read as an all-clear

**White Claw and Truly flag 0 rows — because they are never examined.** Every SKU is one can size, so they form no multi-size family and their kcal never enters a density comparison. "0 flagged" for such a brand means *not looked at*, not *clean*. This is asserted as a test **with its reason** (`qualifyingFamilies === 0`), plus a positive control that giving the brand a genuine second size makes it examinable — otherwise "White Claw never flags" is satisfiable by a detector that flags nothing.

## Tests — 28, pure/offline, no DB and no network

Every fixture family is built in code. The Jersey Mike's fixture uses the panels copied **verbatim** from the corpus, so it is evidence rather than a restatement of the hypothesis (which is why its slope is −1.0029, not −1, and why the flag band is a band).

Covered: size-token stripping (Regular/Giant/32 Oz collapse to one key, with a positive control that two genuinely different products do **not** collapse); the divided family flags and both sizes recover the same density on every field; every numeric field is repaired and a missing field stays `null` rather than becoming a measured zero; the Atwater blindness; too-close sizes and noisy families are rejected; the member guard; the arms partition and the retail family stays out of the default arm; the White Claw structural blind spot; the guard refuses **and counts**; `--limit` truncates the plan but never the counts and says so.

Plus a **fail-injection block** in the `fail-closed.test.ts` / PR #177 style: a dead query propagates instead of returning an empty report, a mid-stream failure propagates too, the CLI shape proves no summary is ever composed on a rejection, and an empty result set (or one where every row fails the base filter) exits **2**. The anti-pattern this exists to prevent is `cache-parity-sweep.ts` printing "0 changed records" on total HTTP failure with exit 0. A converse test asserts a genuinely clean corpus still exits **0**, so the exit code keeps meaning something.

## ⚠️ The data-op is NOT in this PR and needs approval

This PR adds **a detector and its tests, nothing else**. It is read-only **by construction**: there is no `--execute` path in the file, and it contains no `create`/`update`/`upsert`/`delete`/`executeRaw` call of any kind. It writes one JSON repair **plan** to the gitignored `scripts/eval/results/`.

Nothing under `scripts/mark-corrupt-off.ts`, `src/lib/mapping/**`, or any request path is touched. **Applying the 3,172-row repair plan requires its own reviewed, separately approved script and is explicitly out of scope here.**

## CI (all run locally before pushing)

- `lint:ci` — **0 errors**, 448 warnings (cap 700)
- `typecheck` — clean
- `next build` — succeeds
- `jest` — **110 suites, 2,298 passed**, 1 skipped, 0 failed (28 of them new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx
