### PR TITLE
fix(eval): make the search gate able to see list destruction

### DIFF
--- a/scripts/eval/__tests__/fail-closed.test.ts
+++ b/scripts/eval/__tests__/fail-closed.test.ts
@@ -24,8 +24,11 @@
  */
 
 import {
+    DEFAULT_MIN_ITEMS,
+    describeDrift,
     driftedKnownIssues,
     evalExitCode,
+    mergeBaseline,
     scoreNlpCase,
     scoreSearchCase,
     type BaselineEntry,
@@ -148,12 +151,98 @@ describe('golden-set harness: abstention is not a pass', () => {
     });
 
     it('search: an empty hit list FAILS instead of having nothing to disagree with', () => {
-        const c = { match: [['almond']] };
+        // minItems:1 keeps this case about the EMPTY-list contract alone. Without it the
+        // one-hit positive control below trips the browse-list floor and this test would
+        // pass for the wrong reason — green because the list is short, not because the
+        // empty list was rejected.
+        const c = { match: [['almond']], minItems: 1 };
         expect(scoreSearchCase(c, []).pass).toBe(false);
         expect(scoreSearchCase(c, { error: 'typesense unreachable' }).pass).toBe(false);
         expect(scoreSearchCase(c, []).detail).toContain('EMPTY');
         // POSITIVE CONTROL
         expect(scoreSearchCase(c, [{ name: 'Almonds', kcal100: 600 }]).pass).toBe(true);
+    });
+
+    // -----------------------------------------------------------------------
+    // Browse-list destruction (the Stage 0 blind spot, closed 2026-07-29)
+    //
+    // Measured before writing these: `scoreSearchCase` scored `list.slice(0, rank ?? 3)`
+    // and never read `list.length`, and the largest `rank` in the golden set is 5 — so
+    // truncating every list to 5 rows passed all 105 search cases BY CONSTRUCTION. The
+    // top hit does not move, and the top hit was the only thing anyone looked at.
+    // -----------------------------------------------------------------------
+
+    /** 24 plausible rows, the shape a healthy browse list has. */
+    const fullList = (n = 24) =>
+        Array.from({ length: n }, (_, i) => ({ name: i === 0 ? 'Almond butter' : `Filler ${i}`, kcal100: 600 }));
+
+    it('search: a gutted list FAILS even though the expected hit is still #1', () => {
+        const c = { match: [['almond']], minItems: 14 };
+        // THE REGRESSION. Identical winner, identical top-3, 24 rows -> 3.
+        const gutted = scoreSearchCase(c, fullList(3));
+        expect(gutted.pass).toBe(false);
+        expect(gutted.detail).toContain('LIST TOO SHORT');
+        // ...and the winner is still named, because "right hit" and "gutted list" are
+        // two facts and a reader needs both to tell a filter bug from a ranking bug.
+        expect(gutted.detail).toContain('Almond butter');
+        // POSITIVE CONTROL — the same case, same winner, intact list.
+        expect(scoreSearchCase(c, fullList(24)).pass).toBe(true);
+    });
+
+    it('search: the floor is per-case, and DEFAULT_MIN_ITEMS applies when it is unset', () => {
+        expect(DEFAULT_MIN_ITEMS).toBeGreaterThan(1);
+        const noFloor = { match: [['almond']] };
+        expect(scoreSearchCase(noFloor, fullList(DEFAULT_MIN_ITEMS - 1)).pass).toBe(false);
+        expect(scoreSearchCase(noFloor, fullList(DEFAULT_MIN_ITEMS)).pass).toBe(true);
+        // A per-case floor OVERRIDES the default in both directions — a narrow query may
+        // legitimately return fewer rows, and a broad one must be held to more.
+        expect(scoreSearchCase({ match: [['almond']], minItems: 1 }, fullList(1)).pass).toBe(true);
+        expect(scoreSearchCase({ match: [['almond']], minItems: 20 }, fullList(19)).pass).toBe(false);
+    });
+
+    it('search: a short list cannot LAUNDER a wrong winner into a pass', () => {
+        // Both defects at once. The floor must not overwrite the match verdict with a
+        // friendlier one, and neither check may mask the other.
+        const c = { match: [['almond']], minItems: 14 };
+        const r = scoreSearchCase(c, [{ name: 'Peanut butter', kcal100: 600 }]);
+        expect(r.pass).toBe(false);
+        expect(r.detail).toContain('LIST TOO SHORT');
+    });
+
+    it('drift: itemCount collapse on a pinned case is reported', () => {
+        const was: BaselineEntry = { foodId: 'off:1', itemCount: 24 };
+        expect(describeDrift(was, { foodId: 'off:1', itemCount: 3 })
+            .some(s => s.includes('itemCount'))).toBe(true);
+        // Zero is the degenerate shape and must always register.
+        expect(describeDrift(was, { foodId: 'off:1', itemCount: 0 })
+            .some(s => s.includes('itemCount'))).toBe(true);
+        // POSITIVE CONTROL — ordinary corpus churn is not drift.
+        expect(describeDrift(was, { foodId: 'off:1', itemCount: 23 })).toEqual([]);
+    });
+
+    it('baseline refresh PRESERVES pins the run did not observe', () => {
+        // The real shape: 15 pins stored, 13 of them nlp, and `--only search` observes 2.
+        const stored: Record<string, BaselineEntry> = {
+            's-typo-08': { foodId: 'off:old', itemCount: 20 },
+            'n-cook-06': { foodId: 'oats', kcal100: 361 },
+            'n-mq-38': { foodId: 'burrito', kcal100: 166 },
+        };
+        const m = mergeBaseline(stored, { 's-typo-08': { foodId: 'off:new', itemCount: 22 } });
+        expect(m.cases['s-typo-08'].foodId).toBe('off:new');   // refreshed
+        expect(m.cases['n-cook-06']).toEqual(stored['n-cook-06']); // untouched, not deleted
+        expect(m.cases['n-mq-38']).toEqual(stored['n-mq-38']);
+        expect(Object.keys(m.cases)).toHaveLength(3);
+        expect(m.refreshed).toBe(1);
+        expect(m.preserved).toBe(2);
+    });
+
+    it('a refresh that observed NOTHING does not empty the baseline', () => {
+        // `--grep` matching nothing is the same input shape as a total outage. Emptying
+        // the file here would exempt every pin from drift forever, silently.
+        const stored: Record<string, BaselineEntry> = { 'n-cook-06': { foodId: 'oats' } };
+        const m = mergeBaseline(stored, {});
+        expect(m.cases).toEqual(stored);
+        expect(m.refreshed).toBe(0);
     });
 
     it('a run that executed ZERO cases exits 2, not 0', () => {

--- a/scripts/eval/assertions.ts
+++ b/scripts/eval/assertions.ts
@@ -176,7 +176,28 @@ export interface SearchCaseSpec {
     match: string[][];
     rank?: number;
     requireNutrition?: boolean;
+    /**
+     * Floor on how many rows the query must return. See DEFAULT_MIN_ITEMS for why
+     * this exists at all; see the golden set for how each value was derived.
+     */
+    minItems?: number;
 }
+
+/**
+ * Floor applied to a search case that declares no `minItems` of its own.
+ *
+ * WHY THIS EXISTS. Until 2026-07-29 nothing in this file read `list.length`. The
+ * pass criterion is "an expected name appears in `list.slice(0, rank ?? 3)`", and the
+ * largest `rank` in the golden set is 5 — so **any change truncating every result list
+ * to 5 rows passed all 105 search cases, by construction, not by luck.** Manual search
+ * is a browse list; destroying it while keeping the top hit is exactly the failure mode
+ * the pick-layer/rerank work risks, and it was the one thing the gate could not see.
+ *
+ * Deliberately low. Per-case floors in the golden set carry the real signal; this is
+ * the backstop for a newly added case whose author has not measured one yet, so it must
+ * never be the reason a legitimate narrow query goes red.
+ */
+export const DEFAULT_MIN_ITEMS = 5;
 
 const MACRO_KEYS = ['kcal100', 'protein100', 'carbs100', 'fat100'];
 function hasNum(v: unknown): boolean {
@@ -209,6 +230,15 @@ export function scoreSearchCase(c: SearchCaseSpec, hits: unknown): { pass: boole
         const bad = topN.find(nutritionMissing);
         if (bad) { pass = false; detail = `NULL-NUTRITION "${bad.name}" | ${detail}`; }
     }
+    // Browse-list invariant. Checked AFTER the match so the detail still names the
+    // winner: "the right hit is still first" and "the list was gutted" are different
+    // facts and a reader needs both. This is the only check here that reads
+    // list.length, and without it list destruction is invisible — see DEFAULT_MIN_ITEMS.
+    const floor = c.minItems ?? DEFAULT_MIN_ITEMS;
+    if (list.length < floor) {
+        pass = false;
+        detail = `LIST TOO SHORT ${list.length} < ${floor} | ${detail}`;
+    }
     return { pass, detail };
 }
 
@@ -223,6 +253,14 @@ export interface BaselineEntry {
     grams?: number | null;
     kcal100?: number | null;
     abstained?: boolean;
+    /**
+     * How many rows came back. Compared as of 2026-07-29 — it was recorded by
+     * run-eval from the start and never diffed, so a pinned case could lose most of
+     * its list silently. NOTE this only reaches `knownIssue` cases (2 of the 105
+     * search cases), which is why it is the SECOND half of the fix: the pass/fail
+     * floor in scoreSearchCase is what covers the other 103.
+     */
+    itemCount?: number;
     /**
      * The case did not produce a reading at all — transport error, non-array body,
      * zero items. Recorded because `knownIssue` otherwise swallows it completely:
@@ -262,6 +300,7 @@ export function describeDrift(was: BaselineEntry, now: BaselineEntry): string[] 
     }
     if (numberDrifted(was.grams, now.grams)) changes.push(`grams ${was.grams} -> ${now.grams}`);
     if (numberDrifted(was.kcal100, now.kcal100)) changes.push(`kcal100 ${was.kcal100} -> ${now.kcal100}`);
+    if (numberDrifted(was.itemCount, now.itemCount)) changes.push(`itemCount ${was.itemCount} -> ${now.itemCount}`);
     return changes;
 }
 
@@ -285,6 +324,28 @@ export interface DriftableResult {
     id: string;
     knownIssue?: boolean;
     observed?: BaselineEntry;
+}
+
+/**
+ * Fold this run's pin readings over the stored baseline, PRESERVING every entry the
+ * run did not observe.
+ *
+ * Pure and exported for the same reason driftedKnownIssues is: the replace-don't-merge
+ * version lived inside run-eval.ts, which calls main() at import and therefore cannot be
+ * imported by a test, so nothing could have caught it. What it did: the baseline held 15
+ * pins, 13 of them nlp, and `--write-baseline --only search` rebuilt the file from the 2
+ * pins that ran. The other 13 vanished — and since driftedKnownIssues() skips any case
+ * with no baseline entry, they would have become permanently exempt from drift detection
+ * with no error and a 0 exit. An empty `fresh` (a --grep that matched nothing) must
+ * likewise leave the file untouched rather than empty it.
+ */
+export function mergeBaseline(
+    existing: Record<string, BaselineEntry>,
+    fresh: Record<string, BaselineEntry>,
+): { cases: Record<string, BaselineEntry>; refreshed: number; preserved: number } {
+    const cases = { ...existing, ...fresh };
+    const refreshed = Object.keys(fresh).length;
+    return { cases, refreshed, preserved: Object.keys(cases).length - refreshed };
 }
 
 /**

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -10,7 +10,8 @@
         [
           "chicken breast"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-gen-02",
@@ -21,7 +22,8 @@
         [
           "brown rice"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-gen-03",
@@ -32,7 +34,8 @@
         [
           "broccoli"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-gen-04",
@@ -46,7 +49,8 @@
         [
           "oats"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-gen-05",
@@ -57,7 +61,8 @@
         [
           "banana"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-gen-06",
@@ -71,7 +76,8 @@
         [
           "greek yoghurt"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-gen-07",
@@ -82,7 +88,8 @@
         [
           "ground beef"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-gen-08",
@@ -93,7 +100,8 @@
         [
           "salmon"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-gen-09",
@@ -104,7 +112,8 @@
         [
           "egg"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-gen-10",
@@ -118,7 +127,8 @@
         [
           "milk, whole"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-gen-11",
@@ -129,7 +139,8 @@
         [
           "peanut butter"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-gen-12",
@@ -140,7 +151,8 @@
         [
           "olive oil"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-brand-01",
@@ -152,7 +164,8 @@
           "ghost",
           "oreo"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-brand-02",
@@ -163,7 +176,8 @@
         [
           "oikos"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-brand-03",
@@ -174,7 +188,8 @@
         [
           "quest"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-brand-04",
@@ -185,7 +200,8 @@
         [
           "cheerios"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-brand-05",
@@ -199,7 +215,8 @@
         [
           "coke"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-brand-06",
@@ -210,7 +227,8 @@
         [
           "fairlife"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-brand-07",
@@ -221,7 +239,8 @@
         [
           "chobani"
         ]
-      ]
+      ],
+      "minItems": 11
     },
     {
       "id": "s-brand-08",
@@ -232,7 +251,8 @@
         [
           "oreo"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-sem-01",
@@ -248,7 +268,8 @@
           "protein",
           "yoghurt"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-sem-02",
@@ -260,7 +281,8 @@
           "carb",
           "tortilla"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-sem-03",
@@ -271,7 +293,8 @@
         [
           "meal replacement"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-sem-04",
@@ -290,7 +313,8 @@
           "zero",
           "cola"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-sem-05",
@@ -302,7 +326,8 @@
           "protein",
           "ice cream"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-typo-01",
@@ -313,7 +338,8 @@
         [
           "broccoli"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-typo-02",
@@ -324,7 +350,8 @@
         [
           "avocado"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-typo-03",
@@ -336,7 +363,8 @@
           "chicken",
           "breast"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-typo-04",
@@ -350,7 +378,8 @@
         [
           "yoghurt"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-reg-01",
@@ -362,7 +391,8 @@
           "sweet potato"
         ]
       ],
-      "notes": "produce-hijack fix pin (c199643)"
+      "notes": "produce-hijack fix pin (c199643)",
+      "minItems": 16
     },
     {
       "id": "s-reg-02",
@@ -373,7 +403,8 @@
         [
           "potato"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-reg-03",
@@ -384,7 +415,8 @@
         [
           "spinach"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-mod-01",
@@ -408,7 +440,8 @@
           "fat-free",
           "milk"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-mod-02",
@@ -420,7 +453,8 @@
           "unsweetened",
           "almond"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-mod-03",
@@ -431,7 +465,8 @@
         [
           "cottage cheese"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-prod-01",
@@ -442,7 +477,8 @@
         [
           "apple"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-prod-02",
@@ -453,7 +489,8 @@
         [
           "kale"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-prod-03",
@@ -464,7 +501,8 @@
         [
           "strawberr"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-prod-04",
@@ -475,7 +513,8 @@
         [
           "blueberr"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-prod-05",
@@ -486,7 +525,8 @@
         [
           "cucumber"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-prod-06",
@@ -497,7 +537,8 @@
         [
           "avocado"
         ]
-      ]
+      ],
+      "minItems": 11
     },
     {
       "id": "s-prod-07",
@@ -508,7 +549,8 @@
         [
           "carrot"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-prod-08",
@@ -519,7 +561,8 @@
         [
           "tomato"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-prod-09",
@@ -530,7 +573,8 @@
         [
           "pepper"
         ]
-      ]
+      ],
+      "minItems": 11
     },
     {
       "id": "s-prod-10",
@@ -544,7 +588,8 @@
         [
           "courgette"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-prod-11",
@@ -555,7 +600,8 @@
         [
           "asparagus"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-prod-12",
@@ -566,7 +612,8 @@
         [
           "cauliflower"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-prot-01",
@@ -581,7 +628,8 @@
           "chicken",
           "thigh"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-prot-02",
@@ -596,7 +644,8 @@
           "pork",
           "chop"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-prot-03",
@@ -607,7 +656,8 @@
         [
           "tofu"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-prot-04",
@@ -621,7 +671,8 @@
         [
           "prawn"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-prot-05",
@@ -632,7 +683,8 @@
         [
           "tuna"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-prot-06",
@@ -643,7 +695,8 @@
         [
           "turkey"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-prot-07",
@@ -654,7 +707,8 @@
         [
           "black bean"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-prot-08",
@@ -665,7 +719,8 @@
         [
           "lentil"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-prot-09",
@@ -676,7 +731,8 @@
         [
           "tilapia"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-prot-10",
@@ -687,7 +743,8 @@
         [
           "cottage cheese"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-brand-09",
@@ -698,7 +755,8 @@
         [
           "doritos"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-brand-10",
@@ -709,7 +767,8 @@
         [
           "gatorade"
         ]
-      ]
+      ],
+      "minItems": 10
     },
     {
       "id": "s-brand-11",
@@ -720,7 +779,8 @@
         [
           "clif"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-brand-12",
@@ -731,7 +791,8 @@
         [
           "red bull"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-brand-13",
@@ -746,7 +807,8 @@
         [
           "pop-tart"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-brand-14",
@@ -757,7 +819,8 @@
         [
           "nature valley"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-brand-15",
@@ -769,7 +832,8 @@
           "ben",
           "jerry"
         ]
-      ]
+      ],
+      "minItems": 9
     },
     {
       "id": "s-brand-16",
@@ -784,7 +848,8 @@
           "premier",
           "protein"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-typo-05",
@@ -798,7 +863,8 @@
         [
           "yoghurt"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-typo-06",
@@ -809,7 +875,8 @@
         [
           "turmeric"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-typo-07",
@@ -820,7 +887,8 @@
         [
           "quinoa"
         ]
-      ]
+      ],
+      "minItems": 11
     },
     {
       "id": "s-typo-08",
@@ -833,7 +901,8 @@
         ]
       ],
       "knownIssue": true,
-      "notes": "typo hijacked by literal 'banna'-named junk products in OFF corpus (banna yoghurt/bread); should correct to banana"
+      "notes": "typo hijacked by literal 'banna'-named junk products in OFF corpus (banna yoghurt/bread); should correct to banana",
+      "minItems": 12
     },
     {
       "id": "s-typo-09",
@@ -844,7 +913,8 @@
         [
           "cauliflower"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-typo-10",
@@ -855,7 +925,8 @@
         [
           "spinach"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-uni-01",
@@ -866,7 +937,8 @@
         [
           "jalape"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-uni-02",
@@ -880,7 +952,8 @@
         [
           "açaí"
         ]
-      ]
+      ],
+      "minItems": 11
     },
     {
       "id": "s-uni-03",
@@ -897,7 +970,8 @@
         [
           "cream"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-edge-01",
@@ -908,7 +982,8 @@
         [
           "egg"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-edge-02",
@@ -919,7 +994,8 @@
         [
           "chocolate"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-edge-03",
@@ -930,7 +1006,8 @@
         [
           "water"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-edge-04",
@@ -941,7 +1018,8 @@
         [
           "coffee"
         ]
-      ]
+      ],
+      "minItems": 14
     },
     {
       "id": "s-supp-01",
@@ -954,7 +1032,8 @@
           "vegan"
         ]
       ],
-      "notes": "Regression pin: was falsely flagged as a brand hijack by an eval-harness bug (search API returns brand under 'brand', textOf read 'brandName'). Manual search ranks Ghost records correctly."
+      "notes": "Regression pin: was falsely flagged as a brand hijack by an eval-harness bug (search API returns brand under 'brand', textOf read 'brandName'). Manual search ranks Ghost records correctly.",
+      "minItems": 16
     },
     {
       "id": "s-supp-02",
@@ -966,7 +1045,8 @@
           "ghost",
           "whey"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-supp-03",
@@ -980,7 +1060,8 @@
         [
           "optimum"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-supp-04",
@@ -991,7 +1072,8 @@
         [
           "quest"
         ]
-      ]
+      ],
+      "minItems": 19
     },
     {
       "id": "s-supp-05",
@@ -1002,7 +1084,8 @@
         [
           "premier protein"
         ]
-      ]
+      ],
+      "minItems": 13
     },
     {
       "id": "s-supp-06",
@@ -1013,7 +1096,8 @@
         [
           "muscle milk"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-supp-07",
@@ -1024,7 +1108,8 @@
         [
           "legion"
         ]
-      ]
+      ],
+      "minItems": 15
     },
     {
       "id": "s-supp-08",
@@ -1035,7 +1120,8 @@
         [
           "orgain"
         ]
-      ]
+      ],
+      "minItems": 17
     },
     {
       "id": "s-trap-01",
@@ -1049,7 +1135,8 @@
         [
           "fairlife"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-trap-02",
@@ -1060,7 +1147,8 @@
         [
           "quest"
         ]
-      ]
+      ],
+      "minItems": 18
     },
     {
       "id": "s-trap-03",
@@ -1071,7 +1159,8 @@
         [
           "pure protein"
         ]
-      ]
+      ],
+      "minItems": 16
     },
     {
       "id": "s-trap-04",
@@ -1083,7 +1172,8 @@
           "kirkland"
         ]
       ],
-      "notes": "brand-vs-generic trap. NOTE: 'kirkland protein bar' was the original trap but Kirkland protein bars appear genuinely absent from the corpus (only granola bars/other Kirkland Signature items exist), so the query was retargeted to an existing product."
+      "notes": "brand-vs-generic trap. NOTE: 'kirkland protein bar' was the original trap but Kirkland protein bars appear genuinely absent from the corpus (only granola bars/other Kirkland Signature items exist), so the query was retargeted to an existing product.",
+      "minItems": 13
     },
     {
       "id": "s-trap-05",
@@ -1094,7 +1184,8 @@
         [
           "ghost"
         ]
-      ]
+      ],
+      "minItems": 12
     },
     {
       "id": "s-trap-06",
@@ -1107,7 +1198,8 @@
           "birthday cake"
         ]
       ],
-      "notes": "Regression pin: was falsely flagged as a brand-token hijack by the same eval-harness 'brand' vs 'brandName' field bug. ONE-branded records actually rank 1-3 with conf 1.0."
+      "notes": "Regression pin: was falsely flagged as a brand-token hijack by the same eval-harness 'brand' vs 'brandName' field bug. ONE-branded records actually rank 1-3 with conf 1.0.",
+      "minItems": 13
     },
     {
       "id": "s-supp-09",
@@ -1119,7 +1211,8 @@
           "ghost"
         ]
       ],
-      "notes": "Pattern 1/4 (brand hijack via flavor suffix + core-token rescue), SEARCH stage. 'cinnamon roll' flavor collides with generic/competitor cinnamon-roll protein records; manual search has no 6-word segmenter cap, so this exercises ranking (query-token-coverage gating + brand-rescue), not segmentation. CURRENT: expected to rank Ghost top-3 post-fix. Hard assertion."
+      "notes": "Pattern 1/4 (brand hijack via flavor suffix + core-token rescue), SEARCH stage. 'cinnamon roll' flavor collides with generic/competitor cinnamon-roll protein records; manual search has no 6-word segmenter cap, so this exercises ranking (query-token-coverage gating + brand-rescue), not segmentation. CURRENT: expected to rank Ghost top-3 post-fix. Hard assertion.",
+      "minItems": 15
     },
     {
       "id": "s-supp-10",
@@ -1131,7 +1224,8 @@
           "quest"
         ]
       ],
-      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. 'birthday cake' is a widely-shared flavor across brands; assert Quest-branded record still wins top-3. Hard assertion."
+      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. 'birthday cake' is a widely-shared flavor across brands; assert Quest-branded record still wins top-3. Hard assertion.",
+      "minItems": 15
     },
     {
       "id": "s-supp-11",
@@ -1143,7 +1237,8 @@
           "ryse"
         ]
       ],
-      "notes": "PROMOTED HARD 2026-07-25: the ingest gap that made this unfixable is closed. The FatSecret lane (live on master since 2026-07-23, FATSECRET_RETRIEVAL_ENABLED=1) supplies a RYSE candidate for this flavor, so a 'ryse' hit now lands in the top 3 instead of the query falling through to generic cereal records. Green on every run across 2026-07-24/25 including the FS-hardening gates. This case therefore asserts the fs lane's contribution to /api/foods/search — if the flag is turned off or fs candidates stop reaching the search route, this goes red first, which is the intended signal. | Previously: Pattern 1 (flavor-suffix collision), SEARCH. VERIFIED 2026-07-19: INGEST-BLOCKED, not ranking-fixable. RYSE brand IS in corpus (Ryse Clear Protein, RYSE Loaded Protein Banana Pudding) but NO Cinnamon-Toast-Crunch flavor SKU exists, so nothing RYSE can be ranked up; the query lands on generic cereal records. Needs the flavor SKU ingested before any ranking fix engages."
+      "notes": "PROMOTED HARD 2026-07-25: the ingest gap that made this unfixable is closed. The FatSecret lane (live on master since 2026-07-23, FATSECRET_RETRIEVAL_ENABLED=1) supplies a RYSE candidate for this flavor, so a 'ryse' hit now lands in the top 3 instead of the query falling through to generic cereal records. Green on every run across 2026-07-24/25 including the FS-hardening gates. This case therefore asserts the fs lane's contribution to /api/foods/search — if the flag is turned off or fs candidates stop reaching the search route, this goes red first, which is the intended signal. | Previously: Pattern 1 (flavor-suffix collision), SEARCH. VERIFIED 2026-07-19: INGEST-BLOCKED, not ranking-fixable. RYSE brand IS in corpus (Ryse Clear Protein, RYSE Loaded Protein Banana Pudding) but NO Cinnamon-Toast-Crunch flavor SKU exists, so nothing RYSE can be ranked up; the query lands on generic cereal records. Needs the flavor SKU ingested before any ranking fix engages.",
+      "minItems": 12
     },
     {
       "id": "s-supp-12",
@@ -1155,7 +1250,8 @@
           "gatorade"
         ]
       ],
-      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. 'cool blue' flavor vs generic blue drinks; assert Gatorade wins top-5 (brand confirmed in corpus via s-brand-10). Hard assertion."
+      "notes": "Pattern 1 (flavor-suffix collision), SEARCH. 'cool blue' flavor vs generic blue drinks; assert Gatorade wins top-5 (brand confirmed in corpus via s-brand-10). Hard assertion.",
+      "minItems": 11
     },
     {
       "id": "s-supp-13",
@@ -1170,7 +1266,8 @@
           "gold standard"
         ]
       ],
-      "notes": "Pattern 1 (flavor-suffix collision with in-flavor 'and'), SEARCH. 'cookies and cream' is a generic flavor; assert an Optimum Nutrition record wins top-3 rather than a no-brand cookies-and-cream record. Hard assertion."
+      "notes": "Pattern 1 (flavor-suffix collision with in-flavor 'and'), SEARCH. 'cookies and cream' is a generic flavor; assert an Optimum Nutrition record wins top-3 rather than a no-brand cookies-and-cream record. Hard assertion.",
+      "minItems": 13
     },
     {
       "id": "s-supp-14",
@@ -1185,7 +1282,8 @@
           "fairlife"
         ]
       ],
-      "notes": "Pattern 4 (core-token/brand-rescue), SEARCH. 'vanilla' core token would otherwise pull in generic vanilla shakes; assert the fairlife Core Power record survives (brand confirmed via s-trap-01). Hard assertion."
+      "notes": "Pattern 4 (core-token/brand-rescue), SEARCH. 'vanilla' core token would otherwise pull in generic vanilla shakes; assert the fairlife Core Power record survives (brand confirmed via s-trap-01). Hard assertion.",
+      "minItems": 12
     },
     {
       "id": "s-supp-15",
@@ -1201,7 +1299,8 @@
           "protein"
         ]
       ],
-      "notes": "Pattern 5 (NO_BRAND bonus suppression), SEARCH. A generic 'protein vanilla' record would otherwise win on the +0.05 no-brand bonus; assert the branded Premier Protein record wins top-3 (bonus suppressed in simpleRerank). Hard assertion."
+      "notes": "Pattern 5 (NO_BRAND bonus suppression), SEARCH. A generic 'protein vanilla' record would otherwise win on the +0.05 no-brand bonus; assert the branded Premier Protein record wins top-3 (bonus suppressed in simpleRerank). Hard assertion.",
+      "minItems": 17
     },
     {
       "id": "s-supp-16",
@@ -1213,7 +1312,8 @@
           "muscle milk"
         ]
       ],
-      "notes": "Pattern 5 (NO_BRAND bonus suppression), SEARCH. Assert the Muscle Milk brand beats a generic 'chocolate protein shake' no-brand record. Hard assertion."
+      "notes": "Pattern 5 (NO_BRAND bonus suppression), SEARCH. Assert the Muscle Milk brand beats a generic 'chocolate protein shake' no-brand record. Hard assertion.",
+      "minItems": 12
     },
     {
       "id": "s-typo-11",
@@ -1225,7 +1325,8 @@
           "cheese"
         ]
       ],
-      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'chesse' -> cheese. Hard assertion."
+      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'chesse' -> cheese. Hard assertion.",
+      "minItems": 14
     },
     {
       "id": "s-typo-12",
@@ -1240,7 +1341,8 @@
           "yoghurt"
         ]
       ],
-      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'yogrt' -> yogurt. Hard assertion."
+      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'yogrt' -> yogurt. Hard assertion.",
+      "minItems": 14
     },
     {
       "id": "s-typo-13",
@@ -1252,7 +1354,8 @@
           "broccoli"
         ]
       ],
-      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'brocoli' -> broccoli (single-c variant; complements s-typo-01 'brocolli'). Hard assertion."
+      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'brocoli' -> broccoli (single-c variant; complements s-typo-01 'brocolli'). Hard assertion.",
+      "minItems": 16
     },
     {
       "id": "s-typo-14",
@@ -1265,7 +1368,8 @@
         ]
       ],
       "knownIssue": true,
-      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'banan' -> banana. KNOWN GAP, same family as s-typo-08 'banna': truncated/misspelled banana queries get hijacked by literal 'banan'/'banna'-named junk products in the OFF corpus. Non-gating until the banana typo cluster is fixed."
+      "notes": "Pattern 8 (typo/fuzzy tolerance), SEARCH. 'banan' -> banana. KNOWN GAP, same family as s-typo-08 'banna': truncated/misspelled banana queries get hijacked by literal 'banan'/'banna'-named junk products in the OFF corpus. Non-gating until the banana typo cluster is fixed.",
+      "minItems": 13
     },
     {
       "id": "s-supp-17",
@@ -1277,7 +1381,8 @@
           "ghost"
         ]
       ],
-      "notes": "PROMOTED 2026-07-19 after 3 consecutive passing runs (Ghost Gamer in corpus, ranking stable). | Previously: DEFECT (flavor-ingest-blocked), SEARCH. Ghost Gamer line IS in corpus (off_0810028292666 'Gamer' brand 'Ghost') but the 'sour patch' flavor is not; nearest is 'Sour Watermelon' with an empty brand field. Not ranking-fixable without the flavor SKU. knownIssue, non-gating."
+      "notes": "PROMOTED 2026-07-19 after 3 consecutive passing runs (Ghost Gamer in corpus, ranking stable). | Previously: DEFECT (flavor-ingest-blocked), SEARCH. Ghost Gamer line IS in corpus (off_0810028292666 'Gamer' brand 'Ghost') but the 'sour patch' flavor is not; nearest is 'Sour Watermelon' with an empty brand field. Not ranking-fixable without the flavor SKU. knownIssue, non-gating.",
+      "minItems": 9
     }
   ],
   "nlp": [

--- a/scripts/eval/known-issue-baseline.json
+++ b/scripts/eval/known-issue-baseline.json
@@ -1,20 +1,24 @@
 {
-  "_readme": "Recorded state of each knownIssue case. run-eval compares against this and reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the new values are understood to be the intended state.",
-  "writtenAt": "2026-07-25T16:05:32.011Z",
+  "_readme": "Recorded state of each knownIssue case. run-eval compares against this and reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the new values are understood to be the intended state. Writes MERGE: a filtered (--only/--grep) run refreshes only the pins it ran and leaves the rest intact.",
+  "writtenAt": "2026-07-30T16:44:36.506Z",
   "cases": {
     "s-typo-08": {
       "foodId": "off_9310653104835",
       "foodName": "banna yoghurt",
       "grams": null,
       "kcal100": 73.69999694824219,
-      "abstained": false
+      "abstained": false,
+      "errored": false,
+      "itemCount": 20
     },
     "s-typo-14": {
       "foodId": "off_5060929632145",
       "foodName": "Banan",
       "grams": null,
       "kcal100": 80,
-      "abstained": false
+      "abstained": false,
+      "errored": false,
+      "itemCount": 22
     },
     "n-supp-06": {
       "foodId": "off_0851770007795",

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -23,6 +23,7 @@ import {
     isAbstention,
     driftedKnownIssues,
     evalExitCode,
+    mergeBaseline,
     scoreNlpCase,
     scoreSearchCase,
     type BaselineEntry,
@@ -104,27 +105,49 @@ function loadKnownIssueBaseline(): Record<string, BaselineEntry> {
     }
 }
 
+/**
+ * Re-record the baseline for the pins THIS RUN observed, preserving every other entry.
+ *
+ * MERGES rather than replaces, and that is not a nicety. The baseline held 15 pins, 13
+ * of them nlp; a `--write-baseline --only search` run knows about 2. Rebuilding the file
+ * from `rs` alone deleted the other 13 — and because driftedKnownIssues() skips any case
+ * with no baseline entry ("nothing to compare"), those 13 would have gone PERMANENTLY
+ * exempt from drift detection, silently, with the run still exiting 0. The same applies
+ * to any --grep. A filtered run must be able to refresh its own pins without quietly
+ * dropping coverage for the ones it did not execute.
+ */
 function writeKnownIssueBaseline(rs: CaseResult[]): void {
-    const cases: Record<string, BaselineEntry> = {};
+    const fresh: Record<string, BaselineEntry> = {};
     for (const r of rs) {
         if (!r.knownIssue || !r.observed) continue;
-        cases[r.id] = {
+        fresh[r.id] = {
             foodId: r.observed.foodId ?? null,
             foodName: r.observed.foodName ?? null,
             grams: r.observed.grams ?? null,
             kcal100: r.observed.kcal100 ?? null,
             abstained: r.observed.abstained ?? false,
             errored: r.observed.errored ?? false,
+            itemCount: r.observed.itemCount,
         };
     }
+    const { cases, refreshed, preserved } = mergeBaseline(loadKnownIssueBaseline(), fresh);
     fs.writeFileSync(baselinePath, JSON.stringify({
         _readme: 'Recorded state of each knownIssue case. run-eval compares against this and '
             + 'reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the '
             + 'signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the '
-            + 'new values are understood to be the intended state.',
+            + 'new values are understood to be the intended state. Writes MERGE: a filtered '
+            + '(--only/--grep) run refreshes only the pins it ran and leaves the rest intact.',
         writtenAt: new Date().toISOString(),
         cases,
     }, null, 2) + '\n');
+    // Say what was and was not touched. A refresh that silently covers fewer cases than
+    // the reader assumes is the failure this whole file exists to prevent.
+    console.log(`baseline written: ${refreshed} pin(s) refreshed from this run, ${preserved} preserved untouched `
+        + `(${Object.keys(cases).length} total).`);
+    if (ONLY || GREP) {
+        console.log(`  NOTE: run was filtered (${ONLY ? `--only ${ONLY}` : ''}${GREP ? ` --grep ${GREP}` : ''}) — `
+            + `the preserved entries were NOT re-measured.`);
+    }
 }
 
 /** Every knownIssue case whose recorded values moved since the baseline was written. */
@@ -311,8 +334,11 @@ async function main() {
     summary.knownIssueDrift = drifts.length;
 
     if (WRITE_BASELINE) {
+        // The per-pin accounting (refreshed vs preserved) is printed inside the writer —
+        // this count is only the pins THIS run saw, which on a filtered run is not the
+        // size of the file and must not be reported as though it were.
+        console.log(`\nBaseline written to ${path.relative(process.cwd(), baselinePath)}:`);
         writeKnownIssueBaseline(results);
-        console.log(`\nBaseline written to ${path.relative(process.cwd(), baselinePath)} (${results.filter(r => r.knownIssue).length} knownIssue cases).`);
     }
 
     const outDir = path.join(__dirname, 'results');


### PR DESCRIPTION
## The defect

`scoreSearchCase` scored `list.slice(0, c.rank ?? 3)` and **never read `list.length`**. The largest `rank` in the golden set is 5, so **any change truncating every result list to 5 rows passed all 105 search cases by construction** — not by luck. Manual search is a browse list, and destroying it while keeping the top hit is exactly what the pick-layer/rerank work risks.

This is Stage 0 of `sync-docs/reports/2026-07-29_search-unification-plan.md` — the detector that every later stage is judged by.

## Measured, not inferred

Against a proxy forwarding to the box but cutting every list to 5 rows:

| | result |
|---|---|
| pre-change code | `103/105 pass` · **`0 real failures`** — byte-identical to a healthy run |
| with this change | `0/105 pass` · `103 real failures` |

A previously circulated version of this finding said "cutting 24 rows to 3 passes 105/105". That is **overstated** — it holds for the 57 cases at `rank ≤ 3`, while the 48 at `rank 5` fail only if their expected hit happens to sit at position 4–5. Testing *that* version can show red and produce a false all-clear. The provable statement is the one above: invisible at ≥5.

## Changes

- **`scoreSearchCase`** — per-case `minItems` floor with a `DEFAULT_MIN_ITEMS` backstop. Checked *after* the match so the detail still names the winner: `LIST TOO SHORT 5 < 18 | hit: "Chicken Breast"`. "Right hit" and "gutted list" are two different facts and a reader needs both to tell a filter bug from a ranking bug.
- **`golden-set.json`** — 105 measured floors, `max(5, 0.6 × measured)`. Counts were verified deterministic *before* being baked in (two full runs, **0 of 105 differed**, max delta 0). Observed range was 15–32 rows, so every floor has real headroom.
- **`describeDrift`** — compares `itemCount`, which `run-eval` already recorded and never diffed. Note this reaches only the **2** pinned search cases, since `driftedKnownIssues()` skips unpinned ones — which is precisely why the floor carries the other 103.
- **`writeKnownIssueBaseline`** — now **merges** instead of replacing. It rebuilt the file from the pins the run observed, so `--write-baseline --only search` would have deleted the **13 nlp pins**, and because `driftedKnownIssues()` skips cases with no baseline entry they would have gone *permanently exempt from drift detection* — silently, exit 0. Extracted as the pure `mergeBaseline()` because `run-eval.ts` calls `main()` at import and cannot be imported by a test, the same reason `driftedKnownIssues` was extracted.

## Verification

- `npx jest` — 122 suites, 2,719 passed. `typecheck` clean. `lint:ci` 0 errors.
- Eval against the box: `103/105`, **0 real failures** — no false failures from the new floors.
- Baseline refresh on a filtered run now reports `2 pin(s) refreshed, 13 preserved untouched (15 total)`.
- **Playbook §13 mutation pass: 12 deliberate mutations, 12 killed** by *named* assertion failures. The harness separates an assertion failure from a suite that merely failed to compile — the latter exits non-zero too and would score as a false kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu