### PR TITLE
docs(off-refresh): point next-steps at embed-off-cpu.ts + the second Typesense sync

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -603,6 +603,30 @@
                 "value": "0"
             },
             "verified": "2026-07-30"
+        },
+        {
+            "id": "embed-off-cpu-uses-cls-pooling",
+            "claim": "embed-off-cpu.ts writes CLS-pooled vectors, matching the stored corpus (cosine 1.00000 vs ~0.93 for mean)",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "backend",
+            "command": "grep -c \"pooling: 'cls'\" scripts/embed-off-cpu.ts",
+            "expect": {
+                "kind": "count",
+                "value": "1"
+            },
+            "verified": "2026-07-30"
+        },
+        {
+            "id": "query-embedding-still-mean-pooled",
+            "claim": "KNOWN DEFECT tripwire: query-embedding.ts still embeds queries with pooling:'mean' while the corpus is CLS. When this claim FAILS the mismatch has been fixed — update the owner doc's pooling section and delete this entry.",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "backend",
+            "command": "grep -c \"pooling: 'mean'\" src/lib/search/query-embedding.ts",
+            "expect": {
+                "kind": "count",
+                "value": "1"
+            },
+            "verified": "2026-07-30"
         }
     ]
 }

--- a/scripts/refresh-off-from-parquet.sh
+++ b/scripts/refresh-off-from-parquet.sh
@@ -197,6 +197,10 @@ rm -f "$PARQUET"
 # The snapshot is deliberately NOT deleted: it is the only record of what the
 # pointers were, and the restore's residue worklist is only actionable against it.
 echo "[$(date -Is)] ✅ Refresh complete."
-echo "[$(date -Is)] NEXT: every OffFood row now has a NULL embedding — semantic recall is"
-echo "     degraded until you run scripts/embed_foods.py (keyword search is unaffected;"
-echo "     the Typesense vector field is optional). Snapshot retained at: $SNAP"
+echo "[$(date -Is)] NEXT, two steps — semantic recall is degraded until BOTH are done"
+echo "     (keyword search is unaffected; the Typesense vector field is optional):"
+echo "       1. scripts/embed-off-cpu.ts   — every OffFood row now has a NULL embedding."
+echo "          Use this, NOT embed_foods.py: the box has no torch/sentence_transformers."
+echo "       2. scripts/sync-typesense.ts  — AGAIN. searchOffSemantic() reads vectors from"
+echo "          Typesense, not pgvector, and the sync above ran before the embeddings existed."
+echo "     Snapshot retained at: $SNAP"


### PR DESCRIPTION
The refresh's completion message named `embed_foods.py` (which cannot run on the box) and omitted the **second** `sync-typesense.ts` pass entirely.

That omission matters: `searchOffSemantic()` reads vectors via `vectorSearchTypesense`, **not** pgvector, and the refresh's own sync runs *before* the embeddings exist. Following the old message would leave `OffFood.embedding` fully populated and semantic search still returning nothing — an hour of CPU silently wasted.

Two registry claims pin the pooling facts (50 → 52):
- `embed-off-cpu-uses-cls-pooling` — must stay CLS; matches the stored corpus at cosine 1.00000 (mean scores ~0.93).
- `query-embedding-still-mean-pooled` — a **tripwire for a known defect**. Queries are mean-pooled while the corpus is CLS. When this claim *fails*, the mismatch has been fixed and the owner doc's pooling section needs updating.

`doc-check` 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu