### PR TITLE
Refresh fallout: query pooling, detector reachability, and a persisted serving draw

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,6 +209,14 @@ TYPESENSE_API_KEY=xyzapikey
 # `vector` extension and populated OffFood.embedding column.
 SEMANTIC_SEARCH_ENABLED=false
 
+# DIAGNOSTIC ONLY — leave unset in every deployed environment.
+# Forces query-side pooling ('cls' | 'mean'). The corpus is CLS-pooled, so the
+# only correct value is the default (CORPUS_POOLING in
+# src/lib/search/query-embedding.ts); setting 'mean' deliberately puts queries in
+# a different vector space and exists so scripts/eval/semantic-recall-probe.ts can
+# A/B the two in one process. It logs a warning whenever it is honoured.
+# EMBED_QUERY_POOLING=cls
+
 # Per-line mapping telemetry (MappingEventLog table) written by /api/nlp/parse:
 # cache hit/escape, serving-resolution tier, billed totals, latency. Default on;
 # set to "false" to disable writes (reads/analytics unaffected).

--- a/.env.example
+++ b/.env.example
@@ -215,7 +215,9 @@ SEMANTIC_SEARCH_ENABLED=false
 # src/lib/search/query-embedding.ts); setting 'mean' deliberately puts queries in
 # a different vector space and exists so scripts/eval/semantic-recall-probe.ts can
 # A/B the two in one process. It logs a warning whenever it is honoured.
