### PR TITLE
feat(doc-check): devmachine context, so the box can check mobile claims

### DIFF
--- a/ops/systemd/doc-check.service
+++ b/ops/systemd/doc-check.service
@@ -8,10 +8,12 @@ Type=oneshot
 WorkingDirectory=%h/Recipe-App
 Environment=NODE_ENV=production
 Environment=PATH=%h/.nvm/versions/node/v24.18.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# --where backend,box: the box has no copy of the mobile repo (no Syncthing share carries
-# it), so mobile-context claims are out of scope HERE and are covered by full runs from the
-# Mac. The runner prints the excluded claim ids loudly — never let this read as full coverage.
-ExecStart=%h/.nvm/versions/node/v24.18.0/bin/npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts --where backend,box
+# --where backend,box,mobile: since 2026-07-30 Syncthing DOES deliver the mobile repo here
+# (folder msmwx-9fkha, receive-only at %h/KindaHealthyMobile, ignoring ios/android/node_modules),
+# so mobile-context claims now run on this host. `devmachine` claims stay out of scope: they
+# need an installed toolchain (npx tsc) and node_modules is Syncthing-ignored by design. The
+# runner prints every excluded claim id — never let this read as full coverage.
+ExecStart=%h/.nvm/versions/node/v24.18.0/bin/npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts --where backend,box,mobile
 TimeoutStartSec=1800
 StandardOutput=append:%h/Recipe-App/logs/doc-check.log
 StandardError=append:%h/Recipe-App/logs/doc-check.log

--- a/scripts/doc-check/__tests__/doc-check-core.test.ts
+++ b/scripts/doc-check/__tests__/doc-check-core.test.ts
@@ -60,6 +60,19 @@ describe('parseRegistry fails closed', () => {
     test('duplicate ids are rejected — two claims sharing an id would let one shadow the other', () => {
         expect(() => parseRegistry(JSON.stringify({ claims: [claim(), claim()] }))).toThrow(/duplicate/);
     });
+
+    // Pinned because a context is what decides which host is ALLOWED to skip a
+    // claim. A typo'd context that still parsed would silently drop the claim
+    // from every --where run; the 'laptop' case above is the negative control
+    // for exactly that, and this is its positive counterpart.
+    test.each([['backend'], ['mobile'], ['box'], ['devmachine']])(
+        'context %s is accepted — the full set, so adding one is a deliberate edit here too',
+        (where) => {
+            const parsed = parseRegistry(JSON.stringify({ claims: [claim({ id: `c-${where}`, where: where as never })] }));
+            expect(parsed).toHaveLength(1);
+            expect(parsed[0].where).toBe(where);
+        },
+    );
 });
 
 describe('evaluateClaim fails closed', () => {

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -195,9 +195,9 @@
         },
         {
             "id": "tsc-baseline-30-total-0-src",
-            "claim": "npx tsc --noEmit fails with exactly 30 pre-existing errors, none under src/ (all sync-docs probe scripts) — that red is not your change",
+            "claim": "Mobile `npx tsc --noEmit` exits non-zero on exactly 30 pre-existing errors, 0 of them under src/ — all backend probe scripts Syncthing'd into sync-docs/. Needs an installed toolchain, so it runs on a dev machine, not the box.",
             "ownerDoc": "mobile:CLAUDE.md#ci",
-            "where": "mobile",
+            "where": "devmachine",
             "command": "npx tsc --noEmit 2>&1 | awk '/error TS/{t++} /^src\\// {s++} END{print t\":\"s+0}'",
             "expect": {
                 "kind": "equals",
@@ -540,6 +540,30 @@
             "expect": {
                 "kind": "equals",
                 "value": "ok"
+            },
+            "verified": "2026-07-30"
+        },
+        {
+            "id": "box-has-mobile-repo",
+            "claim": "The box holds a receive-only copy of the mobile repo at ~/KindaHealthyMobile (Syncthing folder msmwx-9fkha, added 2026-07-30) — this is what lets its nightly check mobile-context claims instead of skipping 15 of them",
+            "ownerDoc": "mobile:CLAUDE.md#machines--repos",
+            "where": "box",
+            "command": "test -f $HOME/KindaHealthyMobile/CLAUDE.md && test -d $HOME/KindaHealthyMobile/sync-docs/log && echo ok || echo missing",
+            "expect": {
+                "kind": "equals",
+                "value": "ok"
+            },
+            "verified": "2026-07-30"
+        },
+        {
+            "id": "box-mobile-copy-stays-small",
+            "claim": "The box's mobile copy stays under 200MB — its ignores drop ios/, android/, assets/, node_modules and the sync-docs data dirs; without them it would pull the 2.4GB working tree",
+            "ownerDoc": "mobile:CLAUDE.md#machines--repos",
+            "where": "box",
+            "command": "du -sm $HOME/KindaHealthyMobile 2>/dev/null | cut -f1",
+            "expect": {
+                "kind": "max",
+                "value": "200"
             },
             "verified": "2026-07-30"
         }

--- a/scripts/doc-check/doc-check-core.ts
+++ b/scripts/doc-check/doc-check-core.ts
@@ -24,7 +24,18 @@
  */
 
 /** Where a claim's command runs. The runner maps each to a cwd or an ssh wrapper. */
-export type ClaimContext = 'backend' | 'mobile' | 'box';
+/**
+ * Where a claim's command must run.
+ *
+ * `devmachine` is deliberately distinct from `mobile`: both live in the mobile
+ * repo, but a devmachine claim also needs an installed toolchain (node_modules,
+ * a working `npx tsc`). Syncthing does not carry node_modules, so the box has
+ * the mobile FILES but not the mobile TOOLCHAIN. Splitting the context is not a
+ * way to skip a check — it names WHY a host cannot run it, so the runner can
+ * report it as out of scope rather than either failing nightly forever or,
+ * worse, being silently dropped.
+ */
+export type ClaimContext = 'backend' | 'mobile' | 'box' | 'devmachine';
 
 export interface ExpectSpec {
     /**
@@ -92,7 +103,7 @@ export function parseRegistry(raw: string): DocClaim[] {
     if (!Array.isArray(claims)) throw new Error('registry has no claims[] array');
     const seen = new Set<string>();
     const KINDS = new Set(['equals', 'matches', 'count', 'min', 'max']);
-    const CONTEXTS = new Set(['backend', 'mobile', 'box']);
+    const CONTEXTS = new Set(['backend', 'mobile', 'box', 'devmachine']);
     for (const c of claims as DocClaim[]) {
         for (const field of ['id', 'claim', 'ownerDoc', 'where', 'command', 'verified'] as const) {
             if (typeof c?.[field] !== 'string' || c[field].trim() === '') {

--- a/scripts/doc-check/run-doc-check.ts
+++ b/scripts/doc-check/run-doc-check.ts
@@ -23,8 +23,14 @@
  *
  * CONTEXTS
  *   backend — this repo's root.
- *   mobile  — the KindaHealthyMobile repo. Syncthing delivers it to every machine;
- *             resolved via DOC_CHECK_MOBILE_ROOT or the known per-machine paths.
+ *   mobile  — the KindaHealthyMobile repo's FILES. Since 2026-07-30 Syncthing
+ *             delivers them to the box too (folder msmwx-9fkha, receive-only,
+ *             ignoring ios/android/node_modules); resolved via
+ *             DOC_CHECK_MOBILE_ROOT or the known per-machine paths.
+ *   devmachine — the mobile repo PLUS an installed toolchain. node_modules is
+ *             Syncthing-ignored, so `npx tsc` does not exist on the box. These
+ *             claims are out of scope there and are reported as such, never
+ *             silently dropped.
  *   box     — the OptiPlex. Local when this host IS the box, ssh otherwise.
  *             A dead ssh FAILS those claims (never skips): the box being
  *             unreachable is exactly when its state is least verified.
@@ -63,7 +69,7 @@ function runCommand(c: DocClaim): CommandOutcome {
     let argv: string[];
     let cwd = BACKEND_ROOT;
 
-    if (c.where === 'mobile') {
+    if (c.where === 'mobile' || c.where === 'devmachine') {
         const root = mobileRoot();
         if (!root) {
             return { ran: false, stdout: '', exitCode: null, error: 'mobile repo not found (set DOC_CHECK_MOBILE_ROOT)' };


### PR DESCRIPTION
The box now Syncthings a receive-only copy of the mobile repo
(`~/KindaHealthyMobile`, folder `msmwx-9fkha`, ignoring ios/android/assets/
node_modules/.git and the sync-docs data dirs — 3.6MB, not 2.4GB). That takes
its nightly from **25 of 47 claims to 46**.

One claim genuinely cannot run there: `tsc-baseline-30-total-0-src` needs
`npx tsc`, and node_modules is Syncthing-ignored by design.

The tempting fixes were both wrong. Installing node_modules on the box gives it
a second dependency tree that drifts from the Mac's and makes the claim flap.
Leaving the nightly permanently red at 46/47 trains people to ignore it — the
exact failure mode this checker exists to prevent.

So `where` gains a fourth value, **`devmachine`**: the mobile repo PLUS an
installed toolchain. It is not a way to silence a check — it names WHY a host
cannot run one, which is what lets the runner report it as out of scope
(loudly, by id) instead of failing forever or silently dropping it. The box's
unit moves to `--where backend,box,mobile` and prints what it skipped.

Verified: `npm run doc-check` 47/47 from the Mac; on the box 46/46 with
`1 claim(s) OUT OF SCOPE ... tsc-baseline-30-total-0-src`, unit exit 0.
`npx jest scripts/doc-check` 26/26, `scripts/eval` 18 suites/1,030,
`typecheck` 0, `lint:ci` 0 errors.

Adds a test pinning the full context set. A typo'd context that still parsed
would silently drop its claim from every `--where` run; the existing
`'laptop'` rejection is the negative control and this is its positive half.

New claims: `box-has-mobile-repo`, `box-mobile-copy-stays-small` (guards the
ignores — without them the box pulls the whole 2.4GB tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu