### PR TITLE
docs(doc-check): tripwire claims for the wiped OFF curation marks

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -627,6 +627,30 @@
                 "value": "1"
             },
             "verified": "2026-07-30"
+        },
+        {
+            "id": "off-refresh-does-not-preserve-marks",
+            "claim": "KNOWN DEFECT tripwire: refresh-off-from-parquet.sh does not snapshot/restore OffFood.corruptReason, so a --fresh rebuild silently destroys every curation mark (6,822 lost on 2026-07-30). When this claim FAILS the restore has been added — update the owner doc's 'The marks are data' section and delete this entry.",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "backend",
+            "command": "grep -c 'corruptReason' scripts/refresh-off-from-parquet.sh || true",
+            "expect": {
+                "kind": "count",
+                "value": "0"
+            },
+            "verified": "2026-07-31"
+        },
+        {
+            "id": "off-corrupt-marks-wiped",
+            "claim": "KNOWN DEFECT tripwire: OffFood.corruptReason is 0 rows after the 2026-07-30 refresh (was 6,822), so corrupt records are unexcluded from Typesense and the corrupt_record escape cannot fire. When this claim FAILS the marks have been restored — re-date the owner doc and the warm-push plan's B1, and delete this entry.",
+            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+            "where": "box",
+            "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"corruptReason\" IS NOT NULL;'",
+            "expect": {
+                "kind": "count",
+                "value": "0"
+            },
+            "verified": "2026-07-31"
         }
     ]
 }


### PR DESCRIPTION
The 2026-07-30 quarterly OFF refresh truncated `OffFood` and destroyed **6,822 `corruptReason` marks** plus every `duplicateOfBarcode` mark. Those columns live on the deleted rows — no readable statement NULLs them, and no upstream export regenerates them.

Consequence, measured: corrupt records are back in the live Typesense index (the re-sync excluded nothing), the `corrupt_record` escape cannot fire, and the nightly eval gate has been red since — nlp **229/243 → 225/243**, with `n-supp-23` traced end to end (`core fairlife power` → `9568310020398`, 230 kcal/100 g on a 414 g serving, billing 952 kcal).

Registry-only change. Two entries, both **tripwires** in the same shape as `query-embedding-still-mean-pooled` — they assert the defect *still exists*, so the checker goes red exactly when someone fixes it and the owner doc needs re-dating:

| id | asserts | fails when |
|---|---|---|
| `off-refresh-does-not-preserve-marks` | the refresh script has no snapshot/restore for `corruptReason` | that restore ships |
| `off-corrupt-marks-wiped` | `OffFood.corruptReason` is 0 rows | the marks are restored |

Owner doc for both: mobile `sync-docs/backend_integration_guide.md` §"The marks are data, and `--fresh` deletes them". Recovery is scripted and sequenced as blocker B1 in mobile `sync-docs/reports/2026-07-31_warm-push-handoff.md`.

**Verified:** `npm run doc-check` → **54/54 claims hold**, both new claims executing (the box claim over ssh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu