### PR TITLE
fix(ops): the quarterly OFF refresh must never run unattended

### DIFF
--- a/ops/systemd/off-parquet-refresh.service
+++ b/ops/systemd/off-parquet-refresh.service
@@ -8,12 +8,19 @@ Type=oneshot
 WorkingDirectory=%h/Recipe-App
 Environment=NODE_ENV=production
 Environment=PATH=%h/.local/bin:%h/.nvm/versions/node/v24.18.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# DESTRUCTIVE: ingest-off.ts --fresh truncates and rebuilds OffFood, then
-# sync-typesense.ts rebuilds the collections. The script's own preflight
-# refuses (exit 2, nothing changed) unless duckdb, both TS entrypoints, ts-node,
-# DATABASE_URL and >=15GB free are all present AND it is running on this host —
-# every dev machine's .env points at this box's Postgres, so an unguarded run
-# from a laptop would truncate production.
+# DESTRUCTIVE, AND DELIBERATELY REFUSES ON A TIMER. Measured 2026-07-30, a
+# --fresh run deletes 1,073,542 OffFood rows carrying 1,073,537 pgvector
+# embeddings, deletes 762,156 OffServing rows, and NULLs FoodMapping.offBarcode
+# on 2,854 of 3,508 cache rows (81%). Re-embedding needs the Windows RTX 5080
+# listener. That is not something to do unattended at 02:00, so the script
+# prints the live blast radius and then exits 3 unless a human sets
+# OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 — which this unit does NOT set. A quarterly
+# firing therefore shows up as a FAILED unit, on purpose: it is a loud reminder
+# that the corpus is due a refresh, not an automatic rebuild.
+# The preflight also exits 2 (nothing changed) unless duckdb, both TS
+# entrypoints, ts-node, DATABASE_URL and >=15GB free are present AND it is
+# running on this host — every dev machine's .env points at this box's Postgres,
+# so an unguarded run from a laptop would truncate production.
 ExecStart=%h/Recipe-App/scripts/refresh-off-from-parquet.sh
 TimeoutStartSec=28800
 StandardOutput=append:%h/Recipe-App/logs/off-parquet-refresh.log

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -566,6 +566,19 @@
                 "value": "200"
             },
             "verified": "2026-07-30"
+        },
+        {
+            "id": "parquet-refresh-refuses-without-ack",
+            "claim": "The quarterly OFF refresh refuses (exit 3, nothing downloaded or written) unless a human sets OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 — it destroys ~1.07M pgvector embeddings and NULLs the OFF pointer on ~81% of FoodMapping cache rows, so the timer must never run it unattended",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "box",
+            "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh >/dev/null 2>&1; echo $?",
+            "expect": {
+                "kind": "equals",
+                "value": "3"
+            },
+            "verified": "2026-07-30",
+            "timeoutMs": 180000
         }
     ]
 }

--- a/scripts/refresh-off-from-parquet.sh
+++ b/scripts/refresh-off-from-parquet.sh
@@ -81,10 +81,47 @@ if [ "$PREFLIGHT_FAIL" -ne 0 ]; then
   exit 2
 fi
 echo "[$(date -Is)] Preflight OK."
+
+# BLAST RADIUS — print what `ingest-off.ts --fresh` will destroy, from the live
+# DB, every time. Measured 2026-07-30 the first time anyone looked: this is not
+# "refresh the corpus", it is a rebuild that also drops ~1.07M pgvector
+# embeddings and NULLs the offBarcode on ~81% of the FoodMapping cache.
+echo "[$(date -Is)] Blast radius (live):"
+node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only -e '
+const { PrismaClient } = require("@prisma/client");
+(async () => {
+  const p = new PrismaClient();
+  const [r] = await p.$queryRawUnsafe(`SELECT
+    (SELECT count(*) FROM "OffFood")                                     AS offfood,
+    (SELECT count(*) FROM "OffFood" WHERE embedding IS NOT NULL)         AS embedded,
+    (SELECT count(*) FROM "OffServing")                                  AS servings,
+    (SELECT count(*) FROM "FoodMapping" WHERE "offBarcode" IS NOT NULL)  AS mapped`);
+  console.log(`  OffFood rows deleted        : ${r.offfood}`);
+  console.log(`  ...pgvector embeddings lost : ${r.embedded}  (re-embedding needs the Windows RTX 5080 listener)`);
+  console.log(`  OffServing rows deleted     : ${r.servings}`);
+  console.log(`  FoodMapping.offBarcode NULLed: ${r.mapped}  (cache rows that lose their OFF pointer)`);
+  await p.$disconnect();
+})();' || { echo "  ❌ could not read the blast radius — refusing to guess"; exit 2; }
+
 if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
   echo "[$(date -Is)] --preflight-only: all guards pass. Nothing downloaded, nothing written."
   exit 0
 fi
+
+# ACKNOWLEDGEMENT GATE — the numbers above are why this cannot be an unattended
+# job. A timer fires with a bare environment, so a scheduled run lands here and
+# stops; a human who has read the blast radius and has a re-embedding plan sets
+# the variable. This is deliberate: losing 1M embeddings quietly at 02:00 on a
+# Tuesday is exactly the kind of failure this codebase keeps writing gates for.
+if [ "${OFF_REFRESH_I_ACCEPT_DATA_LOSS:-0}" != "1" ]; then
+  echo "[$(date -Is)] ⛔ Refusing: this destroys the embeddings and the cache's OFF pointers above."
+  echo "     Nothing was downloaded or written. To proceed you need BOTH:"
+  echo "       1. a plan to re-embed (the Windows listener, or scripts to backfill), and"
+  echo "       2. a FoodMapping snapshot — see the food-cache flywheel procedure."
+  echo "     Then re-run with OFF_REFRESH_I_ACCEPT_DATA_LOSS=1."
+  exit 3
+fi
+echo "[$(date -Is)] OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 — proceeding with the destructive refresh."
 
 echo "[$(date -Is)] Downloading Parquet export..."
 curl -fsSL --retry 3 -o "$PARQUET.tmp" "$PARQUET_URL"


### PR DESCRIPTION
Earlier today I installed `off-parquet-refresh.timer` without measuring what
`ingest-off.ts --fresh` actually destroys. Measured now, against the live DB:

| What `--fresh` does | Rows |
|---|---|
| `DELETE FROM "OffServing"` | 762,156 |
| `UPDATE "FoodMapping" SET "offBarcode" = NULL` | **2,854 of 3,508** (81% of the cache) |
| `DELETE FROM "OffFood"` | 1,073,542 — of which **1,073,537 carry pgvector embeddings** |

That is not "refresh the corpus". Re-embedding 1.07M rows needs the Windows
RTX 5080 listener, and 81% of the FoodMapping cache loses its OFF pointer. I
had scheduled that to happen unattended on 1 Oct.

## Fix

The script prints the live blast radius on every run, then exits 3 unless
`OFF_REFRESH_I_ACCEPT_DATA_LOSS=1`. The timer does **not** set it, so a
quarterly firing surfaces as a *failed unit* — a loud "the corpus is due"
reminder rather than an automatic rebuild. Keeping the timer and letting it
fail is deliberate: deleting the timer would make the corpus silently rot
instead, which is the failure mode this whole day was about.

If the blast-radius query itself cannot run, the script exits 2 rather than
guessing — it refuses to proceed without knowing what it would destroy.

## Verified on the box

```
Blast radius (live):
  OffFood rows deleted        : 1073542
  ...pgvector embeddings lost : 1073537
  OffServing rows deleted     : 762156
  FoodMapping.offBarcode NULLed: 2854
⛔ Refusing: ...
exit=3          # nothing downloaded, nothing written
```

`systemctl --user start off-parquet-refresh.service` → `Result=exit-code`,
`ExecMainStatus=3`. `npm run doc-check` 48/48. `jest scripts/doc-check` 26/26.
`typecheck` 0.

New claim `parquet-refresh-refuses-without-ack` pins the gate at exit 3, so
removing it turns the nightly red.

## Not done

The real fix is a refresh that upserts by barcode and re-embeds only changed
rows, instead of delete-and-rebuild. That is a design change, not a patch, and
it is what should happen before anyone sets that variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu