### PR TITLE
feat(mapping): persist the multi-component signal on AiNormalizeCache

### DIFF
--- a/prisma/migrations/20260729120000_add_ainormalizecache_multi_ingredient/migration.sql
+++ b/prisma/migrations/20260729120000_add_ainormalizecache_multi_ingredient/migration.sql
@@ -1,0 +1,14 @@
+-- Persist the multi-component signal that aiNormalizeIngredient() already computes.
+-- The LLM returns is_multi_ingredient / split_ingredients on every normalize call, but
+-- AiNormalizeCache had no column for either, so the detection survived only for the life
+-- of one request and was re-derived (or lost) on every cache hit.
+--
+-- Both columns are additive. isMultiIngredient defaults to false so pre-existing rows —
+-- which were written before the signal was persisted and cannot be backfilled without a
+-- re-run of the LLM — read as "not known to be multi-component", the same answer the
+-- dead `(cached as any).isMultiIngredient ?? false` read gave before this migration.
+-- splitIngredients is nullable rather than defaulting to '[]': null means "never asked",
+-- an empty array would mean "asked, and there are no components".
+
+ALTER TABLE "AiNormalizeCache" ADD COLUMN "isMultiIngredient" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "AiNormalizeCache" ADD COLUMN "splitIngredients" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -550,6 +550,10 @@ model AiNormalizeCache {
   estimatedFatPer100g      Float?         // AI estimate (g)
   nutritionConfidence      Float?         // 0-1 confidence for nutrition estimate
   isBranded                Boolean  @default(false)
+  // Multi-component detection. The LLM already returns these; before 2026-07-29 they
+  // were dropped on the floor, so the signal survived only for the life of one request.
+  isMultiIngredient        Boolean  @default(false)
+  splitIngredients         Json?          // string[] when isMultiIngredient; null otherwise
   createdAt                DateTime @default(now())
   lastUsedAt               DateTime @default(now())
   useCount                 Int      @default(0)

--- a/src/lib/mapping/__tests__/split-ingredients-persist.test.ts
+++ b/src/lib/mapping/__tests__/split-ingredients-persist.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Multi-component signal (isMultiIngredient / splitIngredients) survives the cache.
+ *
+ * The LLM has always returned these two fields, and aiNormalizeIngredient has always
+ * read them back on a cache hit — through `(cached as any)`, against a projection that
+ * did not carry them and a table that had no column for them. The read could only ever
+ * yield undefined, so multi-component detection fired on a cache MISS and nowhere else.
+ *
+ * Three edits were needed, and the third is the one that is easy to skip:
+ *   1. columns on AiNormalizeCache,
+ *   2. the fields in saveAiNormalizeCache's signature + upsert,
+ *   3. THE PROJECTION in getAiNormalizeCache — which hand-builds an object literal
+ *      rather than spreading the Prisma row, so a new column is invisible until it is
+ *      named there too.
+ *
+ * The cache-hit test below is the one that dies if edit 3 is reverted. The others would
+ * still pass against a permanently-undefined read, which is exactly how this shipped.
+ */
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+const mockUpsert = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        aiNormalizeCache: {
+            findUnique: (...args: unknown[]) => mockFindUnique(...args),
+            update: (...args: unknown[]) => mockUpdate(...args),
+            upsert: (...args: unknown[]) => mockUpsert(...args),
+        },
+    },
+}));
+
+// aiNormalizeIngredient must return from the cache before this is ever reached; a call
+// here means the cache-hit branch did not fire and the test is measuring the wrong path.
+const mockCallStructuredLlm = jest.fn();
+jest.mock('../../ai/structured-client', () => ({
+    callStructuredLlm: (...args: unknown[]) => mockCallStructuredLlm(...args),
+}));
+
+import { getAiNormalizeCache, saveAiNormalizeCache } from '../validated-mapping-helpers';
+import { aiNormalizeIngredient } from '../ai-normalize';
+
+/** A stored row as Prisma returns it. `salt and pepper` is the prompt's own example. */
+function storedRow(overrides: Record<string, unknown> = {}) {
+    return {
+        normalizedKey: 'pepper salt',
+        rawLine: 'salt and pepper',
+        normalizedName: 'salt',
+        canonicalBase: 'salt',
+        synonyms: [],
+        prepPhrases: [],
+        sizePhrases: [],
+        cookingModifier: null,
+        estimatedCaloriesPer100g: null,
+        estimatedProteinPer100g: null,
+        estimatedCarbsPer100g: null,
+        estimatedFatPer100g: null,
+        nutritionConfidence: null,
+        isBranded: false,
+        isMultiIngredient: true,
+        splitIngredients: ['salt', 'pepper'],
+        useCount: 3,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockUpdate.mockReset().mockResolvedValue(undefined);
+    mockUpsert.mockReset().mockResolvedValue(undefined);
+    mockCallStructuredLlm.mockReset();
+});
+
+describe('saveAiNormalizeCache writes the multi-component signal', () => {
+    it('carries isMultiIngredient + splitIngredients into the create payload', async () => {
+        await saveAiNormalizeCache('salt and pepper', {
+            normalizedName: 'salt',
+            synonyms: [],
+            prepPhrases: [],
+            sizePhrases: [],
+            isMultiIngredient: true,
+            splitIngredients: ['salt', 'pepper'],
+        });
+
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+        const call = mockUpsert.mock.calls[0][0];
+        expect(call.create.isMultiIngredient).toBe(true);
+        expect(call.create.splitIngredients).toEqual(['salt', 'pepper']);
+    });
+
+    it('defaults isMultiIngredient to false and omits splitIngredients when a caller does not compute them', async () => {
+        // aiSimplifyIngredient and batchNormalizeIngredients share this table and pass
+        // neither field. `undefined` must reach Prisma as "column omitted", not as false/null.
+        await saveAiNormalizeCache('jif peanut butter', {
+            normalizedName: 'peanut butter',
+            synonyms: [],
+            prepPhrases: [],
+            sizePhrases: [],
+        });
+
+        const call = mockUpsert.mock.calls[0][0];
+        expect(call.create.isMultiIngredient).toBe(false);
+        expect(call.create.splitIngredients).toBeUndefined();
+    });
+
+    it('does not clobber a stored signal on the update branch', async () => {
+        // Prisma reads `undefined` in an update as "leave the column alone". If these were
+        // written as `?? false` / `?? null`, a later save by a caller that cannot compute
+        // them would erase a detection made by one that could.
+        await saveAiNormalizeCache('jif peanut butter', {
+            normalizedName: 'peanut butter',
+            synonyms: [],
+            prepPhrases: [],
+            sizePhrases: [],
+        });
+
+        const call = mockUpsert.mock.calls[0][0];
+        expect(call.update).toHaveProperty('isMultiIngredient', undefined);
+        expect(call.update).toHaveProperty('splitIngredients', undefined);
+    });
+});
+
+describe('getAiNormalizeCache projects the multi-component signal', () => {
+    it('returns splitIngredients from a stored row', async () => {
+        mockFindUnique.mockResolvedValue(storedRow());
+
+        const cached = await getAiNormalizeCache('salt and pepper');
+
+        expect(cached?.isMultiIngredient).toBe(true);
+        expect(cached?.splitIngredients).toEqual(['salt', 'pepper']);
+    });
+
+    it('reads a pre-migration row as not-multi rather than throwing', async () => {
+        // Rows written before the columns existed cannot be backfilled without re-running
+        // the LLM. `false` / `undefined` is the same answer the old dead read gave.
+        mockFindUnique.mockResolvedValue(storedRow({ isMultiIngredient: false, splitIngredients: null }));
+
+        const cached = await getAiNormalizeCache('salt and pepper');
+
+        expect(cached?.isMultiIngredient).toBe(false);
+        expect(cached?.splitIngredients).toBeUndefined();
+    });
+});
+
+describe('aiNormalizeIngredient surfaces the signal on a CACHE HIT', () => {
+    it('returns the persisted splitIngredients without calling the LLM', async () => {
+        mockFindUnique.mockResolvedValue(storedRow());
+
+        const result = await aiNormalizeIngredient('salt and pepper');
+
+        expect(mockCallStructuredLlm).not.toHaveBeenCalled();  // proves this is the hit path
+        expect(result.status).toBe('success');
+        if (result.status !== 'success') return;
+        expect(result.isMultiIngredient).toBe(true);
+        expect(result.splitIngredients).toEqual(['salt', 'pepper']);
+    });
+});
+
+describe('aiNormalizeIngredient hands the signal to the cache on a MISS', () => {
+    it('forwards the LLM split_ingredients into the save', async () => {
+        mockFindUnique.mockResolvedValue(null);  // cold key
+        mockCallStructuredLlm.mockResolvedValue({
+            status: 'success',
+            content: {
+                normalized_name: 'salt',
+                canonical_base: 'salt',
+                prep_phrases: [],
+                size_phrases: [],
+                synonyms: [],
+                is_multi_ingredient: true,
+                split_ingredients: ['salt', 'pepper'],
+            },
+        });
+
+        const result = await aiNormalizeIngredient('salt and pepper');
+
+        expect(result.status).toBe('success');
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+        // Without this, the detection reaches the console.warn and nothing else — which is
+        // precisely the state this change exists to end.
+        const call = mockUpsert.mock.calls[0][0];
+        expect(call.create.isMultiIngredient).toBe(true);
+        expect(call.create.splitIngredients).toEqual(['salt', 'pepper']);
+    });
+});

--- a/src/lib/mapping/ai-normalize.ts
+++ b/src/lib/mapping/ai-normalize.ts
@@ -169,13 +169,13 @@ export async function aiNormalizeIngredient(
   // Check persistent database cache first
   const cached = await getAiNormalizeCache(rawLine);
   if (cached) {
+    // getAiNormalizeCache's projection supplies isBranded, isMultiIngredient and
+    // splitIngredients directly; the column defaults cover rows written before those
+    // columns existed. The `(cached as any)` casts that used to sit here read fields
+    // the projection never returned, so they resolved to undefined every single time.
     return {
       status: 'success',
       ...cached,
-      // Provide defaults for new fields (backward compatibility with older cache entries)
-      isBranded: (cached as any).isBranded ?? false,
-      isMultiIngredient: (cached as any).isMultiIngredient ?? false,
-      splitIngredients: (cached as any).splitIngredients ?? undefined,
     };
   }
 
@@ -253,6 +253,8 @@ export async function aiNormalizeIngredient(
       sizePhrases: normalizeResult.sizePhrases,
       cookingModifier: normalizeResult.cookingModifier,
       isBranded: normalizeResult.isBranded,
+      isMultiIngredient: normalizeResult.isMultiIngredient,
+      splitIngredients: normalizeResult.splitIngredients,
       nutritionEstimate: normalizeResult.nutritionEstimate,
     });
 

--- a/src/lib/mapping/validated-mapping-helpers.ts
+++ b/src/lib/mapping/validated-mapping-helpers.ts
@@ -1038,6 +1038,10 @@ export async function getAiNormalizeCache(rawLine: string) {
             },
         });
 
+        // NOTE: this is a hand-built projection, not a spread of the row. A new column on
+        // AiNormalizeCache is invisible to every caller until it is added HERE as well —
+        // splitIngredients had a live read in ai-normalize.ts for months that could only
+        // ever yield undefined, because the column and this projection were both missing.
         return {
             normalizedName: cached.normalizedName,
             canonicalBase: cached.canonicalBase ?? cached.normalizedName,  // Fallback for backward compatibility
@@ -1046,6 +1050,8 @@ export async function getAiNormalizeCache(rawLine: string) {
             sizePhrases: cached.sizePhrases as string[],
             cookingModifier: cached.cookingModifier ?? undefined,
             isBranded: cached.isBranded ?? false,
+            isMultiIngredient: cached.isMultiIngredient ?? false,
+            splitIngredients: (cached.splitIngredients as string[] | null) ?? undefined,
             nutritionEstimate: cached.estimatedCaloriesPer100g != null ? {
                 caloriesPer100g: cached.estimatedCaloriesPer100g,
                 proteinPer100g: cached.estimatedProteinPer100g ?? 0,
@@ -1077,6 +1083,8 @@ export async function saveAiNormalizeCache(
         sizePhrases: string[];
         cookingModifier?: string;
         isBranded?: boolean;  // Whether AI identified this as a branded product query
+        isMultiIngredient?: boolean;  // Input names two distinct ingredients ("salt and pepper")
+        splitIngredients?: string[];  // The separated components, when isMultiIngredient
         nutritionEstimate?: {
             caloriesPer100g: number;
             proteinPer100g: number;
@@ -1100,6 +1108,8 @@ export async function saveAiNormalizeCache(
                 sizePhrases: result.sizePhrases,
                 cookingModifier: result.cookingModifier,
                 isBranded: result.isBranded ?? false,
+                isMultiIngredient: result.isMultiIngredient ?? false,
+                splitIngredients: result.splitIngredients,  // undefined → column omitted → NULL
                 estimatedCaloriesPer100g: result.nutritionEstimate?.caloriesPer100g,
                 estimatedProteinPer100g: result.nutritionEstimate?.proteinPer100g,
                 estimatedCarbsPer100g: result.nutritionEstimate?.carbsPer100g,
@@ -1110,6 +1120,12 @@ export async function saveAiNormalizeCache(
             update: {
                 useCount: { increment: 1 },
                 lastUsedAt: new Date(),
+                // Undefined-safe on purpose: aiSimplifyIngredient and batchNormalizeIngredients
+                // share this table and never compute these two, so they pass `undefined`, which
+                // Prisma treats as "leave the column alone" rather than "write null/false".
+                // A caller that DOES know must be able to fill a row written by one that didn't.
+                isMultiIngredient: result.isMultiIngredient,
+                splitIngredients: result.splitIngredients,
             },
         });
 


### PR DESCRIPTION
## What

`aiNormalizeIngredient()` detects multi-component foods ("salt and pepper" → `["salt", "pepper"]`) and threw the answer away to a `console.warn`. This persists it.

## Why it was worse than "not persisted"

The cache **read** path already existed and was dead:

```ts
splitIngredients: (cached as any).splitIngredients ?? undefined,
```

`cached` is the return of `getAiNormalizeCache()`, which hand-builds an object literal and never carried that field — and `AiNormalizeCache` had no column for it either. So the read could only ever yield `undefined`. Multi-component detection therefore fired on a cache **miss** and nowhere else, and the `console.warn` under-reported by the entire cache-hit rate.

## Four edits, not two

The design note called this "two columns plus adding the fields to the existing save". It is four, and the last two are the ones that are easy to skip:

1. `isMultiIngredient` / `splitIngredients` columns on `AiNormalizeCache` (+ migration)
2. the fields in `saveAiNormalizeCache`'s signature and **both** upsert branches
3. **the projection in `getAiNormalizeCache`** — it hand-builds an object literal rather than spreading the Prisma row, so a new column stays invisible to every caller until it is named there too
4. **the two fields in `aiNormalizeIngredient`'s own save call** — it passes 8 named fields; without this the LLM's answer still never reaches the cache

The `(cached as any)` casts are gone; the projection returns real typed fields.

## The update branch is undefined-safe on purpose

`aiSimplifyIngredient` and `batchNormalizeIngredients` share this table and compute neither field. They pass `undefined`, which Prisma reads as "leave the column alone" rather than "write null/false" — so a caller that cannot compute the signal never erases one written by a caller that can.

## Blast radius

**None on mapping outcomes.** Nothing downstream reads either field yet — the only consumer of the multi-component signal is the `console.warn` inside `ai-normalize.ts`. `map-ingredient-with-fallback.ts` does not read it. This makes the data exist; it does not change a single pick.

**Existing rows cannot be backfilled.** A cache hit returns before the LLM call, so no re-detection runs for a key already in the table. The signal lights up only for keys resolved cold from here on. `isMultiIngredient` defaults to `false` and `splitIngredients` is nullable, so pre-migration rows read exactly as the old dead cast did.

## Tests

`split-ingredients-persist.test.ts`, 7 cases, **mutation-validated** per playbook §13 — reverting each of the four edits kills at least one named test:

| mutation | tests killed |
|---|---|
| delete the projection | 3 |
| delete the create payload | 3 |
| delete the update carry | 1 |
| delete the `ai-normalize.ts` save call | 1 |

Green restored after each. (The first mutation harness I wrote silently no-op'd and printed "7 passed" three times; the second exits non-zero on a no-op.)

## Local gate

- `npx jest` → 121 suites / 2,702 tests, 0 fail
- `npm run typecheck` → clean
- `npm run build` → succeeds
- `npm run lint:ci` → 0 errors / 585 warnings (baseline exact)
- `node scripts/check-env-example.js` → 90 vars documented
- `npx prisma generate` → client carries both fields

`migrate-smoke` will fire on this PR (`prisma/**` touched). No DB was written from this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
