### PR TITLE
fix(eval): close the remaining class-B fail-open holes (flywheel/warm, parity sweep, stress, detect-corrupt-*)

### DIFF
--- a/scripts/eval/__tests__/fail-open-sweep.test.ts
+++ b/scripts/eval/__tests__/fail-open-sweep.test.ts
@@ -29,7 +29,8 @@ import * as path from 'path';
 import {
     EvalRunEvidence, judgeEvalGate, sweepVerdict,
 } from '../flywheel-verdict';
-import { runWarm, warmExitCode, WarmResult } from '../warm-cache';
+import { runEvalGate } from '../flywheel-sweep';
+import { main as warmMain, runWarm, warmExitCode, WarmResult } from '../warm-cache';
 import { parityExitCode, summarizeParity } from '../cache-parity-sweep';
 import { Sample, stressExitCode } from '../stress-latency';
 import {
@@ -147,6 +148,54 @@ describe('judgeEvalGate: run-eval exit 2 can never be re-derived into a PASS', (
     });
 });
 
+describe('runEvalGate: the evidence ASSEMBLY judged against a real child, not a hand-built receipt', () => {
+    // The 35 judgeEvalGate tests above prove the judge; none of them prove
+    // that the spawn's exit code, the before/after eval-* file diff and the
+    // JSON parse actually REACH it. This block spawns a real child — a local
+    // node stub, no network, no DB — that reproduces run-eval's fail-closed
+    // shape: write a plausible results file FIRST, then exit 2.
+    const writeStub = (dir: string, exitCode: number): string => {
+        const stub = path.join(dir, `stub-run-eval-exit${exitCode}.js`);
+        fs.writeFileSync(stub, [
+            "const fs = require('fs');",
+            "const path = require('path');",
+            'const resultsDir = process.argv[2];',
+            "fs.writeFileSync(path.join(resultsDir, 'eval-stub-' + process.pid + '.json'),",
+            "    JSON.stringify({ results: [{ id: 'n-a-01', query: 'apple', detail: '', pass: true }] }));",
+            `process.exit(${exitCode});`,
+        ].join('\n'));
+        return stub;
+    };
+
+    it('a child that writes a plausible results file and THEN exits 2 comes out RED through the real assembly', () => {
+        const resultsDir = tmpDir();
+        const stub = writeStub(resultsDir, 2);
+        const gate = runEvalGate({
+            spawn: { cmd: process.execPath, args: [stub, resultsDir] },
+            resultsDir, allowFail: [], timeoutMs: 30000,
+        });
+        expect(gate.ran).toBe(false);
+        expect(gate.pass).toBe(false);
+        expect(gate.error).toContain('exited 2');
+        expect(gate.error).toContain('does not override');
+        // ...and the sweep-level consequence systemd sees: instrument failure.
+        expect(sweepVerdict(gate, { seedCount: 10, resultCount: 10, okCount: 10 }).code).toBe(2);
+    });
+
+    it('POSITIVE CONTROL — the same stub exiting 0 passes, so the assembly (not the stub) is what decides', () => {
+        const resultsDir = tmpDir();
+        const stub = writeStub(resultsDir, 0);
+        const gate = runEvalGate({
+            spawn: { cmd: process.execPath, args: [stub, resultsDir] },
+            resultsDir, allowFail: [], timeoutMs: 30000,
+        });
+        expect(gate.error).toBeUndefined();
+        expect(gate.ran).toBe(true);
+        expect(gate.pass).toBe(true);
+        expect(gate.casesRun).toBe(1);
+    });
+});
+
 describe('sweepVerdict: the sweep exit code systemd sees', () => {
     const goodGate = () => judgeEvalGate({
         status: 0, signal: null, resultsFile: '/x/eval.json',
@@ -251,6 +300,52 @@ describe('warm-cache: a warm run that warmed nothing is RED', () => {
     }, 20000);
 });
 
+describe('warm-cache main: the zero-seed guard binds the --dry path too', () => {
+    // Reviewer finding on PR #181: main()'s --dry branch returned BEFORE the
+    // zero-seed guard, so `--dry` over a zero-seed corpus printed
+    // "Warm corpus: 0 names" and exited 0 — the exact absence-as-pass shape
+    // warmExitCode was added to refuse. These tests run the real main() with
+    // an injected seed assembler; fetch is spied to prove dry stays dry.
+    let logSpy: jest.SpyInstance;
+    let errSpy: jest.SpyInstance;
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => { logSpy.mockRestore(); errSpy.mockRestore(); });
+
+    it('--dry over a ZERO-seed corpus returns exit 2 — a dry run that lists nothing is not a green preview', async () => {
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not be reached'));
+        try {
+            const code = await warmMain(['--dry'], () => []);
+            expect(code).toBe(2);
+            expect(errSpy.mock.calls.flat().join(' ')).toContain('ZERO seeds');
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally { fetchSpy.mockRestore(); }
+    });
+
+    it('the WET path shares the same guard: zero seeds never reach runWarm or the network', async () => {
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not be reached'));
+        try {
+            const code = await warmMain([], () => []);
+            expect(code).toBe(2);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally { fetchSpy.mockRestore(); }
+    });
+
+    it('POSITIVE CONTROL — --dry over the real corpus lists the seeds and returns 0, with zero network calls', async () => {
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not be reached'));
+        try {
+            const code = await warmMain(['--dry', '--limit', '5']);
+            expect(code).toBe(0);
+            const lines = logSpy.mock.calls.flat().filter((l): l is string => typeof l === 'string');
+            expect(lines[0]).toContain('Warm corpus: 5 names');
+            expect(lines.filter(l => l.startsWith('  '))).toHaveLength(5);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally { fetchSpy.mockRestore(); }
+    });
+});
+
 // ===========================================================================
 // 3. cache-parity-sweep — total HTTP failure vs verified-clean cache
 // ===========================================================================
@@ -319,6 +414,46 @@ describe('cache-parity-sweep: "0 changed records" needs rows that actually came 
         const { counts } = summarizeParity([bare]);
         expect(counts.changedRecord).toBe(0);
         expect(counts.unresolvableBefore).toBe(1);
+    });
+
+    // Reviewer probe on PR #181: parityExitCode was blind to unresolvableBefore
+    // — the same absence-encoded-as-clean class this PR closes, inside the
+    // function it added. Every replay can come back fine and still ZERO
+    // identity comparisons happen, because no incumbent id was reconstructable.
+    it('REVIEWER PROBE: all replays fine but NO incumbent ids → zero comparisons ran → exit 2 VOID, never "0 changed"', () => {
+        const rows = ['a', 'b', 'c'].map(k =>
+            row(k, { foodId: 'off_999' }, before(k, { offBarcode: null, fdcId: null, fsId: null })));
+        const { counts } = summarizeParity(rows);
+        expect(counts).toMatchObject({ total: 3, sameRecord: 0, changedRecord: 0, errors: 0, unresolvableBefore: 3 });
+        expect(counts.verifiedReachable).toBe(0);   // pre-fix this read 3 — rows nothing was diffed against
+        const verdict = parityExitCode(counts);
+        expect(verdict.code).toBe(2);
+        expect(verdict.reason).toContain('NOTHING DIFFED');
+        expect(verdict.reason).toContain('ZERO identity comparisons');
+    });
+
+    it('PARTIALLY unresolvable: the verified denominator no longer counts rows that were never diffed', () => {
+        const rows = [
+            row('a', { foodId: 'off_123' }),   // diffed: same record
+            row('b', { foodId: 'off_123' }),   // diffed: same record
+            row('c', { foodId: 'off_999' }, before('c', { offBarcode: null, fdcId: null, fsId: null })),
+        ];
+        const { counts } = summarizeParity(rows);
+        expect(counts.unresolvableBefore).toBe(1);
+        expect(counts.verifiedReachable).toBe(2);   // pre-fix this read 3
+        // Real comparisons ran, so the run is not void; the excluded row is
+        // reported via unresolvableBefore + the console warning.
+        expect(parityExitCode(counts).code).toBe(0);
+    });
+
+    it('errors and unresolvable rows covering the WHOLE run is exit 2 even when neither alone reaches total', () => {
+        const rows = [
+            row('a', { error: 'http 502' }),
+            row('b', { foodId: 'off_999' }, before('b', { offBarcode: null, fdcId: null, fsId: null })),
+        ];
+        const { counts } = summarizeParity(rows);
+        expect(counts.verifiedReachable).toBe(0);
+        expect(parityExitCode(counts).code).toBe(2);
     });
 });
 

--- a/scripts/eval/__tests__/fail-open-sweep.test.ts
+++ b/scripts/eval/__tests__/fail-open-sweep.test.ts
@@ -1,0 +1,447 @@
+/**
+ * fail-open-sweep.test.ts — FAIL INJECTION for the instruments PR #177 did not
+ * reach: the flywheel sweep + warm runner (one unit — flywheel imports
+ * runWarm), the cache-parity sweep, the stress runner, and the two
+ * detect-corrupt-* scans.
+ *
+ * Same contract as fail-closed.test.ts: every block FORCES the underlying
+ * signal to be absent (dead HTTP, empty result set, a child exit code the
+ * caller used to ignore) and asserts the verdict is NOT the passing one; and
+ * every block carries a POSITIVE CONTROL, because "never green" is satisfiable
+ * by an instrument that never passes anything (playbook §5).
+ *
+ * The headline hole (found writing these): flywheel-sweep's old runEvalGate
+ * ignored run-eval's exit code whenever a results file existed. run-eval
+ * writes its results file BEFORE exiting — including on the zero-case path
+ * where evalExitCode (PR #177) makes it exit 2 — so `results: []` re-derived
+ * as "no unexpected failures" and the sweep turned run-eval's own fail-closed
+ * red into a green exit 0 for systemd. PR #177's fix was being defeated by
+ * PR #177's most important consumer.
+ *
+ * NO NETWORK, NO DATABASE: fetch is replaced per-test, the detect scans get a
+ * stub db, and everything else under test is pure.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+    EvalRunEvidence, judgeEvalGate, sweepVerdict,
+} from '../flywheel-verdict';
+import { runWarm, warmExitCode, WarmResult } from '../warm-cache';
+import { parityExitCode, summarizeParity } from '../cache-parity-sweep';
+import { Sample, stressExitCode } from '../stress-latency';
+import {
+    runScan as runNutritionScan, ScanDb as NutritionScanDb, Row as NutritionRow,
+} from '../detect-corrupt-nutrition';
+import {
+    runScan as runPanelScan, ScanDb as PanelScanDb, Row as PanelRow,
+} from '../detect-corrupt-panel';
+
+const tmpDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'fail-open-sweep-'));
+
+// ===========================================================================
+// 1. flywheel eval gate — the child's exit code is evidence, not decoration
+// ===========================================================================
+
+describe('judgeEvalGate: run-eval exit 2 can never be re-derived into a PASS', () => {
+    const passCase = (id: string) => ({ id, query: id, detail: '', pass: true });
+    const failCase = (id: string) => ({ id, query: id, detail: 'boom', pass: false });
+
+    const evidence = (over: Partial<EvalRunEvidence> = {}): EvalRunEvidence => ({
+        status: 0,
+        signal: null,
+        resultsFile: '/x/results/eval-2026.json',
+        data: { results: [passCase('n-a-01'), passCase('n-a-02')] },
+        ...over,
+    });
+
+    it('THE DEFEAT CASE: exit 2 + a results file with ZERO cases is an instrument failure, not a pass', () => {
+        // Exactly what a zero-case run-eval leaves behind: it writes the file,
+        // THEN exits 2. The old gate read the empty results array, computed
+        // zero unexpected failures, and passed the sweep.
+        const gate = judgeEvalGate(evidence({ status: 2, data: { results: [] } }), ['n-mq-10']);
+        expect(gate.pass).toBe(false);
+        expect(gate.ran).toBe(false);
+        expect(gate.error).toContain('exited 2');
+        expect(gate.error).toContain('does not override');
+    });
+
+    it('exit 2 is refused even when the results file is FULL of passing cases', () => {
+        const gate = judgeEvalGate(evidence({ status: 2 }), []);
+        expect(gate.pass).toBe(false);
+        expect(gate.error).toContain('exited 2');
+    });
+
+    it('a KILLED child (signal, no status) has no receipt to trust', () => {
+        const gate = judgeEvalGate(evidence({ status: null, signal: 'SIGTERM' }), []);
+        expect(gate.pass).toBe(false);
+        expect(gate.error).toContain('KILLED');
+    });
+
+    it('spawn failure, missing results file, unreadable results file — all refuse', () => {
+        expect(judgeEvalGate(evidence({ spawnError: 'ETIMEDOUT' }), []).error).toContain('spawn failed');
+        expect(judgeEvalGate(evidence({ resultsFile: null, data: null }), []).error).toContain('no results file');
+        expect(judgeEvalGate(evidence({ parseError: 'Unexpected end of JSON input', data: null }), []).error)
+            .toContain('unreadable');
+    });
+
+    it('exit 0 over a results file with ZERO cases is still not a pass', () => {
+        const gate = judgeEvalGate(evidence({ data: { results: [] } }), []);
+        expect(gate.pass).toBe(false);
+        expect(gate.error).toContain('ZERO cases');
+    });
+
+    it('an exit code that CONTRADICTS the file means the wrong file was read — refuse both ways', () => {
+        // exit 1 (real failures) but the file shows none: stale file picked up.
+        const staleGreen = judgeEvalGate(evidence({ status: 1 }), []);
+        expect(staleGreen.pass).toBe(false);
+        expect(staleGreen.error).toContain('wrong or stale');
+        // exit 0 but the file shows a real failure: same defect, other polarity.
+        const staleRed = judgeEvalGate(
+            evidence({ status: 0, data: { results: [failCase('n-x-01')] } }), []);
+        expect(staleRed.pass).toBe(false);
+        expect(staleRed.error).toContain('wrong or stale');
+    });
+
+    it('an unrecognised exit code is refused, not defaulted', () => {
+        const gate = judgeEvalGate(evidence({ status: 3 }), []);
+        expect(gate.pass).toBe(false);
+        expect(gate.error).toContain('unrecognised');
+    });
+
+    it('POSITIVE CONTROL — a clean exit-0 receipt passes', () => {
+        const gate = judgeEvalGate(evidence(), ['n-mq-10']);
+        expect(gate.error).toBeUndefined();
+        expect(gate.ran).toBe(true);
+        expect(gate.pass).toBe(true);
+        expect(gate.casesRun).toBe(2);
+    });
+
+    it('POSITIVE CONTROL — allow-fail absorbs exactly its ids, visibly, and stale entries are named', () => {
+        const gate = judgeEvalGate(
+            evidence({ status: 1, data: { results: [passCase('n-a-01'), failCase('n-mq-10')] } }),
+            ['n-mq-10', 'n-old-99']);
+        expect(gate.pass).toBe(true);
+        // The suppression is REPORTED — a standing red must stay visible.
+        expect(gate.suppressedFails).toEqual(['n-mq-10']);
+        // ...and the entry that no longer fails is flagged for pruning.
+        expect(gate.staleAllowFail).toEqual(['n-old-99']);
+    });
+
+    it('an UNLISTED real failure fails the gate', () => {
+        const gate = judgeEvalGate(
+            evidence({ status: 1, data: { results: [failCase('n-supp-23')] } }), ['n-mq-10']);
+        expect(gate.error).toBeUndefined();
+        expect(gate.pass).toBe(false);
+        expect(gate.unexpectedFails).toEqual(['n-supp-23']);
+    });
+
+    it('knownIssue failures do not count as real failures (matches evalExitCode semantics)', () => {
+        const gate = judgeEvalGate(
+            evidence({ data: { results: [passCase('n-a-01'), { id: 'n-k-01', pass: false, knownIssue: true }] } }),
+            []);
+        expect(gate.pass).toBe(true);
+        expect(gate.knownIssues).toBe(1);
+    });
+});
+
+describe('sweepVerdict: the sweep exit code systemd sees', () => {
+    const goodGate = () => judgeEvalGate({
+        status: 0, signal: null, resultsFile: '/x/eval.json',
+        data: { results: [{ id: 'a', pass: true }] },
+    }, []);
+    const brokenGate = () => judgeEvalGate({
+        status: 2, signal: null, resultsFile: '/x/eval.json', data: { results: [] },
+    }, []);
+    const failedGate = () => judgeEvalGate({
+        status: 1, signal: null, resultsFile: '/x/eval.json',
+        data: { results: [{ id: 'n-x-01', query: 'x', detail: 'd', pass: false }] },
+    }, []);
+    const warmOk = { seedCount: 100, resultCount: 100, okCount: 97 };
+
+    it('an instrument failure is exit 2 and says the numbers are void', () => {
+        const v = sweepVerdict(brokenGate(), warmOk);
+        expect(v.code).toBe(2);
+        expect(v.reasons.join(' ')).toContain('INSTRUMENT');
+    });
+
+    it('a genuine gate failure is exit 1 and NAMES the post-hoc writes', () => {
+        const v = sweepVerdict(failedGate(), warmOk);
+        expect(v.code).toBe(1);
+        expect(v.reasons.join(' ')).toContain('EVAL GATE FAILED');
+        // The gate runs AFTER the warm has written (playbook §2) — a red exit
+        // must never read as "nothing happened".
+        expect(v.reasons.join(' ')).toContain('NOT rolled back');
+    });
+
+    it('a warm that reached NOTHING is exit 2 even when the gate was skipped', () => {
+        expect(sweepVerdict(null, { seedCount: 100, resultCount: 100, okCount: 0 }).code).toBe(2);
+        expect(sweepVerdict(null, { seedCount: 100, resultCount: 0, okCount: 0 }).code).toBe(2);
+        expect(sweepVerdict(null, { seedCount: 0, resultCount: 0, okCount: 0 }).code).toBe(2);
+    });
+
+    it('instrument failure (2) outranks gate failure (1) when both fire', () => {
+        expect(sweepVerdict(failedGate(), { seedCount: 100, resultCount: 100, okCount: 0 }).code).toBe(2);
+    });
+
+    it('POSITIVE CONTROLS — clean runs exit 0, skipped steps contribute nothing', () => {
+        expect(sweepVerdict(goodGate(), warmOk).code).toBe(0);
+        expect(sweepVerdict(goodGate(), null).code).toBe(0);   // --skip-warm
+        expect(sweepVerdict(null, warmOk).code).toBe(0);       // --skip-eval
+        expect(sweepVerdict(null, null).code).toBe(0);
+    });
+});
+
+// ===========================================================================
+// 2. warm-cache — "0 warmed" is an outage report, not a warm report
+// ===========================================================================
+
+describe('warm-cache: a warm run that warmed nothing is RED', () => {
+    const err = (seed: string): WarmResult => ({ seed, ok: false, ms: 1, error: 'fetch failed' });
+    const ok = (seed: string): WarmResult => ({ seed, ok: true, ms: 1, foodId: 'off_1' });
+
+    it('warmExitCode fails closed on all three nothing-shapes', () => {
+        expect(warmExitCode(0, []).code).toBe(2);                    // zero seeds assembled
+        expect(warmExitCode(5, []).code).toBe(2);                    // pool never ran
+        expect(warmExitCode(2, [err('a'), err('b')]).code).toBe(2);  // total request failure
+        expect(warmExitCode(2, [err('a'), err('b')]).reason).toContain('TOTAL failure');
+    });
+
+    it('POSITIVE CONTROL — partial errors are not a void run', () => {
+        expect(warmExitCode(2, [ok('a'), err('b')]).code).toBe(0);
+    });
+
+    it('a TOTAL HTTP outage produces per-seed errors and a code-2 verdict (fetch mocked dead)', async () => {
+        const spy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+        try {
+            const out = tmpDir();
+            const report = await runWarm(['apple', 'banana'], {
+                base: 'http://api.invalid', concurrency: 2, timeoutMs: 50, quiet: true, outDir: out,
+            });
+            expect(report.results).toHaveLength(2);
+            expect(report.results.every(r => !r.ok)).toBe(true);
+            expect(report.summary.ok).toBe(0);
+            expect(warmExitCode(2, report.results).code).toBe(2);
+            // The report file IS written — a record of the failure is fine; the
+            // exit code is what must refuse to be green.
+            expect(fs.readdirSync(out).filter(f => f.startsWith('warm-'))).toHaveLength(1);
+        } finally { spy.mockRestore(); }
+    }, 20000);
+
+    it('a NaN --concurrency cannot silently build ZERO workers and skip the corpus', async () => {
+        const spy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => ([{
+                foodId: 'off_1', foodName: 'Apple', source: 'openfoodfacts', grams: 100,
+                matchConfidence: 0.95, nutritionPer100g: { kcal100: 52 },
+            }]),
+        } as unknown as Response);
+        try {
+            const report = await runWarm(['apple', 'banana'], {
+                base: 'http://api.invalid', concurrency: Number('abc'), timeoutMs: 1000, quiet: true, outDir: tmpDir(),
+            });
+            // Array.from({length: NaN}) is [] — before the floor, this recorded
+            // zero results and summarised "ok 0 · errors 0" as if clean.
+            expect(report.results).toHaveLength(2);
+            expect(report.summary.ok).toBe(2);
+            expect(warmExitCode(2, report.results).code).toBe(0);   // POSITIVE CONTROL
+        } finally { spy.mockRestore(); }
+    }, 20000);
+});
+
+// ===========================================================================
+// 3. cache-parity-sweep — total HTTP failure vs verified-clean cache
+// ===========================================================================
+
+describe('cache-parity-sweep: "0 changed records" needs rows that actually came back', () => {
+    const before = (key: string, over: Record<string, unknown> = {}) => ({
+        normalizedForm: key, foodName: 'Almonds', brandName: null, source: 'openfoodfacts',
+        offBarcode: '123', fdcId: null, fsId: null, aiConfidence: 0.9, usedCount: 3, ...over,
+    });
+    const row = (key: string, cold: Record<string, unknown>, b: Record<string, unknown> = before(key)) =>
+        ({ key, queriedAs: key, before: b, cold, ms: 5 });
+
+    it('TOTAL HTTP FAILURE: every replay errored → 0 changed, 0 verified, exit 2 with an explicit reason', () => {
+        const rows = ['a', 'b', 'c'].map(k => row(k, { error: 'AbortError: This operation was aborted' }));
+        const { counts } = summarizeParity(rows);
+        expect(counts.changedRecord).toBe(0);          // the OLD headline number...
+        expect(counts.errors).toBe(3);
+        expect(counts.verifiedReachable).toBe(0);      // ...now paired with what it was verified against
+        const verdict = parityExitCode(counts);
+        expect(verdict.code).toBe(2);
+        expect(verdict.reason).toContain('NOTHING REACHABLE');
+        expect(verdict.reason).toContain('VOID');
+    });
+
+    it('an EMPTY --before file is a void run, not a clean one', () => {
+        const { counts } = summarizeParity([]);
+        const verdict = parityExitCode(counts);
+        expect(verdict.code).toBe(2);
+        expect(verdict.reason).toContain('ZERO rows');
+    });
+
+    it('partial transport failure exits 1 — the errored rows were verified by nothing', () => {
+        const rows = [
+            row('a', { foodId: 'off_123' }),
+            row('b', { error: 'http 502' }),
+            row('c', { foodId: 'off_123' }),
+        ];
+        const { counts } = summarizeParity(rows);
+        expect(counts.verifiedReachable).toBe(2);
+        const verdict = parityExitCode(counts);
+        expect(verdict.code).toBe(1);
+        expect(verdict.reason).toContain('verified by NOTHING');
+    });
+
+    it('POSITIVE CONTROL — a fully reachable, unchanged sweep is exit 0', () => {
+        const rows = [row('a', { foodId: 'off_123' }), row('b', { foodId: 'off_123' })];
+        const { counts } = summarizeParity(rows);
+        expect(counts).toMatchObject({ sameRecord: 2, changedRecord: 0, errors: 0, verifiedReachable: 2 });
+        expect(parityExitCode(counts).code).toBe(0);
+    });
+
+    it('POSITIVE CONTROL — a genuine record change is still counted and reported', () => {
+        const { counts, changes } = summarizeParity([row('a', { foodId: 'off_999', foodName: 'Other', source: 'openfoodfacts' })]);
+        expect(counts.changedRecord).toBe(1);
+        expect(changes[0].was).toContain('off_123');
+        expect(changes[0].now).toContain('off_999');
+    });
+
+    it('fatsecret incumbents resolve through fsId instead of reading as changes', () => {
+        const fsRow = row('fs key', { foodId: 'fs_1646' }, before('fs key', { offBarcode: null, fsId: '1646' }));
+        expect(summarizeParity([fsRow]).counts.sameRecord).toBe(1);
+    });
+
+    it('an incumbent with NO reconstructable id is unresolvable, never a change', () => {
+        const bare = row('a', { foodId: 'off_999' }, before('a', { offBarcode: null, fdcId: null, fsId: null }));
+        const { counts } = summarizeParity([bare]);
+        expect(counts.changedRecord).toBe(0);
+        expect(counts.unresolvableBefore).toBe(1);
+    });
+});
+
+// ===========================================================================
+// 4. stress-latency — a run that measured nothing, and a dead index
+// ===========================================================================
+
+describe('stress-latency: zero requests and HTTP-200-over-nothing are not green', () => {
+    const sample = (over: Partial<Sample> = {}): Sample => ({
+        kind: 'search', q: 'apple', ms: 20, ok: true, empty: false, nullNut: false,
+        status: 200, expectHits: true, ...over,
+    });
+
+    it('ZERO samples (e.g. --n 0 or NaN built an empty task list) exits 2', () => {
+        const v = stressExitCode([]);
+        expect(v.code).toBe(2);
+        expect(v.reasons.join(' ')).toContain('ZERO requests');
+    });
+
+    it('request errors and null-nutrition leaks stay hard failures', () => {
+        expect(stressExitCode([sample(), sample({ ok: false, status: 0 })]).code).toBe(1);
+        expect(stressExitCode([sample(), sample({ nullNut: true })]).code).toBe(1);
+    });
+
+    it('EVERY should-hit search empty = dead index = exit 1, even with zero HTTP errors', () => {
+        const v = stressExitCode([
+            sample({ q: 'apple', empty: true }),
+            sample({ q: 'banana', empty: true }),
+            // a typo probe that is ALLOWED to be empty must not mask the signal
+            sample({ q: 'bananna', empty: true, expectHits: false }),
+        ]);
+        expect(v.code).toBe(1);
+        expect(v.reasons.join(' ')).toContain('EMPTY');
+    });
+
+    it('POSITIVE CONTROL — one real hit defuses the dead-index rule; a healthy run is 0', () => {
+        expect(stressExitCode([sample({ empty: true }), sample({ q: 'banana' })]).code).toBe(0);
+        expect(stressExitCode([sample(), sample({ kind: 'nlp', expectHits: undefined })]).code).toBe(0);
+    });
+});
+
+// ===========================================================================
+// 5. detect-corrupt-* — a scan that saw nothing must not write a clean report
+// ===========================================================================
+
+describe('detect-corrupt scans: zero rows scanned is a broken instrument, not a clean corpus', () => {
+    let logSpy: jest.SpyInstance;
+    let errSpy: jest.SpyInstance;
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => { logSpy.mockRestore(); errSpy.mockRestore(); });
+
+    /** findMany stub: first (cursor-less) page returns `rows`, pagination then ends. */
+    const pagedFindMany = <T,>(rows: T[]) =>
+        async (q: unknown) => ((q as { cursor?: unknown })?.cursor ? [] : rows);
+
+    describe('detect-corrupt-nutrition', () => {
+        it('an EMPTY result set (wrong DB, filter typo) returns 2 and writes NO report', async () => {
+            const out = tmpDir();
+            const db: NutritionScanDb = { offFood: { findMany: pagedFindMany<NutritionRow>([]) } };
+            const code = await runNutritionScan(db, { outDir: out });
+            expect(code).toBe(2);
+            expect(errSpy.mock.calls.flat().join(' ')).toContain('ZERO rows');
+            // No report: a failed scan must not fake an empty population for
+            // mark-corrupt-off.ts to consume.
+            expect(fs.readdirSync(out)).toHaveLength(0);
+        });
+
+        it('POSITIVE CONTROL — one impossible row is scanned, flagged and reported (exit 0)', async () => {
+            const out = tmpDir();
+            const rows: NutritionRow[] = [{
+                barcode: '0001', name: 'Mystery Jerky', brandName: null,
+                servingGrams: null, nutrientsPer100g: { calories: 81818 },
+            }];
+            const db: NutritionScanDb = { offFood: { findMany: pagedFindMany(rows) } };
+            const code = await runNutritionScan(db, { outDir: out });
+            expect(code).toBe(0);
+            const files = fs.readdirSync(out).filter(f => f.startsWith('corrupt-nutrition-scan-'));
+            expect(files).toHaveLength(1);
+            const report = JSON.parse(fs.readFileSync(path.join(out, files[0]), 'utf8'));
+            expect(report.summary.scanned).toBe(1);
+            expect(report.summary.flagged).toBe(1);
+            expect(report.summary.byDirection['kcal-impossible']).toBe(1);
+        });
+    });
+
+    describe('detect-corrupt-panel', () => {
+        const panelDb = (rows: PanelRow[]): PanelScanDb => ({
+            offFood: {
+                findMany: pagedFindMany(rows),
+                findUnique: async () => null,   // triage cross-check misses offline
+            },
+        });
+
+        it('an EMPTY result set returns 2 and writes NO report', async () => {
+            const out = tmpDir();
+            const code = await runPanelScan(panelDb([]), { outDir: out });
+            expect(code).toBe(2);
+            expect(errSpy.mock.calls.flat().join(' ')).toContain('ZERO rows');
+            expect(fs.readdirSync(out)).toHaveLength(0);
+        });
+
+        it('POSITIVE CONTROL — the oreo-shaped panel-as-100g signature is still caught (exit 0)', async () => {
+            const out = tmpDir();
+            const mk = (barcode: string, kcal: number, servingGrams: number): PanelRow => ({
+                barcode, name: 'Oreo Chocolate Sandwich Cookies', brandName: 'Nabisco',
+                servingGrams, nutrientsPer100g: { calories: kcal },
+            });
+            const rows = [
+                mk('b1', 480, 100), mk('b2', 500, 100), mk('b3', 510, 100), mk('b4', 520, 100),
+                // the corrupt row: the 2-cookie serving panel stored as per-100g
+                mk('corrupt1', 143, 29),
+            ];
+            const code = await runPanelScan(panelDb(rows), { outDir: out });
+            expect(code).toBe(0);
+            const files = fs.readdirSync(out).filter(f => f.startsWith('corrupt-panel-scan-'));
+            expect(files).toHaveLength(1);
+            const report = JSON.parse(fs.readFileSync(path.join(out, files[0]), 'utf8'));
+            expect(report.summary.scanned).toBe(5);
+            expect(report.flagged).toHaveLength(1);
+            expect(report.flagged[0]).toMatchObject({ barcode: 'corrupt1', direction: 'panel-low' });
+        });
+    });
+});

