### PR TITLE
feat(off-refresh): snapshot + restore FoodMapping.offBarcode around --fresh

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -579,6 +579,30 @@
             },
             "verified": "2026-07-30",
             "timeoutMs": 180000
+        },
+        {
+            "id": "off-refresh-snapshots-before-truncate",
+            "claim": "refresh-off-from-parquet.sh snapshots FoodMapping BEFORE the --fresh ingest and restores offBarcode AFTER it, in that order",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "backend",
+            "command": "awk 'index($0,\"scripts/eval/_snap_foodmapping.ts \\\"$SNAP\\\"\"){s=NR} index($0,\"scripts/ingest-off.ts \\\"$SLIM_JSONL\\\" --fresh\"){i=NR} index($0,\"scripts/eval/restore-off-pointers.ts \\\"$SNAP\\\" --execute\"){r=NR} END{print (s&&i&&r&&s<i&&i<r)?\"ok\":\"BROKEN\"}' scripts/refresh-off-from-parquet.sh",
+            "expect": {
+                "kind": "equals",
+                "value": "ok"
+            },
+            "verified": "2026-07-30"
+        },
+        {
+            "id": "off-refresh-timer-does-not-set-ack",
+            "claim": "off-parquet-refresh.service does NOT set OFF_REFRESH_I_ACCEPT_DATA_LOSS, so an unattended quarterly firing fails as a unit instead of rebuilding the corpus",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "backend",
+            "command": "grep -c '^Environment=.*OFF_REFRESH_I_ACCEPT_DATA_LOSS' ops/systemd/off-parquet-refresh.service",
+            "expect": {
+                "kind": "count",
+                "value": "0"
+            },
+            "verified": "2026-07-30"
         }
     ]
 }

--- a/scripts/eval/__tests__/restore-off-pointers.test.ts
+++ b/scripts/eval/__tests__/restore-off-pointers.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Guards for restore-off-pointers.ts.
+ *
+ * Same discipline as cache-ops-guards.test.ts: this is the post-disaster path,
+ * so every way the run could quietly restore nothing and still look clean is
+ * forced, and every block carries a POSITIVE CONTROL so "always refuses" cannot
+ * satisfy the suite.
+ */
+
+import {
+    corpusLooksEmpty,
+    extractOffPointers,
+    partitionPointerRestore,
+    pointerExitCode,
+    residueReportLines,
+    type OffPointer,
+    type PointerPartition,
+} from '../restore-off-pointers';
+import type { SnapshotRow } from '../_evict_rows';
+
+const row = (normalizedForm: string, offBarcode: unknown): SnapshotRow =>
+    ({ normalizedForm, offBarcode } as SnapshotRow);
+
+const ptr = (normalizedForm: string, offBarcode: string): OffPointer => ({ normalizedForm, offBarcode });
+
+const emptyPartition = (): PointerPartition =>
+    ({ restorable: [], orphaned: [], missingRow: [], alreadySet: [] });
+
+describe('extractOffPointers', () => {
+    test('positive control: rows carrying a barcode become pointers', () => {
+        expect(extractOffPointers([row('greek plain yogurt', '0123456789012')]))
+            .toEqual([ptr('greek plain yogurt', '0123456789012')]);
+    });
+
+    test.each([
+        ['null — a FatSecret/FDC row, never part of this operation', null],
+        ['undefined — column absent from the snapshot row', undefined],
+        ['empty string', ''],
+        ['whitespace only', '   '],
+        ['a number — pgvector/JSON round-trips can retype; a non-string is not a barcode', 12345],
+    ])('%s yields no pointer', (_name, bad) => {
+        expect(extractOffPointers([row('k', bad)])).toEqual([]);
+    });
+
+    test('mixed rows keep only the pointered ones — the FS/FDC majority must not be invented', () => {
+        const got = extractOffPointers([
+            row('a', '111'), row('b', null), row('c', '222'), row('d', undefined),
+        ]);
+        expect(got.map(p => p.normalizedForm)).toEqual(['a', 'c']);
+    });
+});
+
+describe('partitionPointerRestore', () => {
+    const pointers = [ptr('a', '111'), ptr('b', '222'), ptr('c', '333'), ptr('d', '444')];
+    const live = new Map<string, string | null>([
+        ['a', null],   // restorable
+        ['b', null],   // barcode delisted -> orphaned
+        ['c', '999'],  // live traffic repointed it -> alreadySet
+        // 'd' absent    -> missingRow
+    ]);
+    const surviving = new Set(['111', '333', '444']);
+
+    test('positive control: each row lands in exactly one bucket', () => {
+        const p = partitionPointerRestore(pointers, live, surviving);
+        expect(p.restorable.map(x => x.normalizedForm)).toEqual(['a']);
+        expect(p.orphaned.map(x => x.normalizedForm)).toEqual(['b']);
+        expect(p.alreadySet.map(x => x.normalizedForm)).toEqual(['c']);
+        expect(p.missingRow.map(x => x.normalizedForm)).toEqual(['d']);
+    });
+
+    test('every pointer is accounted for — nothing may be silently dropped', () => {
+        const p = partitionPointerRestore(pointers, live, surviving);
+        const total = p.restorable.length + p.orphaned.length + p.missingRow.length + p.alreadySet.length;
+        expect(total).toBe(pointers.length);
+    });
+
+    test('a row whose live pointer already equals the snapshot is STILL not rewritten', () => {
+        // Same value, but the column is not NULL, so --fresh did not strip it and
+        // this key is not ours to touch. Writing it would be a no-op today and a
+        // clobber the day the values differ.
+        const p = partitionPointerRestore([ptr('a', '111')], new Map([['a', '111']]), new Set(['111']));
+        expect(p.restorable).toHaveLength(0);
+        expect(p.alreadySet).toHaveLength(1);
+    });
+
+    test('a surviving barcode cannot rescue a key that no longer exists', () => {
+        const p = partitionPointerRestore([ptr('gone', '111')], new Map(), new Set(['111']));
+        expect(p.missingRow).toHaveLength(1);
+        expect(p.restorable).toHaveLength(0);
+    });
+});
+
+describe('corpusLooksEmpty — the refusal that stops a green no-op', () => {
+    test('positive control: a normal partial-survival read is NOT empty', () => {
+        expect(corpusLooksEmpty(2854, 2701)).toBe(false);
+    });
+    test('even a single survivor is a real corpus', () => {
+        expect(corpusLooksEmpty(2854, 1)).toBe(false);
+    });
+    test('asking about barcodes and matching none is a refusal, not 100% delisting', () => {
+        expect(corpusLooksEmpty(2854, 0)).toBe(true);
+    });
+    test('asking about nothing is not an empty corpus — the zero-pointer case refuses earlier', () => {
+        expect(corpusLooksEmpty(0, 0)).toBe(false);
+    });
+});
+
+describe('pointerExitCode — residue is never success', () => {
+    test('positive control: a clean full restore exits 0', () => {
+        const p = emptyPartition();
+        p.restorable.push(ptr('a', '111'));
+        expect(pointerExitCode(p)).toBe(0);
+    });
+
+    test.each([
+        ['orphaned', 'orphaned'],
+        ['missingRow', 'missingRow'],
+        ['alreadySet', 'alreadySet'],
+    ] as const)('a single %s row alone exits 3', (_name, bucket) => {
+        const p = emptyPartition();
+        p.restorable.push(ptr('a', '111'));
+        p[bucket].push(ptr('b', '222'));
+        expect(pointerExitCode(p)).toBe(3);
+    });
+
+    test('exit 3 even when NOTHING was restorable — an all-residue run must not read as 0', () => {
+        const p = emptyPartition();
+        p.orphaned.push(ptr('b', '222'));
+        expect(pointerExitCode(p)).toBe(3);
+    });
+});
+
+describe('residueReportLines — every unrestored key is printed', () => {
+    test('positive control: a clean partition prints nothing', () => {
+        expect(residueReportLines(emptyPartition())).toEqual([]);
+    });
+
+    test('each unrestored key appears by name, so the report is a worklist not a count', () => {
+        const p = emptyPartition();
+        p.orphaned.push(ptr('discontinued bar', '111'));
+        p.missingRow.push(ptr('evicted key', '222'));
+        p.alreadySet.push(ptr('repointed key', '333'));
+        const text = residueReportLines(p).join('\n');
+        expect(text).toContain('discontinued bar');
+        expect(text).toContain('evicted key');
+        expect(text).toContain('repointed key');
+    });
+
+    test('restorable rows are not reported as residue', () => {
+        const p = emptyPartition();
+        p.restorable.push(ptr('fine key', '111'));
+        expect(residueReportLines(p)).toEqual([]);
+    });
+});

--- a/scripts/eval/restore-off-pointers.ts
+++ b/scripts/eval/restore-off-pointers.ts
@@ -1,0 +1,240 @@
+/**
+ * restore-off-pointers.ts — put FoodMapping.offBarcode back after a --fresh OFF re-ingest.
+ *
+ * WHY THIS EXISTS: `ingest-off.ts --fresh` runs
+ *   UPDATE "FoodMapping" SET "offBarcode" = NULL WHERE "offBarcode" IS NOT NULL
+ * before `DELETE FROM "OffFood"`. That is not the pipeline discarding knowledge —
+ * it is satisfying the real FK `FoodMapping.offBarcode -> OffFood.barcode`
+ * (schema.prisma, `offFood` relation) so the delete can proceed. Measured on the
+ * live DB 2026-07-30: 2,854 of 3,508 cache rows (81%) carry an offBarcode, so a
+ * refresh silently strips the OFF pointer off four fifths of the cache and leaves
+ * those rows with source='openfoodfacts' and nothing to hydrate from.
+ *
+ * Barcode is Open Food Facts' STABLE primary key — the same product keeps it
+ * across exports — so the pointers are recoverable from a pre-refresh snapshot
+ * for every product that still exists in the new corpus. That is the whole job.
+ *
+ * The residue is real and is the point of the report: a product OFF has actually
+ * delisted cannot be repointed, and its cache row is now a broken
+ * openfoodfacts-sourced row with no record behind it. Those keys are PRINTED as a
+ * worklist. This script never deletes them — evicting cache rows is
+ * `_evict_rows.ts`'s job and its own five-step procedure.
+ *
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/restore-off-pointers.ts \
+ *     <pre-refresh-snapshot.json> [--execute]
+ *
+ * The snapshot is a `_snap_foodmapping.ts` file taken IMMEDIATELY BEFORE the
+ * destructive ingest (Role B, restore anchor — see that script's header).
+ *
+ * Dry run by default, like every other cache-touching script here.
+ *
+ *   exit 0 = every snapshot pointer restored, nothing left over
+ *   exit 3 = completed, but >=1 pointer was NOT restored — the printed lists are
+ *            the reconciliation worklist (delisted products, keys evicted since,
+ *            keys a live write already repointed)
+ *   exit 2 = refused / error — INCLUDING the cases where the run would otherwise
+ *            look like a clean no-op (see refusals below)
+ *
+ * REFUSALS, all of which would otherwise encode absence-of-restore as success
+ * (mapping playbook §11 class B):
+ *   - a snapshot holding zero offBarcode pointers: it is not a valid restore
+ *     anchor for this operation, and "restored 0/0" would exit 0 and read green;
+ *   - asking OffFood about N>0 barcodes and matching zero: that is an empty or
+ *     still-loading corpus, not a corpus where every product was delisted. It
+ *     would mark all 2,854 orphaned and restore nothing, reported as expected
+ *     residue.
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { loadSnapshot, type SnapshotRow } from './_evict_rows';
+
+// ---------------------------------------------------------------------------
+// Pure, unit-testable pieces (scripts/eval/__tests__/restore-off-pointers.test.ts)
+// ---------------------------------------------------------------------------
+
+export interface OffPointer {
+    normalizedForm: string;
+    offBarcode: string;
+}
+
+/**
+ * The (key -> barcode) pairs a snapshot can restore. Rows without a pointer are
+ * not part of this operation at all: FatSecret- and FDC-sourced rows never had
+ * an offBarcode, and `--fresh` does not touch them.
+ */
+export function extractOffPointers(rows: SnapshotRow[]): OffPointer[] {
+    const out: OffPointer[] = [];
+    for (const r of rows) {
+        const bc = r.offBarcode;
+        if (typeof bc === 'string' && bc.trim() !== '') {
+            out.push({ normalizedForm: r.normalizedForm, offBarcode: bc });
+        }
+    }
+    return out;
+}
+
+export interface PointerPartition {
+    /** live row exists, offBarcode is NULL, and the barcode survived the re-ingest */
+    restorable: OffPointer[];
+    /** the product is gone from the new corpus — repointing it would recreate an FK violation */
+    orphaned: OffPointer[];
+    /** the key no longer exists in FoodMapping (evicted or re-keyed since the snapshot) */
+    missingRow: OffPointer[];
+    /** a live write already set a pointer — never clobbered, same rule as _restore_rows.ts */
+    alreadySet: OffPointer[];
+}
+
+/**
+ * Pure: the caller supplies live state. `live` maps key -> current offBarcode
+ * (null when the column is NULL); a key absent from the map does not exist.
+ * `survivingBarcodes` is the set of snapshot barcodes still present in OffFood.
+ */
+export function partitionPointerRestore(
+    pointers: OffPointer[],
+    live: Map<string, string | null>,
+    survivingBarcodes: Set<string>,
+): PointerPartition {
+    const p: PointerPartition = { restorable: [], orphaned: [], missingRow: [], alreadySet: [] };
+    for (const ptr of pointers) {
+        if (!live.has(ptr.normalizedForm)) p.missingRow.push(ptr);
+        else if (live.get(ptr.normalizedForm) !== null) p.alreadySet.push(ptr);
+        else if (!survivingBarcodes.has(ptr.offBarcode)) p.orphaned.push(ptr);
+        else p.restorable.push(ptr);
+    }
+    return p;
+}
+
+/**
+ * Matching zero barcodes out of a non-empty request is indistinguishable, in the
+ * partition, from "OFF delisted every single product" — and that reading exits 3
+ * with a tidy report instead of stopping the operator. Refuse instead.
+ */
+export function corpusLooksEmpty(requested: number, matched: number): boolean {
+    return requested > 0 && matched === 0;
+}
+
+/** Anything not restored is residue, and residue is its own outcome — never success. */
+export function pointerExitCode(p: PointerPartition): number {
+    return p.orphaned.length + p.missingRow.length + p.alreadySet.length > 0 ? 3 : 0;
+}
+
+/** Every unrestored key is printed: the lists ARE the reconciliation worklist. */
+export function residueReportLines(p: PointerPartition): string[] {
+    const lines: string[] = [];
+    if (p.orphaned.length) {
+        lines.push(
+            `NOT RESTORED — ${p.orphaned.length} product(s) no longer in the OFF corpus (delisted upstream).`,
+            '  These cache rows are now source=openfoodfacts with no record behind them. Triage with _evict_rows.ts:',
+        );
+        for (const o of p.orphaned) lines.push(`  ORPHANED ${JSON.stringify(o.normalizedForm)} -> ${o.offBarcode}`);
+    }
+    if (p.missingRow.length) {
+        lines.push(`NOT RESTORED — ${p.missingRow.length} key(s) absent from FoodMapping (evicted or re-keyed since the snapshot):`);
+        for (const m of p.missingRow) lines.push(`  MISSING ${JSON.stringify(m.normalizedForm)}`);
+    }
+    if (p.alreadySet.length) {
+        // Not necessarily live traffic: a snapshot taken when the pointers were
+        // still intact (a rehearsal) lands every row here too. State what is
+        // observed — the column is set — not an inferred cause.
+        lines.push(`NOT RESTORED — ${p.alreadySet.length} key(s) already carry an offBarcode (never clobbered):`);
+        for (const a of p.alreadySet) lines.push(`  ALREADY SET ${JSON.stringify(a.normalizedForm)}`);
+    }
+    return lines;
+}
+
+// ---------------------------------------------------------------------------
+
+const CHUNK = 1000;
+
+function chunk<T>(xs: T[], n: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
+    return out;
+}
+
+async function main(): Promise<number> {
+    const args = process.argv.slice(2);
+    const execute = args.includes('--execute');
+    const snapPath = args.find(a => !a.startsWith('--'));
+    if (!snapPath) throw new Error('usage: restore-off-pointers.ts <pre-refresh-snapshot.json> [--execute]');
+
+    const parsed = loadSnapshot(snapPath);
+    if (!parsed.ok) { console.error(`REFUSED: ${parsed.reason}`); return 2; }
+    const snap = parsed.snap;
+
+    const pointers = extractOffPointers(snap.rows);
+    console.log(`snapshot: ${snap.rows.length} rows, taken ${snap.takenAt}`);
+    console.log(`snapshot: ${pointers.length} carry an offBarcode`);
+    if (pointers.length === 0) {
+        console.error('REFUSED: snapshot holds no offBarcode pointers — wrong file, or taken after the ingest already NULLed them.');
+        return 2;
+    }
+
+    const prisma = new PrismaClient();
+    try {
+        // Live FoodMapping state for exactly the snapshot's keys.
+        const live = new Map<string, string | null>();
+        for (const part of chunk(pointers.map(p => p.normalizedForm), CHUNK)) {
+            const rows = await prisma.foodMapping.findMany({
+                where: { normalizedForm: { in: part } },
+                select: { normalizedForm: true, offBarcode: true },
+            });
+            for (const r of rows) live.set(r.normalizedForm, r.offBarcode);
+        }
+
+        // Which snapshot barcodes survived the re-ingest.
+        const wanted = [...new Set(pointers.map(p => p.offBarcode))];
+        const surviving = new Set<string>();
+        for (const part of chunk(wanted, CHUNK)) {
+            const rows = await prisma.offFood.findMany({
+                where: { barcode: { in: part } },
+                select: { barcode: true },
+            });
+            for (const r of rows) surviving.add(r.barcode);
+        }
+        console.log(`corpus: ${surviving.size}/${wanted.length} snapshot barcodes present in the new OffFood`);
+        if (corpusLooksEmpty(wanted.length, surviving.size)) {
+            console.error('REFUSED: zero of the snapshot barcodes are in OffFood — the corpus is empty or still ingesting.');
+            console.error('         Proceeding would report every pointer as an upstream delisting and restore nothing.');
+            return 2;
+        }
+
+        const p = partitionPointerRestore(pointers, live, surviving);
+        console.log(`\nrestorable : ${p.restorable.length}`);
+        console.log(`orphaned   : ${p.orphaned.length}`);
+        console.log(`missing row: ${p.missingRow.length}`);
+        console.log(`already set: ${p.alreadySet.length}`);
+
+        if (!execute) {
+            console.log('\nDRY RUN — nothing written. Re-run with --execute to apply.');
+        } else {
+            let applied = 0;
+            for (const part of chunk(p.restorable, CHUNK)) {
+                await prisma.$transaction(
+                    part.map(ptr => prisma.foodMapping.updateMany({
+                        // offBarcode: null in the predicate keeps this idempotent and
+                        // race-safe: a key repointed between the read and this write is
+                        // not overwritten, matching _restore_rows.ts's never-clobber rule.
+                        where: { normalizedForm: ptr.normalizedForm, offBarcode: null },
+                        data: { offBarcode: ptr.offBarcode },
+                    })),
+                );
+                applied += part.length;
+            }
+            console.log(`\nrestored ${applied} offBarcode pointer(s).`);
+        }
+
+        const residue = residueReportLines(p);
+        if (residue.length) { console.log(''); for (const l of residue) console.log(l); }
+        return pointerExitCode(p);
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+if (require.main === module) {
+    main()
+        .then(c => process.exit(c))
+        .catch(e => { console.error(e); process.exit(2); });
+}

--- a/scripts/refresh-off-from-parquet.sh
+++ b/scripts/refresh-off-from-parquet.sh
@@ -13,7 +13,16 @@
 # "the corpus is fresh".
 #
 #   download Parquet (~7GB) -> off-parquet-to-jsonl.sh (slim ~330MB JSONL)
-#   -> ingest-off.ts --fresh -> sync-typesense.ts
+#   -> snapshot FoodMapping -> ingest-off.ts --fresh -> restore-off-pointers.ts
+#   -> sync-typesense.ts
+#
+# The snapshot/restore pair either side of the ingest is not optional bookkeeping:
+# `--fresh` NULLs FoodMapping.offBarcode on ~81% of the cache to satisfy the FK
+# before deleting OffFood. Barcodes are OFF's stable primary key, so those
+# pointers are recoverable — but only from a snapshot taken BEFORE the truncate.
+# Embeddings are the other loss and are NOT restored here: re-run embed_foods.py
+# afterwards (measured 2026-07-30: ~327 rows/sec on the box's CPU, so ~55min for
+# the full corpus — a GPU is not required).
 #
 # See the mobile repo's sync-docs/archive/handoff_food_data_quality_audit.md
 # ("TRUE root cause" section) for the full investigation.
@@ -71,6 +80,10 @@ command -v duckdb >/dev/null 2>&1 || { echo "  ❌ duckdb CLI not on PATH (neede
 [ -x "$REPO/scripts/off-parquet-to-jsonl.sh" ] || { echo "  ❌ scripts/off-parquet-to-jsonl.sh missing or not executable"; PREFLIGHT_FAIL=1; }
 [ -f "$REPO/scripts/ingest-off.ts" ]           || { echo "  ❌ scripts/ingest-off.ts missing"; PREFLIGHT_FAIL=1; }
 [ -f "$REPO/scripts/sync-typesense.ts" ]       || { echo "  ❌ scripts/sync-typesense.ts missing"; PREFLIGHT_FAIL=1; }
+# The snapshot/restore pair is checked HERE because a missing restore path
+# discovered after the truncate is a missing restore path, not an error message.
+[ -f "$REPO/scripts/eval/_snap_foodmapping.ts" ]     || { echo "  ❌ scripts/eval/_snap_foodmapping.ts missing — no pre-truncate snapshot is possible"; PREFLIGHT_FAIL=1; }
+[ -f "$REPO/scripts/eval/restore-off-pointers.ts" ]  || { echo "  ❌ scripts/eval/restore-off-pointers.ts missing — the cache pointers would be unrecoverable"; PREFLIGHT_FAIL=1; }
 [ -x "$REPO/node_modules/.bin/ts-node" ]       || { echo "  ❌ node_modules/.bin/ts-node missing — run npm ci"; PREFLIGHT_FAIL=1; }
 [ -n "${DATABASE_URL:-}" ]                     || { echo "  ❌ DATABASE_URL empty"; PREFLIGHT_FAIL=1; }
 # ~7GB parquet + ~330MB slim JSONL + headroom.
@@ -97,9 +110,9 @@ const { PrismaClient } = require("@prisma/client");
     (SELECT count(*) FROM "OffServing")                                  AS servings,
     (SELECT count(*) FROM "FoodMapping" WHERE "offBarcode" IS NOT NULL)  AS mapped`);
   console.log(`  OffFood rows deleted        : ${r.offfood}`);
-  console.log(`  ...pgvector embeddings lost : ${r.embedded}  (re-embedding needs the Windows RTX 5080 listener)`);
+  console.log(`  ...pgvector embeddings lost : ${r.embedded}  (NOT restored here — re-run scripts/embed_foods.py; ~55min on this box CPU, measured 2026-07-30)`);
   console.log(`  OffServing rows deleted     : ${r.servings}`);
-  console.log(`  FoodMapping.offBarcode NULLed: ${r.mapped}  (cache rows that lose their OFF pointer)`);
+  console.log(`  FoodMapping.offBarcode NULLed: ${r.mapped}  (RESTORED automatically after the ingest, minus products OFF delisted)`);
   await p.$disconnect();
 })();' || { echo "  ❌ could not read the blast radius — refusing to guess"; exit 2; }
 
@@ -114,10 +127,15 @@ fi
 # the variable. This is deliberate: losing 1M embeddings quietly at 02:00 on a
 # Tuesday is exactly the kind of failure this codebase keeps writing gates for.
 if [ "${OFF_REFRESH_I_ACCEPT_DATA_LOSS:-0}" != "1" ]; then
-  echo "[$(date -Is)] ⛔ Refusing: this destroys the embeddings and the cache's OFF pointers above."
-  echo "     Nothing was downloaded or written. To proceed you need BOTH:"
-  echo "       1. a plan to re-embed (the Windows listener, or scripts to backfill), and"
-  echo "       2. a FoodMapping snapshot — see the food-cache flywheel procedure."
+  echo "[$(date -Is)] ⛔ Refusing: this rebuilds the corpus and drops the embeddings above."
+  echo "     Nothing was downloaded or written."
+  echo "     Recoverable automatically by this script:"
+  echo "       - FoodMapping.offBarcode — snapshotted before the truncate and restored after."
+  echo "     NOT recovered here, plan for it first:"
+  echo "       - the pgvector embeddings. Re-run scripts/embed_foods.py afterwards"
+  echo "         (~327 rows/sec on this box's CPU, measured 2026-07-30 — no GPU needed)."
+  echo "         Until it finishes, keyword search is unaffected but semantic recall is degraded."
+  echo "       - cache rows whose product OFF has delisted; the restore prints them as a worklist."
   echo "     Then re-run with OFF_REFRESH_I_ACCEPT_DATA_LOSS=1."
   exit 3
 fi
@@ -131,9 +149,36 @@ echo "[$(date -Is)] Downloaded: $(du -h "$PARQUET" | cut -f1)"
 echo "[$(date -Is)] Converting Parquet -> slim JSONL..."
 "$REPO/scripts/off-parquet-to-jsonl.sh" "$PARQUET" "$SLIM_JSONL"
 
+# SNAPSHOT — Role B (restore anchor): taken as late as possible, immediately
+# before the truncate, so live traffic between here and the ingest is minimal.
+# Deliberately AFTER the slow download/convert, which can take hours.
+SNAP="$WORKDIR/FoodMapping-pre-refresh-$(date -u +%Y-%m-%dT%H-%M-%SZ).json"
+echo "[$(date -Is)] Snapshotting FoodMapping -> $SNAP"
+node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only \
+  -r tsconfig-paths/register scripts/eval/_snap_foodmapping.ts "$SNAP"
+
 echo "[$(date -Is)] Running --fresh ingest..."
 node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only \
   scripts/ingest-off.ts "$SLIM_JSONL" --fresh
+
+# RESTORE — exit 3 means "completed, with residue an operator must reconcile"
+# (products OFF delisted). That is an expected outcome of a real refresh, not a
+# failure, so it must not abort the run under `set -e`; exit 2 is a refusal and
+# MUST stop everything. Anything else is unknown and also stops.
+echo "[$(date -Is)] Restoring FoodMapping.offBarcode pointers..."
+set +e
+node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only \
+  -r tsconfig-paths/register scripts/eval/restore-off-pointers.ts "$SNAP" --execute
+RESTORE_RC=$?
+set -e
+case "$RESTORE_RC" in
+  0) echo "[$(date -Is)] Pointers fully restored." ;;
+  3) echo "[$(date -Is)] ⚠️  Pointers restored with residue (see the worklist above). Snapshot kept: $SNAP" ;;
+  *) echo "[$(date -Is)] ❌ Pointer restore FAILED (rc=$RESTORE_RC). The cache is missing its OFF pointers."
+     echo "     The snapshot is intact — replay by hand:"
+     echo "     scripts/eval/restore-off-pointers.ts $SNAP --execute"
+     exit "$RESTORE_RC" ;;
+esac
 
 echo "[$(date -Is)] Re-syncing Typesense..."
 node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only \
@@ -143,4 +188,9 @@ node_modules/.bin/ts-node --project tsconfig.scripts.json --transpile-only \
 # record of what was ingested (and for cheap re-runs without a re-download).
 rm -f "$PARQUET"
 
+# The snapshot is deliberately NOT deleted: it is the only record of what the
+# pointers were, and the restore's residue worklist is only actionable against it.
 echo "[$(date -Is)] ✅ Refresh complete."
+echo "[$(date -Is)] NEXT: every OffFood row now has a NULL embedding — semantic recall is"
+echo "     degraded until you run scripts/embed_foods.py (keyword search is unaffected;"
+echo "     the Typesense vector field is optional). Snapshot retained at: $SNAP"


### PR DESCRIPTION
## What

`ingest-off.ts --fresh` NULLs `offBarcode` on **2,854 of 3,508** cache rows (81%, measured 2026-07-30) before `DELETE FROM "OffFood"`. That is FK maintenance — `FoodMapping.offBarcode → OffFood.barcode` is a real relation — not a decision to discard the pointers. Barcode is OFF's *stable* primary key, so they are recoverable from a snapshot taken before the truncate.

## Changes

- **`scripts/eval/restore-off-pointers.ts`** (new) — replays a `_snap_foodmapping.ts` file after the ingest. Never clobbers a pointer already set. Refuses (exit 2) on a snapshot with zero pointers, and on a zero-barcode match — both would otherwise restore nothing and report a clean run. Exits 3 with a printed worklist for products OFF has delisted.
- **23 fail-injection tests**, positive control per block.
- **`refresh-off-from-parquet.sh`** — snapshot immediately before the ingest, restore immediately after; both existence-checked in preflight, so a missing restore path is found *before* the truncate. Restore exit 3 is expected residue and must not abort under `set -e`; exit 2 stops everything.
- **Corrected a false claim in the blast-radius output**: re-embedding does *not* require the RTX 5080. Measured 2026-07-30, `bge-small-en-v1.5` does **327 rows/sec on the box's CPU (~55 min for 1.07M)**, 1,062/sec on the Mac. Keyword search is unaffected meanwhile — `sync-typesense` declares the vector field `optional: true`.
- Two registry claims pin the snapshot→ingest→restore ordering and the timer's refusal to set the ack variable.

## Verification

- `npx jest scripts/eval/__tests__/` → **1027 passed, 18 suites**
- `npm run doc-check` → **50/50**
- `npx tsc --noEmit` → clean; `npm run lint:ci` → 0 errors
- Box preflight → passes, exit 0, nothing written
- **Live dry-run rehearsal against prod**: 2,854 pointers read, 2,739/2,739 barcodes matched, all correctly classed "already set", nothing written

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu