### PR TITLE
feat(schema): give IngredientFoodMap a FatSecret leg, with a real FK

### DIFF
--- a/prisma/migrations/20260729200000_add_ingredientfoodmap_fsid/migration.sql
+++ b/prisma/migrations/20260729200000_add_ingredientfoodmap_fsid/migration.sql
@@ -1,0 +1,28 @@
+-- Give IngredientFoodMap a FatSecret leg.
+--
+-- Until now the model could reference a legacy Food, an OffFood barcode, an FdcFood id or an
+-- AiGeneratedFood — but NOT a FatSecret food, which is the mapper's most common winner
+-- (autoMapIngredients logs itself as mode: 'fatsecret-only'). A FatSecret pick therefore had
+-- nowhere to be stored and recipe auto-mapping could not complete for it.
+--
+-- Unlike offBarcode and fdcId, whose "FK →" comments are aspirational and carry no constraint,
+-- this leg gets a REAL foreign key. The trade-off is deliberate and matches FoodMapping.fsId:
+-- a FatSecret parent row is fetched on demand and is not guaranteed to be present, so without
+-- the constraint a dangling reference would be silently written and only discovered when
+-- something tried to read the food back. With it, the insert fails loudly at write time.
+--
+-- ON DELETE SET NULL rather than CASCADE: losing the cached FatSecret row should orphan the
+-- link, not delete the user's ingredient mapping.
+--
+-- Stores the BARE FatSecret food_id — no "fs_" prefix. The mapper's foodId is `fs_<id>`;
+-- FatSecretFood.fsId is `<id>`. Writing the prefixed form here reproduces exactly the class of
+-- bug this table just had removed (`fatsecretFoodId: 'fdc:<id>'` aimed at a phantom column).
+
+ALTER TABLE "IngredientFoodMap" ADD COLUMN "fsId" TEXT;
+
+CREATE INDEX "IngredientFoodMap_fsId_idx" ON "IngredientFoodMap"("fsId");
+
+ALTER TABLE "IngredientFoodMap"
+  ADD CONSTRAINT "IngredientFoodMap_fsId_fkey"
+  FOREIGN KEY ("fsId") REFERENCES "FatSecretFood"("fsId")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -305,8 +305,9 @@ model IngredientFoodMap {
   id                String     @id @default(cuid())
   ingredientId      String
   foodId            String?              // FK → legacy Food table
-  offBarcode        String?              // FK → OffFood.barcode
-  fdcId             Int?                 // FK → FdcFood.fdcId
+  offBarcode        String?              // no FK constraint — the comment is aspirational
+  fdcId             Int?                 // no FK constraint — the comment is aspirational
+  fsId              String?              // REAL FK → FatSecretFood.fsId (no "fs_" prefix)
   aiGeneratedFoodId String?
   pendingVolume     Boolean    @default(false)
   mappedBy          String
@@ -317,11 +318,13 @@ model IngredientFoodMap {
   food              Food?      @relation(fields: [foodId], references: [id], onDelete: Cascade)
   ingredient        Ingredient @relation(fields: [ingredientId], references: [id], onDelete: Cascade)
   aiGeneratedFood   AiGeneratedFood? @relation(fields: [aiGeneratedFoodId], references: [id], onDelete: SetNull)
+  fatSecretFood     FatSecretFood?   @relation(fields: [fsId], references: [fsId], onDelete: SetNull)
 
   @@index([ingredientId])
   @@index([foodId])
   @@index([offBarcode])
   @@index([fdcId])
+  @@index([fsId])
   @@index([aiGeneratedFoodId])
 }
 
@@ -435,6 +438,7 @@ model FatSecretFood {
   updatedAt        DateTime      @updatedAt
   servings         FatSecretServing[]
   foodMappings     FoodMapping[]
+  ingredientMaps   IngredientFoodMap[]
 
   @@index([name])
   @@index([brandName])

--- a/src/lib/nutrition/__tests__/ingredient-food-map-link.test.ts
+++ b/src/lib/nutrition/__tests__/ingredient-food-map-link.test.ts
@@ -30,6 +30,21 @@ describe('ingredientFoodMapLink — storable sources', () => {
         });
     });
 
+    it('routes fs_<id> to fsId and STRIPS the prefix', () => {
+        // FatSecretFood.fsId stores the bare food_id. Keeping the `fs_` prefix here would
+        // violate the foreign key — the same prefix-mismatch class as the old `fdc:` hack.
+        expect(ingredientFoodMapLink('fs_12345')).toEqual({
+            columns: { fsId: '12345' },
+            source: 'fs',
+        });
+    });
+
+    it('does not strip an fs_ prefix from an id that merely contains it', () => {
+        // slice(3) is positional, so guard that only a genuine leading prefix is removed.
+        const link = ingredientFoodMapLink('fs_fs_9');
+        expect(link).toEqual({ columns: { fsId: 'fs_9' }, source: 'fs' });
+    });
+
     it('routes an unprefixed id to aiGeneratedFoodId', () => {
         expect(ingredientFoodMapLink('clx0abc123def456')).toEqual({
             columns: { aiGeneratedFoodId: 'clx0abc123def456' },
@@ -38,18 +53,15 @@ describe('ingredientFoodMapLink — storable sources', () => {
     });
 
     it('never emits more than one identity column', () => {
-        for (const id of ['fdc_1', 'off_9', 'clx0abc']) {
+        for (const id of ['fdc_1', 'off_9', 'fs_7', 'clx0abc']) {
             expect(Object.keys(ingredientFoodMapLink(id)!.columns)).toHaveLength(1);
         }
     });
 });
 
 describe('ingredientFoodMapLink — unstorable sources return null', () => {
-    it('refuses a FatSecret winner: there is no fsId column', () => {
-        // The single most likely input in production, and the one with no home.
-        // Returning null is what makes autoMapIngredients report it instead of
-        // silently writing a row that means something else.
-        expect(ingredientFoodMapLink('fs_12345')).toBeNull();
+    it('refuses an empty fs id', () => {
+        expect(ingredientFoodMapLink('fs_')).toBeNull();
     });
 
     it('refuses water_default, which resolves to no record at all', () => {
@@ -75,8 +87,8 @@ describe('ingredientFoodMapLink — unstorable sources return null', () => {
 describe('ingredientFoodMapLink — the columns it emits are real', () => {
     it('only ever names columns that exist on IngredientFoodMap', () => {
         // Guards the original defect directly: `fatsecret*` must never reappear here.
-        const REAL_COLUMNS = new Set(['foodId', 'offBarcode', 'fdcId', 'aiGeneratedFoodId']);
-        for (const id of ['fdc_167762', 'off_0123456789012', 'clx0abc123def456']) {
+        const REAL_COLUMNS = new Set(['foodId', 'offBarcode', 'fdcId', 'fsId', 'aiGeneratedFoodId']);
+        for (const id of ['fdc_167762', 'off_0123456789012', 'fs_12345', 'clx0abc123def456']) {
             for (const key of Object.keys(ingredientFoodMapLink(id)!.columns)) {
                 expect(REAL_COLUMNS.has(key)).toBe(true);
             }

--- a/src/lib/nutrition/auto-map.ts
+++ b/src/lib/nutrition/auto-map.ts
@@ -16,6 +16,7 @@ type IngredientFoodMapColumns = {
   foodId?: string;
   offBarcode?: string;
   fdcId?: number;
+  fsId?: string;
   aiGeneratedFoodId?: string;
 };
 
@@ -23,14 +24,16 @@ type IngredientFoodMapColumns = {
  * Decompose the mapper's prefixed `foodId` into the IngredientFoodMap columns that exist.
  *
  * The mapper emits `fdc_<int>` | `off_<barcode>` | `fs_<id>` | a bare AiGeneratedFood id —
- * the same prefix scheme `resolveFoodDetails` reads. IngredientFoodMap has a typed column
- * for three of those four and NONE for FatSecret, so `fs_` returns null and the caller must
- * decide what to do about it. Do not "solve" that by stuffing a prefixed string into a text
- * column: this function replaced exactly that hack (`fatsecretFoodId: \`fdc:${id}\``), which
- * targeted a column that does not exist and silently failed every write.
+ * the same prefix scheme `resolveFoodDetails` reads. Every one of those now has a typed
+ * column. Do not "solve" a future gap by stuffing a prefixed string into a text column:
+ * this function replaced exactly that hack (`fatsecretFoodId: \`fdc:${id}\``), which targeted
+ * a column that does not exist and silently failed every write.
  *
- * Returns null for anything unstorable — FatSecret, `water_default`, and any id whose
- * numeric part does not parse — never a partially-populated row.
+ * ⚠️ `fs_` is STRIPPED. `FatSecretFood.fsId` stores the bare FatSecret food_id, so the
+ * prefixed form would violate the foreign key — the same prefix-mismatch bug in a new place.
+ *
+ * Returns null for anything unstorable — `water_default`, and any id whose numeric or id part
+ * does not parse — never a partially-populated row.
  */
 export function ingredientFoodMapLink(
   foodId: string | null | undefined,
@@ -45,9 +48,13 @@ export function ingredientFoodMapLink(
     const offBarcode = foodId.slice(4);
     return offBarcode ? { columns: { offBarcode }, source: 'off' } : null;
   }
-  // fs_ has no column, and `water_default` (the zero-calorie fast path) resolves to no
-  // record at all. Both are unstorable; say so rather than inventing a home for them.
-  if (foodId.startsWith('fs_') || foodId === 'water_default') return null;
+  if (foodId.startsWith('fs_')) {
+    const fsId = foodId.slice(3);   // BARE id — FatSecretFood.fsId carries no prefix
+    return fsId ? { columns: { fsId }, source: 'fs' } : null;
+  }
+  // `water_default` is the zero-calorie fast path and resolves to no record at all. It is
+  // genuinely unstorable; say so rather than inventing a home for it.
+  if (foodId === 'water_default') return null;
 
   // No recognised prefix ⇒ an AiGeneratedFood id. This leg has a real FK, so a wrong guess
   // is rejected by the database rather than written as a dangling reference.
@@ -234,17 +241,26 @@ export async function autoMapIngredients(recipeId: string, options?: { concurren
         const link = ingredientFoodMapLink(mapped.foodId);
 
         if (!link) {
-          // A FatSecret winner has no home: IngredientFoodMap has no fsId column and no
-          // FatSecretFood relation. Report it rather than dropping it — a silent skip here
-          // is what let this whole path read as "working" while writing nothing.
+          // Only `water_default` and malformed ids land here now. Report rather than skip —
+          // a silent skip is what let this whole path read as "working" while writing nothing.
           logger.warn('autoMap:unstorable-source', {
             ingredientId: ingredient.id,
             foodId: mapped.foodId,
-            reason: 'IngredientFoodMap has no fsId column — see queue item #29',
             rawLine: ingredientLine,
             foodName: mapped.foodName,
           });
           return { success: false, ingredientId: ingredient.id, error: 'unstorable_source' };
+        }
+
+        // INVARIANT: fsId is a real foreign key, and a FatSecret parent row is fetched on
+        // demand rather than guaranteed to exist. Writing the link without first ensuring the
+        // parent is persisted throws a FK violation into the catch below and loses the mapping
+        // while the request still succeeds — the failure mode that cost warm batch 01 31.4%
+        // of its FatSecret saves. `saveValidatedMapping` calls this insert-bound for the same
+        // reason; the call is idempotent and a hit is a single PK read.
+        if (link.source === 'fs' && link.columns.fsId) {
+          const { ensureFatSecretParentPersisted } = await import('../mapping/fatsecret-lane');
+          await ensureFatSecretParentPersisted(link.columns.fsId);
         }
 
         await prisma.ingredientFoodMap.create({


### PR DESCRIPTION
## What

Closes the gap #188 left open. `IngredientFoodMap` could reference a legacy `Food`, an `OffFood` barcode, an `FdcFood` id or an `AiGeneratedFood` — but **not a FatSecret food**, which is the mapper's most common winner (`autoMapIngredients` logs itself as `mode: 'fatsecret-only'`).

#188 could therefore only report a FatSecret pick as `autoMap:unstorable-source`. With this, recipe auto-mapping completes for every source the mapper can produce.

## A real FK, deliberately

`offBarcode` and `fdcId` on this model have `// FK →` comments and **no constraint**. This leg gets a real one, matching `FoodMapping.fsId`.

The reasoning is specific to FatSecret: a parent row is fetched **on demand** and is not guaranteed to exist. Without the constraint a dangling reference is written silently and only surfaces much later, when something tries to read the food back and gets nothing. With it, the write fails at write time where it can be seen.

`ON DELETE SET NULL`, not `CASCADE` — losing a cached FatSecret row should orphan the link, not delete the user's ingredient mapping.

## Two traps, both handled explicitly

**The prefix.** The mapper emits `fs_<id>`; `FatSecretFood.fsId` stores the **bare** id. `ingredientFoodMapLink` strips it. Writing the prefixed form would violate the new FK — and it is the *identical* prefix-mismatch class as the `fatsecretFoodId: 'fdc:<id>'` hack #188 just removed. Two tests pin it, including one that checks `slice(3)` only removes a genuine leading prefix (`fs_fs_9` → `fs_9`).

**The FK race.** `autoMapIngredients` now calls `ensureFatSecretParentPersisted` before the create, exactly as `saveValidatedMapping` does insert-bound. Without it, a missing parent throws a FK violation into the per-ingredient catch and **loses the mapping while the request still succeeds** — the failure mode that cost warm batch 01 **31.4% of its FatSecret saves**. The call is idempotent and a hit is a single PK read.

Adding a FK without that guard would have traded a loud "unstorable" report for a silent loss, which is strictly worse.

## Tests

12 cases, **mutation-validated**:

| mutation | tests killed |
|---|---|
| keep the `fs_` prefix | 3 |
| drop the empty-id guard | 1 |

## Gate

`npx jest` 122 suites / 2,714 tests · `typecheck` clean · `lint:ci` 0 errors / 585 warnings (baseline) · `next build` succeeds. `migrate-smoke` will fire (`prisma/**`).

CRLF preserved on both touched tracked files — checked, since a Python rewrite flipped them during #188 and rendered the diff as a whole-file rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