--- a/scripts/eval/apply-repoints.ts
+++ b/scripts/eval/apply-repoints.ts
@@ -114,6 +114,13 @@ async function planOne(r: Repoint): Promise<Plan> {
 
 async function main() {
     const repoints: Repoint[] = JSON.parse(fs.readFileSync(FILE!, 'utf8'));
+    if (!Array.isArray(repoints) || repoints.length === 0) {
+        // Fail closed: "Plan: 0 updates, 0 creates, 0 skips" over exit 0 reads
+        // as a successful apply of nothing — an empty or mis-shaped file must
+        // be loud instead.
+        console.error(`FAIL: ${FILE} contains ZERO repoints — nothing to plan; exit 2.`);
+        process.exit(2);
+    }
     console.log(`${repoints.length} repoints from ${FILE} — ${APPLY ? 'APPLYING' : 'DRY RUN'}\n`);
 
     const plans: Plan[] = [];

--- a/scripts/eval/cache-parity-sweep.ts
+++ b/scripts/eval/cache-parity-sweep.ts
@@ -34,8 +34,10 @@
  *
  * EXIT CODES (fail-closed, see parityExitCode): 0 = every row's replay came
  * back and was diffed · 1 = partial transport failure (errored rows were
- * verified by nothing) · 2 = the run was VOID — zero rows evaluated or zero
- * rows reachable; "0 changed records" from an exit-2 run means nothing.
+ * verified by nothing) · 2 = the run was VOID — zero rows evaluated, zero
+ * rows reachable, or zero identity comparisons ran (every row errored or had
+ * no reconstructable incumbent id); "0 changed records" from an exit-2 run
+ * means nothing.
  */
 
 import * as fs from 'fs';
@@ -524,7 +526,14 @@ export interface ParityCounts {
     changedSource: number;
     errors: number;
     unresolvableBefore: number;
-    /** rows whose replay actually came back — the only rows this sweep VERIFIED */
+    /**
+     * Rows whose replay came back AND whose incumbent id could be
+     * reconstructed — the only rows an identity comparison actually ran on.
+     * Unresolvable rows are excluded: their replay reached the API, but the
+     * diff had nothing to compare it against, so they were verified by
+     * NOTHING (the same absence-as-clean shape parityExitCode exists to
+     * refuse).
+     */
     verifiedReachable: number;
 }
 
@@ -552,7 +561,8 @@ export function summarizeParity(rows: any[]): { counts: ParityCounts; changes: a
     return {
         counts: {
             total: rows.length, sameRecord: same, changedRecord: changedId, changedSource,
-            errors, unresolvableBefore, verifiedReachable: rows.length - errors,
+            errors, unresolvableBefore,
+            verifiedReachable: rows.length - errors - unresolvableBefore,
         },
         changes,
     };
@@ -570,8 +580,15 @@ export function summarizeParity(rows: any[]): { counts: ParityCounts; changes: a
  *
  * Partial transport failure is exit 1: the sweep ran, but the errored rows
  * were verified by NOTHING and the run cannot be quoted as whole-cache parity.
+ *
+ * `unresolvableBefore` rows are a second kind of nothing (found in review of
+ * THIS fix, the same class it closes): their replay comes back fine, but the
+ * --before export carries no reconstructable incumbent id, so no identity
+ * comparison ever runs. A run where every row is errored-or-unresolvable
+ * performed ZERO comparisons — "0 changed records" over such a run is a
+ * statement about the export file, not the cache — so it is exit 2 VOID.
  */
-export function parityExitCode(counts: Pick<ParityCounts, 'total' | 'errors'>): { code: 0 | 1 | 2; reason: string | null } {
+export function parityExitCode(counts: Pick<ParityCounts, 'total' | 'errors' | 'unresolvableBefore'>): { code: 0 | 1 | 2; reason: string | null } {
     if (counts.total === 0) {
         return { code: 2, reason: 'evaluated ZERO rows — the --before file is empty; "0 changed records" would be vacuous, not clean' };
     }
@@ -580,6 +597,14 @@ export function parityExitCode(counts: Pick<ParityCounts, 'total' | 'errors'>): 
             code: 2,
             reason: `NOTHING REACHABLE: all ${counts.total} replay attempts failed. This sweep verified 0 rows — `
                 + '"0 changed records" is VOID, not a clean cache',
+        };
+    }
+    if (counts.errors + counts.unresolvableBefore >= counts.total) {
+        return {
+            code: 2,
+            reason: `NOTHING DIFFED: of ${counts.total} rows, ${counts.errors} errored and ${counts.unresolvableBefore} `
+                + 'carry no reconstructable incumbent id (--before export missing offBarcode/fdcId/fsId). '
+                + 'ZERO identity comparisons ran — "0 changed records" is VOID, not a clean cache',
         };
     }
     if (counts.errors > 0) {
@@ -704,7 +729,7 @@ async function main() {
     // Fail-closed verdict — "0 changed records" is only a finding when rows
     // actually came back to be diffed (see parityExitCode).
     if (verdict.code === 0) {
-        console.log(`✅ ${changedId} changed record(s) over ${counts.verifiedReachable} rows verified reachable.`);
+        console.log(`✅ ${changedId} changed record(s) over ${counts.verifiedReachable} rows diffed (replay returned AND incumbent id resolvable).`);
     } else {
         console.error(`\n${verdict.code === 2 ? '💥' : '⚠️'} ${verdict.reason} (exit ${verdict.code})`);
         process.exitCode = verdict.code;

--- a/scripts/eval/cache-parity-sweep.ts
+++ b/scripts/eval/cache-parity-sweep.ts
@@ -31,6 +31,11 @@
  *
  * Writes results/cache-parity-<timestamp>.json (full) and prints a summary +
  * the changed-record list to stdout.
+ *
+ * EXIT CODES (fail-closed, see parityExitCode): 0 = every row's replay came
+ * back and was diffed · 1 = partial transport failure (errored rows were
+ * verified by nothing) · 2 = the run was VOID — zero rows evaluated or zero
+ * rows reachable; "0 changed records" from an exit-2 run means nothing.
  */
 
 import * as fs from 'fs';
@@ -492,11 +497,106 @@ async function sweepOne(row: BeforeRow) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Diff + verdict (pure, exported for fail-injection tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Every source the cache can hold must be expressible here. FatSecret was
+ * missing, and because `beforeId` returned null for those rows the diff
+ * compared `fs_1646 !== null` and called every one of them a changed record —
+ * a false-positive floor equal to the whole fatsecret share of the cache
+ * (441 of 3,246 rows, 13.6%, as of 2026-07-26; it was ~19 rows when the lane
+ * shipped, which is why nobody noticed). Making the replay text faithful is
+ * pointless if a seventh of the resulting diff is noise.
+ */
+function beforeId(b: BeforeRow): string | null {
+    return b.offBarcode ? `off_${b.offBarcode}`
+        : b.fdcId != null ? `fdc_${b.fdcId}`
+            : b.fsId ? `fs_${b.fsId}`
+                : null;
+}
+
+export interface ParityCounts {
+    total: number;
+    sameRecord: number;
+    changedRecord: number;
+    changedSource: number;
+    errors: number;
+    unresolvableBefore: number;
+    /** rows whose replay actually came back — the only rows this sweep VERIFIED */
+    verifiedReachable: number;
+}
+
+/** Fold the per-row sweep results into the diff counts + printable changes. */
+export function summarizeParity(rows: any[]): { counts: ParityCounts; changes: any[] } {
+    let same = 0, changedId = 0, changedSource = 0, errors = 0, unresolvableBefore = 0;
+    const changes: any[] = [];
+    for (const r of rows) {
+        if (r.cold.error) { errors++; changes.push({ key: r.key, error: r.cold.error }); continue; }
+        const oldId = beforeId(r.before);
+        if (r.cold.foodId === oldId) { same++; continue; }
+        // No id at all for the incumbent: an old --before export missing a column,
+        // not evidence the record moved. Counted separately so it can never be
+        // read as a regression.
+        if (oldId === null) { unresolvableBefore++; continue; }
+        changedId++;
+        if (r.cold.source !== r.before.source) changedSource++;
+        changes.push({
+            key: r.key,
+            was: `${oldId} "${r.before.foodName}" (${r.before.source}, used=${r.before.usedCount})`,
+            now: `${r.cold.foodId} "${r.cold.foodName}" (${r.cold.source}, conf=${r.cold.confidence?.toFixed?.(2)})`,
+            kcal100: r.cold.kcal100,
+        });
+    }
+    return {
+        counts: {
+            total: rows.length, sameRecord: same, changedRecord: changedId, changedSource,
+            errors, unresolvableBefore, verifiedReachable: rows.length - errors,
+        },
+        changes,
+    };
+}
+
+/**
+ * Fail-closed exit verdict (playbook §11 class B). This script OVERWRITES
+ * cache rows as an intended side effect, and its old ending printed
+ * `"changedRecord": 0` and exited 0 even when EVERY replay attempt failed —
+ * total HTTP failure was byte-for-byte indistinguishable from a verified-clean
+ * cache. The two states this must never conflate:
+ *
+ *   "0 changed, N rows verified reachable"      → exit 0 (a real measurement)
+ *   "0 evaluated because nothing was reachable" → exit 2 (a void run)
+ *
+ * Partial transport failure is exit 1: the sweep ran, but the errored rows
+ * were verified by NOTHING and the run cannot be quoted as whole-cache parity.
+ */
+export function parityExitCode(counts: Pick<ParityCounts, 'total' | 'errors'>): { code: 0 | 1 | 2; reason: string | null } {
+    if (counts.total === 0) {
+        return { code: 2, reason: 'evaluated ZERO rows — the --before file is empty; "0 changed records" would be vacuous, not clean' };
+    }
+    if (counts.errors >= counts.total) {
+        return {
+            code: 2,
+            reason: `NOTHING REACHABLE: all ${counts.total} replay attempts failed. This sweep verified 0 rows — `
+                + '"0 changed records" is VOID, not a clean cache',
+        };
+    }
+    if (counts.errors > 0) {
+        return {
+            code: 1,
+            reason: `${counts.errors} of ${counts.total} rows could not be replayed (transport errors); `
+                + 'those cache rows were verified by NOTHING this run',
+        };
+    }
+    return { code: 0, reason: null };
+}
+
 async function main() {
     const beforePath = argValue('--before');
     if (!beforePath) {
         console.error('missing --before <foodmapping-rows.json>');
-        process.exit(1);
+        process.exit(2);
     }
     const before: BeforeRow[] = JSON.parse(fs.readFileSync(beforePath, 'utf8'));
 
@@ -527,37 +627,8 @@ async function main() {
     });
     await Promise.all(workers);
 
-    // Every source the cache can hold must be expressible here. FatSecret was
-    // missing, and because `beforeId` returned null for those rows the diff
-    // compared `fs_1646 !== null` and called every one of them a changed record —
-    // a false-positive floor equal to the whole fatsecret share of the cache
-    // (441 of 3,246 rows, 13.6%, as of 2026-07-26; it was ~19 rows when the lane
-    // shipped, which is why nobody noticed). Making the replay text faithful is
-    // pointless if a seventh of the resulting diff is noise.
-    const beforeId = (b: BeforeRow) =>
-        b.offBarcode ? `off_${b.offBarcode}`
-            : b.fdcId != null ? `fdc_${b.fdcId}`
-                : b.fsId ? `fs_${b.fsId}`
-                    : null;
-    let same = 0, changedId = 0, changedSource = 0, errors = 0, unresolvableBefore = 0;
-    const changes: any[] = [];
-    for (const r of results) {
-        if (r.cold.error) { errors++; changes.push({ key: r.key, error: r.cold.error }); continue; }
-        const oldId = beforeId(r.before);
-        if (r.cold.foodId === oldId) { same++; continue; }
-        // No id at all for the incumbent: an old --before export missing a column,
-        // not evidence the record moved. Counted separately so it can never be
-        // read as a regression.
-        if (oldId === null) { unresolvableBefore++; continue; }
-        changedId++;
-        if (r.cold.source !== r.before.source) changedSource++;
-        changes.push({
-            key: r.key,
-            was: `${oldId} "${r.before.foodName}" (${r.before.source}, used=${r.before.usedCount})`,
-            now: `${r.cold.foodId} "${r.cold.foodName}" (${r.cold.source}, conf=${r.cold.confidence?.toFixed?.(2)})`,
-            kcal100: r.cold.kcal100,
-        });
-    }
+    const { counts, changes } = summarizeParity(results);
+    const { sameRecord: same, changedRecord: changedId, changedSource, errors, unresolvableBefore } = counts;
 
     const stamp = new Date().toISOString().replace(/[:.]/g, '-');
     const outPath = path.join(__dirname, 'results', `cache-parity-${stamp}.json`);
@@ -597,7 +668,13 @@ async function main() {
         observedHasColdBreakdown: replayIndex.hasColdBreakdown,
         coldEventsExcluded: replayIndex.coldEventsSeen,
     };
-    const summary = { total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors, unresolvableBefore, replay };
+    const verdict = parityExitCode(counts);
+    const summary = {
+        total: results.length, sameRecord: same, changedRecord: changedId, changedSource, errors,
+        unresolvableBefore, verifiedReachable: counts.verifiedReachable,
+        exit: { code: verdict.code, reason: verdict.reason },
+        replay,
+    };
     fs.writeFileSync(outPath, JSON.stringify({ base: BASE, ranAt: stamp, summary, changes, rejectedDominant, results }, null, 1));
 
     console.log(JSON.stringify(summary, null, 1));
@@ -623,6 +700,15 @@ async function main() {
         else console.log(`  ↻ [${c.key}]\n      was ${c.was}\n      now ${c.now}`);
     }
     console.log(`\nResults written to ${outPath}`);
+
+    // Fail-closed verdict — "0 changed records" is only a finding when rows
+    // actually came back to be diffed (see parityExitCode).
+    if (verdict.code === 0) {
+        console.log(`✅ ${changedId} changed record(s) over ${counts.verifiedReachable} rows verified reachable.`);
+    } else {
+        console.error(`\n${verdict.code === 2 ? '💥' : '⚠️'} ${verdict.reason} (exit ${verdict.code})`);
+        process.exitCode = verdict.code;
+    }
 }
 
 // Guarded so the replay-form selection above can be unit-tested without this
@@ -630,5 +716,7 @@ async function main() {
 // saveValidatedMapping is not gated by skipCache). Same pattern as
 // scripts/dedupe-off-mark.ts:227.
 if (require.main === module) {
-    main();
+    // A crash must be exit 2, never an unhandled rejection whose code depends
+    // on the Node version's default.
+    main().catch(err => { console.error(err); process.exit(2); });
 }

--- a/scripts/eval/classify-drops.ts
+++ b/scripts/eval/classify-drops.ts
@@ -705,6 +705,16 @@ async function main(): Promise<void> {
 
     const rows = inputs.map(makeFunnelRow);
 
+    if (rows.length === 0) {
+        // Fail closed (playbook §11 class B): a funnel report over zero rows
+        // reads as "no drops", which is the opposite of what an empty input
+        // means (a failed warm, a bad --since, the wrong file).
+        console.error(`FAIL: ${label} yielded ZERO rows — a report over nothing must not read as "no drops"; exit 2.`);
+        process.exitCode = 2;
+        if (prisma) await prisma.$disconnect();
+        return;
+    }
+
     if (wantIncumbent) {
         try {
             prisma = prisma ?? openPrisma();

--- a/scripts/eval/detect-corrupt-nutrition.ts
+++ b/scripts/eval/detect-corrupt-nutrition.ts
@@ -82,16 +82,24 @@ import {
     ServingScalePanel,
 } from '../../src/lib/mapping/corrupt-mark';
 
-const prisma = new PrismaClient();
-
-const args = process.argv.slice(2);
-function argValue(flag: string): string | undefined {
-    const i = args.indexOf(flag);
-    return i >= 0 ? args[i + 1] : undefined;
-}
-const MIN_GROUP = Number(argValue('--min-group') ?? MIN_SODIUM_OUTLIER_GROUP);
-const PRINT = Number(argValue('--print') ?? 40);
 const BATCH = 20000;
+
+/**
+ * The one slice of PrismaClient this scan consumes — injectable so the
+ * fail-injection tests can prove the zero-scan refusal offline
+ * (__tests__/fail-open-sweep.test.ts), same pattern as
+ * detect-panel-scale-divided.ts's RowStream.
+ */
+export interface ScanDb {
+    offFood: { findMany(args: unknown): Promise<Row[]> };
+}
+
+export interface NutritionScanOptions {
+    minGroup?: number;
+    print?: number;
+    /** report directory; defaults to scripts/eval/results (tests inject a tmp dir) */
+    outDir?: string;
+}
 
 /** Foods that legitimately live above SODIUM_IMPLAUSIBLE_100G: pure salts,
  *  bouillon/stock concentrates, seasoning/gravy powders, electrolyte mixes.
@@ -118,12 +126,12 @@ function median(sorted: number[]): number {
     return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
-interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
+export interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
 
-async function* streamRows(): AsyncGenerator<Row[]> {
+async function* streamRows(db: ScanDb): AsyncGenerator<Row[]> {
     let cursor: string | undefined;
     for (;;) {
-        const batch: Row[] = await prisma.offFood.findMany({
+        const batch: Row[] = await db.offFood.findMany({
             select: { barcode: true, name: true, brandName: true, servingGrams: true, nutrientsPer100g: true },
             // Marked and deduped rows are already out of retrieval; skipping
             // them also keeps the sibling sodium medians clean.
@@ -138,12 +146,16 @@ async function* streamRows(): AsyncGenerator<Row[]> {
     }
 }
 
-async function main() {
+/** The scan, injectable + exit-code returning. 0 = report written; 2 = the scan saw nothing. */
+export async function runScan(db: ScanDb, opts: NutritionScanOptions = {}): Promise<number> {
+    const MIN_GROUP = opts.minGroup ?? MIN_SODIUM_OUTLIER_GROUP;
+    const PRINT = opts.print ?? 40;
+
     // Pass 1: sibling sodium distributions per name key (for the outlier rule).
     console.log('Pass 1: building sibling sodium medians...');
     const groups = new Map<string, number[]>();
     let scanned = 0;
-    for await (const batch of streamRows()) {
+    for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const nutrients = r.nutrientsPer100g as Record<string, unknown> | null;
             const na = readNum(nutrients, 'sodium');
@@ -166,12 +178,21 @@ async function main() {
     groups.clear();
     console.log(`  ${scanned} rows, ${sodiumMedians.size} name groups with >=${MIN_GROUP} sodium values`);
 
+    // Fail closed (playbook §11 class B): a scan that saw ZERO rows is a broken
+    // instrument — wrong database, a filter typo, an exhausted table — not a
+    // clean corpus. No report is written, so a failed run can never fake an
+    // empty population downstream (mark-corrupt-off.ts consumes these files).
+    if (scanned === 0) {
+        console.error('FAIL: the scan saw ZERO rows. "Flagged 0 (of 0 scanned)" is a void run, not a clean corpus — no report written, exit 2.');
+        return 2;
+    }
+
     // Pass 2: per-row rules, first match wins.
     console.log('Pass 2: testing per-field rules...');
     const flagged: CorruptScanFlag[] = [];
     const guarded: Array<{ barcode: string; name: string; brandName: string | null; sodium: number }> = [];
     let sauceBand = 0;
-    for await (const batch of streamRows()) {
+    for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const nutrients = r.nutrientsPer100g as Record<string, unknown> | null;
             const kcal = readKcal(nutrients);
@@ -280,7 +301,7 @@ async function main() {
     const byDirection: Record<string, number> = {};
     for (const f of flagged) byDirection[f.direction] = (byDirection[f.direction] ?? 0) + 1;
 
-    const outDir = path.join(__dirname, 'results');
+    const outDir = opts.outDir ?? path.join(__dirname, 'results');
     fs.mkdirSync(outDir, { recursive: true });
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
     const outPath = path.join(outDir, `corrupt-nutrition-scan-${ts}.json`);
@@ -327,8 +348,23 @@ async function main() {
     }
     console.log(`\nReport written to ${path.relative(process.cwd(), outPath)}`);
     console.log('Next: scripts/mark-corrupt-off.ts --file <report> (dry-run first, then --apply after approval).');
+    return 0;
 }
 
-main()
-    .catch(err => { console.error(err); process.exit(2); })
-    .finally(() => prisma.$disconnect());
+// Guarded so runScan is importable by the offline test suite (this file used
+// to construct a PrismaClient and start the scan at import time).
+if (require.main === module) {
+    const args = process.argv.slice(2);
+    const argValue = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+    const prisma = new PrismaClient();
+    runScan(prisma as unknown as ScanDb, {
+        minGroup: Number(argValue('--min-group') ?? MIN_SODIUM_OUTLIER_GROUP),
+        print: Number(argValue('--print') ?? 40),
+    })
+        .then(code => { if (code !== 0) process.exitCode = code; })
+        .catch(err => { console.error(err); process.exitCode = 2; })
+        .finally(() => prisma.$disconnect().catch(() => {}));
+}

--- a/scripts/eval/detect-corrupt-panel.ts
+++ b/scripts/eval/detect-corrupt-panel.ts
@@ -40,16 +40,26 @@ import * as path from 'path';
 import { PrismaClient } from '@prisma/client';
 import { normalizeNameKey } from '../../src/lib/search/dedupe-candidates';
 
-const prisma = new PrismaClient();
-
-const args = process.argv.slice(2);
-function argValue(flag: string): string | undefined {
-    const i = args.indexOf(flag);
-    return i >= 0 ? args[i + 1] : undefined;
-}
-const MIN_GROUP = Number(argValue('--min-group') ?? 4);
-const PRINT = Number(argValue('--print') ?? 40);
 const BATCH = 20000;
+
+/**
+ * The slice of PrismaClient this scan consumes — injectable so the
+ * fail-injection tests can prove the zero-scan refusal offline
+ * (__tests__/fail-open-sweep.test.ts).
+ */
+export interface ScanDb {
+    offFood: {
+        findMany(args: unknown): Promise<Row[]>;
+        findUnique(args: unknown): Promise<Pick<Row, 'name' | 'servingGrams' | 'nutrientsPer100g'> | null>;
+    };
+}
+
+export interface PanelScanOptions {
+    minGroup?: number;
+    print?: number;
+    /** report directory; defaults to scripts/eval/results (tests inject a tmp dir) */
+    outDir?: string;
+}
 
 /** Confirmed corrupt in the 2026-07-20 warm-cache triage (adversarial verify vs live corpus). */
 const TRIAGE_CONFIRMED = [
@@ -71,12 +81,12 @@ function median(sorted: number[]): number {
     return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
-interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
+export interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
 
-async function* streamRows(): AsyncGenerator<Row[]> {
+async function* streamRows(db: ScanDb): AsyncGenerator<Row[]> {
     let cursor: string | undefined;
     for (;;) {
-        const batch: Row[] = await prisma.offFood.findMany({
+        const batch: Row[] = await db.offFood.findMany({
             select: { barcode: true, name: true, brandName: true, servingGrams: true, nutrientsPer100g: true },
             where: { nutrientsPer100g: { not: undefined } },
             orderBy: { barcode: 'asc' },
@@ -89,12 +99,16 @@ async function* streamRows(): AsyncGenerator<Row[]> {
     }
 }
 
-async function main() {
+/** The scan, injectable + exit-code returning. 0 = report written; 2 = the scan saw nothing. */
+export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<number> {
+    const MIN_GROUP = opts.minGroup ?? 4;
+    const PRINT = opts.print ?? 40;
+
     // Pass 1: sibling kcal + serving distributions per name key
     console.log('Pass 1: building sibling kcal/serving medians...');
     const groups = new Map<string, { kcals: number[]; servings: number[] }>();
     let scanned = 0;
-    for await (const batch of streamRows()) {
+    for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const kcal = readKcal(r.nutrientsPer100g);
             if (kcal == null) continue;
@@ -130,6 +144,14 @@ async function main() {
     groups.clear();
     console.log(`  ${scanned} rows, ${medians.size} sane name groups with >=${MIN_GROUP} members, ${inflatedGroups.length} mass-inflated groups (median > ${MAX_SANE_MEDIAN}) excluded`);
 
+    // Fail closed (playbook §11 class B): a scan that saw ZERO rows is a broken
+    // instrument, not a clean corpus. No report is written, so a failed run can
+    // never fake an empty population downstream.
+    if (scanned === 0) {
+        console.error('FAIL: the scan saw ZERO rows. "Flagged 0 (of 0 scanned)" is a void run, not a clean corpus — no report written, exit 2.');
+        return 2;
+    }
+
     // Pass 2: test the panel-as-100g signature
     console.log('Pass 2: testing serving-rescale signature...');
     const flagged: Array<{
@@ -138,7 +160,7 @@ async function main() {
         direction: 'panel-low' | 'panel-inflated';
         rescaled: number; siblingMedian: number; groupSize: number; triageConfirmed: boolean;
     }> = [];
-    for await (const batch of streamRows()) {
+    for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const kcal = readKcal(r.nutrientsPer100g);
             if (kcal == null) continue;
@@ -166,7 +188,7 @@ async function main() {
     }
 
     flagged.sort((a, b) => b.siblingMedian - a.siblingMedian);
-    const outDir = path.join(__dirname, 'results');
+    const outDir = opts.outDir ?? path.join(__dirname, 'results');
     fs.mkdirSync(outDir, { recursive: true });
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
     const outPath = path.join(outDir, `corrupt-panel-scan-${ts}.json`);
@@ -191,7 +213,7 @@ async function main() {
     const flaggedSet = new Set(flagged.map(f => f.barcode));
     for (const b of TRIAGE_CONFIRMED) {
         if (flaggedSet.has(b)) { console.log(`  CAUGHT  off_${b}`); continue; }
-        const row = await prisma.offFood.findUnique({
+        const row = await db.offFood.findUnique({
             where: { barcode: b },
             select: { name: true, servingGrams: true, nutrientsPer100g: true },
         });
@@ -202,8 +224,23 @@ async function main() {
     }
 
     console.log(`\nReport written to ${path.relative(process.cwd(), outPath)}`);
+    return 0;
 }
 
-main()
-    .catch(err => { console.error(err); process.exit(2); })
-    .finally(() => prisma.$disconnect());
+// Guarded so runScan is importable by the offline test suite (this file used
+// to construct a PrismaClient and start the scan at import time).
+if (require.main === module) {
+    const args = process.argv.slice(2);
+    const argValue = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+    const prisma = new PrismaClient();
+    runScan(prisma as unknown as ScanDb, {
+        minGroup: Number(argValue('--min-group') ?? 4),
+        print: Number(argValue('--print') ?? 40),
+    })
+        .then(code => { if (code !== 0) process.exitCode = code; })
+        .catch(err => { console.error(err); process.exitCode = 2; })
+        .finally(() => prisma.$disconnect().catch(() => {}));
+}

--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -18,7 +18,15 @@
  *   3. DIFF       — compare against the previous warm-*.json report: identity
  *      flips, per-100g kcal drift >5%, grams flap >25%, error deltas.
  *   4. EVAL GATE  — spawn run-eval.ts; real failures must be a subset of
- *      --allow-fail (default n-mq-10). Gate failure → exit 1.
+ *      --allow-fail (default n-mq-10). Gate failure → exit 1. An INSTRUMENT
+ *      failure — run-eval crashed/killed, exited 2 (its own fail-closed
+ *      zero-case signal), receipt missing/unreadable/contradicting the exit
+ *      code, or a warm step that reached nothing — → exit 2: the sweep
+ *      measured NOTHING and must not read as either green or "gate red".
+ *      The gate is POST-HOC: step [2/4] has already written to FoodMapping
+ *      before it runs, and nothing rolls back — a red gate means "writes
+ *      happened AND the gate is red", and the exit reasons say so.
+ *      Verdict logic is pure + fail-injection tested: flywheel-verdict.ts.
  *      4b. SEG REPLAY-DIFF (REPORT-ONLY) — top-N SegmentationCache lines by
  *      hitCount re-run through fresh AI segmentation with the cache bypassed
  *      (no cache read, NO cache write) and diffed against the cached splits;
@@ -66,6 +74,9 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { PrismaClient } from '@prisma/client';
 import { assembleSeeds, runWarm, WarmResult, WarmRunReport } from './warm-cache';
+import {
+    EvalGate, EvalRunEvidence, judgeEvalGate, sweepVerdict, WarmFacts,
+} from './flywheel-verdict';
 import {
     collectStuckKeys, computeStuckTrend, findPreviousStuckReport, formatStuckKeysSection,
     StuckKeysReport, StuckTrend,
@@ -347,19 +358,18 @@ function diffWarmRuns(prevPath: string | null, current: WarmResult[]): WarmDiff 
 // 4. Eval gate
 // ---------------------------------------------------------------------------
 
-interface EvalGate {
-    ran: boolean;
-    pass: boolean;
-    realFails: { id: string; query: string; detail: string }[];
-    unexpectedFails: string[];
-    knownIssues: number;
-    knownNowPassing: string[];
-    kinds?: Record<string, { pass: number; total: number; p50ms: number; p95ms: number }>;
-    error?: string;
-}
-
+/**
+ * Spawn run-eval.ts and JUDGE it — exit code first, results file second.
+ *
+ * The verdict logic itself is pure and lives in flywheel-verdict.ts
+ * (judgeEvalGate), where it is fail-injection tested. The old version of this
+ * function ignored `proc.status` whenever a results file existed, which
+ * defeated run-eval's own `evalExitCode` fail-closed signal (PR #177):
+ * run-eval writes its results file even on the zero-case path, exits 2, and
+ * an empty `results` array re-derived here as "no unexpected failures" — a
+ * PASS. That is playbook §11 class B, absence encoded as a pass.
+ */
 function runEvalGate(): EvalGate {
-    const gate: EvalGate = { ran: false, pass: true, realFails: [], unexpectedFails: [], knownIssues: 0, knownNowPassing: [] };
     const before = new Set(
         fs.existsSync(RESULTS_DIR) ? fs.readdirSync(RESULTS_DIR).filter(f => f.startsWith('eval-')) : []);
 
@@ -369,28 +379,29 @@ function runEvalGate(): EvalGate {
         path.join(__dirname, 'run-eval.ts'), '--base', BASE,
     ], { cwd: REPO_ROOT, stdio: 'inherit', timeout: 30 * 60 * 1000 });
 
-    if (proc.error) {
-        return { ...gate, pass: false, error: `run-eval spawn failed: ${proc.error.message}` };
-    }
-    const evalFile = fs.readdirSync(RESULTS_DIR)
-        .filter(f => f.startsWith('eval-') && !before.has(f))
-        .map(f => path.join(RESULTS_DIR, f))
-        .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
-    if (!evalFile) {
-        return { ...gate, pass: false, error: `run-eval produced no results file (exit ${proc.status})` };
+    const evidence: EvalRunEvidence = {
+        spawnError: proc.error ? proc.error.message : undefined,
+        status: proc.status ?? null,
+        signal: (proc.signal as string | null) ?? null,
+        resultsFile: null,
+    };
+
+    if (!evidence.spawnError && fs.existsSync(RESULTS_DIR)) {
+        const evalFile = fs.readdirSync(RESULTS_DIR)
+            .filter(f => f.startsWith('eval-') && !before.has(f))
+            .map(f => path.join(RESULTS_DIR, f))
+            .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
+        if (evalFile) {
+            evidence.resultsFile = evalFile;
+            try {
+                evidence.data = JSON.parse(fs.readFileSync(evalFile, 'utf8'));
+            } catch (err) {
+                evidence.parseError = (err as Error).message;
+            }
+        }
     }
 
-    const data = JSON.parse(fs.readFileSync(evalFile, 'utf8'));
-    const results: any[] = data.results ?? [];
-    gate.ran = true;
-    gate.realFails = results.filter(r => !r.pass && !r.knownIssue)
-        .map(r => ({ id: r.id, query: r.query, detail: r.detail }));
-    gate.unexpectedFails = gate.realFails.map(r => r.id).filter(id => !ALLOW_FAIL.includes(id));
-    gate.knownIssues = results.filter(r => !r.pass && r.knownIssue).length;
-    gate.knownNowPassing = results.filter(r => r.pass && r.knownIssue).map(r => r.id);
-    gate.kinds = data.summary?.kinds;
-    gate.pass = gate.unexpectedFails.length === 0;
-    return gate;
+    return judgeEvalGate(evidence, ALLOW_FAIL);
 }
 
 // ---------------------------------------------------------------------------
@@ -493,12 +504,18 @@ function buildMarkdown(ranAt: string, telemetry: Telemetry, warm: WarmRunReport 
     if (!gate) {
         lines.push('_skipped (--skip-eval)_');
     } else if (gate.error) {
-        lines.push(`❌ **ERROR**: ${gate.error}`);
+        lines.push(`💥 **INSTRUMENT ERROR** (exit 2 — this sweep has NO gate verdict): ${gate.error}`);
     } else {
         lines.push(gate.pass
-            ? `✅ **PASS** — real failures ⊆ allowlist [${ALLOW_FAIL.join(', ')}]`
+            ? `✅ **PASS** — ${gate.casesRun} cases; real failures ⊆ allowlist [${ALLOW_FAIL.join(', ')}]`
             : `❌ **FAIL** — unexpected real failures: ${gate.unexpectedFails.join(', ')}`);
         for (const f of gate.realFails) lines.push(`- [${f.id}] "${f.query}" — ${f.detail}`);
+        if (gate.suppressedFails.length) {
+            lines.push(`- ⚠️ real failures ABSORBED by --allow-fail (a standing red, kept visible): ${gate.suppressedFails.join(', ')}`);
+        }
+        if (gate.staleAllowFail.length) {
+            lines.push(`- 🧹 --allow-fail entries that did NOT fail this run (stale — prune before they absorb a genuine red): ${gate.staleAllowFail.join(', ')}`);
+        }
         lines.push(`- known issues still failing: ${gate.knownIssues}`);
         if (gate.knownNowPassing.length) {
             lines.push(`- 🟢 known issues NOW PASSING (promote after stability): ${gate.knownNowPassing.join(', ')}`);
@@ -619,11 +636,19 @@ async function main() {
     const ranAt = new Date().toISOString();
     const stamp = ranAt.replace(/[:.]/g, '-');
 
+    // The *-only modes exist to produce exactly ONE report. Inside a full sweep
+    // these steps are fail-soft by design (report-only, never gating), but when
+    // the step IS the whole invocation, "unavailable: <error>" over an exit 0
+    // is absence-encoded-as-success — fail closed instead.
     if (COVERAGE_ONLY) {
         console.log(`Coverage-only read @ ${ranAt} · corpus ${path.basename(COVERAGE_CORPUS)}`);
         const cov = await runCoverageStep(ranAt, stamp);
         console.log('');
         console.log(formatCoverageSection(cov.report, cov.trend).join('\n'));
+        if (!cov.report.ok) {
+            console.error(`\nFAIL: coverage-only run produced NO coverage read (${cov.report.error ?? 'unknown'}) — exit 2.`);
+            process.exitCode = 2;
+        }
         return;
     }
 
@@ -633,6 +658,10 @@ async function main() {
         console.log('');
         console.log(formatStuckKeysSection(stuck.report, stuck.trend).join('\n'));
         if (stuck.outPath) console.log(`\nJSON: ${stuck.outPath}`);
+        if (!stuck.report.ok) {
+            console.error(`\nFAIL: stuck-keys-only run produced NO report (${stuck.report.error ?? 'unknown'}) — exit 2.`);
+            process.exitCode = 2;
+        }
         return;
     }
 
@@ -642,6 +671,10 @@ async function main() {
         console.log('');
         console.log(formatSegReplaySection(seg.report, seg.trend).join('\n'));
         if (seg.outPath) console.log(`\nJSON: ${seg.outPath}`);
+        if (!seg.report.ok) {
+            console.error(`\nFAIL: seg-replay-only run produced NO report (${seg.report.error ?? 'unknown'}) — exit 2.`);
+            process.exitCode = 2;
+        }
         return;
     }
 
@@ -685,8 +718,12 @@ async function main() {
         console.log('\n[4/4] Golden-set eval gate…');
         gate = runEvalGate();
         console.log(gate.error
-            ? `  ERROR: ${gate.error}`
-            : `  ${gate.pass ? 'PASS' : 'FAIL'} (real fails: ${gate.realFails.map(f => f.id).join(', ') || 'none'})`);
+            ? `  INSTRUMENT ERROR (no verdict): ${gate.error}`
+            : `  ${gate.pass ? 'PASS' : 'FAIL'} (${gate.casesRun} cases; real fails: ${gate.realFails.map(f => f.id).join(', ') || 'none'}`
+              + `${gate.suppressedFails.length ? `; suppressed by allow-fail: ${gate.suppressedFails.join(', ')}` : ''})`);
+        if (!gate.error && gate.staleAllowFail.length) {
+            console.log(`  note: --allow-fail entries not failing any more: ${gate.staleAllowFail.join(', ')} (prune, or they absorb a future genuine red)`);
+        }
     }
 
     // Report-only drift check — runs after the gate, never changes its verdict.
@@ -708,10 +745,18 @@ async function main() {
             : `  unavailable: ${coverage.report.error}`);
     }
 
+    // The sweep's own exit verdict — computed BEFORE the report is written so
+    // the JSON carries the same code systemd will see (flywheel-verdict.ts).
+    const warmFacts: WarmFacts | null = warm
+        ? { seedCount, resultCount: warm.results.length, okCount: warm.summary.ok }
+        : null;
+    const verdict = sweepVerdict(gate, warmFacts);
+
     fs.mkdirSync(RESULTS_DIR, { recursive: true });
     const jsonPath = path.join(RESULTS_DIR, `flywheel-${stamp}.json`);
     fs.writeFileSync(jsonPath, JSON.stringify({
         ranAt, base: BASE, days: DAYS, allowFail: ALLOW_FAIL,
+        exit: verdict,
         telemetry, warmSummary: warm?.summary ?? null, warmReport: warm?.outPath ?? null,
         diff, gate,
         // Rows live in the dedicated stuck-keys-<ts>.json (triage-batch input);
@@ -750,10 +795,19 @@ async function main() {
         }
     }
 
-    if (gate && !gate.pass) {
-        console.error('\nEval gate FAILED');
-        process.exit(1);
+    // LOUD, machine-readable failure: one summary line + one reason per line on
+    // stderr, and an exit code that reaches systemd (Type=oneshot marks the unit
+    // failed on any nonzero). process.exitCode — not process.exit() — so every
+    // report above is already flushed and nothing here can truncate it.
+    if (verdict.code !== 0) {
+        console.error(`\n${verdict.code === 2
+            ? '💥 FLYWHEEL INSTRUMENT FAILURE — this sweep has no trustworthy numbers'
+            : '❌ FLYWHEEL EVAL GATE FAILED'} (exit ${verdict.code})`);
+        for (const r of verdict.reasons) console.error(`  - ${r}`);
+        process.exitCode = verdict.code;
     }
 }
 
-main().catch(err => { console.error(err); process.exit(2); });
+if (require.main === module) {
+    main().catch(err => { console.error(err); process.exit(2); });
+}

--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -368,16 +368,43 @@ function diffWarmRuns(prevPath: string | null, current: WarmResult[]): WarmDiff 
  * run-eval writes its results file even on the zero-case path, exits 2, and
  * an empty `results` array re-derived here as "no unexpected failures" — a
  * PASS. That is playbook §11 class B, absence encoded as a pass.
+ *
+ * Exported with an injectable child + results dir so the jest suite can run
+ * the EVIDENCE ASSEMBLY itself against a stub child process — the 35
+ * fail-injection tests on judgeEvalGate prove the judge, but only a real
+ * spawn proves that the exit code, the before/after file diff and the JSON
+ * parse actually reach it. Defaults reproduce production behaviour exactly;
+ * main() calls this with no arguments.
  */
-function runEvalGate(): EvalGate {
-    const before = new Set(
-        fs.existsSync(RESULTS_DIR) ? fs.readdirSync(RESULTS_DIR).filter(f => f.startsWith('eval-')) : []);
+export interface RunEvalGateOptions {
+    /** Child to spawn; defaults to the real run-eval.ts under ts-node. */
+    spawn?: { cmd: string; args: string[] };
+    /** Where eval-*.json receipts appear; defaults to scripts/eval/results. */
+    resultsDir?: string;
+    /** Failure ids the gate may absorb; defaults to --allow-fail. */
+    allowFail?: string[];
+    cwd?: string;
+    timeoutMs?: number;
+}
 
-    const proc = spawnSync('npx', [
-        'ts-node', '--transpile-only',
-        '--compilerOptions', '{"module":"commonjs","moduleResolution":"node"}',
-        path.join(__dirname, 'run-eval.ts'), '--base', BASE,
-    ], { cwd: REPO_ROOT, stdio: 'inherit', timeout: 30 * 60 * 1000 });
+export function runEvalGate(opts: RunEvalGateOptions = {}): EvalGate {
+    const resultsDir = opts.resultsDir ?? RESULTS_DIR;
+    const allowFail = opts.allowFail ?? ALLOW_FAIL;
+    const child = opts.spawn ?? {
+        cmd: 'npx',
+        args: [
+            'ts-node', '--transpile-only',
+            '--compilerOptions', '{"module":"commonjs","moduleResolution":"node"}',
+            path.join(__dirname, 'run-eval.ts'), '--base', BASE,
+        ],
+    };
+
+    const before = new Set(
+        fs.existsSync(resultsDir) ? fs.readdirSync(resultsDir).filter(f => f.startsWith('eval-')) : []);
+
+    const proc = spawnSync(child.cmd, child.args, {
+        cwd: opts.cwd ?? REPO_ROOT, stdio: 'inherit', timeout: opts.timeoutMs ?? 30 * 60 * 1000,
+    });
 
     const evidence: EvalRunEvidence = {
         spawnError: proc.error ? proc.error.message : undefined,
@@ -386,10 +413,10 @@ function runEvalGate(): EvalGate {
         resultsFile: null,
     };
 
-    if (!evidence.spawnError && fs.existsSync(RESULTS_DIR)) {
-        const evalFile = fs.readdirSync(RESULTS_DIR)
+    if (!evidence.spawnError && fs.existsSync(resultsDir)) {
+        const evalFile = fs.readdirSync(resultsDir)
             .filter(f => f.startsWith('eval-') && !before.has(f))
-            .map(f => path.join(RESULTS_DIR, f))
+            .map(f => path.join(resultsDir, f))
             .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
         if (evalFile) {
             evidence.resultsFile = evalFile;
@@ -401,7 +428,7 @@ function runEvalGate(): EvalGate {
         }
     }
 
-    return judgeEvalGate(evidence, ALLOW_FAIL);
+    return judgeEvalGate(evidence, allowFail);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/eval/flywheel-verdict.ts
+++ b/scripts/eval/flywheel-verdict.ts
@@ -1,0 +1,215 @@
+/**
+ * flywheel-verdict.ts — the flywheel sweep's PURE verdict logic, split out of
+ * flywheel-sweep.ts so it can be fail-injection tested offline (no Prisma, no
+ * network, no child processes; see __tests__/fail-open-sweep.test.ts).
+ *
+ * WHY THIS FILE EXISTS (playbook §11 class B — absence encoded as a PASS)
+ *
+ * run-eval.ts exits 2 when it executed ZERO cases — that is PR #177's
+ * `evalExitCode` fix, and it is run-eval's own fail-closed signal. But
+ * flywheel-sweep's old `runEvalGate()` never looked at the child's exit code:
+ * whenever a results file existed it re-derived pass/fail from
+ * `data.results ?? []`, and an empty results array yields zero real failures,
+ * which reads as "real failures ⊆ allowlist" — a PASS. run-eval writes its
+ * results file BEFORE exiting, including on the zero-case path, so the sweep
+ * converted run-eval's own red into a green and exited 0 into systemd.
+ * `judgeEvalGate` closes that: the child's exit code is evidence that a
+ * results file cannot override.
+ *
+ * The same audit found three sibling holes, all closed here:
+ *   - a warm step whose every request failed ("0 warmed" summarised, exit 0);
+ *   - a warm step that recorded zero results because the worker pool never
+ *     ran (NaN --concurrency);
+ *   - an eval exit code that CONTRADICTS the results file (wrong/stale file
+ *     picked up from results/) being resolved in favour of whichever side
+ *     looked greener.
+ *
+ * And one thing deliberately NOT fixed here: the gate is POST-HOC. The warm
+ * at step [2/4] has already written to FoodMapping before the gate at [4/4]
+ * runs, and nothing is rolled back on failure (playbook §2). This module
+ * cannot change that ordering — what it does is say so, loudly, in the
+ * failure reasons, so a red gate is never read as "the sweep wrote nothing".
+ */
+
+export interface EvalGate {
+    /** true only when run-eval produced a receipt this module trusts end-to-end */
+    ran: boolean;
+    pass: boolean;
+    /** number of cases the results file actually contains */
+    casesRun: number;
+    realFails: { id: string; query: string; detail: string }[];
+    /** real failures NOT covered by --allow-fail — these fail the gate */
+    unexpectedFails: string[];
+    /** real failures absorbed by --allow-fail — reported so a standing red stays visible */
+    suppressedFails: string[];
+    /** --allow-fail ids that did NOT fail this run — stale entries worth pruning */
+    staleAllowFail: string[];
+    knownIssues: number;
+    knownNowPassing: string[];
+    kinds?: Record<string, { pass: number; total: number; p50ms: number; p95ms: number }>;
+    /** set when the gate could not produce a trustworthy verdict (instrument failure) */
+    error?: string;
+}
+
+/** Everything the spawned run-eval.ts left behind, gathered by flywheel-sweep. */
+export interface EvalRunEvidence {
+    /** spawnSync failed outright (ENOENT, ETIMEDOUT, ...) */
+    spawnError?: string;
+    /** child exit code; null when the child was killed by a signal */
+    status: number | null;
+    signal?: string | null;
+    /** the new results file the run produced, if one was found */
+    resultsFile: string | null;
+    /** set when the results file existed but could not be parsed */
+    parseError?: string;
+    data?: { summary?: { kinds?: EvalGate['kinds'] }; results?: unknown[] } | null;
+}
+
+interface RawCaseResult {
+    id?: string;
+    query?: string;
+    detail?: string;
+    pass?: boolean;
+    knownIssue?: boolean;
+}
+
+function failedGate(error: string): EvalGate {
+    return {
+        ran: false, pass: false, casesRun: 0, realFails: [], unexpectedFails: [],
+        suppressedFails: [], staleAllowFail: [], knownIssues: 0, knownNowPassing: [],
+        error,
+    };
+}
+
+/**
+ * Turn the evidence of one run-eval invocation into a gate verdict.
+ *
+ * Ordering of the refusals matters: the child's own exit code is judged BEFORE
+ * the results file's contents, because run-eval exiting 2 is its fail-closed
+ * signal (evalExitCode, PR #177) and a results file — which run-eval writes
+ * even on the zero-case path — must never override it.
+ */
+export function judgeEvalGate(run: EvalRunEvidence, allowFail: string[]): EvalGate {
+    if (run.spawnError) {
+        return failedGate(`run-eval spawn failed: ${run.spawnError}`);
+    }
+    if (run.status === null) {
+        return failedGate(`run-eval was KILLED (signal ${run.signal ?? 'unknown'}) — there is no receipt to trust`);
+    }
+    if (!run.resultsFile) {
+        return failedGate(`run-eval produced no results file (exit ${run.status})`);
+    }
+    if (run.parseError) {
+        return failedGate(`run-eval results file is unreadable: ${run.parseError}`);
+    }
+
+    const results = (run.data?.results ?? []) as RawCaseResult[];
+
+    if (run.status === 2) {
+        // run-eval's OWN fail-closed verdict (zero cases executed, or an internal
+        // crash after main started). It writes the results file before exiting,
+        // so "the file exists and lists no failures" is exactly the shape this
+        // branch must refuse to read as a pass.
+        return {
+            ...failedGate(`run-eval exited 2 — its own fail-closed signal (zero cases or internal failure). `
+                + `A results file listing ${results.length} case(s) does not override the exit code.`),
+            casesRun: results.length,
+        };
+    }
+    if (run.status !== 0 && run.status !== 1) {
+        return failedGate(`run-eval exited ${run.status} — unrecognised code, refusing to read it as any verdict`);
+    }
+    if (results.length === 0) {
+        return failedGate('run-eval results file contains ZERO cases — a gate that evaluated nothing cannot pass');
+    }
+
+    const realFails = results
+        .filter(r => !r.pass && !r.knownIssue)
+        .map(r => ({ id: String(r.id ?? '?'), query: String(r.query ?? ''), detail: String(r.detail ?? '') }));
+
+    // Exit code and file must AGREE, or we are reading the wrong file — e.g. a
+    // stale results/ entry picked up because the child died before writing its
+    // own. evalExitCode returns 1 iff a non-knownIssue case failed, so any
+    // disagreement means the receipt does not belong to this run.
+    if (run.status === 1 && realFails.length === 0) {
+        return failedGate('run-eval exited 1 (real failures) but the results file shows none — '
+            + 'wrong or stale file; refusing to pass on it');
+    }
+    if (run.status === 0 && realFails.length > 0) {
+        return failedGate(`run-eval exited 0 but the results file shows ${realFails.length} real failure(s) — `
+            + 'wrong or stale file; refusing to judge from it');
+    }
+
+    const failIds = realFails.map(f => f.id);
+    const gate: EvalGate = {
+        ran: true,
+        pass: false,
+        casesRun: results.length,
+        realFails,
+        unexpectedFails: failIds.filter(id => !allowFail.includes(id)),
+        suppressedFails: failIds.filter(id => allowFail.includes(id)),
+        staleAllowFail: allowFail.filter(id => !failIds.includes(id)),
+        knownIssues: results.filter(r => !r.pass && r.knownIssue).length,
+        knownNowPassing: results.filter(r => r.pass && r.knownIssue).map(r => String(r.id ?? '?')),
+        kinds: run.data?.summary?.kinds,
+    };
+    gate.pass = gate.unexpectedFails.length === 0;
+    return gate;
+}
+
+/** The warm step's outcome, reduced to what the sweep verdict needs. */
+export interface WarmFacts {
+    seedCount: number;
+    resultCount: number;
+    okCount: number;
+}
+
+export interface SweepVerdict {
+    /** 0 = clean · 1 = the gate ran and FAILED · 2 = an instrument failed (numbers are void) */
+    code: 0 | 1 | 2;
+    reasons: string[];
+}
+
+/**
+ * The sweep's process exit code, from the gate verdict and the warm facts.
+ * Pass null for a step that was skipped (--skip-warm / --skip-eval).
+ *
+ * 2 beats 1: "the sweep could not measure" and "the sweep measured a failure"
+ * are different states and systemd should be able to tell them apart.
+ */
+export function sweepVerdict(gate: EvalGate | null, warm: WarmFacts | null): SweepVerdict {
+    const reasons: string[] = [];
+    let code: 0 | 1 | 2 = 0;
+
+    if (warm) {
+        if (warm.seedCount === 0) {
+            code = 2;
+            reasons.push('INSTRUMENT: the warm step assembled ZERO seeds — corpus files missing or empty; nothing was warmed');
+        } else if (warm.resultCount === 0) {
+            code = 2;
+            reasons.push(`INSTRUMENT: the warm step attempted ${warm.seedCount} seeds but recorded ZERO results — the worker pool never ran`);
+        } else if (warm.okCount === 0) {
+            code = 2;
+            reasons.push(`INSTRUMENT: warm TOTAL failure — 0 of ${warm.resultCount} seeds resolved; nothing was reachable, `
+                + 'so every downstream number in this sweep is void');
+        }
+    }
+
+    if (gate) {
+        if (gate.error) {
+            code = 2;
+            reasons.push(`INSTRUMENT: the eval gate could not produce a verdict — ${gate.error}`);
+        } else if (!gate.pass) {
+            if (code < 1) code = 1;
+            reasons.push(`EVAL GATE FAILED: unexpected real failures [${gate.unexpectedFails.join(', ')}]`);
+            if (warm && warm.okCount > 0) {
+                // The gate is post-hoc (playbook §2): make the write-before-gate
+                // ordering explicit so a red exit is never read as "nothing happened".
+                reasons.push(`POST-HOC GATE: the warm step already ran (${warm.okCount}/${warm.seedCount} ok) `
+                    + 'BEFORE this gate failed — its writes to FoodMapping are NOT rolled back');
+            }
+        }
+    }
+
+    return { code, reasons };
+}

--- a/scripts/eval/measure-serving-divergence.ts
+++ b/scripts/eval/measure-serving-divergence.ts
@@ -27,6 +27,11 @@ async function main(): Promise<number> {
         rows: Array<{ verdict: string; row: ScreenRow }>;
     };
     const rows = fx.rows.map(e => e.row);
+    if (rows.length === 0) {
+        // Fail closed: an agreement rate over zero rows is not a measurement.
+        console.error('FAIL: the fixture contains ZERO rows — nothing was measured; exit 2.');
+        return 2;
+    }
     const verdicts = new Map(fx.rows.map(e => [e.row.key, e.verdict]));
 
     const before = rows.map(r => resolveServingGrams(r));
@@ -72,6 +77,12 @@ async function main(): Promise<number> {
         const i = rows.indexOf(r);
         console.log(`  ${verdictOf(verdicts, r.key).padEnd(8)} ${r.key.slice(0, 46).padEnd(46)} `
             + `${d56(before[i].grams)} -> ${d56(realServing(r).grams)}`);
+    }
+    if (errored === rows.length) {
+        // Fail closed: every anchor errored, so the "divergence" above compared
+        // the reconstruction against NOTHING (DB/FDC unreachable, most likely).
+        console.error('\nFAIL: every serving anchor errored — the divergence was measured against nothing; exit 2.');
+        return 2;
     }
     return 0;
 }

--- a/scripts/eval/probe-bare-serving.ts
+++ b/scripts/eval/probe-bare-serving.ts
@@ -65,6 +65,13 @@ const { getBareQueryDefault } = require('../../src/lib/ai/ambiguous-serving-esti
 
 async function main() {
     const lines = fs.readFileSync(0, 'utf8').split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('#'));
+    if (lines.length === 0) {
+        // Fail closed: "probing 0 queries" over exit 0 reads as a clean probe.
+        console.error('FAIL: ZERO queries on stdin — nothing was probed; exit 2.');
+        process.exitCode = 2;
+        await prisma.$disconnect();
+        return;
+    }
     console.log(`probing ${lines.length} queries — READ-ONLY, skipCache forced\n`);
 
     for (const line of lines) {

--- a/scripts/eval/stress-latency.ts
+++ b/scripts/eval/stress-latency.ts
@@ -101,7 +101,36 @@ const NLP_PHRASES = [
 
 // ---- Runner ------------------------------------------------------------
 
-interface Sample { kind: 'search' | 'nlp'; q: string; ms: number; ok: boolean; empty: boolean; nullNut: boolean; status: number; expectHits?: boolean }
+export interface Sample { kind: 'search' | 'nlp'; q: string; ms: number; ok: boolean; empty: boolean; nullNut: boolean; status: number; expectHits?: boolean }
+
+/**
+ * Fail-closed exit verdict (playbook §11 class B).
+ *
+ *   2 = the run measured NOTHING (zero requests — e.g. `--n 0` or a NaN
+ *       repeat count built an empty task list; the old code exited 0 there).
+ *   1 = hard problems: request errors, null-nutrition leaks, or EVERY
+ *       should-hit search coming back empty — an index that answers HTTP 200
+ *       with an empty catalogue for the whole corpus is dead, and "0 errors"
+ *       must not read as green (the header names empty-result rate as a thing
+ *       this script exists to catch; total emptiness is the unambiguous case).
+ *   0 = measured, with no hard problems.
+ */
+export function stressExitCode(samples: Sample[]): { code: 0 | 1 | 2; reasons: string[] } {
+    if (samples.length === 0) {
+        return { code: 2, reasons: ['ZERO requests executed — check --n/--concurrency; a run that measured nothing is not a green run'] };
+    }
+    const reasons: string[] = [];
+    const errors = samples.filter(s => !s.ok).length;
+    if (errors > 0) reasons.push(`${errors} request error(s)`);
+    const nullNut = samples.filter(s => s.nullNut).length;
+    if (nullNut > 0) reasons.push(`${nullNut} null-nutrition leak(s)`);
+    const shouldHit = samples.filter(s => s.kind === 'search' && s.expectHits === true && s.ok);
+    if (shouldHit.length > 0 && shouldHit.every(s => s.empty)) {
+        reasons.push(`EVERY should-hit search returned EMPTY (${shouldHit.length}/${shouldHit.length}) — `
+            + 'the index is answering with nothing; HTTP 200 over an empty catalogue is not a pass');
+    }
+    return { code: reasons.length > 0 ? 1 : 0, reasons };
+}
 
 async function timedFetch(url: string, init?: any): Promise<{ ms: number; status: number; body: any; ok: boolean }> {
     const ctl = new AbortController();
@@ -219,10 +248,19 @@ async function main() {
     }, null, 2));
     console.log(`\nResults written to ${path.relative(process.cwd(), outPath)}`);
 
-    // Fail only on hard problems: any request error, or a null-nutrition leak.
-    const hardFail = searchSamples.some(s => !s.ok) || nlpSamples.some(s => !s.ok)
-        || searchSamples.some(s => s.nullNut) || nlpSamples.some(s => s.nullNut);
-    process.exit(hardFail ? 1 : 0);
+    // Fail-closed verdict: hard problems are exit 1; a run that measured
+    // NOTHING is exit 2, never green (see stressExitCode).
+    const verdict = stressExitCode([...searchSamples, ...nlpSamples]);
+    if (verdict.code !== 0) {
+        console.error(`\n${verdict.code === 2 ? '💥' : '❌'} STRESS RUN ${verdict.code === 2 ? 'VOID' : 'FAILED'} (exit ${verdict.code}):`);
+        for (const r of verdict.reasons) console.error(`  - ${r}`);
+    }
+    process.exit(verdict.code);
 }
 
-main().catch(err => { console.error(err); process.exit(2); });
+// Guarded so stressExitCode is importable by the offline test suite without
+// firing a single request (this file used to self-execute on import, which is
+// why warm-cache.ts had to mirror its corpus lists instead of importing them).
+if (require.main === module) {
+    main().catch(err => { console.error(err); process.exit(2); });
+}

--- a/scripts/eval/triage-drops.ts
+++ b/scripts/eval/triage-drops.ts
@@ -1471,6 +1471,16 @@ async function main(): Promise<void> {
             + 'precise read.');
     }
 
+    if (rows.length === 0) {
+        // Fail closed (playbook §11 class B): an empty triage batch must not
+        // read as "nothing to triage" — it means the input was empty or the
+        // DB window matched nothing.
+        console.error(`FAIL: ${inputLabel} yielded ZERO rows — an empty triage batch is a broken input, not a clean one; exit 2.`);
+        process.exitCode = 2;
+        if (prisma) await prisma.$disconnect();
+        return;
+    }
+
     if (wantIncumbent) {
         try {
             prisma = prisma ?? openPrisma();

--- a/scripts/eval/warm-cache.ts
+++ b/scripts/eval/warm-cache.ts
@@ -163,6 +163,37 @@ export interface WarmOptions {
     concurrency?: number;
     timeoutMs?: number;
     quiet?: boolean;
+    /** Where warm-<ts>.json goes; defaults to scripts/eval/results (tests inject a tmp dir). */
+    outDir?: string;
+}
+
+/**
+ * The warm run's process exit code (playbook §11 class B — a warm that warmed
+ * NOTHING must not read as a clean run).
+ *
+ *   2 = the instrument failed: zero seeds assembled, zero requests recorded
+ *       (a worker pool that never ran, e.g. NaN --concurrency), or a TOTAL
+ *       request failure — nothing was reachable, so "ok 0 · errors N" is an
+ *       outage report, not a warm report.
+ *   0 = the run measured something (partial errors stay visible in the
+ *       summary and in the flywheel diff, which is where they are judged).
+ */
+export function warmExitCode(seedCount: number, results: WarmResult[]): { code: 0 | 2; reason: string | null } {
+    if (seedCount === 0) {
+        return { code: 2, reason: 'assembled ZERO seeds — corpus files missing or empty; nothing was warmed' };
+    }
+    if (results.length === 0) {
+        return { code: 2, reason: `attempted ${seedCount} seeds but recorded ZERO results — the worker pool never ran` };
+    }
+    const ok = results.filter(r => r.ok).length;
+    if (ok === 0) {
+        return {
+            code: 2,
+            reason: `TOTAL failure: 0 of ${results.length} seeds resolved — nothing was reachable, `
+                + 'and "0 warmed" must never read as a clean run',
+        };
+    }
+    return { code: 0, reason: null };
 }
 
 export interface WarmRunReport {
@@ -208,7 +239,11 @@ async function warmOne(seed: string, base: string, apiKey: string, timeoutMs: nu
 
 export async function runWarm(seeds: string[], opts: WarmOptions): Promise<WarmRunReport> {
     const apiKey = opts.apiKey ?? process.env.EVAL_API_KEY ?? 'adminAPI_dev_key_bypass';
-    const concurrency = opts.concurrency ?? 4;
+    // Sanitised, not trusted: Number('abc') is NaN and Array.from({length: NaN})
+    // builds ZERO workers — the whole corpus is silently skipped and the run
+    // reports "0 ok, 0 errors" as if it were clean. Class-B shape; floor at 1.
+    const rawConcurrency = Math.floor(Number(opts.concurrency ?? 4));
+    const concurrency = Math.max(1, Number.isFinite(rawConcurrency) && rawConcurrency > 0 ? rawConcurrency : 4);
     const timeoutMs = opts.timeoutMs ?? 45000;
     const say = (msg: string) => { if (!opts.quiet) console.log(msg); };
 
@@ -234,7 +269,7 @@ export async function runWarm(seeds: string[], opts: WarmOptions): Promise<WarmR
     const bySource: Record<string, number> = {};
     for (const r of ok) bySource[r.source ?? 'unknown'] = (bySource[r.source ?? 'unknown'] ?? 0) + 1;
 
-    const outDir = path.join(__dirname, 'results');
+    const outDir = opts.outDir ?? path.join(__dirname, 'results');
     fs.mkdirSync(outDir, { recursive: true });
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
     const outPath = path.join(outDir, `warm-${ts}.json`);
@@ -278,7 +313,12 @@ async function main() {
         seeds.forEach(s => console.log(`  ${s}`));
         return;
     }
-    await runWarm(seeds, { base, concurrency, timeoutMs });
+    const report = await runWarm(seeds, { base, concurrency, timeoutMs });
+    const verdict = warmExitCode(seeds.length, report.results);
+    if (verdict.code !== 0) {
+        console.error(`\n💥 WARM RUN FAILED (exit ${verdict.code}): ${verdict.reason}`);
+        process.exitCode = verdict.code;
+    }
 }
 
 if (require.main === module) {

--- a/scripts/eval/warm-cache.ts
+++ b/scripts/eval/warm-cache.ts
@@ -293,34 +293,55 @@ export async function runWarm(seeds: string[], opts: WarmOptions): Promise<WarmR
     return { outPath, summary, results };
 }
 
-async function main() {
-    const args = process.argv.slice(2);
+/**
+ * CLI entry. Exported with injectable argv + seed assembly so the jest suite
+ * can prove the WIRING, not just the pure verdict: review of PR #181 found
+ * the --dry path returned before warmExitCode ever ran, so --dry over a
+ * zero-seed corpus printed "Warm corpus: 0 names" and exited 0 — the same
+ * class-B absence-as-pass this file's own warmExitCode exists to refuse.
+ * The guard now sits ABOVE the --dry fork so both paths share it, and main
+ * RETURNS the exit code instead of setting process state (testable without
+ * touching process.exitCode).
+ */
+export async function main(
+    argv: string[] = process.argv.slice(2),
+    assemble: typeof assembleSeeds = assembleSeeds,
+): Promise<number> {
     const argValue = (flag: string): string | undefined => {
-        const i = args.indexOf(flag);
-        return i >= 0 ? args[i + 1] : undefined;
+        const i = argv.indexOf(flag);
+        return i >= 0 ? argv[i + 1] : undefined;
     };
 
     const base = argValue('--base') ?? process.env.EVAL_API_BASE ?? 'http://192.168.1.133:3000';
     const concurrency = Number(argValue('--concurrency') ?? 4);
     const timeoutMs = Number(argValue('--timeout') ?? 45000);
     const limit = argValue('--limit') ? Number(argValue('--limit')) : undefined;
-    const dry = args.includes('--dry');
+    const dry = argv.includes('--dry');
     const seedFile = argValue('--seed');
 
-    const seeds = assembleSeeds({ seedFile, limit });
+    const seeds = assemble({ seedFile, limit });
     console.log(`Warm corpus: ${seeds.length} names → ${base} (concurrency ${concurrency})`);
+    if (seeds.length === 0) {
+        // Shared zero-seed guard — the --dry path must hit it too: a dry run
+        // that lists nothing is a broken corpus, not a clean preview.
+        const verdict = warmExitCode(0, []);
+        console.error(`\n💥 WARM RUN FAILED (exit ${verdict.code}): ${verdict.reason}`);
+        return verdict.code;
+    }
     if (dry) {
         seeds.forEach(s => console.log(`  ${s}`));
-        return;
+        return 0;
     }
     const report = await runWarm(seeds, { base, concurrency, timeoutMs });
     const verdict = warmExitCode(seeds.length, report.results);
     if (verdict.code !== 0) {
         console.error(`\n💥 WARM RUN FAILED (exit ${verdict.code}): ${verdict.reason}`);
-        process.exitCode = verdict.code;
     }
+    return verdict.code;
 }
 
 if (require.main === module) {
-    main().catch(err => { console.error(err); process.exit(2); });
+    main()
+        .then(code => { if (code !== 0) process.exitCode = code; })
+        .catch(err => { console.error(err); process.exit(2); });
 }


### PR DESCRIPTION
Part of handoff §5a Phase 1 (task 1a) — **do not merge until adversarial review completes.**

## What changed

Playbook §11 class B (absence encoded as a PASS), the holes PR #177 did not close. Every fix follows the `detect-panel-scale-divided.ts` fail-closed pattern: refusals counted and printed, nonzero exit on failure, one deliberate fail-injection test per instrument (offline, mocked at the module boundary), each with positive controls.

### 1. flywheel-sweep.ts + warm-cache.ts (one unit) — the headline
**The exact mechanism defeating PR #177's `evalExitCode` fix:** `run-eval.ts` writes its results file *before* exiting — including on the zero-case path where `evalExitCode([])` makes it exit 2 — and `runEvalGate()` never read `proc.status` when a new results file existed. It re-derived pass/fail from `data.results ?? []`, and an empty array yields zero unexpected failures = **PASS**, exit 0 into systemd. run-eval's own fail-closed red was being converted to green by its most important consumer.

- New pure module `scripts/eval/flywheel-verdict.ts` (`judgeEvalGate`, `sweepVerdict`), wired into the sweep. Exit code is judged FIRST: exit 2, signal kill, spawn failure, missing/unreadable receipt, zero-case file, and a receipt that *contradicts* the exit code (stale file) are all instrument failures — never a pass, never a plain "gate red".
- Sweep exit codes, propagated to systemd via `process.exitCode`: **0** clean · **1** gate ran and FAILED · **2** instrument failure / measured nothing (warm total failure, zero seeds, zero results included). The verdict + reasons also land in the flywheel JSON (`exit` block) and stderr.
- Post-hoc gate made explicit (playbook §2): a gate-failure exit now *names* the warm writes that already happened ("NOT rolled back") — unchanged ordering, no longer silent.
- `ALLOW_FAIL` visibility: suppressed real failures and **stale** allow-fail entries are printed in console + markdown. Semantics unchanged (the nightly with default `n-mq-10` still goes red on `n-supp-23`, as it already did since #167 — now with reasons).
- `warm-cache.ts` standalone: `warmExitCode` exits 2 on zero seeds / zero results / total request failure; NaN `--concurrency` can no longer build a zero-worker pool (`Array.from({length: NaN})` = no workers, "ok 0 · errors 0" looked clean).
- `--stuck-keys-only` / `--seg-replay-only` / `--coverage-only` exit 2 when the single report they exist to produce failed (in-sweep these steps stay fail-soft/report-only by documented design).

### 2. cache-parity-sweep.ts
Overwrites cache rows as an intended side effect, yet printed `"changedRecord": 0` and exited 0 on **total HTTP failure**. Now distinguishes, exactly as specified:
- `0 changed record(s) over N rows verified reachable` → exit 0;
- partial transport failure → exit 1 ("those cache rows were verified by NOTHING this run");
- **nothing reachable / empty `--before`** → exit 2 + explicit `NOTHING REACHABLE … "0 changed records" is VOID` error.
Summary gains `verifiedReachable` + `exit`; diff logic extracted to pure `summarizeParity`/`parityExitCode`; `main()` previously had **no `.catch`** — crashes now exit 2 deterministically.

### 3. stress-latency.ts
Zero requests executed (`--n 0`, NaN repeat) exited 0 → now exit 2. New unambiguous hard-fail: EVERY should-hit search returning empty (dead index answering HTTP 200 over nothing — the header names empty-rate as a thing this script exists to catch, but it never gated on it). Existing error/null-nutrition fails preserved. Now importable (`require.main` guard — it used to self-execute on import, which is why warm-cache had to mirror its corpus lists).

### 4. detect-corrupt-nutrition.ts / detect-corrupt-panel.ts
A scan that saw ZERO rows (wrong DB, filter typo) wrote `Flagged 0 rows (of 0 scanned)` + a report file and exited 0. Now: exit 2 and **no report written**, so a failed scan can never fake an empty population for `mark-corrupt-off.ts`. Both scans take an injectable `ScanDb` (same shape as the reference detector's `RowStream`) and no longer construct PrismaClient at import. Report format unchanged.

### 5. Sweep of the rest of scripts/eval/*.ts — zero-input guards (empty in = green out)
`apply-repoints.ts` (0 repoints → "Plan: 0 updates" exit 0), `classify-drops.ts` + `triage-drops.ts` (0 rows → a report reading "no drops"), `probe-bare-serving.ts` (0 stdin queries), `measure-serving-divergence.ts` (0 fixture rows; all anchors errored → agreement measured against nothing). All now exit 2 with explicit errors.

### Audited, NOT changed (deliberate — listed so the cap is explicit)
- `serving-provenance.ts`: zero-row DB prints a zeros report + exit 0. One-off diagnostic; whether an empty `OffServing` table is instrument failure is ambiguous. Left as-is.
- Flywheel telemetry/stuck/seg-replay/coverage failures **inside a full sweep** remain fail-soft report-only (documented contract; seg-replay explicitly "must never change the sweep's exit code").
- `classify-drops.ts`/`triage-drops.ts` `attachIncumbents` catch-and-warn ("counts read as unknown") — visible degradation, left.
- `winner-diff.ts`/`winner-diff-screens.ts`: already hardened by #172/#177 (noiseGate, exitCode 1/2 paths); not re-audited beyond grep this pass.
- `correctness-screen.ts`: out of scope (parallel D8 agent owns it); `screenExitCode` already fail-closed from #177.
- `ops/systemd/flywheel-sweep.service` untouched (deploy-only box; `Type=oneshot` already surfaces nonzero exits).

## Numbers
- Baseline reproduced exactly: `npx jest scripts/eval/__tests__` **708 passed, ~13s**, offline.
- After: **743 passed** (+35 in `__tests__/fail-open-sweep.test.ts`); full suite **111 suites, 2,333 passed, 1 skipped**; `typecheck` clean; `lint:ci` 0 errors (448/700 warnings, pre-existing).
- Method rule honored: fixes were broken on purpose — reverting the exit-2 branch, the zero-case branch, and the parity total-failure branch each turned a named test red (1, 1, and 1 failures respectively), then restored.
- Wiring proven by grep: `judgeEvalGate`/`sweepVerdict`/`warmExitCode`/`parityExitCode`/`stressExitCode` all reached from their runners; no caller still re-derives pass from a results file.

## Discrepancies from the spec
- None material. One nuance worth review attention: the old flywheel *did* exit 1 on a red gate — the defeat was confined to the **exit-2 / zero-case / contradictory-receipt** shapes (and to error paths that produced no results file being indistinguishable from gate-red). The PR makes red-vs-void a first-class distinction rather than introducing exit-on-red.
- The three writing scripts (`warm-cache`, `flywheel-sweep`, `cache-parity-sweep`) and `stress-latency` were exercised ONLY through the offline jest suite with mocked I/O, per the task's safety constraints — none were run against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmxGgB4L6tBMVBaTRqRArx