-# EMBED_QUERY_POOLING=cls
+# Left empty deliberately: the code treats empty exactly as unset, so this
+# documents the knob and satisfies .env.example parity without pinning a value.
+EMBED_QUERY_POOLING=
 
 # Per-line mapping telemetry (MappingEventLog table) written by /api/nlp/parse:
 # cache hit/escape, serving-resolution tier, billed totals, latency. Default on;

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1,656 +1,716 @@
 {
-    "$comment": "Doc-claims registry. Every entry: the claim as its owner doc states it, the ONE doc that owns the fact, the command that re-derives it, the expected value, and the date last measured. Run: npm run doc-check (or npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts). A failing claim means the DOC is now wrong — fix the owner doc AND this entry together, with a fresh date. Contexts: backend = this repo, mobile = KindaHealthyMobile repo, box = the OptiPlex (ssh when not local). The box has no copy of the mobile repo, so its nightly run uses --where backend,box; mobile claims are covered from the Mac.",
-    "claims": [
-        {
-            "id": "attribution-client-sources",
-            "claim": "CLIENT_SOURCES whitelist is exactly fatsecret/fdc/openfoodfacts/ai_estimated, in src/lib/attribution.ts",
-            "ownerDoc": "mobile:CLAUDE.md#attribution",
-            "where": "backend",
-            "command": "grep 'CLIENT_SOURCES' src/lib/attribution.ts | head -1",
-            "expect": {
-                "kind": "matches",
-                "value": "fatsecret.+fdc.+openfoodfacts.+ai_estimated"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "attribution-importers-two",
-            "claim": "Exactly two API routes import the attribution chokepoint (foods/search and foods/[id]); parse deliberately does not",
-            "ownerDoc": "mobile:CLAUDE.md#attribution",
-            "where": "backend",
-            "command": "grep -rl 'lib/attribution' src/app/api | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "2"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "parse-owns-whitelist",
-            "claim": "The parse lane carries its own STANDARD_SOURCES whitelist (floors unknowns to ai_estimated) instead of importing attribution.ts",
-            "ownerDoc": "mobile:CLAUDE.md#attribution",
-            "where": "backend",
-            "command": "grep -c 'STANDARD_SOURCES' src/app/api/nlp/parse/route.ts",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "parse-no-attribution-import",
-            "claim": "nlp/parse does not import lib/attribution (its whitelist is deliberately separate)",
-            "ownerDoc": "mobile:CLAUDE.md#attribution",
-            "where": "backend",
-            "command": "grep -c 'lib/attribution' src/app/api/nlp/parse/route.ts",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "ghost-models-gone",
-            "claim": "GlobalIngredientMapping and FdcFoodCache do not exist in the Prisma schema (deleted as ghosts, PR #188)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "grep -cE 'model (GlobalIngredientMapping|FdcFoodCache) ' prisma/schema.prisma",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "ingredientfoodmap-fsid-fk",
-            "claim": "IngredientFoodMap.fsId is a real FK to FatSecretFood (PR #189)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "awk '/^model IngredientFoodMap /,/^}/' prisma/schema.prisma | grep -c 'FatSecretFood'",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "ingredientfoodmap-no-fk-offbarcode-fdcid",
-            "claim": "offBarcode and fdcId on IngredientFoodMap carry NO FK relation",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "awk '/^model IngredientFoodMap /,/^}/' prisma/schema.prisma | grep -E 'offBarcode|fdcId' | grep -c '@relation'",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "fatsecretfood-no-gtin",
-            "claim": "FatSecretFood has no gtin column (the only gtin lives on the legacy Barcode model)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "awk '/^model FatSecretFood /,/^}/' prisma/schema.prisma | grep -c 'gtin'",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "search-route-key-only",
-            "claim": "/api/foods/search has no bearer-token path — key-only auth (part of why item #23 is not a one-liner)",
-            "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
-            "where": "backend",
-            "command": "grep -cE 'Authorization|Bearer' src/app/api/foods/search/route.ts",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "dev-bypass-emails-still-present",
-            "claim": "Item #23 second trap still open: emails containing test/dev get the parse-route bypass",
-            "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
-            "where": "backend",
-            "command": "grep -c \"includes('test')\" src/app/api/nlp/parse/route.ts",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "hardcoded-fallback-key-still-present",
-            "claim": "Item #23 still open: the hardcoded dev key fallback exists in backend src",
-            "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
-            "where": "backend",
-            "command": "grep -rn 'adminAPI_dev_key_bypass' src | wc -l",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "split-ingredients-persisted",
-            "claim": "splitIngredients is a persisted column on AiNormalizeCache (PR #187)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "awk '/^model AiNormalizeCache /,/^}/' prisma/schema.prisma | grep -c 'splitIngredients'",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "apply-rls-deleted",
-            "claim": "prisma/apply-rls.sql is deleted (PR #190)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "test -f prisma/apply-rls.sql && echo present || echo gone",
-            "expect": {
-                "kind": "equals",
-                "value": "gone"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "search-uses-gathercandidates",
-            "claim": "Manual search calls the same gatherCandidates() as the mapper — retrieval is shared; the pick layer is the gap",
-            "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
-            "where": "backend",
-            "command": "grep -c 'gatherCandidates' src/app/api/foods/search/route.ts",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "coverage-dominance-not-implemented",
-            "claim": "No CODE implements a coverage-dominance partition — the term exists only in golden-set case notes as a PROPOSED fix (it was once misdocumented as shipped)",
-            "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
-            "where": "backend",
-            "command": "grep -rl 'coverage-dominance' src --include='*.ts' --include='*.tsx' | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "mapping-modal-orphaned",
-            "claim": "IngredientMappingModal.tsx (backend repo) has zero external references in src/",
-            "ownerDoc": "mobile:sync-docs/design_food_customization_2026-07-28.md",
-            "where": "backend",
-            "command": "grep -rn 'IngredientMappingModal' src | grep -v 'IngredientMappingModal.tsx' | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "tsc-baseline-30-total-0-src",
-            "claim": "Mobile `npx tsc --noEmit` exits non-zero on exactly 30 pre-existing errors, 0 of them under src/ — all backend probe scripts Syncthing'd into sync-docs/. Needs an installed toolchain, so it runs on a dev machine, not the box.",
-            "ownerDoc": "mobile:CLAUDE.md#ci",
-            "where": "devmachine",
-            "command": "npx tsc --noEmit 2>&1 | awk '/error TS/{t++} /^src\\// {s++} END{print t\":\"s+0}'",
-            "expect": {
-                "kind": "equals",
-                "value": "30:0"
-            },
-            "verified": "2026-07-30",
-            "timeoutMs": 300000
-        },
-        {
-            "id": "mobile-no-ci",
-            "claim": "The mobile repo has no CI — no .github directory at all; every gate is local",
-            "ownerDoc": "mobile:CLAUDE.md#ci",
-            "where": "mobile",
-            "command": "test -d .github && echo present || echo none",
-            "expect": {
-                "kind": "equals",
-                "value": "none"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "docs-reader-builds",
-            "claim": "npm run docs (scripts/docs-reader/build.mjs) still parses sync-docs/log + sync-docs/reports and writes .docs-reader/index.html",
-            "ownerDoc": "mobile:sync-docs/log/README.md#reading-them",
-            "where": "mobile",
-            "command": "node ./scripts/docs-reader/build.mjs >/dev/null 2>&1 && test -s .docs-reader/index.html && echo ok || echo broken",
-            "expect": {
-                "kind": "equals",
-                "value": "ok"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "resolve-default-serving-five-sites",
-            "claim": "resolveDefaultServing() is called at exactly 5 sites in logging.tsx — the ONE way to pick a card's starting weight",
-            "ownerDoc": "mobile:CLAUDE.md#logging-traps",
-            "where": "mobile",
-            "command": "grep -c 'resolveDefaultServing(' 'src/app/(tabs)/logging.tsx'",
-            "expect": {
-                "kind": "count",
-                "value": "5"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "resolve-watcher-gate",
-            "claim": "The resolve watcher is gated on status==='loading' && !item.foodId — mapped items must be constructed as 'success'",
-            "ownerDoc": "mobile:CLAUDE.md#logging-traps",
-            "where": "mobile",
-            "command": "grep -c \"status === 'loading' && !item.foodId\" 'src/app/(tabs)/logging.tsx'",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "parsed-to-staged-wired",
-            "claim": "handleParse routes mapper output through stagedItemsFromParsed (src/lib/parsed-to-staged.ts) — never spreads a parse item onto a card",
-            "ownerDoc": "mobile:plans/v1/api-contract.md",
-            "where": "mobile",
-            "command": "grep -c 'stagedItemsFromParsed' 'src/app/(tabs)/logging.tsx'",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "api-key-item23-open-mobile",
-            "claim": "Item #23 still open on the client: api-client.ts sends x-api-key unconditionally",
-            "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
-            "where": "mobile",
-            "command": "grep -c 'x-api-key' src/lib/api-client.ts",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "source-check-nullable",
-            "claim": "food_log_items.source is CHECK-constrained but nullable (no NOT NULL) — the basis of the toDbSource total-function safety argument",
-            "ownerDoc": "mobile:plans/v1/api-contract.md",
-            "where": "mobile",
-            "command": "grep -c 'source TEXT CHECK' supabase/migrations/001_mobile_schema.sql",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "sprint-s4-total",
-            "claim": "Sprint plan §4 numbered items: 54 (re-derive, never trust the prose total)",
-            "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
-            "where": "mobile",
-            "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\.'",
-            "expect": {
-                "kind": "count",
-                "value": "54"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "sprint-s4-struck",
-            "claim": "Sprint plan §4 struck items: 6 (struck §4 items are 'N. ~~' list lines, NOT '| ~~' table rows — that pattern only fits §5)",
-            "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
-            "where": "mobile",
-            "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\. ~~'",
-            "expect": {
-                "kind": "count",
-                "value": "6"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "sprint-s5-struck",
-            "claim": "Sprint plan §5 struck rows: 11",
-            "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
-            "where": "mobile",
-            "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| ~~'",
-            "expect": {
-                "kind": "count",
-                "value": "11"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "citations-zero-normative-docs",
-            "claim": "Zero file.ts:123-style line citations in normative docs (CLAUDE.md, plans/v1, sync-docs top level, log/README, the search plan) — symbols, not line numbers",
-            "ownerDoc": "mobile:CLAUDE.md#doc-rules",
-            "where": "mobile",
-            "command": "grep -roE '[a-zA-Z0-9_/.-]+\\.(ts|tsx|sql|json|js):[0-9]+' CLAUDE.md plans/v1 sync-docs/*.md sync-docs/log/README.md sync-docs/reports/2026-07-29_search-unification-plan.md 2>/dev/null | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "banners-zero-normative-docs",
-            "claim": "No blanket verification banners in normative docs — they are how stale pointers survive",
-            "ownerDoc": "mobile:CLAUDE.md#doc-rules",
-            "where": "mobile",
-            "command": "grep -riE 'every [a-z ]+ below (was|were) (re-)?verified' CLAUDE.md plans/v1 sync-docs/*.md 2>/dev/null | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "fatsecret-flag-box",
-            "claim": "FATSECRET_RETRIEVAL_ENABLED=1 in the box .env (producer side; see fatsecret-live-wire for the consumer side)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "grep '^FATSECRET_RETRIEVAL_ENABLED=' /home/owner/Recipe-App/.env",
-            "expect": {
-                "kind": "matches",
-                "value": "^FATSECRET_RETRIEVAL_ENABLED=1$"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "fatsecret-live-wire",
-            "claim": "Live search returns FatSecret rows (consumer-side proof the lane runs — verify at the consumer, not just the producer)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "key=$(grep \"^DEV_API_KEY=\" /home/owner/Recipe-App/.env | cut -d= -f2- | tr -d '\"'); best=0; for i in 1 2 3; do n=$(curl -s --max-time 30 \"http://localhost:3000/api/foods/search?s=chobani+greek+yogurt&local=true&api_key=${key:-adminAPI_dev_key_bypass}\" | grep -c '\"source\":\"fatsecret\"'); [ \"$n\" -gt \"$best\" ] && best=$n; [ \"$best\" -gt 0 ] && break; sleep 10; done; echo $best",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30",
-            "timeoutMs": 180000
-        },
-        {
-            "id": "recipe-api-active",
-            "claim": "recipe-api systemd user service is active on the box",
-            "ownerDoc": "mobile:CLAUDE.md#topology",
-            "where": "box",
-            "command": "systemctl --user is-active recipe-api",
-            "expect": {
-                "kind": "equals",
-                "value": "active"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "typesense-healthy",
-            "claim": "Typesense answers healthy on :8108",
-            "ownerDoc": "mobile:CLAUDE.md#topology",
-            "where": "box",
-            "command": "curl -s --max-time 10 http://localhost:8108/health",
-            "expect": {
-                "kind": "matches",
-                "value": "\"ok\" *: *true"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "aigen-zero-fatsecret-rows",
-            "claim": "AiGeneratedFood contains zero FatSecret-derived rows — why the fatsecret-cache label must render NO badge",
-            "ownerDoc": "mobile:CLAUDE.md#attribution",
-            "where": "box",
-            "command": "docker exec mealspire-db psql -U postgres -d mealspire -t -A -c 'SELECT COUNT(*) FROM \"AiGeneratedFood\" WHERE \"aiModel\" ILIKE $$%fatsecret%$$'",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "box-git-stignored",
-            "claim": "The box's .stignore excludes .git — why the box's git state is meaningless and content hashes are the only comparison",
-            "ownerDoc": "mobile:CLAUDE.md#deploy",
-            "where": "box",
-            "command": "grep -c '\\.git' /home/owner/Recipe-App/.stignore",
-            "expect": {
-                "kind": "min",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "claude-md-doc-pointers-resolve",
-            "claim": "Every sync-docs/ or plans/ markdown path cited in CLAUDE.md exists in this repo — a dead pointer in the read-now tier sends the next reader nowhere",
-            "ownerDoc": "mobile:CLAUDE.md#doc-rules",
-            "where": "mobile",
-            "command": "grep -oE '`(sync-docs|plans)/[A-Za-z0-9_/.-]+\\.md`' CLAUDE.md | tr -d '`' | sort -u | while read p; do [ -e \"$p\" ] || echo \"$p\"; done | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "read-now-tier-within-budget",
-            "claim": "The read-now tier (CLAUDE.md + the newest 2 files in sync-docs/log/) is at most 1,500 lines — the agreed reading budget",
-            "ownerDoc": "mobile:CLAUDE.md#reading",
-            "where": "mobile",
-            "command": "{ cat CLAUDE.md; ls -1t sync-docs/log/2026-*.md | head -2 | xargs cat; } | wc -l",
-            "expect": {
-                "kind": "max",
-                "value": "1500"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "handoff-format-retired",
-            "claim": "No handoff_*.md survives at the sync-docs top level — sync-docs/log/README.md declares that format replaced by session write-offs, and the 7 that remained were archived 2026-07-30",
-            "ownerDoc": "mobile:sync-docs/log/README.md",
-            "where": "mobile",
-            "command": "ls sync-docs/handoff_*.md 2>/dev/null | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "eval-golden-npm-script",
-            "claim": "npm run eval:golden runs the golden-set harness (scripts/eval/run-eval.ts) — the command CLAUDE.md's read-now tier names for running the eval",
-            "ownerDoc": "mobile:CLAUDE.md#commands",
-            "where": "backend",
-            "command": "node -e \"const s=require('./package.json').scripts['eval:golden']||'';process.stdout.write(String(s.includes('scripts/eval/run-eval.ts')?1:0))\"",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "doc-check-timer-installed-on-box",
-            "claim": "The nightly doc-claims checker is installed and enabled on the box (doc-check.timer, 04:50) — installed 2026-07-30 and verified by a manual run that exited 0",
-            "ownerDoc": "mobile:CLAUDE.md#deploying-the-backend",
-            "where": "box",
-            "command": "systemctl --user is-enabled doc-check.timer 2>/dev/null",
-            "expect": {
-                "kind": "equals",
-                "value": "enabled"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "sprint-s5-total",
-            "claim": "Sprint plan §5 numbered rows: 51 — the doc states this at the head of §5 and it moves with every edit",
-            "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
-            "where": "mobile",
-            "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| (~~)?\\*?\\*?[0-9]'",
-            "expect": {
-                "kind": "count",
-                "value": "51"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "log-writeoffs-under-50-lines",
-            "claim": "Every session write-off in sync-docs/log/ is within the 50-line hard cap its README sets — the rule most likely to erode, since the pressure to exceed it is highest on the sessions worth recording",
-            "ownerDoc": "mobile:sync-docs/log/README.md",
-            "where": "mobile",
-            "command": "for f in sync-docs/log/2026-*.md; do n=$(wc -l < \"$f\"); [ \"$n\" -gt 50 ] && echo \"$f:$n\"; done | wc -l",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "off-ingest-timers-enabled",
-            "claim": "Both OFF ingest timers are enabled on the box — off-delta.timer (weekly) and off-parquet-refresh.timer (quarterly), installed 2026-07-30 after the Mini-PC retirement left the corpus with no refresh path at all",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "systemctl --user is-enabled off-delta.timer off-parquet-refresh.timer 2>/dev/null | sort -u | tr -d '\\n'",
-            "expect": {
-                "kind": "equals",
-                "value": "enabled"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "off-delta-cursor-fresh",
-            "claim": "The OFF delta cursor is inside its ~14-day retention window — outside it, un-ingested changes are only recoverable by a full Parquet re-ingest",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "node -e \"const s=require(process.env.HOME+'/Recipe-App/data/off-delta-state.json');process.stdout.write(String(Math.floor((Date.now()/1000-s.lastProcessedEnd)/86400)))\"",
-            "expect": {
-                "kind": "max",
-                "value": "13"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "parquet-refresh-preflight-passes",
-            "claim": "The quarterly Parquet refresh's preflight passes on the box (duckdb, both TS entrypoints, ts-node, DATABASE_URL, >=15GB free, correct host) — the destructive run cannot be rehearsed, so this is the only advance warning that it would abort",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh --preflight-only >/dev/null 2>&1 && echo ok || echo broken",
-            "expect": {
-                "kind": "equals",
-                "value": "ok"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "box-has-mobile-repo",
-            "claim": "The box holds a receive-only copy of the mobile repo at ~/KindaHealthyMobile (Syncthing folder msmwx-9fkha, added 2026-07-30) — this is what lets its nightly check mobile-context claims instead of skipping 15 of them",
-            "ownerDoc": "mobile:CLAUDE.md#machines--repos",
-            "where": "box",
-            "command": "test -f $HOME/KindaHealthyMobile/CLAUDE.md && test -d $HOME/KindaHealthyMobile/sync-docs/log && echo ok || echo missing",
-            "expect": {
-                "kind": "equals",
-                "value": "ok"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "box-mobile-copy-stays-small",
-            "claim": "The box's mobile copy stays under 200MB — its ignores drop ios/, android/, assets/, node_modules and the sync-docs data dirs; without them it would pull the 2.4GB working tree",
-            "ownerDoc": "mobile:CLAUDE.md#machines--repos",
-            "where": "box",
-            "command": "du -sm $HOME/KindaHealthyMobile 2>/dev/null | cut -f1",
-            "expect": {
-                "kind": "max",
-                "value": "200"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "parquet-refresh-refuses-without-ack",
-            "claim": "The quarterly OFF refresh refuses (exit 3, nothing downloaded or written) unless a human sets OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 — it destroys ~1.07M pgvector embeddings and NULLs the OFF pointer on ~81% of FoodMapping cache rows, so the timer must never run it unattended",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh >/dev/null 2>&1; echo $?",
-            "expect": {
-                "kind": "equals",
-                "value": "3"
-            },
-            "verified": "2026-07-30",
-            "timeoutMs": 180000
-        },
-        {
-            "id": "off-refresh-snapshots-before-truncate",
-            "claim": "refresh-off-from-parquet.sh snapshots FoodMapping BEFORE the --fresh ingest and restores offBarcode AFTER it, in that order",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "awk 'index($0,\"scripts/eval/_snap_foodmapping.ts \\\"$SNAP\\\"\"){s=NR} index($0,\"scripts/ingest-off.ts \\\"$SLIM_JSONL\\\" --fresh\"){i=NR} index($0,\"scripts/eval/restore-off-pointers.ts \\\"$SNAP\\\" --execute\"){r=NR} END{print (s&&i&&r&&s<i&&i<r)?\"ok\":\"BROKEN\"}' scripts/refresh-off-from-parquet.sh",
-            "expect": {
-                "kind": "equals",
-                "value": "ok"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "off-refresh-timer-does-not-set-ack",
-            "claim": "off-parquet-refresh.service does NOT set OFF_REFRESH_I_ACCEPT_DATA_LOSS, so an unattended quarterly firing fails as a unit instead of rebuilding the corpus",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "grep -c '^Environment=.*OFF_REFRESH_I_ACCEPT_DATA_LOSS' ops/systemd/off-parquet-refresh.service",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "embed-off-cpu-uses-cls-pooling",
-            "claim": "embed-off-cpu.ts writes CLS-pooled vectors, matching the stored corpus (cosine 1.00000 vs ~0.93 for mean)",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "grep -c \"pooling: 'cls'\" scripts/embed-off-cpu.ts",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "query-embedding-still-mean-pooled",
-            "claim": "KNOWN DEFECT tripwire: query-embedding.ts still embeds queries with pooling:'mean' while the corpus is CLS. When this claim FAILS the mismatch has been fixed — update the owner doc's pooling section and delete this entry.",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "grep -c \"pooling: 'mean'\" src/lib/search/query-embedding.ts",
-            "expect": {
-                "kind": "count",
-                "value": "1"
-            },
-            "verified": "2026-07-30"
-        },
-        {
-            "id": "off-refresh-does-not-preserve-marks",
-            "claim": "KNOWN DEFECT tripwire: refresh-off-from-parquet.sh does not snapshot/restore OffFood.corruptReason, so a --fresh rebuild silently destroys every curation mark (6,822 lost on 2026-07-30). When this claim FAILS the restore has been added — update the owner doc's 'The marks are data' section and delete this entry.",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "backend",
-            "command": "grep -c 'corruptReason' scripts/refresh-off-from-parquet.sh || true",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-31"
-        },
-        {
-            "id": "off-corrupt-marks-wiped",
-            "claim": "KNOWN DEFECT tripwire: OffFood.corruptReason is 0 rows after the 2026-07-30 refresh (was 6,822), so corrupt records are unexcluded from Typesense and the corrupt_record escape cannot fire. When this claim FAILS the marks have been restored — re-date the owner doc and the warm-push plan's B1, and delete this entry.",
-            "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
-            "where": "box",
-            "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"corruptReason\" IS NOT NULL;'",
-            "expect": {
-                "kind": "count",
-                "value": "0"
-            },
-            "verified": "2026-07-31"
-        }
-    ]
+  "$comment": "Doc-claims registry. Every entry: the claim as its owner doc states it, the ONE doc that owns the fact, the command that re-derives it, the expected value, and the date last measured. Run: npm run doc-check (or npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts). A failing claim means the DOC is now wrong \u2014 fix the owner doc AND this entry together, with a fresh date. Contexts: backend = this repo, mobile = KindaHealthyMobile repo, box = the OptiPlex (ssh when not local). The box has no copy of the mobile repo, so its nightly run uses --where backend,box; mobile claims are covered from the Mac.",
+  "claims": [
+    {
+      "id": "attribution-client-sources",
+      "claim": "CLIENT_SOURCES whitelist is exactly fatsecret/fdc/openfoodfacts/ai_estimated, in src/lib/attribution.ts",
+      "ownerDoc": "mobile:CLAUDE.md#attribution",
+      "where": "backend",
+      "command": "grep 'CLIENT_SOURCES' src/lib/attribution.ts | head -1",
+      "expect": {
+        "kind": "matches",
+        "value": "fatsecret.+fdc.+openfoodfacts.+ai_estimated"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "attribution-importers-two",
+      "claim": "Exactly two API routes import the attribution chokepoint (foods/search and foods/[id]); parse deliberately does not",
+      "ownerDoc": "mobile:CLAUDE.md#attribution",
+      "where": "backend",
+      "command": "grep -rl 'lib/attribution' src/app/api | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "2"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "parse-owns-whitelist",
+      "claim": "The parse lane carries its own STANDARD_SOURCES whitelist (floors unknowns to ai_estimated) instead of importing attribution.ts",
+      "ownerDoc": "mobile:CLAUDE.md#attribution",
+      "where": "backend",
+      "command": "grep -c 'STANDARD_SOURCES' src/app/api/nlp/parse/route.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "parse-no-attribution-import",
+      "claim": "nlp/parse does not import lib/attribution (its whitelist is deliberately separate)",
+      "ownerDoc": "mobile:CLAUDE.md#attribution",
+      "where": "backend",
+      "command": "grep -c 'lib/attribution' src/app/api/nlp/parse/route.ts",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "ghost-models-gone",
+      "claim": "GlobalIngredientMapping and FdcFoodCache do not exist in the Prisma schema (deleted as ghosts, PR #188)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -cE 'model (GlobalIngredientMapping|FdcFoodCache) ' prisma/schema.prisma",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "ingredientfoodmap-fsid-fk",
+      "claim": "IngredientFoodMap.fsId is a real FK to FatSecretFood (PR #189)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "awk '/^model IngredientFoodMap /,/^}/' prisma/schema.prisma | grep -c 'FatSecretFood'",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "ingredientfoodmap-no-fk-offbarcode-fdcid",
+      "claim": "offBarcode and fdcId on IngredientFoodMap carry NO FK relation",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "awk '/^model IngredientFoodMap /,/^}/' prisma/schema.prisma | grep -E 'offBarcode|fdcId' | grep -c '@relation'",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "fatsecretfood-no-gtin",
+      "claim": "FatSecretFood has no gtin column (the only gtin lives on the legacy Barcode model)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "awk '/^model FatSecretFood /,/^}/' prisma/schema.prisma | grep -c 'gtin'",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "search-route-key-only",
+      "claim": "/api/foods/search has no bearer-token path \u2014 key-only auth (part of why item #23 is not a one-liner)",
+      "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
+      "where": "backend",
+      "command": "grep -cE 'Authorization|Bearer' src/app/api/foods/search/route.ts",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "dev-bypass-emails-still-present",
+      "claim": "Item #23 second trap still open: emails containing test/dev get the parse-route bypass",
+      "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
+      "where": "backend",
+      "command": "grep -c \"includes('test')\" src/app/api/nlp/parse/route.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "hardcoded-fallback-key-still-present",
+      "claim": "Item #23 still open: the hardcoded dev key fallback exists in backend src",
+      "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
+      "where": "backend",
+      "command": "grep -rn 'adminAPI_dev_key_bypass' src | wc -l",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "split-ingredients-persisted",
+      "claim": "splitIngredients is a persisted column on AiNormalizeCache (PR #187)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "awk '/^model AiNormalizeCache /,/^}/' prisma/schema.prisma | grep -c 'splitIngredients'",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "apply-rls-deleted",
+      "claim": "prisma/apply-rls.sql is deleted (PR #190)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "test -f prisma/apply-rls.sql && echo present || echo gone",
+      "expect": {
+        "kind": "equals",
+        "value": "gone"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "search-uses-gathercandidates",
+      "claim": "Manual search calls the same gatherCandidates() as the mapper \u2014 retrieval is shared; the pick layer is the gap",
+      "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
+      "where": "backend",
+      "command": "grep -c 'gatherCandidates' src/app/api/foods/search/route.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "coverage-dominance-not-implemented",
+      "claim": "No CODE implements a coverage-dominance partition \u2014 the term exists only in golden-set case notes as a PROPOSED fix (it was once misdocumented as shipped)",
+      "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
+      "where": "backend",
+      "command": "grep -rl 'coverage-dominance' src --include='*.ts' --include='*.tsx' | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "mapping-modal-orphaned",
+      "claim": "IngredientMappingModal.tsx (backend repo) has zero external references in src/",
+      "ownerDoc": "mobile:sync-docs/design_food_customization_2026-07-28.md",
+      "where": "backend",
+      "command": "grep -rn 'IngredientMappingModal' src | grep -v 'IngredientMappingModal.tsx' | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "tsc-baseline-30-total-0-src",
+      "claim": "Mobile `npx tsc --noEmit` exits non-zero on exactly 30 pre-existing errors, 0 of them under src/ \u2014 all backend probe scripts Syncthing'd into sync-docs/. Needs an installed toolchain, so it runs on a dev machine, not the box.",
+      "ownerDoc": "mobile:CLAUDE.md#ci",
+      "where": "devmachine",
+      "command": "npx tsc --noEmit 2>&1 | awk '/error TS/{t++} /^src\\// {s++} END{print t\":\"s+0}'",
+      "expect": {
+        "kind": "equals",
+        "value": "30:0"
+      },
+      "verified": "2026-07-30",
+      "timeoutMs": 300000
+    },
+    {
+      "id": "mobile-no-ci",
+      "claim": "The mobile repo has no CI \u2014 no .github directory at all; every gate is local",
+      "ownerDoc": "mobile:CLAUDE.md#ci",
+      "where": "mobile",
+      "command": "test -d .github && echo present || echo none",
+      "expect": {
+        "kind": "equals",
+        "value": "none"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "docs-reader-builds",
+      "claim": "npm run docs (scripts/docs-reader/build.mjs) still parses sync-docs/log + sync-docs/reports and writes .docs-reader/index.html",
+      "ownerDoc": "mobile:sync-docs/log/README.md#reading-them",
+      "where": "mobile",
+      "command": "node ./scripts/docs-reader/build.mjs >/dev/null 2>&1 && test -s .docs-reader/index.html && echo ok || echo broken",
+      "expect": {
+        "kind": "equals",
+        "value": "ok"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "resolve-default-serving-five-sites",
+      "claim": "resolveDefaultServing() is called at exactly 5 sites in logging.tsx \u2014 the ONE way to pick a card's starting weight",
+      "ownerDoc": "mobile:CLAUDE.md#logging-traps",
+      "where": "mobile",
+      "command": "grep -c 'resolveDefaultServing(' 'src/app/(tabs)/logging.tsx'",
+      "expect": {
+        "kind": "count",
+        "value": "5"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "resolve-watcher-gate",
+      "claim": "The resolve watcher is gated on status==='loading' && !item.foodId \u2014 mapped items must be constructed as 'success'",
+      "ownerDoc": "mobile:CLAUDE.md#logging-traps",
+      "where": "mobile",
+      "command": "grep -c \"status === 'loading' && !item.foodId\" 'src/app/(tabs)/logging.tsx'",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "parsed-to-staged-wired",
+      "claim": "handleParse routes mapper output through stagedItemsFromParsed (src/lib/parsed-to-staged.ts) \u2014 never spreads a parse item onto a card",
+      "ownerDoc": "mobile:plans/v1/api-contract.md",
+      "where": "mobile",
+      "command": "grep -c 'stagedItemsFromParsed' 'src/app/(tabs)/logging.tsx'",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "api-key-item23-open-mobile",
+      "claim": "Item #23 still open on the client: api-client.ts sends x-api-key unconditionally",
+      "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
+      "where": "mobile",
+      "command": "grep -c 'x-api-key' src/lib/api-client.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "source-check-nullable",
+      "claim": "food_log_items.source is CHECK-constrained but nullable (no NOT NULL) \u2014 the basis of the toDbSource total-function safety argument",
+      "ownerDoc": "mobile:plans/v1/api-contract.md",
+      "where": "mobile",
+      "command": "grep -c 'source TEXT CHECK' supabase/migrations/001_mobile_schema.sql",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "sprint-s4-total",
+      "claim": "Sprint plan \u00a74 numbered items: 54 (re-derive, never trust the prose total)",
+      "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
+      "where": "mobile",
+      "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\.'",
+      "expect": {
+        "kind": "count",
+        "value": "54"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "sprint-s4-struck",
+      "claim": "Sprint plan \u00a74 struck items: 6 (struck \u00a74 items are 'N. ~~' list lines, NOT '| ~~' table rows \u2014 that pattern only fits \u00a75)",
+      "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
+      "where": "mobile",
+      "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\. ~~'",
+      "expect": {
+        "kind": "count",
+        "value": "6"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "sprint-s5-struck",
+      "claim": "Sprint plan \u00a75 struck rows: 11",
+      "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
+      "where": "mobile",
+      "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| ~~'",
+      "expect": {
+        "kind": "count",
+        "value": "11"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "citations-zero-normative-docs",
+      "claim": "Zero file.ts:123-style line citations in normative docs (CLAUDE.md, plans/v1, sync-docs top level, log/README, the search plan) \u2014 symbols, not line numbers",
+      "ownerDoc": "mobile:CLAUDE.md#doc-rules",
+      "where": "mobile",
+      "command": "grep -roE '[a-zA-Z0-9_/.-]+\\.(ts|tsx|sql|json|js):[0-9]+' CLAUDE.md plans/v1 sync-docs/*.md sync-docs/log/README.md sync-docs/reports/2026-07-29_search-unification-plan.md 2>/dev/null | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "banners-zero-normative-docs",
+      "claim": "No blanket verification banners in normative docs \u2014 they are how stale pointers survive",
+      "ownerDoc": "mobile:CLAUDE.md#doc-rules",
+      "where": "mobile",
+      "command": "grep -riE 'every [a-z ]+ below (was|were) (re-)?verified' CLAUDE.md plans/v1 sync-docs/*.md 2>/dev/null | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "fatsecret-flag-box",
+      "claim": "FATSECRET_RETRIEVAL_ENABLED=1 in the box .env (producer side; see fatsecret-live-wire for the consumer side)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "grep '^FATSECRET_RETRIEVAL_ENABLED=' /home/owner/Recipe-App/.env",
+      "expect": {
+        "kind": "matches",
+        "value": "^FATSECRET_RETRIEVAL_ENABLED=1$"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "fatsecret-live-wire",
+      "claim": "Live search returns FatSecret rows (consumer-side proof the lane runs \u2014 verify at the consumer, not just the producer)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "key=$(grep \"^DEV_API_KEY=\" /home/owner/Recipe-App/.env | cut -d= -f2- | tr -d '\"'); best=0; for i in 1 2 3; do n=$(curl -s --max-time 30 \"http://localhost:3000/api/foods/search?s=chobani+greek+yogurt&local=true&api_key=${key:-adminAPI_dev_key_bypass}\" | grep -c '\"source\":\"fatsecret\"'); [ \"$n\" -gt \"$best\" ] && best=$n; [ \"$best\" -gt 0 ] && break; sleep 10; done; echo $best",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30",
+      "timeoutMs": 180000
+    },
+    {
+      "id": "recipe-api-active",
+      "claim": "recipe-api systemd user service is active on the box",
+      "ownerDoc": "mobile:CLAUDE.md#topology",
+      "where": "box",
+      "command": "systemctl --user is-active recipe-api",
+      "expect": {
+        "kind": "equals",
+        "value": "active"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "typesense-healthy",
+      "claim": "Typesense answers healthy on :8108",
+      "ownerDoc": "mobile:CLAUDE.md#topology",
+      "where": "box",
+      "command": "curl -s --max-time 10 http://localhost:8108/health",
+      "expect": {
+        "kind": "matches",
+        "value": "\"ok\" *: *true"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "aigen-zero-fatsecret-rows",
+      "claim": "AiGeneratedFood contains zero FatSecret-derived rows \u2014 why the fatsecret-cache label must render NO badge",
+      "ownerDoc": "mobile:CLAUDE.md#attribution",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -t -A -c 'SELECT COUNT(*) FROM \"AiGeneratedFood\" WHERE \"aiModel\" ILIKE $$%fatsecret%$$'",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "box-git-stignored",
+      "claim": "The box's .stignore excludes .git \u2014 why the box's git state is meaningless and content hashes are the only comparison",
+      "ownerDoc": "mobile:CLAUDE.md#deploy",
+      "where": "box",
+      "command": "grep -c '\\.git' /home/owner/Recipe-App/.stignore",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "claude-md-doc-pointers-resolve",
+      "claim": "Every sync-docs/ or plans/ markdown path cited in CLAUDE.md exists in this repo \u2014 a dead pointer in the read-now tier sends the next reader nowhere",
+      "ownerDoc": "mobile:CLAUDE.md#doc-rules",
+      "where": "mobile",
+      "command": "grep -oE '`(sync-docs|plans)/[A-Za-z0-9_/.-]+\\.md`' CLAUDE.md | tr -d '`' | sort -u | while read p; do [ -e \"$p\" ] || echo \"$p\"; done | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "read-now-tier-within-budget",
+      "claim": "The read-now tier (CLAUDE.md + the newest 2 files in sync-docs/log/) is at most 1,500 lines \u2014 the agreed reading budget",
+      "ownerDoc": "mobile:CLAUDE.md#reading",
+      "where": "mobile",
+      "command": "{ cat CLAUDE.md; ls -1t sync-docs/log/2026-*.md | head -2 | xargs cat; } | wc -l",
+      "expect": {
+        "kind": "max",
+        "value": "1500"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "handoff-format-retired",
+      "claim": "No handoff_*.md survives at the sync-docs top level \u2014 sync-docs/log/README.md declares that format replaced by session write-offs, and the 7 that remained were archived 2026-07-30",
+      "ownerDoc": "mobile:sync-docs/log/README.md",
+      "where": "mobile",
+      "command": "ls sync-docs/handoff_*.md 2>/dev/null | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "eval-golden-npm-script",
+      "claim": "npm run eval:golden runs the golden-set harness (scripts/eval/run-eval.ts) \u2014 the command CLAUDE.md's read-now tier names for running the eval",
+      "ownerDoc": "mobile:CLAUDE.md#commands",
+      "where": "backend",
+      "command": "node -e \"const s=require('./package.json').scripts['eval:golden']||'';process.stdout.write(String(s.includes('scripts/eval/run-eval.ts')?1:0))\"",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "doc-check-timer-installed-on-box",
+      "claim": "The nightly doc-claims checker is installed and enabled on the box (doc-check.timer, 04:50) \u2014 installed 2026-07-30 and verified by a manual run that exited 0",
+      "ownerDoc": "mobile:CLAUDE.md#deploying-the-backend",
+      "where": "box",
+      "command": "systemctl --user is-enabled doc-check.timer 2>/dev/null",
+      "expect": {
+        "kind": "equals",
+        "value": "enabled"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "sprint-s5-total",
+      "claim": "Sprint plan \u00a75 numbered rows: 51 \u2014 the doc states this at the head of \u00a75 and it moves with every edit",
+      "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
+      "where": "mobile",
+      "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| (~~)?\\*?\\*?[0-9]'",
+      "expect": {
+        "kind": "count",
+        "value": "51"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "log-writeoffs-under-50-lines",
+      "claim": "Every session write-off in sync-docs/log/ is within the 50-line hard cap its README sets \u2014 the rule most likely to erode, since the pressure to exceed it is highest on the sessions worth recording",
+      "ownerDoc": "mobile:sync-docs/log/README.md",
+      "where": "mobile",
+      "command": "for f in sync-docs/log/2026-*.md; do n=$(wc -l < \"$f\"); [ \"$n\" -gt 50 ] && echo \"$f:$n\"; done | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "off-ingest-timers-enabled",
+      "claim": "Both OFF ingest timers are enabled on the box \u2014 off-delta.timer (weekly) and off-parquet-refresh.timer (quarterly), installed 2026-07-30 after the Mini-PC retirement left the corpus with no refresh path at all",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "systemctl --user is-enabled off-delta.timer off-parquet-refresh.timer 2>/dev/null | sort -u | tr -d '\\n'",
+      "expect": {
+        "kind": "equals",
+        "value": "enabled"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "off-delta-cursor-fresh",
+      "claim": "The OFF delta cursor is inside its ~14-day retention window \u2014 outside it, un-ingested changes are only recoverable by a full Parquet re-ingest",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "node -e \"const s=require(process.env.HOME+'/Recipe-App/data/off-delta-state.json');process.stdout.write(String(Math.floor((Date.now()/1000-s.lastProcessedEnd)/86400)))\"",
+      "expect": {
+        "kind": "max",
+        "value": "13"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "parquet-refresh-preflight-passes",
+      "claim": "The quarterly Parquet refresh's preflight passes on the box (duckdb, both TS entrypoints, ts-node, DATABASE_URL, >=15GB free, correct host) \u2014 the destructive run cannot be rehearsed, so this is the only advance warning that it would abort",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh --preflight-only >/dev/null 2>&1 && echo ok || echo broken",
+      "expect": {
+        "kind": "equals",
+        "value": "ok"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "box-has-mobile-repo",
+      "claim": "The box holds a receive-only copy of the mobile repo at ~/KindaHealthyMobile (Syncthing folder msmwx-9fkha, added 2026-07-30) \u2014 this is what lets its nightly check mobile-context claims instead of skipping 15 of them",
+      "ownerDoc": "mobile:CLAUDE.md#machines--repos",
+      "where": "box",
+      "command": "test -f $HOME/KindaHealthyMobile/CLAUDE.md && test -d $HOME/KindaHealthyMobile/sync-docs/log && echo ok || echo missing",
+      "expect": {
+        "kind": "equals",
+        "value": "ok"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "box-mobile-copy-stays-small",
+      "claim": "The box's mobile copy stays under 200MB \u2014 its ignores drop ios/, android/, assets/, node_modules and the sync-docs data dirs; without them it would pull the 2.4GB working tree",
+      "ownerDoc": "mobile:CLAUDE.md#machines--repos",
+      "where": "box",
+      "command": "du -sm $HOME/KindaHealthyMobile 2>/dev/null | cut -f1",
+      "expect": {
+        "kind": "max",
+        "value": "200"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "parquet-refresh-refuses-without-ack",
+      "claim": "The quarterly OFF refresh refuses (exit 3, nothing downloaded or written) unless a human sets OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 \u2014 it destroys ~1.07M pgvector embeddings and NULLs the OFF pointer on ~81% of FoodMapping cache rows, so the timer must never run it unattended",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh >/dev/null 2>&1; echo $?",
+      "expect": {
+        "kind": "equals",
+        "value": "3"
+      },
+      "verified": "2026-07-30",
+      "timeoutMs": 180000
+    },
+    {
+      "id": "off-refresh-snapshots-before-truncate",
+      "claim": "refresh-off-from-parquet.sh snapshots FoodMapping BEFORE the --fresh ingest and restores offBarcode AFTER it, in that order",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "awk 'index($0,\"scripts/eval/_snap_foodmapping.ts \\\"$SNAP\\\"\"){s=NR} index($0,\"scripts/ingest-off.ts \\\"$SLIM_JSONL\\\" --fresh\"){i=NR} index($0,\"scripts/eval/restore-off-pointers.ts \\\"$SNAP\\\" --execute\"){r=NR} END{print (s&&i&&r&&s<i&&i<r)?\"ok\":\"BROKEN\"}' scripts/refresh-off-from-parquet.sh",
+      "expect": {
+        "kind": "equals",
+        "value": "ok"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "off-refresh-timer-does-not-set-ack",
+      "claim": "off-parquet-refresh.service does NOT set OFF_REFRESH_I_ACCEPT_DATA_LOSS, so an unattended quarterly firing fails as a unit instead of rebuilding the corpus",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -c '^Environment=.*OFF_REFRESH_I_ACCEPT_DATA_LOSS' ops/systemd/off-parquet-refresh.service",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "embed-off-cpu-uses-cls-pooling",
+      "claim": "embed-off-cpu.ts writes CLS-pooled vectors, matching the stored corpus (cosine 1.00000 vs ~0.93 for mean)",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -c \"pooling: 'cls'\" scripts/embed-off-cpu.ts",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-30"
+    },
+    {
+      "id": "off-refresh-does-not-preserve-marks",
+      "claim": "KNOWN DEFECT tripwire: refresh-off-from-parquet.sh does not snapshot/restore OffFood.corruptReason, so a --fresh rebuild silently destroys every curation mark (6,822 lost on 2026-07-30). When this claim FAILS the restore has been added \u2014 update the owner doc's 'The marks are data' section and delete this entry.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -c 'corruptReason' scripts/refresh-off-from-parquet.sh || true",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-corrupt-marks-restored",
+      "claim": "OffFood.corruptReason is populated: 6,905 rows marked 2026-07-31 (6,901 from corrupt-panel-scan-2026-07-31T14-49-22-771Z.json + 4 hand-audited panel-inflated-family rows). Replaces the off-corrupt-marks-wiped tripwire, which fired when the restore ran.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"corruptReason\" IS NOT NULL;'",
+      "expect": {
+        "kind": "min",
+        "value": "6000"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-duplicate-marks-restored",
+      "claim": "OffFood.duplicateOfBarcode is populated: 93,608 rows marked 2026-07-31 by dedupe-off-mark.ts, which recomputes from scratch every run.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"duplicateOfBarcode\" IS NOT NULL;'",
+      "expect": {
+        "kind": "min",
+        "value": "50000"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "query-embedding-matches-corpus-pooling",
+      "claim": "embedQuery() resolves pooling from CORPUS_POOLING='cls' rather than hardcoding 'mean', so query and document vectors share a space. Measured effect is gate clearance, not recall: recall@10 is unchanged 58/58 over 135 identity seeds, but top-1 similarity rises 0.8249 -> 0.8748 and 10/135 queries stop falling below SEMANTIC_MIN_SIMILARITY=0.72 entirely.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -c \"pooling: 'mean'\" src/lib/search/query-embedding.ts || true",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-package-quantity-wiped",
+      "claim": "KNOWN DEFECT tripwire: OffFood.packageQuantity is 0 rows after the 2026-07-30 refresh, which kills borrowSiblingPackageGrams() and with it the whole-package-count serving tier \u2014 branded unitless counts fall through to a flat 100 g floor. When this claim FAILS the backfill has been rerun; re-date the owner doc and delete this entry.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"packageQuantity\" IS NOT NULL;'",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-ingest-never-writes-package-quantity",
+      "claim": "STRUCTURAL DEFECT tripwire: ingest-off.ts contains no reference to quantity at all, so packageQuantity/packageQuantityUnit are written ONLY by the out-of-band CSV backfill and every --fresh rebuild destroys them permanently. The Parquet export does carry code/product_quantity/product_quantity_unit/quantity (verified remotely via duckdb parquet_schema 2026-07-31); the fix is to add them to off-parquet-to-jsonl.sh's SELECT and to the ingest. When this claim FAILS the pipeline regenerates the column itself.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -ci 'quantity' scripts/ingest-off.ts || true",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-fresh-deletes-derived-servings",
+      "claim": "STRUCTURAL DEFECT tripwire: ingest-off.ts --fresh runs DELETE FROM \"OffServing\", which destroys the DERIVED servings (source ai / sibling_borrow), not just the OFF label rows. No snapshot covers them. This is the n-svk-05 mechanism: a cached 150 g 'sleeve' was deleted, the estimator redrew 200 g, and upsertServing persisted it \u2014 turning an intermittent bad sample into a permanent red.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -c 'DELETE FROM \"OffServing\"' scripts/ingest-off.ts",
+      "expect": {
+        "kind": "count",
+        "value": "1"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "corrupt-detector-reachability-gap",
+      "claim": "Sibling grouping in detect-corrupt-panel.ts is a coverage decision: rows in exact-name groups below MIN_GROUP=4 are never signature-tested. Measured 2026-07-31: 661,150 of 1,083,139 kcal-bearing rows (61.0%). The axis is NAME LENGTH, not brandedness \u2014 25.5% unreachable at 1 token rising monotonically to 98.3% at 8+ tokens (branded 61.8% vs unbranded 58.9%). The scan prints these counters on every run so the number re-derives itself.",
+      "ownerDoc": "mobile:sync-docs/mapping_investigation_playbook.md",
+      "where": "backend",
+      "command": "grep -c 'UNREACHABLE by tier 1' scripts/eval/detect-corrupt-panel.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-31"
+    }
+  ]
 }

--- a/scripts/eval/__tests__/panel-inflated-family.test.ts
+++ b/scripts/eval/__tests__/panel-inflated-family.test.ts
@@ -1,0 +1,539 @@
+/**
+ * panel-inflated-family.test.ts — tier 2 of detect-corrupt-panel.ts: the
+ * per-SERVING panel stored as per-100g, found through a COARSER sibling group
+ * than exact normalizeNameKey() equality.
+ *
+ * WHAT THIS TIER EXISTS FOR. normalizeNameKey() is a token-SET identity, so one
+ * extra brand or flavour token makes a row a singleton and tier 1 can never
+ * test it. Measured on the live corpus 2026-07-31: 661,150 of 1,083,139
+ * kcal-bearing rows (61.0%) sit in groups below MIN_GROUP=4. The two live
+ * records this tier was built to reach:
+ *   off_9568310020398 "Fairlife core power elite" -> exact group size 1
+ *   off_9337369550008 "Core power elite vanilla"  -> exact group size 2
+ * Both store 230 kcal/100g at servingGrams 414 (the whole bottle) against a
+ * true density of 55.6. 230 / 4.14 = 55.56.
+ *
+ * ASSERTIONS ARE POSITIVE (playbook: "assert the right answer, never enumerate
+ * the wrong ones"). The integration test pins the EXACT flagged set over the
+ * fixture corpus, so a rule that starts flagging something new fails even if
+ * nobody predicted what that something would be.
+ *
+ * MUTATION RESULTS — each guard below has a named test that dies when the guard
+ * is deleted; recorded here because a passing test is not evidence until it has
+ * been watched to fail (playbook §13). See the block at the bottom of the file.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    runScan,
+    familyKey,
+    nameTokens,
+    relativeMad,
+    FAMILY_DF_MAX,
+    type ScanDb,
+    type Row,
+} from '../detect-corrupt-panel';
+import {
+    decideMark,
+    rejectPanelInflatedFamily,
+    FAMILY_MIN_TOKENS,
+    FAMILY_MIN_GROUP,
+    FAMILY_MAX_REL_MAD,
+    FAMILY_RESCALE_TOL,
+    FAMILY_INFLATED_RATIO,
+    MAX_REAL_GTIN_LENGTH,
+    MAX_TRUSTABLE_SIBLING_MEDIAN,
+    FAMILY_TIER_AUDITED_FP_RATE,
+    type CorruptScanFlag,
+    type FamilyScaleInputs,
+} from '../../../src/lib/mapping/corrupt-mark';
+
+// ===========================================================================
+// The fixture corpus
+// ===========================================================================
+//
+// FIXTURE SCALE NOTE. The shipped FAMILY_DF_MAX is 2000, calibrated on a
+// 1.08M-row corpus where `vanilla` has df 13,166 and `core` has df 198. In a
+// 77-row fixture every token is rare, so 2000 would strip nothing and the test
+// would exercise a grouping the production scan never performs. The fixture
+// therefore reproduces the RATIO instead: `familyDfMax: 15`, with 40 filler
+// products that push `vanilla` and `chocolate` over the cutoff while `core`,
+// `power` and `elite` stay under it. That is the same relationship the live
+// corpus has, at fixture scale.
+
+const FIXTURE_DF_MAX = 15;
+
+const row = (
+    barcode: string, name: string, brandName: string | null,
+    calories: number, servingGrams: number | null
+): Row => ({ barcode, name, brandName, servingGrams, nutrientsPer100g: { calories } });
+
+/** Core Power Elite: 8 clean rows at the true 55.6 density + the two live
+ *  corrupt records, all landing on family key `core elite power`. */
+const CORE_POWER: Row[] = [
+    row('CP1', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP2', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP3', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP4', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP5', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP6', 'Core Power Elite', 'Fairlife', 55.6, 414),
+    row('CP7', 'Core Power Elite Vanilla', 'Fairlife', 55.6, 414),
+    row('CP8', 'Core Power Elite Chocolate', 'Fairlife', 55.6, 414),
+    // THE TARGETS — the two live barcodes, verbatim name/brand/panel/serving.
+    row('9568310020398', 'Fairlife core power elite', 'Fairlife', 230, 414),
+    row('9337369550008', 'Core power elite vanilla', 'Fairlife', 230, 414),
+];
+const TARGETS = ['9568310020398', '9337369550008'];
+/** The ~55 kcal siblings that must NEVER be flagged. */
+const CLEAN_SIBLINGS = ['CP1', 'CP2', 'CP3', 'CP4', 'CP5', 'CP6', 'CP7', 'CP8'];
+
+/** The mass-INFLATED family: median 3200 kcal/100g. A different corruption in
+ *  which the plausible-looking row is the corrupt one, so this tier must not
+ *  judge it. `MC` satisfies every OTHER condition — ratio 1.63, rescale within
+ *  1.6% of the median — so removing the median guard flags it immediately. */
+const MARASCHINO: Row[] = [
+    ...Array.from({ length: 8 }, (_, i) =>
+        row(`MR${i + 1}`, 'Maraschino Cherry Red', 'Luxardo', 3200, 30)),
+    row('MCORRUPT', 'Acme Maraschino Cherry Red', 'Acme', 5200, 160),
+];
+
+/** The OFF chain-restaurant import: >13-digit synthetic barcodes carrying the
+ *  DIVIDED-panel corruption, whose repair runs the opposite direction. */
+const CHAIN: Row[] = [
+    ...Array.from({ length: 8 }, (_, i) =>
+        row(`100000000000${i + 1}`, 'Castle Lavaburst Orange', 'White Castle', 7.1, 295.735)),
+    row('12228445487636949309', 'White Castle Lavaburst Orange', 'White Castle', 20, 295.735),
+];
+
+/** A FUSED family: one key covering products of genuinely different densities.
+ *  `GCORRUPT` passes ratio and rescale; only the dispersion guard rejects it. */
+const FUSED: Row[] = [
+    ...[20, 30, 40, 50, 60, 70, 80, 85].map((k, i) =>
+        row(`FG${i + 1}`, 'Acme Gamma Delta', 'Acme Labs', k, 200)),
+    row('GCORRUPT', 'Epsilon Acme Gamma Delta', 'Epsilon Acme', 110, 200),
+];
+
+/** A row BOTH tiers reach: its exact-name group is large enough for tier 1 AND
+ *  its family group is large enough for tier 2, and it satisfies both
+ *  signatures. Without the tier-2 dedupe it is flagged twice, which would put
+ *  the same barcode into two populations the parent is restoring separately. */
+const DOUBLE_REACH: Row[] = [
+    ...Array.from({ length: 8 }, (_, i) => row(`Z${i + 1}`, 'Zeta Omega Bar', 'Acme', 50, 200)),
+    row('ZDUP', 'Zeta Omega Bar', 'Acme', 100, 200),
+];
+
+/** Ballast that pushes `vanilla` and `chocolate` past the fixture DF cutoff,
+ *  exactly as the live corpus does. servingGrams null keeps them inert. */
+const FILLER: Row[] = [
+    ...Array.from({ length: 20 }, (_, i) => row(`FV${i}`, 'Vanilla Pudding Cup', 'Store', 100, null)),
+    ...Array.from({ length: 20 }, (_, i) => row(`FC${i}`, 'Chocolate Bar Snack', 'Store', 500, null)),
+];
+
+const CORPUS: Row[] = [...CORE_POWER, ...MARASCHINO, ...CHAIN, ...FUSED, ...DOUBLE_REACH, ...FILLER];
+
+const pagedFindMany = (rows: Row[]) =>
+    async (q: unknown) => ((q as { cursor?: unknown })?.cursor ? [] : rows);
+const scanDb = (rows: Row[]): ScanDb => ({
+    offFood: { findMany: pagedFindMany(rows), findUnique: async () => null },
+});
+
+interface Flag {
+    barcode: string; direction: string; kcal100: number; servingGrams: number;
+    rescaled: number; siblingMedian: number; groupSize: number;
+    family?: { key: string; relMad: number; median: number };
+}
+
+async function scan(rows: Row[] = CORPUS): Promise<Flag[]> {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), 'panel-family-'));
+    const code = await runScan(scanDb(rows), { outDir: out, familyDfMax: FIXTURE_DF_MAX, print: 0 });
+    expect(code).toBe(0);
+    const file = fs.readdirSync(out).find(f => f.startsWith('corrupt-panel-scan-'))!;
+    return JSON.parse(fs.readFileSync(path.join(out, file), 'utf8')).flagged as Flag[];
+}
+
+let logSpy: jest.SpyInstance;
+beforeEach(() => { logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { logSpy.mockRestore(); });
+
+// ===========================================================================
+// 1. The grouping key
+// ===========================================================================
+
+describe('familyKey — the discriminative-token grouping key', () => {
+    // The live document frequencies, so this test is about the real corpus's
+    // token distribution rather than an invented one.
+    const liveDf = new Map<string, number>([
+        ['core', 198], ['elite', 176], ['power', 1346], ['fairlife', 29],
+        ['vanilla', 13166], ['chocolate', 58054], ['strawberry', 15302],
+        ['protein', 25343], ['milk', 25721], ['shake', 4558], ['high', 30000],
+    ]);
+
+    it('THE DEFEAT CASE: the two live records join the family exact grouping splits apart', () => {
+        // Under normalizeNameKey these are `core elite fairlife power` (group 1)
+        // and `core elite power vanilla` (group 2). Under familyKey they are the
+        // same family as every other Core Power Elite row.
+        expect(familyKey('Fairlife core power elite', 'Fairlife', liveDf)).toBe('core elite power');
+        expect(familyKey('Core power elite vanilla', 'Fairlife', liveDf)).toBe('core elite power');
+        expect(familyKey('Core Power Elite Chocolate', 'Fairlife', liveDf)).toBe('core elite power');
+        expect(familyKey('Core Power Elite Strawberry', 'fairlife', liveDf)).toBe('core elite power');
+    });
+
+    it('keeps a genuinely different product in a different family', () => {
+        // Plain Core Power is 41.1 kcal/100g; Elite is 55.6. Fusing them would
+        // put a 35% error into the reference the whole tier rests on.
+        expect(familyKey('Core Power High Protein Milk Shake', 'Fairlife', liveDf)).toBe('core power');
+        expect(familyKey('Core Power High Protein Milk Shake', 'Fairlife', liveDf))
+            .not.toBe(familyKey('Core Power Elite Chocolate', 'Fairlife', liveDf));
+    });
+
+    it('returns null rather than a 1-token key when the strip leaves too little', () => {
+        // Playbook §3: ask what happens when the strip removes everything. A
+        // single generic token is the measured worst false-positive mode
+        // (`filet` fused beef tenderloin with a 132 kcal median).
+        expect(familyKey('Chocolate Milk', 'Store', liveDf)).toBeNull();     // all generic
+        expect(familyKey('Elite Protein', 'Store', liveDf)).toBeNull();      // 1 token survives
+        expect(FAMILY_MIN_TOKENS).toBe(2);
+    });
+
+    it('returns null when the name normalizes away entirely', () => {
+        expect(familyKey('!!!', null, liveDf)).toBeNull();
+        expect(nameTokens('!!!')).toEqual([]);
+        expect(nameTokens(null)).toEqual([]);
+    });
+
+    it('strips brand tokens by BRAND, not by rarity — a rare brand token is still dropped', () => {
+        // `fairlife` has df 29, far below the cutoff, so only the brand strip
+        // removes it. Without that strip the first defeat case above fails.
+        expect(familyKey('Fairlife core power elite', null, liveDf))
+            .toBe('core elite fairlife power');
+        expect(familyKey('Fairlife core power elite', 'Fairlife', liveDf))
+            .toBe('core elite power');
+    });
+
+    it('defaults to the shipped FAMILY_DF_MAX, and the shipped value is 2000', () => {
+        // Pinned so a future tweak has to argue with the audit that set it.
+        expect(FAMILY_DF_MAX).toBe(2000);
+        expect(familyKey('Core power elite vanilla', 'Fairlife', liveDf))
+            .toBe(familyKey('Core power elite vanilla', 'Fairlife', liveDf, FAMILY_DF_MAX));
+    });
+});
+
+describe('the audited population number', () => {
+    it('pins the LIVE false-positive rate, not the fixture one', () => {
+        // Playbook §2: a fixture number is a claim about the fixture. This suite
+        // is 100% precise on its own corpus and the live tier-2 set is 29% FP.
+        // Both numbers are correct; only one of them is about the population,
+        // and it is the one that decides whether anything may be marked.
+        expect(FAMILY_TIER_AUDITED_FP_RATE).toBeCloseTo(9 / 31, 10);
+        expect(FAMILY_TIER_AUDITED_FP_RATE).toBeGreaterThan(0.2);
+    });
+});
+
+describe('relativeMad — dispersion measured robustly', () => {
+    it('is zero for a family whose corrupt members are a minority', () => {
+        // The whole point: 2 corrupt rows at 230 must not make the Core Power
+        // family look dispersed. A stddev here would read 0.9 and the group
+        // would be thrown away — detecting nothing.
+        expect(relativeMad([55.6, 55.6, 55.6, 55.6, 55.6, 55.6, 55.6, 55.6, 230, 230], 55.6)).toBe(0);
+    });
+
+    it('is large for a fused family', () => {
+        expect(relativeMad([20, 30, 40, 50, 60, 70, 80, 85], 55)).toBeCloseTo(20 / 55, 5);
+    });
+
+    it('refuses a non-positive median instead of dividing by it', () => {
+        expect(relativeMad([1, 2], 0)).toBe(Infinity);
+        expect(relativeMad([], 10)).toBe(Infinity);
+    });
+});
+
+// ===========================================================================
+// 2. The rule
+// ===========================================================================
+
+describe('rejectPanelInflatedFamily — every condition names its own refusal', () => {
+    /** The live off_9568310020398 measurements. */
+    const target = (): FamilyScaleInputs => ({
+        barcode: '9568310020398',
+        kcal100: 230,
+        servingGrams: 414,
+        familyMedian: 55.6,
+        groupSize: 16,
+        relMad: 0,
+    });
+
+    it('ACCEPTS the live record behind golden case n-supp-23', () => {
+        expect(rejectPanelInflatedFamily(target())).toBeNull();
+    });
+
+    it('REJECTS the clean 55.6 siblings — they are not inflated against their own median', () => {
+        expect(rejectPanelInflatedFamily({ ...target(), barcode: 'CP1', kcal100: 55.6 }))
+            .toBe('family_not_inflated_vs_median');
+        // and the boundary is exactly FAMILY_INFLATED_RATIO
+        const atRatio = 55.6 * FAMILY_INFLATED_RATIO;
+        expect(rejectPanelInflatedFamily({ ...target(), kcal100: atRatio, servingGrams: 160 }))
+            .toBeNull();
+        expect(rejectPanelInflatedFamily({ ...target(), kcal100: atRatio - 0.001, servingGrams: 160 }))
+            .toBe('family_not_inflated_vs_median');
+    });
+
+    it('REJECTS the mass-inflated family (median > the trustable ceiling)', () => {
+        // 5200 kcal/100g against a 3200 median: ratio 1.63, rescale 3250 vs
+        // 3200. Every other condition passes. Only this guard stops it.
+        const maraschino: FamilyScaleInputs = {
+            barcode: 'MCORRUPT', kcal100: 5200, servingGrams: 160,
+            familyMedian: 3200, groupSize: 9, relMad: 0,
+        };
+        expect(rejectPanelInflatedFamily(maraschino)).toBe('family_median_implausible');
+        expect(rejectPanelInflatedFamily({ ...maraschino, familyMedian: MAX_TRUSTABLE_SIBLING_MEDIAN + 0.001 }))
+            .toBe('family_median_implausible');
+    });
+
+    it('REJECTS synthetic chain-import barcodes — a different corruption family', () => {
+        const chain: FamilyScaleInputs = {
+            barcode: '12228445487636949309', kcal100: 20, servingGrams: 295.735,
+            familyMedian: 7.1, groupSize: 9, relMad: 0,
+        };
+        expect(rejectPanelInflatedFamily(chain)).toBe('family_barcode_not_real_gtin');
+        expect(rejectPanelInflatedFamily({ ...chain, barcode: '1'.repeat(MAX_REAL_GTIN_LENGTH) }))
+            .toBeNull();
+        expect(rejectPanelInflatedFamily({ ...chain, barcode: '1'.repeat(MAX_REAL_GTIN_LENGTH + 1) }))
+            .toBe('family_barcode_not_real_gtin');
+    });
+
+    it('REJECTS a group that is too small or too dispersed to be a reference', () => {
+        expect(rejectPanelInflatedFamily({ ...target(), groupSize: FAMILY_MIN_GROUP - 1 }))
+            .toBe('family_group_too_small');
+        expect(rejectPanelInflatedFamily({ ...target(), groupSize: FAMILY_MIN_GROUP }))
+            .toBeNull();
+        expect(rejectPanelInflatedFamily({ ...target(), relMad: FAMILY_MAX_REL_MAD + 0.001 }))
+            .toBe('family_dispersion_too_high');
+        expect(rejectPanelInflatedFamily({ ...target(), relMad: FAMILY_MAX_REL_MAD }))
+            .toBeNull();
+    });
+
+    it('REJECTS servings outside the single-occasion window and inside the 90-110 dead zone', () => {
+        expect(rejectPanelInflatedFamily({ ...target(), servingGrams: 1 }))
+            .toBe('family_serving_out_of_window');
+        expect(rejectPanelInflatedFamily({ ...target(), servingGrams: 601 }))
+            .toBe('family_serving_out_of_window');
+        // 100 g cannot distinguish a per-serving panel from a correct one at all.
+        expect(rejectPanelInflatedFamily({ ...target(), kcal100: 100, servingGrams: 100, familyMedian: 55.6 }))
+            .toBe('family_serving_in_dead_zone');
+    });
+
+    it('REJECTS a row whose rescale misses the family median, at the tolerance edge', () => {
+        // Tolerance is 0.15, NOT tier 1's 0.30 — a coarser group buys precision
+        // here. Audited: 0.30 -> 0.15 removed 7 of 15 false positives.
+        const med = 100;
+        const base: FamilyScaleInputs = {
+            barcode: 'X', kcal100: 0, servingGrams: 200, familyMedian: med, groupSize: 10, relMad: 0,
+        };
+        // rescaled = kcal100/2, so kcal100 = 2*(med +/- tol*med)
+        expect(rejectPanelInflatedFamily({ ...base, kcal100: 2 * med * (1 + FAMILY_RESCALE_TOL) }))
+            .toBeNull();
+        expect(rejectPanelInflatedFamily({ ...base, kcal100: 2 * med * (1 + FAMILY_RESCALE_TOL) + 0.01 }))
+            .toBe('family_rescale_misses_median');
+        expect(FAMILY_RESCALE_TOL).toBe(0.15);
+    });
+
+    it('REJECTS missing or non-finite evidence rather than treating it as zero', () => {
+        expect(rejectPanelInflatedFamily(null)).toBe('family_evidence_missing');
+        expect(rejectPanelInflatedFamily(undefined)).toBe('family_evidence_missing');
+        expect(rejectPanelInflatedFamily({ ...target(), servingGrams: NaN }))
+            .toBe('family_evidence_missing');
+        expect(rejectPanelInflatedFamily({ ...target(), familyMedian: 0 }))
+            .toBe('family_evidence_missing');
+        expect(rejectPanelInflatedFamily({ ...target(), barcode: '' }))
+            .toBe('family_evidence_missing');
+    });
+});
+
+// ===========================================================================
+// 3. decideMark — the marking gate
+// ===========================================================================
+
+describe('decideMark — panel-inflated-family', () => {
+    const flag = (over: Partial<CorruptScanFlag> = {}): CorruptScanFlag => ({
+        barcode: '9568310020398', name: 'Fairlife core power elite', brandName: 'Fairlife',
+        kcal100: 230, servingGrams: 414, tier: 'direct',
+        direction: 'panel-inflated-family',
+        rescaled: 56, siblingMedian: 56, groupSize: 16, triageConfirmed: false,
+        family: { key: 'core elite power', relMad: 0, median: 55.6 },
+        ...over,
+    });
+
+    it('marks the target with its own reason string', () => {
+        expect(decideMark(flag())).toEqual({ mark: true, reason: 'panel-inflated-family:direct' });
+    });
+
+    it('the two panel-inflated populations stay separable by prefix', () => {
+        // The parent is restoring the tier-1 population separately; the marks
+        // must not be entangled. Note the same footgun panel-inflated-serving
+        // documents: bare "panel-inflated" selects BOTH generations, so a
+        // --clear-prefix must carry the colon.
+        expect('panel-inflated-family:direct'.startsWith('panel-inflated')).toBe(true);
+        expect('panel-inflated-family:direct'.startsWith('panel-inflated:')).toBe(false);
+        expect('panel-inflated-family:direct'.startsWith('panel-inflated-family:')).toBe(true);
+    });
+
+    it('re-runs the WHOLE rule from measurements — a hand-edited scan cannot mark', () => {
+        // Every one of these files claims the row is corrupt. decideMark must
+        // believe the measurements instead.
+        expect(decideMark(flag({ kcal100: 55.6 })))
+            .toEqual({ mark: false, skip: 'family_not_inflated_vs_median' });
+        expect(decideMark(flag({ groupSize: 3 })))
+            .toEqual({ mark: false, skip: 'family_group_too_small' });
+        expect(decideMark(flag({ family: { key: 'k', relMad: 0.9, median: 55.6 } })))
+            .toEqual({ mark: false, skip: 'family_dispersion_too_high' });
+        expect(decideMark(flag({ barcode: '9'.repeat(20) })))
+            .toEqual({ mark: false, skip: 'family_barcode_not_real_gtin' });
+        expect(decideMark(flag({ family: { key: 'k', relMad: 0, median: 3200 } })))
+            .toEqual({ mark: false, skip: 'family_median_implausible' });
+    });
+
+    it('refuses when the family evidence block is absent entirely', () => {
+        expect(decideMark(flag({ family: undefined })))
+            .toEqual({ mark: false, skip: 'family_evidence_missing' });
+        expect(decideMark(flag({ servingGrams: null })))
+            .toEqual({ mark: false, skip: 'family_evidence_missing' });
+    });
+
+    it('re-verifies against the UNROUNDED median, not the rounded display value', () => {
+        // A 0.3 kcal/100g diet-soda family rounds to 0; reading siblingMedian
+        // would make every such flag refuse for the wrong reason (or, with a
+        // different rounding, mark for the wrong reason).
+        const tiny = flag({
+            barcode: '9300675094498', kcal100: 1, servingGrams: 250,
+            siblingMedian: 0, rescaled: 0,
+            family: { key: 'caffeine zero', relMad: 0, median: 0.4 },
+        });
+        expect(decideMark(tiny)).toEqual({ mark: true, reason: 'panel-inflated-family:direct' });
+    });
+
+    it('leaves the tier-1 directions exactly as they were', () => {
+        const base = flag({ direction: 'panel-inflated', family: undefined });
+        expect(decideMark(base)).toEqual({ mark: true, reason: 'panel-inflated:direct' });
+        expect(decideMark({ ...base, groupSize: 7 }))
+            .toEqual({ mark: false, skip: 'inflated_group_too_small' });
+        expect(decideMark({ ...base, direction: 'panel-low', kcal100: 20, siblingMedian: 55 }))
+            .toEqual({ mark: true, reason: 'panel-low:direct' });
+    });
+});
+
+// ===========================================================================
+// 4. The scan, end to end over the fixture corpus
+// ===========================================================================
+
+describe('runScan — tier 2 over a fixture corpus', () => {
+    it('THE REQUIRED ANSWER: the whole flagged set, by barcode and by direction', async () => {
+        const flagged = await scan();
+        // Positive form: the entire set, not a list of things absent. Anything
+        // newly flagged fails this even if nobody predicted what it would be.
+        expect(
+            flagged.map(f => `${f.barcode}:${f.direction}`).sort()
+        ).toEqual([
+            '9337369550008:panel-inflated-family',
+            '9568310020398:panel-inflated-family',
+            'ZDUP:panel-inflated',
+        ]);
+    });
+
+    it('reconstructs the true density: 230 kcal/100g at 414 g rescales onto 55.6', async () => {
+        const t = (await scan()).find(f => f.barcode === '9568310020398')!;
+        expect(t.kcal100).toBe(230);
+        expect(t.servingGrams).toBe(414);
+        expect(t.family!.key).toBe('core elite power');
+        expect(t.family!.median).toBeCloseTo(55.6, 5);
+        expect(t.rescaled).toBe(56);            // 230 * 100 / 414 = 55.56
+        expect(t.groupSize).toBe(10);
+    });
+
+    it('does NOT flag the ~55 kcal Core Power Elite siblings', async () => {
+        const flagged = new Set((await scan()).map(f => f.barcode));
+        for (const b of CLEAN_SIBLINGS) expect(flagged.has(b)).toBe(false);
+    });
+
+    it('does NOT flag anything in the mass-inflated (>950 median) family', async () => {
+        const flagged = new Set((await scan()).map(f => f.barcode));
+        for (const r of MARASCHINO) expect(flagged.has(r.barcode)).toBe(false);
+    });
+
+    it('does NOT flag the synthetic chain-import row, or the fused family', async () => {
+        const flagged = new Set((await scan()).map(f => f.barcode));
+        expect(flagged.has('12228445487636949309')).toBe(false);
+        expect(flagged.has('GCORRUPT')).toBe(false);
+    });
+
+    it('the two tiers never claim the same row', async () => {
+        // ZDUP satisfies BOTH signatures: exact group n=9 median 50, family
+        // group n=9 median 50, ratio 2.0, rescale exact. Tier 1 decides it and
+        // tier 2 must stay out, or the same barcode lands in two populations
+        // that are being restored independently.
+        const flagged = await scan();
+        expect(new Set(flagged.map(f => f.barcode)).size).toBe(flagged.length);
+        expect(flagged.filter(f => f.barcode === 'ZDUP')).toHaveLength(1);
+        expect(flagged.find(f => f.barcode === 'ZDUP')!.direction).toBe('panel-inflated');
+    });
+
+    it('COUNTER-CONTROL: the corrupt rows are what makes the set non-empty', async () => {
+        // Playbook §5: a detector needs rows it must NOT match, or a passing
+        // test is tautological. Remove the two corrupt rows and the SAME corpus
+        // under the SAME thresholds must produce zero flags.
+        const corrupt = [...TARGETS, 'ZDUP'];
+        const clean = CORPUS.filter(r => !corrupt.includes(r.barcode));
+        expect(await scan(clean)).toEqual([]);
+    });
+
+    it('still fails closed on an empty corpus', async () => {
+        const out = fs.mkdtempSync(path.join(os.tmpdir(), 'panel-family-'));
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(await runScan(scanDb([]), { outDir: out, familyDfMax: FIXTURE_DF_MAX })).toBe(2);
+        expect(fs.readdirSync(out)).toHaveLength(0);
+        errSpy.mockRestore();
+    });
+});
+
+// ===========================================================================
+// MUTATION LOG (playbook §13) — executed 2026-07-31 by a harness that patches
+// the source, runs `npx jest <this file>`, records the dying tests, and
+// restores. Restored-tree re-run: 31 passed, exit 0.
+// ===========================================================================
+//
+// A guard with no named killer is untested regardless of the pass count. 12 of
+// 12 mutations are killed; the first pass had ELEVEN, and the survivor is the
+// reason DOUBLE_REACH exists (see below).
+//
+//   mutation                              | first test that died
+//   --------------------------------------|-----------------------------------
+//   drop family_median_implausible         | REJECTS the mass-inflated family
+//   drop family_barcode_not_real_gtin      | REJECTS synthetic chain-import
+//                                          | barcodes
+//   drop family_dispersion_too_high        | REJECTS a group that is too small
+//                                          | or too dispersed
+//   drop family_group_too_small            | REJECTS a group that is too small
+//                                          | or too dispersed
+//   drop the 90-110 g dead-zone guard      | REJECTS servings outside the
+//                                          | single-occasion window
+//   FAMILY_MIN_TOKENS 2 -> 1               | returns null rather than a
+//                                          | 1-token key
+//   FAMILY_RESCALE_TOL 0.15 -> 0.30        | REJECTS a row whose rescale
+//                                          | misses the family median
+//   FAMILY_MAX_REL_MAD 0.10 -> 0.50        | THE REQUIRED ANSWER
+//   decideMark reads the ROUNDED median    | re-verifies against the UNROUNDED
+//                                          | median
+//   familyKey brand strip removed          | THE DEFEAT CASE
+//   relativeMad -> MEAN abs deviation      | is zero for a family whose
+//                                          | corrupt members are a minority
+//                                          | (0 -> 0.627, and the target then
+//                                          | goes undetected)
+//   tier-2 dedupe `if (tier1Flagged)`      | THE REQUIRED ANSWER + the two
+//     removed                              | tiers never claim the same row
+//
+// THE SURVIVOR, and what it cost. On the first run the dedupe mutation left the
+// suite fully GREEN: the fixture contained no row that both tiers could reach,
+// so no input could distinguish the two implementations. That is the failure
+// mode playbook §13 names — "the fixture was too well-behaved" — and the fix
+// was not another assertion but a new input (DOUBLE_REACH / `ZDUP`), built so
+// the two implementations MUST disagree on it.

--- a/scripts/eval/detect-corrupt-panel.ts
+++ b/scripts/eval/detect-corrupt-panel.ts
@@ -5,22 +5,88 @@
  * The 2026-07-20 warm-cache triage confirmed 17 OFF records whose per-100g
  * nutrition fields actually hold the label's per-SERVING panel (oreo at
  * 143 kcal/100g = the 2-cookie serving, monster at 140 = the can, etc.).
- * The mechanical signature: the stored kcal100 is far BELOW the same-name
+ * The mechanical signature: the stored kcal100 sits far off the same-name
  * sibling median, and rescaling it by 100/servingGrams lands ON the median.
+ * The defect has TWO halves and this scan detects both:
+ *   - serving < 100 g stores the panel LOW  -> direction "panel-low"
+ *   - serving > 100 g stores it INFLATED    -> direction "panel-inflated"
  *
- * Detection (sibling groups keyed by normalizeNameKey(name), the query-time
- * dedupe key, with >= --min-group members for a robust median):
- *   flag when kcal100 < 0.6 * siblingMedian
+ * ===========================================================================
+ * TIER 1 — exact-name siblings (directions "panel-low" / "panel-inflated")
+ * ===========================================================================
+ * Sibling groups keyed by normalizeNameKey(name), the query-time dedupe key,
+ * with >= --min-group members for a robust median:
+ *   flag when kcal100 <= 0.6 * siblingMedian   (panel-low)
+ *          or kcal100 >= 1.6 * siblingMedian   (panel-inflated)
  *        and |kcal100 * 100/serving - siblingMedian| <= 0.3 * siblingMedian
- *   where serving is the row's own servingGrams in [2, 95] (tier "direct"),
+ *   where serving is the row's own servingGrams in [2, 600] (tier "direct"),
  *   falling back to the group's median servingGrams (tier "sibling-serving")
- *   when the corrupt row carries none — corrupt rows often do.
+ *   when the corrupt row carries none — corrupt rows often do. Servings in
+ *   (90, 110) are skipped: there the two readings are indistinguishable.
  *
+ * ===========================================================================
+ * TIER 2 — family siblings (direction "panel-inflated-family")
+ * ===========================================================================
+ * WHY IT EXISTS. normalizeNameKey() is a token-SET identity: it sorts and
+ * dedupes, but does not generalize. One extra brand or flavour token puts a
+ * row in a group of its own, where tier 1 cannot reach it however corrupt it
+ * is. Measured on the live corpus 2026-07-31 (pass 1 prints these counters on
+ * every run, so they re-derive themselves): 661,150 of 1,083,139 kcal-bearing
+ * rows — 61.0% — sit in groups below MIN_GROUP=4 and are never signature-
+ * tested at all. The share rises monotonically with name length: 25.5% at one
+ * token, 55.3% at three, 85.3% at five, 98.3% at eight or more. Brandedness is
+ * NOT the axis (61.8% branded vs 58.9% unbranded); name LENGTH is.
+ *
+ * The two live examples that motivated the tier, both invisible to tier 1:
+ *   off_9568310020398 "Fairlife core power elite" -> key `core elite fairlife
+ *     power`, group size 1
+ *   off_9337369550008 "Core power elite vanilla"  -> key `core elite power
+ *     vanilla`, group size 2
+ * Both store 230 kcal/100g with servingGrams 414 — the whole 414 mL bottle's
+ * panel — against a true density of 55.6, and off_9568310020398 is the record
+ * behind golden-eval case n-supp-23's 4.14x over-bill.
+ *
+ * THE KEY. Drop the row's brand tokens, then drop every token whose corpus
+ * document frequency exceeds FAMILY_DF_MAX; keep the rest. What survives is
+ * the discriminative core of the name, so `Fairlife core power elite`,
+ * `Core power elite vanilla` and `Core Power Elite Chocolate` all land on
+ * `core elite power` (n=16, median 55.6) while plain `Core Power High Protein
+ * Milk Shake` lands on `core power` (n=55, median 41.1) — a genuinely
+ * different product at a genuinely different density.
+ *
+ * A COARSER GROUP IS A WEAKER REFERENCE, so tier 2 is strictly tighter than
+ * tier 1 everywhere else, and every threshold comes from a hand audit rather
+ * than from inspection (playbook section 2: a rule can score 100% on a fixture
+ * and be the worst rule in the population). The thresholds and the measured
+ * evidence for each live in src/lib/mapping/corrupt-mark.ts next to
+ * rejectPanelInflatedFamily(), which is the rule; this file only supplies the
+ * grouping. In summary: >= 2 key tokens, >= 8 members, group relative MAD
+ * <= 0.10, rescale tolerance 0.15 (not 0.30), and barcode length <= 13.
+ *
+ * Tier 2 emits the INFLATED direction only. The deflated half is deliberately
+ * out of scope so a restore of the tier-1 panel-low population cannot become
+ * entangled with this one; that is a scope decision, not evidence that the
+ * deflated half is clean under family grouping.
+ *
+ * MEASURED (live corpus 2026-07-31, --min-group 4, 1,085,525 rows):
+ *   tier 1   7,354 rows — 5,365 panel-low, 1,989 panel-inflated
+ *            (byte-identical to the pre-tier-2 baseline run: this change adds
+ *            a population, it does not move the existing one)
+ *   tier 2      31 rows — panel-inflated-family, disjoint from tier 1 by
+ *            construction, over 3,889 family groups with >= 8 members
+ *
+ * ALL 31 WERE HAND-AUDITED against each row's own macro panel and servingSize
+ * string: 21 true positives, 9 false positives, 1 undecidable — a 29.0% FP
+ * rate, pinned as FAMILY_TIER_AUDITED_FP_RATE in corrupt-mark.ts with the
+ * failure mode described. THIS IS A REVIEW QUEUE, NOT A MARK LIST. Nothing
+ * here may be fed to mark-corrupt-off.ts --apply without a fresh audit.
+ *
+ * ===========================================================================
  * Groups whose MEDIAN exceeds 950 kcal/100g (physical max ~900 for pure fat)
- * are excluded from the signature test and reported separately: those are a
- * different corruption family (mass-INFLATED per-100g values — e.g. whole
- * maraschino-cherry name groups with medians of 3200), where the plausible-
- * looking row is the healthy one, not the corrupt one.
+ * are excluded from BOTH tiers' signature tests and reported separately: those
+ * are a different corruption family (mass-INFLATED per-100g values — e.g.
+ * whole maraschino-cherry name groups with medians of 3200), where the
+ * plausible-looking row is the healthy one, not the corrupt one.
  *
  * The 17 triage-confirmed barcodes are cross-checked at the end; misses are
  * reported with the reason so the marking PR can carry them explicitly.
@@ -30,8 +96,8 @@
  * needs its own column (planned with PR D pt3); this scan produces the input.
  *
  * Run (from repo root, read-only):
- *   npx ts-node -r tsconfig-paths/register --transpile-only --compilerOptions \
- *     '{"module":"commonjs","moduleResolution":"node"}' \
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register \
  *     scripts/eval/detect-corrupt-panel.ts [--min-group 4] [--print 40]
  */
 import 'dotenv/config';
@@ -39,8 +105,34 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PrismaClient } from '@prisma/client';
 import { normalizeNameKey } from '../../src/lib/search/dedupe-candidates';
+import {
+    FAMILY_MIN_TOKENS,
+    FAMILY_MIN_GROUP,
+    rejectPanelInflatedFamily,
+    type FamilyRejection,
+} from '../../src/lib/mapping/corrupt-mark';
 
 const BATCH = 20000;
+
+/**
+ * A token appearing in more than this many product names is a generic modifier
+ * (`chocolate` 58,054, `organic` 34,467, `protein` 25,343) rather than part of
+ * a product's identity, and keeping it fragments the family. Dropping it is
+ * what lets `Core power elite vanilla` join `Core Power Elite Chocolate`.
+ *
+ * Lives here rather than in corrupt-mark.ts because it is a GROUPING parameter
+ * of the scan, not a trust rule: decideMark() cannot re-derive a corpus-wide
+ * document frequency offline, so it re-verifies the group's measured median,
+ * size and dispersion instead.
+ *
+ * Measured on the live corpus 2026-07-31 (both targets found at every value):
+ *   2000 -> `core elite power` n=16; 245,956 keys, 19,248 qualifying
+ *   5000 -> `core elite power` n=11
+ *  20000 -> `Core power elite vanilla` keeps `vanilla` (df 13,166) and falls
+ *           back to a 2-member group — the split this tier exists to close.
+ * 2000 is the loosest value that still strips flavour words corpus-wide.
+ */
+export const FAMILY_DF_MAX = 2000;
 
 /**
  * The slice of PrismaClient this scan consumes — injectable so the
@@ -59,6 +151,17 @@ export interface PanelScanOptions {
     print?: number;
     /** report directory; defaults to scripts/eval/results (tests inject a tmp dir) */
     outDir?: string;
+    /**
+     * Tier-2 generic-token cutoff; defaults to FAMILY_DF_MAX (2000).
+     *
+     * Overridable ONLY so a fixture can reproduce the corpus's token-frequency
+     * RATIO at fixture scale: in a 60-row corpus every token is rare, so the
+     * shipped 2000 would strip nothing and a test would exercise a grouping the
+     * production run never performs. The production entrypoint below never
+     * passes it. Playbook §2: a fixture number is a claim about the fixture —
+     * this keeps the fixture's claim about the right function.
+     */
+    familyDfMax?: number;
 }
 
 /** Confirmed corrupt in the 2026-07-20 warm-cache triage (adversarial verify vs live corpus). */
@@ -80,6 +183,51 @@ function median(sorted: number[]): number {
     const mid = Math.floor(sorted.length / 2);
     return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
+
+/** Tokens of a name under the query-time dedupe key (sorted, deduped,
+ *  singularized). Empty for names that normalize away entirely. */
+export function nameTokens(s: string | null | undefined): string[] {
+    if (!s) return [];
+    const k = normalizeNameKey(s);
+    return k ? k.split(' ').filter(Boolean) : [];
+}
+
+/**
+ * The tier-2 family grouping key: the row's discriminative tokens, i.e. its
+ * name tokens minus its brand tokens minus every corpus-generic token.
+ *
+ * Returns null when fewer than FAMILY_MIN_TOKENS survive. Playbook section 3:
+ * "any time you build a grouping key by stripping tokens, ask what happens when
+ * the strip removes everything" — here it does so 313,369 times on the live
+ * corpus, and a single-token key is exactly the fusion that produced the worst
+ * measured false positives (`filet`, `ale`, `ricotta`), so the floor is 2 and
+ * an under-length key is EXCLUDED rather than backed off to.
+ */
+export function familyKey(
+    name: string,
+    brandName: string | null,
+    df: ReadonlyMap<string, number>,
+    dfMax: number = FAMILY_DF_MAX
+): string | null {
+    const brand = new Set(nameTokens(brandName));
+    const keep = nameTokens(name).filter(
+        t => !brand.has(t) && (df.get(t) ?? 0) <= dfMax
+    );
+    return keep.length >= FAMILY_MIN_TOKENS ? keep.join(' ') : null;
+}
+
+/**
+ * median(|x - med|) / med over a group's kcal100 values — how tight the family
+ * is, measured robustly so the corrupt members do not inflate it themselves.
+ * A mean/stddev here would be moved by the very rows being detected.
+ */
+export function relativeMad(values: number[], med: number): number {
+    if (!(med > 0) || !values.length) return Infinity;
+    const devs = values.map(v => Math.abs(v - med)).sort((a, b) => a - b);
+    return median(devs) / med;
+}
+
+export interface FamilyStats { med: number; n: number; relMad: number }
 
 export interface Row { barcode: string; name: string; brandName: string | null; servingGrams: number | null; nutrientsPer100g: unknown }
 
@@ -103,17 +251,23 @@ async function* streamRows(db: ScanDb): AsyncGenerator<Row[]> {
 export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<number> {
     const MIN_GROUP = opts.minGroup ?? 4;
     const PRINT = opts.print ?? 40;
+    const DF_MAX = opts.familyDfMax ?? FAMILY_DF_MAX;
 
-    // Pass 1: sibling kcal + serving distributions per name key
-    console.log('Pass 1: building sibling kcal/serving medians...');
+    // Pass 1: sibling kcal + serving distributions per name key, plus the token
+    // document frequencies tier 2's family key is derived from.
+    console.log('Pass 1: building sibling kcal/serving medians + token frequencies...');
     const groups = new Map<string, { kcals: number[]; servings: number[] }>();
+    const df = new Map<string, number>();
     let scanned = 0;
+    let kcalBearing = 0;
     for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const kcal = readKcal(r.nutrientsPer100g);
             if (kcal == null) continue;
             const key = normalizeNameKey(r.name);
             if (!key) continue;
+            kcalBearing++;
+            for (const t of key.split(' ')) df.set(t, (df.get(t) ?? 0) + 1);
             let g = groups.get(key);
             if (!g) { g = { kcals: [], servings: [] }; groups.set(key, g); }
             g.kcals.push(kcal);
@@ -124,6 +278,10 @@ export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<
         scanned += batch.length;
         if (scanned % 200000 === 0) console.log(`  ${scanned} rows...`);
     }
+    // The reachability measurement tier 2 exists to close. Printed every run so
+    // it re-derives itself rather than living as a number in prose.
+    let belowMinGroup = 0;
+    for (const g of groups.values()) if (g.kcals.length < MIN_GROUP) belowMinGroup += g.kcals.length;
     const MAX_SANE_MEDIAN = 950; // physical ceiling ~900 kcal/100g (pure fat)
     const medians = new Map<string, { med: number; n: number; medServing: number | null }>();
     const inflatedGroups: Array<{ key: string; med: number; n: number }> = [];
@@ -141,8 +299,10 @@ export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<
             medServing: g.servings.length >= 2 ? median(g.servings) : null,
         });
     }
+    const nameGroupCount = groups.size;
     groups.clear();
     console.log(`  ${scanned} rows, ${medians.size} sane name groups with >=${MIN_GROUP} members, ${inflatedGroups.length} mass-inflated groups (median > ${MAX_SANE_MEDIAN}) excluded`);
+    console.log(`  REACHABILITY: ${kcalBearing} kcal-bearing rows in ${nameGroupCount} exact name groups; ${belowMinGroup} rows (${kcalBearing ? (100 * belowMinGroup / kcalBearing).toFixed(1) : '0'}%) sit in groups below MIN_GROUP=${MIN_GROUP} and are UNREACHABLE by tier 1`);
 
     // Fail closed (playbook §11 class B): a scan that saw ZERO rows is a broken
     // instrument, not a clean corpus. No report is written, so a failed run can
@@ -152,38 +312,101 @@ export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<
         return 2;
     }
 
-    // Pass 2: test the panel-as-100g signature
-    console.log('Pass 2: testing serving-rescale signature...');
+    // Pass 2: family (discriminative-token) groups for tier 2.
+    console.log('Pass 2: building family groups...');
+    const familyKcals = new Map<string, number[]>();
+    for await (const batch of streamRows(db)) {
+        for (const r of batch) {
+            const kcal = readKcal(r.nutrientsPer100g);
+            if (kcal == null) continue;
+            const fk = familyKey(r.name, r.brandName, df, DF_MAX);
+            if (!fk) continue;
+            let a = familyKcals.get(fk);
+            if (!a) { a = []; familyKcals.set(fk, a); }
+            a.push(kcal);
+        }
+    }
+    const families = new Map<string, FamilyStats>();
+    for (const [k, a] of familyKcals) {
+        if (a.length < FAMILY_MIN_GROUP) continue;
+        a.sort((x, y) => x - y);
+        const med = median(a);
+        if (!(med > 0)) continue;
+        families.set(k, { med, n: a.length, relMad: relativeMad(a, med) });
+    }
+    familyKcals.clear();
+    console.log(`  ${families.size} family groups with >=${FAMILY_MIN_GROUP} members`);
+
+    // Pass 3: test both signatures
+    console.log('Pass 3: testing serving-rescale signatures...');
+    const familySkips = new Map<FamilyRejection, number>();
     const flagged: Array<{
         barcode: string; name: string; brandName: string | null;
         kcal100: number; servingGrams: number; tier: 'direct' | 'sibling-serving';
-        direction: 'panel-low' | 'panel-inflated';
+        direction: 'panel-low' | 'panel-inflated' | 'panel-inflated-family';
         rescaled: number; siblingMedian: number; groupSize: number; triageConfirmed: boolean;
+        family?: { key: string; relMad: number; median: number };
     }> = [];
     for await (const batch of streamRows(db)) {
         for (const r of batch) {
             const kcal = readKcal(r.nutrientsPer100g);
             if (kcal == null) continue;
             const m = medians.get(normalizeNameKey(r.name));
-            if (!m || m.med <= 0) continue;
-            const own = r.servingGrams != null && r.servingGrams >= 2 && r.servingGrams <= 600;
-            const s = own ? r.servingGrams! : m.medServing;
-            // Servings near 100g can't distinguish panel-as-100g from correct data
-            if (s == null || (s > 90 && s < 110)) continue;
-            const rescaled = kcal * (100 / s);
-            // Serving < 100g stores the panel LOW (oil at 120), > 100g stores it
-            // INFLATED (a 473ml Monster can panel at 140 vs ~47 real density).
-            const direction = kcal <= 0.6 * m.med ? 'panel-low'
-                : kcal >= 1.6 * m.med ? 'panel-inflated' : null;
-            if (direction && Math.abs(rescaled - m.med) <= 0.3 * m.med) {
-                flagged.push({
-                    barcode: r.barcode, name: r.name, brandName: r.brandName,
-                    kcal100: kcal, servingGrams: s, tier: own ? 'direct' : 'sibling-serving',
-                    direction,
-                    rescaled: Math.round(rescaled), siblingMedian: Math.round(m.med), groupSize: m.n,
-                    triageConfirmed: TRIAGE_CONFIRMED.includes(r.barcode),
-                });
+            let tier1Flagged = false;
+            if (m && m.med > 0) {
+                const own = r.servingGrams != null && r.servingGrams >= 2 && r.servingGrams <= 600;
+                const s = own ? r.servingGrams! : m.medServing;
+                // Servings near 100g can't distinguish panel-as-100g from correct data
+                if (s != null && !(s > 90 && s < 110)) {
+                    const rescaled = kcal * (100 / s);
+                    // Serving < 100g stores the panel LOW (oil at 120), > 100g stores it
+                    // INFLATED (a 473ml Monster can panel at 140 vs ~47 real density).
+                    const direction = kcal <= 0.6 * m.med ? 'panel-low'
+                        : kcal >= 1.6 * m.med ? 'panel-inflated' : null;
+                    if (direction && Math.abs(rescaled - m.med) <= 0.3 * m.med) {
+                        tier1Flagged = true;
+                        flagged.push({
+                            barcode: r.barcode, name: r.name, brandName: r.brandName,
+                            kcal100: kcal, servingGrams: s, tier: own ? 'direct' : 'sibling-serving',
+                            direction,
+                            rescaled: Math.round(rescaled), siblingMedian: Math.round(m.med), groupSize: m.n,
+                            triageConfirmed: TRIAGE_CONFIRMED.includes(r.barcode),
+                        });
+                    }
+                }
             }
+
+            // Tier 2. Only rows tier 1 did not already decide about, so the two
+            // populations never overlap and a restore of one cannot touch the
+            // other. Family tier uses the row's OWN serving only: a borrowed
+            // sibling serving on top of a borrowed sibling median is two
+            // inferences deep, which is more than this reference can carry.
+            if (tier1Flagged) continue;
+            const fk = familyKey(r.name, r.brandName, df, DF_MAX);
+            if (!fk) continue;
+            const fam = families.get(fk);
+            if (!fam) continue;
+            const rejection = rejectPanelInflatedFamily({
+                barcode: r.barcode,
+                kcal100: kcal,
+                servingGrams: r.servingGrams ?? NaN,
+                familyMedian: fam.med,
+                groupSize: fam.n,
+                relMad: fam.relMad,
+            });
+            if (rejection) {
+                familySkips.set(rejection, (familySkips.get(rejection) ?? 0) + 1);
+                continue;
+            }
+            flagged.push({
+                barcode: r.barcode, name: r.name, brandName: r.brandName,
+                kcal100: kcal, servingGrams: r.servingGrams!, tier: 'direct',
+                direction: 'panel-inflated-family',
+                rescaled: Math.round(kcal * (100 / r.servingGrams!)),
+                siblingMedian: Math.round(fam.med), groupSize: fam.n,
+                triageConfirmed: TRIAGE_CONFIRMED.includes(r.barcode),
+                family: { key: fk, relMad: fam.relMad, median: fam.med },
+            });
         }
     }
 
@@ -194,19 +417,39 @@ export async function runScan(db: ScanDb, opts: PanelScanOptions = {}): Promise<
     const outPath = path.join(outDir, `corrupt-panel-scan-${ts}.json`);
     fs.writeFileSync(outPath, JSON.stringify({
         at: new Date().toISOString(),
-        params: { minGroup: MIN_GROUP },
-        summary: { scanned, flagged: flagged.length },
+        params: { minGroup: MIN_GROUP, familyDfMax: DF_MAX, familyMinGroup: FAMILY_MIN_GROUP },
+        summary: {
+            scanned,
+            kcalBearing,
+            rowsBelowMinGroup: belowMinGroup,
+            nameGroups: nameGroupCount,
+            familyGroups: families.size,
+            flagged: flagged.length,
+        },
         flagged,
     }, null, 1));
 
     const low = flagged.filter(f => f.direction === 'panel-low').length;
     const inflated = flagged.filter(f => f.direction === 'panel-inflated').length;
-    console.log(`\nFlagged ${flagged.length} rows (of ${scanned} scanned): ${low} panel-low, ${inflated} panel-inflated`);
+    const family = flagged.filter(f => f.direction === 'panel-inflated-family').length;
+    console.log(`\nFlagged ${flagged.length} rows (of ${scanned} scanned): ${low} panel-low, ${inflated} panel-inflated, ${family} panel-inflated-family`);
     for (const f of flagged.slice(0, PRINT)) {
         const tag = f.triageConfirmed ? ' [TRIAGE-CONFIRMED]' : '';
-        console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''} (${f.direction}/${f.tier}): ${f.kcal100} kcal/100g, serving ${f.servingGrams}g -> rescaled ${f.rescaled} vs sibling median ${f.siblingMedian} (n=${f.groupSize})${tag}`);
+        const fam = f.family ? ` family="${f.family.key}" relMad=${f.family.relMad.toFixed(3)}` : '';
+        console.log(`  ${f.barcode} "${f.name}"${f.brandName ? ` [${f.brandName}]` : ''} (${f.direction}/${f.tier}): ${f.kcal100} kcal/100g, serving ${f.servingGrams}g -> rescaled ${f.rescaled} vs sibling median ${f.siblingMedian} (n=${f.groupSize})${fam}${tag}`);
     }
     if (flagged.length > PRINT) console.log(`  ... ${flagged.length - PRINT} more in the report file`);
+
+    // Every tier-2 refusal, by named condition. A detector that prints only its
+    // hits cannot be told apart from one that is not running (playbook §2).
+    console.log('\npanel-inflated-family refusals by condition:');
+    for (const [reason, n] of [...familySkips.entries()].sort((a, b) => b[1] - a[1])) {
+        console.log(`  ${reason}: ${n}`);
+    }
+    console.log(`\nFAMILY TIER FLAGS (all ${family}):`);
+    for (const f of flagged.filter(x => x.direction === 'panel-inflated-family')) {
+        console.log(`  ${f.barcode} "${f.name}" [${f.brandName ?? ''}] ${f.kcal100} kcal/100g @${f.servingGrams}g -> ${f.rescaled} vs family "${f.family!.key}" median ${f.siblingMedian} (n=${f.groupSize}, relMad ${f.family!.relMad.toFixed(3)})`);
+    }
 
     // Cross-check: which triage-confirmed records did the scan catch?
     console.log('\nTriage-confirmed cross-check:');

--- a/scripts/eval/semantic-recall-probe.ts
+++ b/scripts/eval/semantic-recall-probe.ts
@@ -1,0 +1,473 @@
+/**
+ * semantic-recall-probe.ts — does query-side pooling actually change what
+ * `searchOffSemantic()` retrieves, and by how much?
+ *
+ * WHY THIS EXISTS. The OFF corpus is CLS-pooled (`scripts/embed-off-cpu.ts`,
+ * `scripts/embed_foods.py`) and `embedQuery()` embedded queries with `mean`
+ * pooling until 2026-07-31, so queries and documents sat in different vector
+ * spaces. The golden set is USELESS as the success metric for that fix: its five
+ * `search/semantic` cases scored 5/5 *through* the mismatch (backend
+ * `sync-docs/backend_integration_guide.md`, 2026-07-30 refresh transcript). It is
+ * a regression gate, not evidence. This probe is the measurement.
+ *
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/semantic-recall-probe.ts \
+ *     [--limit N] [--k 10] [--json <path>]
+ *
+ *   --limit N   seeds to use (default 50; 0 = every eligible seed)
+ *   --k K       recall@K, and the `limit` handed to searchOffSemantic (default 10)
+ *   --json P    also write the full per-seed record to P
+ *
+ * Reads Typesense and Postgres. WRITES NOTHING. Point TYPESENSE_HOST at the box
+ * (the Mac `.env` already does) — `searchOffSemantic()` reads vectors from
+ * Typesense, never from pgvector, so there is no local-only way to run this.
+ *
+ * ------------------------------------------------------------------
+ * GROUND TRUTH — where the "correct" barcodes come from, and what they are not
+ * ------------------------------------------------------------------
+ * Seeds are the applied repoint batches in `scripts/eval/repoints-*.json`:
+ * (query seed -> the OFF record a triage agent examined and confirmed is the
+ * right one), restricted to
+ *   - `class: 'identity'`   — the repoint moved WHICH RECORD answers, which is
+ *                             the axis retrieval controls. `nutrition` and
+ *                             `ranking-gap` repoints are about panels and order,
+ *                             so a retrieval probe cannot be scored on them.
+ *   - `target` starting `off_` — FDC has no embeddings; only OFF is searchable
+ *                             semantically.
+ *   - not in `repoints-2026-07-21-reverted.json` — those six were withdrawn the
+ *                             same day and are NOT ground truth.
+ *   - target present in the live `off_foods` index with a 384-d embedding —
+ *                             verified per-seed at startup, because a target the
+ *                             index does not contain scores 0 under every pooling
+ *                             and silently dilutes both arms.
+ * The class filter is not incidental: `identity` is the triage label that
+ * `scripts/eval/triage-drops.ts` maps `identity-query-token-dropped` onto, so
+ * this population IS that failure class with barcodes attached — which the class
+ * registry's own exemplars are not.
+ *
+ * WHAT THIS IS NOT. Recall of ONE barcode is a hard metric on generic seeds:
+ * `whole milk` has thousands of defensible answers and exactly one is scored, so
+ * absolute recall is a floor, not an accuracy estimate. It is still a valid A/B,
+ * because the target is identical in both arms. Read the DELTA; do not quote the
+ * absolute number as "semantic search finds the right food N% of the time".
+ *
+ * ------------------------------------------------------------------
+ * CONTROLS — an instrument nobody has broken on purpose is not evidence
+ * ------------------------------------------------------------------
+ * (playbook §2, "Break the instrument on purpose before you quote its green")
+ *
+ *  C1  SAME-POOLING REPEAT (cls vs cls, and mean vs mean). Two runs of the same
+ *      pooling in the same process. Any difference at all means the probe has a
+ *      noise floor and no A/B smaller than it is a result. Expected: identical.
+ *  C2  QUERY-VECTOR SEPARATION. Cosine between the cls and mean query vectors
+ *      for every seed. If this is ~1.0 the override is not wired and the probe
+ *      is running one pooling twice while reporting two.
+ *  C3  RESULT-SET SEPARATION. cls and mean must retrieve different documents
+ *      somewhere. Zero difference across every seed means the probe is not
+ *      measuring retrieval.
+ *  C4  CORPUS-POOLING RE-DERIVATION (positive control). Re-embed each sampled
+ *      target's own `docText()` and cosine it against that document's STORED
+ *      vector under each pooling. This is what tells you which pooling the
+ *      corpus is actually in today rather than which one a doc says it is in —
+ *      it goes red if the corpus is ever re-embedded differently.
+ *
+ * Exit codes: 0 = ran and every control passed · 1 = a control FAILED (the
+ * numbers above it are not evidence) · 2 = could not run (fail closed).
+ */
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { docText } from '../embed-off-cpu';
+
+const DIM = 384;
+const MODEL_ID = 'Xenova/bge-small-en-v1.5';
+const BGE_QUERY_PREFIX = 'Represent this sentence for searching relevant passages: ';
+
+const REPOINT_FILES = [
+    'repoints-2026-07-20.json',
+    'repoints-2026-07-20-pt2.json',
+    'repoints-2026-07-21-bigwarm.json',
+];
+const REVERTED_FILE = 'repoints-2026-07-21-reverted.json';
+
+type Pooling = 'cls' | 'mean';
+
+interface Seed {
+    query: string;
+    target: string;      // off_<barcode>
+    barcode: string;
+    severity: string;
+    source: string;      // which repoint file
+    docName: string;
+    docBrand: string | null;
+}
+
+interface RunResult {
+    pooling: Pooling;
+    label: string;
+    /** query -> ordered candidate ids returned by searchOffSemantic */
+    hits: Map<string, string[]>;
+    vectors: Map<string, number[]>;
+    /** query -> ordered barcodes from the RAW ANN call, pre-gate (diagnostic) */
+    rawHits: Map<string, string[]>;
+    /** query -> best cosine similarity the ANN index could offer, pre-gate */
+    top1Similarity: Map<string, number>;
+}
+
+// ---------------------------------------------------------------- helpers
+
+function cosine(a: number[], b: number[]): number {
+    let dot = 0, na = 0, nb = 0;
+    for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+    if (na === 0 || nb === 0) return 0;
+    return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function pct(n: number, d: number): string {
+    return d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(1)}%`;
+}
+
+function tsHost(): string {
+    return process.env.TYPESENSE_HOST ?? 'http://localhost:8108';
+}
+
+async function tsGetDoc(barcode: string): Promise<any | null> {
+    const res = await fetch(
+        `${tsHost()}/collections/off_foods/documents/${encodeURIComponent(barcode)}`,
+        { headers: { 'X-TYPESENSE-API-KEY': process.env.TYPESENSE_API_KEY ?? '' } },
+    );
+    if (!res.ok) return null;
+    return res.json();
+}
+
+// ---------------------------------------------------------------- seeds
+
+function loadSeeds(evalDir: string): { seeds: Seed[]; eligible: number } {
+    const reverted = new Set<string>(
+        JSON.parse(fs.readFileSync(path.join(evalDir, REVERTED_FILE), 'utf8')).map((r: any) => r.seed),
+    );
+    const seen = new Set<string>();
+    const out: Seed[] = [];
+    for (const f of REPOINT_FILES) {
+        const rows = JSON.parse(fs.readFileSync(path.join(evalDir, f), 'utf8'));
+        for (const r of rows) {
+            if (r.class !== 'identity') continue;
+            if (!String(r.target ?? '').startsWith('off_')) continue;
+            if (reverted.has(r.seed)) continue;
+            const query = String(r.seed).trim();
+            if (!query || seen.has(query)) continue;   // one row per query text
+            seen.add(query);
+            out.push({
+                query,
+                target: r.target,
+                barcode: String(r.target).slice(4),
+                severity: r.severity ?? '?',
+                source: f,
+                docName: '',
+                docBrand: null,
+            });
+        }
+    }
+    // Stable order so --limit selects the same seeds every run.
+    out.sort((a, b) => (a.query < b.query ? -1 : a.query > b.query ? 1 : 0));
+    return { seeds: out, eligible: out.length };
+}
+
+// ---------------------------------------------------------------- runs
+
+async function runOnce(
+    seeds: Seed[],
+    pooling: Pooling,
+    label: string,
+    k: number,
+): Promise<RunResult> {
+    process.env.EMBED_QUERY_POOLING = pooling;
+    const { embedQuery } = await import('../../src/lib/search/query-embedding');
+    const { searchOffSemantic } = await import('../../src/lib/openfoodfacts/search');
+    const { vectorSearchTypesense } = await import('../../src/lib/search/typesense-client');
+
+    const hits = new Map<string, string[]>();
+    const vectors = new Map<string, number[]>();
+    const rawHits = new Map<string, string[]>();
+    const top1Similarity = new Map<string, number>();
+
+    for (const s of seeds) {
+        const cands = await searchOffSemantic(s.query, { limit: k });
+        hits.set(s.query, cands.map(c => c.id));
+
+        // Diagnostic side-channel: the same embedding, straight at the ANN index,
+        // so a miss can be attributed to retrieval vs to the 0.72 similarity gate
+        // / nutrition filter inside searchOffSemantic. The PRIMARY metric above
+        // never reads this.
+        const vec = await embedQuery(s.query);
+        if (vec) {
+            vectors.set(s.query, vec);
+            const raw = await vectorSearchTypesense('off_foods', vec, k * 2);
+            rawHits.set(s.query, raw.map((d: any) => String(d.barcode)));
+            if (raw.length) top1Similarity.set(s.query, 1 - (raw[0]._vectorDistance ?? 1));
+        }
+    }
+    process.stdout.write(`  [run] ${label} (pooling=${pooling}) done — ${hits.size} seeds\n`);
+    return { pooling, label, hits, vectors, rawHits, top1Similarity };
+}
+
+function recallAt(run: RunResult, seeds: Seed[], k: number): { hit: number; total: number; any: number } {
+    let hit = 0, any = 0;
+    for (const s of seeds) {
+        const ids = run.hits.get(s.query) ?? [];
+        if (ids.length > 0) any++;
+        if (ids.slice(0, k).includes(s.target)) hit++;
+    }
+    return { hit, total: seeds.length, any };
+}
+
+function rawRecallAt(run: RunResult, seeds: Seed[], k: number): number {
+    let hit = 0;
+    for (const s of seeds) {
+        if ((run.rawHits.get(s.query) ?? []).slice(0, k).includes(s.barcode)) hit++;
+    }
+    return hit;
+}
+
+/** Seeds whose returned id list differs between two runs. */
+function diffSeeds(a: RunResult, b: RunResult, seeds: Seed[]): string[] {
+    const out: string[] = [];
+    for (const s of seeds) {
+        const x = (a.hits.get(s.query) ?? []).join('|');
+        const y = (b.hits.get(s.query) ?? []).join('|');
+        if (x !== y) out.push(s.query);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------- main
+
+async function main(): Promise<number> {
+    const args = process.argv.slice(2);
+    const arg = (flag: string, dflt: string) => {
+        const i = args.indexOf(flag);
+        return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : dflt;
+    };
+    const limit = Number(arg('--limit', '50'));
+    const k = Number(arg('--k', '10'));
+    const jsonOut = arg('--json', '');
+
+    if (process.env.SEMANTIC_SEARCH_ENABLED !== 'true') {
+        console.error('FAIL: SEMANTIC_SEARCH_ENABLED is not "true" — embedQuery() returns null and every '
+            + 'run would score 0 for a reason that has nothing to do with pooling.');
+        return 2;
+    }
+    if (!process.env.TYPESENSE_API_KEY) {
+        console.error('FAIL: TYPESENSE_API_KEY unset.');
+        return 2;
+    }
+
+    const evalDir = __dirname;
+    const { seeds: allSeeds, eligible } = loadSeeds(evalDir);
+    console.log(`[seeds] ${eligible} eligible identity repoints with an off_ target (post-revert)`);
+
+    // Verify each target is really in the index with a vector. A target the index
+    // lacks scores 0 under both poolings and dilutes the A/B.
+    const usable: Seed[] = [];
+    const rejected: string[] = [];
+    for (const s of allSeeds) {
+        const doc = await tsGetDoc(s.barcode);
+        if (!doc) { rejected.push(`${s.query} -> ${s.barcode} (not in off_foods)`); continue; }
+        if (!Array.isArray(doc.embedding) || doc.embedding.length !== DIM) {
+            rejected.push(`${s.query} -> ${s.barcode} (no ${DIM}-d embedding)`); continue;
+        }
+        s.docName = doc.name ?? '';
+        s.docBrand = doc.brandName ?? null;
+        (s as any)._stored = doc.embedding as number[];
+        usable.push(s);
+    }
+    console.log(`[seeds] ${usable.length} targets present in off_foods with a ${DIM}-d vector; `
+        + `${rejected.length} rejected`);
+    for (const r of rejected.slice(0, 10)) console.log(`        reject: ${r}`);
+    if (usable.length === 0) { console.error('FAIL: no usable seeds.'); return 2; }
+
+    const seeds = limit > 0 ? usable.slice(0, limit) : usable;
+    console.log(`[seeds] using ${seeds.length} (limit=${limit || 'all'}), recall@${k}\n`);
+
+    // ---- C4: which pooling is the corpus actually in? (positive control)
+    console.log('[C4] corpus-pooling re-derivation — re-embed each doc text, cosine vs its STORED vector');
+    const { pipeline } = await import('@huggingface/transformers');
+    const docExtractor = await pipeline('feature-extraction', MODEL_ID, { dtype: 'fp32' });
+    const sample = seeds.slice(0, 5);
+    const c4: { barcode: string; cls: number; mean: number }[] = [];
+    for (const s of sample) {
+        const text = docText(s.docName, s.docBrand);
+        const outCls = await docExtractor(text, { pooling: 'cls', normalize: true });
+        const outMean = await docExtractor(text, { pooling: 'mean', normalize: true });
+        const stored = (s as any)._stored as number[];
+        c4.push({
+            barcode: s.barcode,
+            cls: cosine(Array.from(outCls.data as Float32Array), stored),
+            mean: cosine(Array.from(outMean.data as Float32Array), stored),
+        });
+        console.log(`     ${s.barcode}  cls=${c4[c4.length - 1].cls.toFixed(5)}  `
+            + `mean=${c4[c4.length - 1].mean.toFixed(5)}  "${text.slice(0, 56)}"`);
+    }
+    const clsAvg = c4.reduce((a, r) => a + r.cls, 0) / c4.length;
+    const meanAvg = c4.reduce((a, r) => a + r.mean, 0) / c4.length;
+    const corpusIs: Pooling = clsAvg >= meanAvg ? 'cls' : 'mean';
+    const c4Pass = Math.abs(clsAvg - meanAvg) > 0.01;
+    console.log(`     -> corpus reproduces best under '${corpusIs}' (cls ${clsAvg.toFixed(5)} vs `
+        + `mean ${meanAvg.toFixed(5)}) — ${c4Pass ? 'CONCLUSIVE' : 'INCONCLUSIVE, the two poolings agree'}\n`);
+
+    // ---- the A/B plus the same-pooling repeats, one process, one loaded model
+    const runs: Record<string, RunResult> = {};
+    runs.clsA = await runOnce(seeds, 'cls', 'cls run A', k);
+    runs.meanA = await runOnce(seeds, 'mean', 'mean run A', k);
+    runs.clsB = await runOnce(seeds, 'cls', 'cls run B (control)', k);
+    runs.meanB = await runOnce(seeds, 'mean', 'mean run B (control)', k);
+    console.log('');
+
+    // ---- controls
+    const c1cls = diffSeeds(runs.clsA, runs.clsB, seeds);
+    const c1mean = diffSeeds(runs.meanA, runs.meanB, seeds);
+    const c1Pass = c1cls.length === 0 && c1mean.length === 0;
+
+    const sep = seeds
+        .map(s => {
+            const a = runs.clsA.vectors.get(s.query);
+            const b = runs.meanA.vectors.get(s.query);
+            return a && b ? cosine(a, b) : null;
+        })
+        .filter((x): x is number => x !== null);
+    const sepMax = sep.length ? Math.max(...sep) : 1;
+    const sepAvg = sep.length ? sep.reduce((a, b) => a + b, 0) / sep.length : 1;
+    const c2Pass = sep.length > 0 && sepMax < 0.999;
+
+    const c3 = diffSeeds(runs.clsA, runs.meanA, seeds);
+    const c3Pass = c3.length > 0;
+
+    // ---- recall
+    const rows: { label: string; pooling: Pooling; r1: number; r5: number; rk: number; any: number; raw: number }[] = [];
+    for (const key of ['clsA', 'meanA'] as const) {
+        const r = runs[key];
+        rows.push({
+            label: r.label,
+            pooling: r.pooling,
+            r1: recallAt(r, seeds, 1).hit,
+            r5: recallAt(r, seeds, 5).hit,
+            rk: recallAt(r, seeds, k).hit,
+            any: recallAt(r, seeds, k).any,
+            raw: rawRecallAt(r, seeds, k),
+        });
+    }
+
+    const N = seeds.length;
+    console.log('================ RESULT ================');
+    console.log(`seeds=${N}  k=${k}  corpus pooling (measured)='${corpusIs}'`);
+    console.log('');
+    console.log('pooling |  R@1        R@5        R@10       returned>=1  rawANN R@10');
+    for (const r of rows) {
+        console.log(
+            `${r.pooling.padEnd(7)} | `
+            + `${String(r.r1).padStart(3)} ${pct(r.r1, N).padStart(6)}  `
+            + `${String(r.r5).padStart(3)} ${pct(r.r5, N).padStart(6)}  `
+            + `${String(r.rk).padStart(3)} ${pct(r.rk, N).padStart(6)}  `
+            + `${String(r.any).padStart(3)} ${pct(r.any, N).padStart(6)}   `
+            + `${String(r.raw).padStart(3)} ${pct(r.raw, N).padStart(6)}`,
+        );
+    }
+    const cls = rows.find(r => r.pooling === 'cls')!;
+    const mn = rows.find(r => r.pooling === 'mean')!;
+    console.log('');
+    console.log(`delta (cls - mean): R@1 ${cls.r1 - mn.r1 >= 0 ? '+' : ''}${cls.r1 - mn.r1}`
+        + `  R@5 ${cls.r5 - mn.r5 >= 0 ? '+' : ''}${cls.r5 - mn.r5}`
+        + `  R@${k} ${cls.rk - mn.rk >= 0 ? '+' : ''}${cls.rk - mn.rk}`
+        + `  returned>=1 ${cls.any - mn.any >= 0 ? '+' : ''}${cls.any - mn.any}`
+        + `  rawANN ${cls.raw - mn.raw >= 0 ? '+' : ''}${cls.raw - mn.raw}`);
+
+    // per-seed movement on the target
+    const gained: string[] = [], lost: string[] = [];
+    for (const s of seeds) {
+        const inCls = (runs.clsA.hits.get(s.query) ?? []).slice(0, k).includes(s.target);
+        const inMean = (runs.meanA.hits.get(s.query) ?? []).slice(0, k).includes(s.target);
+        if (inCls && !inMean) gained.push(s.query);
+        if (!inCls && inMean) lost.push(s.query);
+    }
+    console.log('');
+    console.log(`target found by cls only (${gained.length}): ${gained.join(', ') || '—'}`);
+    console.log(`target found by mean only (${lost.length}): ${lost.join(', ') || '—'}`);
+
+    // ---- similarity shift: the MECHANISM behind any `returned>=1` movement.
+    // searchOffSemantic drops every hit below SEMANTIC_MIN_SIMILARITY (0.72). A
+    // query embedded in the wrong space sits further from every document, so the
+    // gate discards the whole result set — a recall loss that never shows up as a
+    // reordering. This block measures the shift directly, pre-gate.
+    const SIM_GATE = 0.72;
+    const simStats = (r: RunResult) => {
+        const xs = seeds.map(s => r.top1Similarity.get(s.query)).filter((x): x is number => x !== undefined);
+        const sorted = [...xs].sort((a, b) => a - b);
+        return {
+            n: xs.length,
+            avg: xs.reduce((a, b) => a + b, 0) / (xs.length || 1),
+            median: sorted[Math.floor(sorted.length / 2)] ?? 0,
+            min: sorted[0] ?? 0,
+            aboveGate: xs.filter(x => x >= SIM_GATE).length,
+        };
+    };
+    const sc = simStats(runs.clsA), sm = simStats(runs.meanA);
+    console.log('');
+    console.log(`top-1 ANN similarity (pre-gate, gate=${SIM_GATE}):`);
+    console.log(`  cls   avg ${sc.avg.toFixed(4)}  median ${sc.median.toFixed(4)}  min ${sc.min.toFixed(4)}  `
+        + `>=gate ${sc.aboveGate}/${sc.n}`);
+    console.log(`  mean  avg ${sm.avg.toFixed(4)}  median ${sm.median.toFixed(4)}  min ${sm.min.toFixed(4)}  `
+        + `>=gate ${sm.aboveGate}/${sm.n}`);
+    console.log(`  shift avg ${(sc.avg - sm.avg >= 0 ? '+' : '')}${(sc.avg - sm.avg).toFixed(4)}  `
+        + `queries clearing the gate ${(sc.aboveGate - sm.aboveGate >= 0 ? '+' : '')}${sc.aboveGate - sm.aboveGate}`);
+
+    console.log('');
+    console.log('================ CONTROLS ================');
+    console.log(`C1 same-pooling repeat .......... ${c1Pass ? 'PASS' : 'FAIL'}  `
+        + `cls A/B differ on ${c1cls.length}/${N}, mean A/B differ on ${c1mean.length}/${N} (both must be 0)`);
+    if (c1cls.length) console.log(`   cls movers: ${c1cls.slice(0, 8).join(', ')}`);
+    if (c1mean.length) console.log(`   mean movers: ${c1mean.slice(0, 8).join(', ')}`);
+    console.log(`C2 query-vector separation ...... ${c2Pass ? 'PASS' : 'FAIL'}  `
+        + `cos(cls,mean) avg ${sepAvg.toFixed(4)}, max ${sepMax.toFixed(4)} (must be < 0.999)`);
+    console.log(`C3 result-set separation ........ ${c3Pass ? 'PASS' : 'FAIL'}  `
+        + `${c3.length}/${N} seeds return a different list under cls vs mean (must be > 0)`);
+    console.log(`C4 corpus-pooling re-derivation .. ${c4Pass ? 'PASS' : 'FAIL'}  `
+        + `stored vectors reproduce at cls ${clsAvg.toFixed(5)} / mean ${meanAvg.toFixed(5)}`);
+    const allPass = c1Pass && c2Pass && c3Pass && c4Pass;
+    console.log('');
+    console.log(allPass
+        ? 'All controls PASS — the recall numbers above are evidence.'
+        : 'A CONTROL FAILED — the recall numbers above are NOT evidence. Read the control lines.');
+
+    if (jsonOut) {
+        const payload = {
+            measuredAt: new Date().toISOString(),
+            typesenseHost: tsHost(),
+            seedCount: N, k, corpusPooling: corpusIs,
+            recall: rows,
+            top1Similarity: { gate: SIM_GATE, cls: sc, mean: sm },
+            controls: {
+                c1SamePoolingRepeat: { pass: c1Pass, clsMovers: c1cls, meanMovers: c1mean },
+                c2QueryVectorSeparation: { pass: c2Pass, avgCosine: sepAvg, maxCosine: sepMax },
+                c3ResultSetSeparation: { pass: c3Pass, differingSeeds: c3 },
+                c4CorpusPooling: { pass: c4Pass, clsAvg, meanAvg, sample: c4 },
+            },
+            gainedByCls: gained,
+            lostByCls: lost,
+            perSeed: seeds.map(s => ({
+                query: s.query, target: s.target, severity: s.severity, source: s.source,
+                cls: runs.clsA.hits.get(s.query) ?? [],
+                mean: runs.meanA.hits.get(s.query) ?? [],
+            })),
+        };
+        fs.writeFileSync(jsonOut, JSON.stringify(payload, null, 2));
+        console.log(`\n[json] wrote ${jsonOut}`);
+    }
+
+    return allPass ? 0 : 1;
+}
+
+if (require.main === module) {
+    main()
+        .then(c => process.exit(c))
+        .catch(e => { console.error(e); process.exit(2); });
+}

--- a/src/lib/mapping/corrupt-mark.ts
+++ b/src/lib/mapping/corrupt-mark.ts
@@ -38,6 +38,7 @@ export type CorruptDirection =
     // detect-corrupt-panel.ts
     | 'panel-low'
     | 'panel-inflated'
+    | 'panel-inflated-family'
     // detect-corrupt-nutrition.ts
     | 'panel-inflated-serving'
     | 'kcal-impossible'
@@ -81,6 +82,23 @@ export interface CorruptScanFlag {
     /** panel-inflated-serving only: the raw inputs the rule is computed from, so
      *  decideMark() can re-run the entire rule instead of trusting `value`. */
     panel?: ServingScalePanel;
+    /** panel-inflated-family only: the group-quality measurements the family
+     *  tier rests on, so decideMark() can re-derive the whole verdict from
+     *  measurements rather than trusting the scan's conclusion. */
+    family?: FamilyGroupEvidence;
+}
+
+/** The family-tier reference distribution, as measured at scan time.
+ *  `relMad` is median(|x - med|) / med over the family's kcal100 values — a
+ *  dispersion measure that is robust to the corrupt members themselves. */
+export interface FamilyGroupEvidence {
+    /** family grouping key the row was scored against (audit trail only) */
+    key: string;
+    relMad: number;
+    /** UNROUNDED family median. CorruptScanFlag.siblingMedian is rounded for
+     *  display, and rounding a small median (a 0.3 kcal/100g diet-soda family)
+     *  changes the verdict, so re-verification reads this field. */
+    median: number;
 }
 
 /** Raw per-100g panel plus the row's own serving mass — the complete input set
@@ -102,6 +120,167 @@ export const MAX_TRUSTABLE_SIBLING_MEDIAN = 920;
 /** panel-inflated flags lean entirely on the sibling distribution; small groups
  *  are dominated by a few bad rows. Triage review set this floor. */
 export const MIN_INFLATED_GROUP_SIZE = 8;
+
+// ---- panel-inflated-family thresholds (COARSER-GROUPING per-serving-panel rule) ----
+//
+// Same defect as `panel-inflated`: a per-SERVING / whole-container panel stored
+// in the per-100g fields, so kcal100 sits ~servingGrams/100 ABOVE the family's
+// true density. What differs is only HOW SIBLINGS ARE FOUND.
+//
+// `panel-inflated` groups by exact normalizeNameKey() equality, which is a
+// token-SET identity: one extra brand or flavour token puts a row in its own
+// group. Measured on the live corpus 2026-07-31 (scripts/eval/_probe_group_sizes
+// methodology, reproduced by detect-corrupt-panel.ts's own pass-1 counters):
+// 661,150 of 1,083,139 kcal-bearing rows (61.0%) sit in groups below MIN_GROUP=4
+// and are therefore never signature-tested at all, rising monotonically with
+// name length — 25.5% at one token to 98.3% at eight or more. The family tier
+// groups on the row's DISCRIMINATIVE tokens instead, which reaches those rows.
+//
+// A coarser group is a WEAKER reference, so every threshold below is stricter
+// than the exact-key tier's, and each one is set from a measured false-positive
+// audit rather than by inspection (see detect-corrupt-panel.ts's header).
+
+/** The family reference must be a real product family, not one fused ingredient
+ *  word. Measured: allowing single-token families takes the flag set from 201 to
+ *  731 rows, and the 530 additions are dominated by correct densities scored
+ *  against a fused median (beef tenderloin 229 kcal/100g vs a `filet` median of
+ *  132; root beer 45 kcal/100ml vs an `ale` median of 37). */
+export const FAMILY_MIN_TOKENS = 2;
+/** Larger than MIN_INFLATED_GROUP_SIZE's motivation but the same value: a coarse
+ *  group needs at least as many members as an exact one before its median is
+ *  load-bearing. */
+export const FAMILY_MIN_GROUP = 8;
+/** median(|x - med|)/med of the family's kcal100 values. A real product family is
+ *  tight; a fused one is not, and fusion is this tier's whole failure mode.
+ *  Measured: relaxing 0.10 -> 0.15 adds 36 rows of which the hand audit read the
+ *  large majority as correct densities (normal-density burritos at 205 kcal/100g
+ *  against a `carne con` median of 113, pork loin chops at 270 against 152). */
+export const FAMILY_MAX_REL_MAD = 0.10;
+/** |kcal100 * 100/S - med| <= tol * med. The exact-key tier uses 0.30; the family
+ *  tier's reference is weaker so it buys precision here. Measured on the audited
+ *  62-row set: tightening 0.30 -> 0.15 removes 7 of 15 false positives for 5 true
+ *  positives, moving the audited FP rate from 24% to ~17%. */
+export const FAMILY_RESCALE_TOL = 0.15;
+/** Stored kcal100 must exceed the family median by at least this factor. Shared
+ *  with the exact-key tier so the two tiers detect the same shape. */
+export const FAMILY_INFLATED_RATIO = 1.6;
+/** Real EAN/UPC/GTIN barcodes are at most 14 digits and this corpus's real ones
+ *  are <= 13. Longer barcodes are the OFF chain-restaurant import, which carries
+ *  a DIFFERENT corruption (the panel DIVIDED by serving scale — see
+ *  detect-panel-scale-divided.ts) whose repair runs the OPPOSITE direction. The
+ *  audit found ~15 such rows (White Castle / Jersey Mike's / Dunkin') inside the
+ *  loose family flag set; excluding them structurally is why no threshold has to
+ *  try to tell the two families apart by value. */
+export const MAX_REAL_GTIN_LENGTH = 13;
+/** Serving-mass window, matching the exact-key tier: below 2 g or above 600 g the
+ *  field is not a single eating occasion, and 90-110 g cannot distinguish a
+ *  per-serving panel from a correct per-100g one at all. */
+export const FAMILY_SERVING_MIN_G = 2;
+export const FAMILY_SERVING_MAX_G = 600;
+export const FAMILY_DEAD_ZONE_MIN_G = 90;
+export const FAMILY_DEAD_ZONE_MAX_G = 110;
+
+/**
+ * MEASURED false-positive rate of the panel-inflated-family flag set on the
+ * LIVE corpus — 9 of 31 rows, hand-audited 2026-07-31 against each row's own
+ * macro panel and servingSize string (1 further row undecidable and excluded
+ * from the ratio; counting it as a miss gives 32.3%).
+ *
+ * A constant with a test, deliberately, because this project has shipped a rule
+ * that scored 100% on its fixture and false-evicted 73.8% of the real cache
+ * (D1_FALSE_EVICT_RATE_REAL_CACHE in scripts/eval/correctness-screen.ts). A
+ * future "the fixture is green, let's auto-mark these" now has to argue with a
+ * number instead of with the fixture.
+ *
+ * WHY IT IS HIGHER THAN THE PRE-DEDUPE AUDIT (24% over 62 rows). Tier 2 only
+ * ever sees rows tier 1 did not already decide, and the rows tier 1 catches are
+ * the easy ones — juices, milks, single-container drinks. What is left is
+ * enriched in the hard mode.
+ *
+ * THE FALSE-POSITIVE MODE, characterised so a reviewer can recognise it: a
+ * PREPARED COMPOSITE DISH whose correct per-100g density genuinely runs 1.6-2.2x
+ * a family median that plainer members dilute — Tesco nduja ravioli 223 vs a
+ * `mascarpone nduja` median of 126, M&S roast potatoes 159 vs a `mari piper`
+ * median of 83, Wallaby 2% Greek yogurt 76 vs a `lowfat milkfat` median of 46.
+ * Every one of them has a NORMAL macro sum (20-45 g/100g); the true positives
+ * almost all carry a macro sum impossible for their food type (Factor ready
+ * meals at 94-103 g/100g, microwave rice at 91) or an impossible single macro
+ * for a liquid (Core Power at 42 g protein/100 mL).
+ *
+ * CONSEQUENCE, and it is the operative one: this flag set is a REVIEW QUEUE,
+ * not a mark list. decideMark() returning true means "the rule still holds on
+ * today's measurements", never "this row is corrupt".
+ */
+export const FAMILY_TIER_AUDITED_FP_RATE = 9 / 31;
+
+/** Why a row is NOT a panel-inflated-family candidate. Doubles as the
+ *  MarkDecision skip code, so a refusal always names the failing condition. */
+export type FamilyRejection =
+    | 'family_evidence_missing'
+    | 'family_barcode_not_real_gtin'
+    | 'family_group_too_small'
+    | 'family_median_implausible'
+    | 'family_dispersion_too_high'
+    | 'family_serving_out_of_window'
+    | 'family_serving_in_dead_zone'
+    | 'family_not_inflated_vs_median'
+    | 'family_rescale_misses_median';
+
+/** The measurements the panel-inflated-family verdict is computed from. Every
+ *  field is a raw observation; nothing here is a conclusion of the scan. */
+export interface FamilyScaleInputs {
+    barcode: string;
+    kcal100: number;
+    servingGrams: number;
+    familyMedian: number;
+    groupSize: number;
+    relMad: number;
+}
+
+/**
+ * The panel-inflated-family rule. Returns null when the row IS a candidate,
+ * otherwise the first failing condition.
+ *
+ * Exported as a named refusal rather than a boolean for the same reason
+ * rejectPanelInflatedServing() is: both the scan and decideMark() re-run it, and
+ * a named refusal is what makes the marker's re-verification auditable.
+ */
+export function rejectPanelInflatedFamily(
+    input: FamilyScaleInputs | null | undefined
+): FamilyRejection | null {
+    if (
+        !input ||
+        typeof input.barcode !== 'string' || !input.barcode.length ||
+        !isFinite(input.kcal100) || input.kcal100 <= 0 ||
+        !isFinite(input.servingGrams) ||
+        !isFinite(input.familyMedian) || input.familyMedian <= 0 ||
+        !isFinite(input.groupSize) ||
+        !isFinite(input.relMad) || input.relMad < 0
+    ) {
+        return 'family_evidence_missing';
+    }
+    if (input.barcode.length > MAX_REAL_GTIN_LENGTH) return 'family_barcode_not_real_gtin';
+    if (input.groupSize < FAMILY_MIN_GROUP) return 'family_group_too_small';
+    // The mass-INFLATED family (maraschino-cherry name groups with medians of
+    // ~3200) is a different corruption in which the plausible-looking row is the
+    // corrupt one. Testing it here inverts the verdict, so it stays excluded.
+    if (input.familyMedian > MAX_TRUSTABLE_SIBLING_MEDIAN) return 'family_median_implausible';
+    if (input.relMad > FAMILY_MAX_REL_MAD) return 'family_dispersion_too_high';
+    if (input.servingGrams < FAMILY_SERVING_MIN_G || input.servingGrams > FAMILY_SERVING_MAX_G) {
+        return 'family_serving_out_of_window';
+    }
+    if (input.servingGrams > FAMILY_DEAD_ZONE_MIN_G && input.servingGrams < FAMILY_DEAD_ZONE_MAX_G) {
+        return 'family_serving_in_dead_zone';
+    }
+    if (input.kcal100 < FAMILY_INFLATED_RATIO * input.familyMedian) {
+        return 'family_not_inflated_vs_median';
+    }
+    const rescaled = input.kcal100 * (100 / input.servingGrams);
+    if (Math.abs(rescaled - input.familyMedian) > FAMILY_RESCALE_TOL * input.familyMedian) {
+        return 'family_rescale_misses_median';
+    }
+    return null;
+}
 
 // ---- detect-corrupt-nutrition.ts thresholds (corpus-mark tier) ----
 // These sit deliberately ABOVE the rank/save-time gate bounds in
@@ -252,7 +431,8 @@ export type MarkDecision =
               | 'value_below_threshold'
               | 'outlier_group_too_small'
               | 'outlier_below_thresholds'
-              | ServingScaleRejection;
+              | ServingScaleRejection
+              | FamilyRejection;
       };
 
 /**
@@ -276,6 +456,25 @@ export function decideMark(flag: CorruptScanFlag): MarkDecision {
                 return { mark: false, skip: 'inflated_group_too_small' };
             }
             return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        case 'panel-inflated-family': {
+            // Same re-verification discipline as panel-inflated-serving: the rule
+            // is re-run from the raw measurements the scan recorded, so a stale or
+            // hand-edited scan file can only ever mark rows the rule still flags.
+            const rejection = rejectPanelInflatedFamily(
+                flag.family
+                    ? {
+                          barcode: flag.barcode,
+                          kcal100: flag.kcal100,
+                          servingGrams: flag.servingGrams ?? NaN,
+                          familyMedian: flag.family.median,
+                          groupSize: flag.groupSize,
+                          relMad: flag.family.relMad,
+                      }
+                    : null
+            );
+            if (rejection) return { mark: false, skip: rejection };
+            return { mark: true, reason: `${flag.direction}:${flag.tier}` };
+        }
         case 'panel-inflated-serving': {
             // Strictest re-verification of the set: the whole rule is re-run from
             // the raw panel the scan recorded, so `value` (and any hand edit to

--- a/src/lib/search/__tests__/query-embedding-pooling.test.ts
+++ b/src/lib/search/__tests__/query-embedding-pooling.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The pooling contract: QUERIES and DOCUMENTS must be pooled the same way, or
+ * they sit in different vector spaces and every cosine is meaningless.
+ *
+ * This defect shipped and survived for months because nothing connected the two
+ * sides. `scripts/embed-off-cpu.ts` wrote documents with `pooling: 'cls'`,
+ * `embedQuery()` embedded queries with `pooling: 'mean'`, both were internally
+ * consistent, and the golden set's five `search/semantic` cases scored 5/5 right
+ * through it (backend `sync-docs/backend_integration_guide.md`). A gate that
+ * looks at one side can never see this; the only thing that can is a check that
+ * compares the two sides to each other.
+ *
+ * These assertions read the SOURCE TEXT of the writer scripts on purpose. The
+ * document pooling is a call-site literal inside a batch loop, not an exported
+ * value, so importing the module would drag in Prisma and the ONNX stack and
+ * still not expose the argument. Grepping the literal is what actually pins it.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { CORPUS_POOLING } from '../query-embedding';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const read = (rel: string) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+/**
+ * Comments must be stripped first, and that is not incidental: embed-off-cpu.ts's
+ * header discusses BOTH poolings at length, so a naive scan reads the prose as
+ * two conflicting document poolings and the test fails on a file that is correct.
+ */
+function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** `pooling: 'x'` in executable code only. */
+function poolingLiterals(source: string): string[] {
+    const out: string[] = [];
+    const re = /pooling\s*[:=]\s*["']([a-z]+)["']/g;
+    let m: RegExpExecArray | null;
+    const code = stripComments(source);
+    while ((m = re.exec(code)) !== null) out.push(m[1]);
+    return out;
+}
+
+describe('pooling contract: queries and documents share one vector space', () => {
+    it('embed-off-cpu.ts writes document vectors with exactly one pooling', () => {
+        const found = poolingLiterals(read('scripts/embed-off-cpu.ts'));
+        expect(found.length).toBeGreaterThan(0);
+        expect(new Set(found).size).toBe(1);
+    });
+
+    it("the query side's CORPUS_POOLING equals the pooling embed-off-cpu.ts writes", () => {
+        const [docPooling] = poolingLiterals(read('scripts/embed-off-cpu.ts'));
+        expect(CORPUS_POOLING).toBe(docPooling);
+    });
+
+    it('the Python GPU embedder states no pooling of its own — so this check CANNOT cover it', () => {
+        // UNVERIFIABLE FROM SOURCE, stated rather than asserted away. embed_foods.py
+        // wrote the original corpus via bare `SentenceTransformer(MODEL_NAME)` and
+        // `model.encode(...)`; the pooling is whatever the model repo's
+        // 1_Pooling/config.json says (CLS for bge-small-en-v1.5), and the script
+        // never names it. So no source-text assertion can pin that side. What DOES
+        // pin it empirically is scripts/eval/semantic-recall-probe.ts control C4,
+        // which re-embeds a stored document and cosines it against its live vector.
+        // This test only guards that the file stays in that shape: the moment it
+        // grows an explicit pooling argument, that argument must be compared here.
+        const src = stripComments(read('scripts/embed_foods.py'))
+            .replace(/^\s*#.*$/gm, '')
+            .replace(/"""[\s\S]*?"""/g, '');
+        expect(poolingLiterals(src)).toHaveLength(0);
+        expect(src).toMatch(/SentenceTransformer\(/);
+    });
+
+    it('embedQuery does not hardcode a pooling literal — it must resolve one', () => {
+        // A literal here is how the two sides drifted apart in the first place.
+        const src = read('src/lib/search/query-embedding.ts');
+        const inExtractorCall = /extractor\([^)]*pooling\s*:\s*["']/s.test(src);
+        expect(inExtractorCall).toBe(false);
+        expect(src).toContain('resolveQueryPooling');
+    });
+
+    it('EMBED_QUERY_POOLING is documented in .env.example', () => {
+        // The `check` CI job enforces this for src/**; state it here too so the knob
+        // cannot be added quietly.
+        expect(read('.env.example')).toContain('EMBED_QUERY_POOLING');
+    });
+});

--- a/src/lib/search/query-embedding.ts
+++ b/src/lib/search/query-embedding.ts
@@ -49,8 +49,10 @@ export const CORPUS_POOLING: QueryPooling = 'cls';
 /**
  * Diagnostic override, read per call so a probe can A/B both poolings in one
  * process against one loaded model. NOT a tuning knob: any value other than the
- * corpus pooling puts queries in the wrong space, so it warns every time it is
- * honoured. Unset (the production case) means `CORPUS_POOLING`.
+ * corpus pooling puts queries in the wrong space, and warns when honoured.
+ * Setting it to the corpus pooling is a no-op and stays silent; an unparseable
+ * value warns and falls back. Unset or empty (the production case) means
+ * `CORPUS_POOLING`.
  */
 function resolveQueryPooling(): QueryPooling {
     const raw = process.env.EMBED_QUERY_POOLING;

--- a/src/lib/search/query-embedding.ts
+++ b/src/lib/search/query-embedding.ts
@@ -21,6 +21,50 @@ const BGE_QUERY_PREFIX = 'Represent this sentence for searching relevant passage
 
 export const SEMANTIC_SEARCH_ENABLED = process.env.SEMANTIC_SEARCH_ENABLED === 'true';
 
+export type QueryPooling = 'cls' | 'mean';
+
+/**
+ * POOLING MUST MATCH THE CORPUS, AND THE CORPUS IS CLS.
+ *
+ * `scripts/embed-off-cpu.ts` writes document vectors with an explicit
+ * `pooling: 'cls'`. `scripts/embed_foods.py`, which wrote the original corpus,
+ * states no pooling at all — it calls `SentenceTransformer(...).encode()` and
+ * inherits whatever the model repo's `1_Pooling/config.json` specifies, so its
+ * side is settled by MEASUREMENT, not by reading it: re-embedding stored rows
+ * reproduces their live vectors at cosine 1.00000 under 'cls' and ~0.947 under
+ * 'mean' (measured 2026-07-30, re-measured 2026-07-31 over 5 sampled OFF rows;
+ * re-derive with `scripts/eval/semantic-recall-probe.ts`, control C4).
+ * This file embedded queries with 'mean' from the start, so
+ * queries and documents sat in different vector spaces — a silent recall tax
+ * that the golden set could not see (`search/semantic` scored 5/5 through it).
+ * BGE's own documented usage is CLS on both sides, so the query side was the
+ * wrong one. Changed to 'cls' on 2026-07-31.
+ *
+ * If document vectors are ever rewritten with a different pooling, this constant
+ * moves in the SAME commit. `scripts/eval/semantic-recall-probe.ts` measures the
+ * difference and re-derives which pooling the live corpus is actually in.
+ */
+export const CORPUS_POOLING: QueryPooling = 'cls';
+
+/**
+ * Diagnostic override, read per call so a probe can A/B both poolings in one
+ * process against one loaded model. NOT a tuning knob: any value other than the
+ * corpus pooling puts queries in the wrong space, so it warns every time it is
+ * honoured. Unset (the production case) means `CORPUS_POOLING`.
+ */
+function resolveQueryPooling(): QueryPooling {
+    const raw = process.env.EMBED_QUERY_POOLING;
+    if (!raw) return CORPUS_POOLING;
+    if (raw !== 'cls' && raw !== 'mean') {
+        logger.warn('embedding.pooling_override_invalid', { value: raw, using: CORPUS_POOLING });
+        return CORPUS_POOLING;
+    }
+    if (raw !== CORPUS_POOLING) {
+        logger.warn('embedding.pooling_override_mismatched_corpus', { override: raw, corpus: CORPUS_POOLING });
+    }
+    return raw;
+}
+
 let extractorPromise: Promise<any> | null = null;
 
 function getExtractor(): Promise<any> {
@@ -52,9 +96,10 @@ export async function embedQuery(text: string): Promise<number[] | null> {
 
     try {
         const extractor = await getExtractor();
+        const pooling = resolveQueryPooling();
         const started = Date.now();
-        const output = await extractor(BGE_QUERY_PREFIX + cleaned, { pooling: 'mean', normalize: true });
-        logger.debug('embedding.query_embedded', { text: cleaned, embedMs: Date.now() - started });
+        const output = await extractor(BGE_QUERY_PREFIX + cleaned, { pooling, normalize: true });
+        logger.debug('embedding.query_embedded', { text: cleaned, pooling, embedMs: Date.now() - started });
         return Array.from(output.data as Float32Array);
     } catch (err) {
         logger.warn('embedding.query_embed_failed', { text: cleaned, error: (err as Error).message });

--- a/src/lib/servings/__tests__/default-count-grams.test.ts
+++ b/src/lib/servings/__tests__/default-count-grams.test.ts
@@ -30,3 +30,49 @@ describe('getDefaultCountServing — breaded chicken pieces (n-mq-21)', () => {
         expect(getDefaultCountServing('beef tenderloin', 'each')).toBeNull();
     });
 });
+
+/**
+ * Anchored on golden n-svk-05: "1 sleeve saltine crackers".
+ *
+ * A sleeve is a CONTAINER unit, so the 4g per-piece 'cracker' seed is barred
+ * from answering it and the request fell through to the AI estimator — which
+ * PERSISTS its draw. When the 2026-07-30 OFF refresh deleted every derived
+ * OffServing row, the redraw returned 200g (it had been 150g) and upsertServing
+ * made that permanent, so the case went from intermittently right to reliably
+ * wrong. The deterministic rung below removes the estimator from this path.
+ *
+ * These tests exist to catch the two ways the rung can rot: silently ceasing to
+ * match (back to the dice), or widening to foods it was never measured for.
+ */
+describe('getDefaultCountServing — cracker sleeves (n-svk-05)', () => {
+    it('resolves a saltine sleeve deterministically, inside the golden band', () => {
+        const r = getDefaultCountServing('Saltine crackers', 'sleeve');
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBe(113);
+        // The golden assertion for n-svk-05 is grams ∈ [70, 170]. Pin the band,
+        // not just the value: a future re-estimate that stays in band is fine,
+        // one that drifts out is the regression this case is about.
+        expect(r!.grams).toBeGreaterThanOrEqual(70);
+        expect(r!.grams).toBeLessThanOrEqual(170);
+    });
+
+    it('matches the bare brandless name too', () => {
+        expect(getDefaultCountServing('Saltines', 'sleeve')?.grams).toBe(113);
+    });
+
+    it('REJECTS the 200g value that the persisted AI draw produced', () => {
+        // The literal defect. If this ever passes at 200 the rung is bypassed.
+        expect(getDefaultCountServing('Saltine crackers', 'sleeve')?.grams).not.toBe(200);
+    });
+
+    it('does NOT answer a sleeve for crackers it was never measured for', () => {
+        // 113g is derived from a saltine box (453g / 4 sleeves). It is not a
+        // general "cracker sleeve" constant, and must not become one.
+        expect(getDefaultCountServing('Ritz crackers', 'sleeve')).toBeNull();
+        expect(getDefaultCountServing('Graham crackers', 'sleeve')).toBeNull();
+    });
+
+    it('still returns the per-piece weight when the unit is a cracker, not a sleeve', () => {
+        expect(getDefaultCountServing('Saltine crackers', 'cracker')?.grams).toBe(4);
+    });
+});

--- a/src/lib/servings/default-count-grams.ts
+++ b/src/lib/servings/default-count-grams.ts
@@ -167,6 +167,22 @@ const COUNT_DEFAULTS: Record<string, SeedEntry> = {
     // ===== OTHER COMMON ITEMS =====
     'cookie': { grams: 30, confidence: 0.7, sizes: { small: 15, medium: 30, large: 45 }, aliases: ['cookies'] },
     'cracker': { grams: 4, confidence: 0.75, aliases: ['crackers'] },
+    // A cracker SLEEVE is a container unit, so the 4g per-piece seed above is
+    // structurally barred from answering it (see CONTAINER_UNITS below) and the
+    // request falls through to the AI estimator. That estimator PERSISTS what it
+    // draws: after the 2026-07-30 refresh deleted every derived OffServing row,
+    // the redraw came back 200g (was 150g) and upsertServing made it permanent,
+    // turning golden case n-svk-05 into a standing red. A deterministic rung
+    // stops the dice being rolled at all.
+    // DERIVED, not measured: no saltine product in the OFF corpus carries a
+    // sleeve serving (checked 2026-07-31 — servings are per-cracker, 25-48g).
+    // 113g = the corpus's own 453g box (barcode 0011224490904 "Saltines", i.e.
+    // 1 lb) over the standard 4 sleeves. Sits mid-band against the golden
+    // assertion [70,170], and near the 150g the system used pre-refresh.
+    'saltine crackers sleeve': {
+        grams: 113, confidence: 0.8,
+        aliases: ['sleeve saltine crackers', 'sleeve of saltine crackers', 'saltines sleeve', 'sleeve saltines'],
+    },
     'olive': { grams: 4, confidence: 0.8, sizes: { small: 3, medium: 4, large: 5 }, aliases: ['olives'] },
     'kalamata olive': { grams: 4, confidence: 0.8, sizes: { small: 3, medium: 4, large: 5 }, aliases: ['kalamata olives', 'kalamata'] },
     'pickle': { grams: 35, confidence: 0.75, aliases: ['pickles'] },


### PR DESCRIPTION
Three independent defects surfaced while recovering from the 2026-07-30 OFF corpus refresh. They ship together because they were found together; each commit stands alone.

## What is in here

**1. `fix(search)` — query pooling matched to the CLS corpus.** `embedQuery()` hardcoded `pooling:'mean'` against a CLS-pooled corpus.

The result is worth reading even if you skim the rest: **recall@10 is unchanged, 58 vs 58** over 135 identity seeds with verified barcodes. The plan that specified this work named a recall probe as the success metric, and on that metric the honest verdict is "not a real problem, close it."

The effect is one layer down. `searchOffSemantic()` discards every hit below `SEMANTIC_MIN_SIMILARITY = 0.72`; mean pooling depressed top-1 similarity from 0.8748 to 0.8249, so **10 of 135 queries (7.4%) had their entire semantic result set thrown away** and the lane contributed nothing. Gate clearance: 85.9% → 93.3%.

`dtype` was measured alongside and is **closed, not deferred** — q8 vs fp32 sit at cosine 0.99794 and do not move the gate.

**2. `feat(eval)` — family-grouping tier for the corrupt-panel detector.** The detector was not missing a rule; it was missing the rows. Siblings group by exact `normalizeNameKey(name)` needing `MIN_GROUP=4`, so **661,150 of 1,083,139 kcal-bearing rows (61.0%) were never signature-tested at all**. The axis is name *length*, not brandedness — 25.5% unreachable at one token, 98.3% at eight or more.

Tier 1 is byte-identical (verified by diffing two scan reports: 0 added, 0 lost). Tier 2 adds 31 flags at a hand-audited **29.0% FP rate** — it is a review queue, not a mark list, and the code says so.

**3. `fix(servings)` — deterministic rung for a cracker sleeve.** `DELETE FROM "OffServing"` during the refresh took the *derived* servings; the estimator redrew a saltine sleeve at 200 g and `upsertServing` persisted it, turning an intermittent failure into a permanent one. 113 g is **derived, not measured**, and the comment says exactly how (453 g box ÷ 4 sleeves) — flagged for review rather than presented as settled.

**4. `chore(doc-check)` — registry 54 → 59.** Two tripwires fired and were deleted as their own text instructed. Three replacements are *structural* greps rather than state checks, because the refresh blast-radius table has now been wrong twice in the same way, and "enumerate harder" is not a fix when enumerating is what failed.

## Verification

- `npx tsc --noEmit` clean · `npm run lint:ci` 0 errors (587 warnings, cap 700) · `npx jest` **126 suites / 2,810 tests**
- `npm run doc-check` **59/59**
- Mutation-tested: detector 12/12 killed (after adding an *input*, not an assertion, for the one survivor); serving rung 1 and 3 kills for its two mutations
- The semantic probe fails *itself* (exit 1) when both arms are forced to the same pooling, rather than reporting flat numbers as evidence

## Not verified here

The box runs the pre-fix build, so **`eval:golden` has not gated the pooling change**. Baseline to beat: search 103/105, 0 real failures. It must be gated separately from the mark restoration — that was a data op, this moves live ranking, and one variable at a time.

## Deploy ordering — matters

The serving rung must be **deployed before** the poisoned `OffServing` row (id 4256709) is deleted. Deleting first, against a build without the rung, just re-rolls the estimator and may persist another bad draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu