### PR TITLE
fix(off): regenerate packageQuantity in the ingest, and restore the wiped column

### DIFF
--- a/scripts/backfill-off-package-quantity.ts
+++ b/scripts/backfill-off-package-quantity.ts
@@ -2,17 +2,27 @@
  * backfill-off-package-quantity.ts — populate OffFood.packageQuantity(+Unit)
  * from OFF's CSV export (Cluster A pt2 Defect 3, Jul 2026).
  *
- * The OFF CSV carries `product_quantity` (normalized net quantity, g or ml)
- * and the raw `quantity` label string ("591 ml", "1.75 L") that our JSONL
- * ingest never selected. This streams the CSV, collects (barcode, quantity,
- * unit) for rows with a usable product_quantity, loads them into a temp table
- * on ONE connection (transaction-pinned), and joins onto OffFood — barcodes we
- * never ingested are simply skipped by the join.
+ * The OFF export carries `product_quantity` (normalized net quantity, g or ml)
+ * and the raw `quantity` label string ("591 ml", "1.75 L"). This streams the
+ * file, collects (barcode, quantity, unit) for rows with a usable
+ * product_quantity, loads them into a temp table on ONE connection
+ * (transaction-pinned), and joins onto OffFood — barcodes we never ingested
+ * are simply skipped by the join.
  *
- * Run on the Mini-PC (CSV + Postgres both local; node streaming keeps RAM low):
+ * SCOPE: this is a REPAIR tool, not the pipeline. Since 2026-07-31 the normal
+ * ingest writes these columns itself (product_quantity/quantity are in
+ * off-parquet-to-jsonl.sh's SELECT and parseOffProduct() reads them), so a
+ * fresh rebuild no longer needs this script. Keep it for repairing a corpus
+ * ingested before that fix — e.g. the 2026-07-30 refresh, which left the
+ * column at 0 of 1,085,525 rows.
+ *
+ * Run on the box (input + Postgres both local; node streaming keeps RAM low):
  *   ts-node --project tsconfig.scripts.json --transpile-only \
  *     -r tsconfig-paths/register scripts/backfill-off-package-quantity.ts \
- *     ~/Recipe-App/data/openfoodfacts.csv.gz
+ *     ~/Downloads/off-package-quantity-2026-07-31.csv.gz [--dry-run]
+ *
+ * --dry-run reports how many OffFood rows the join WOULD touch, then rolls
+ * back. Production writes to a 1M-row table deserve a measured count first.
  */
 
 import 'dotenv/config';
@@ -21,27 +31,71 @@ import path from 'path';
 import readline from 'readline';
 import zlib from 'zlib';
 import { PrismaClient, Prisma } from '@prisma/client';
+import { parsePackageQuantity } from './lib/off-parse';
 
 // 1-indexed tab-separated columns of the OFF CSV export (verified 2026-07-19
 // against the Apr-2026 file: 1=code, 14=quantity, 73=product_quantity).
-const COL_CODE = 0;
-const COL_QUANTITY = 13;
-const COL_PRODUCT_QUANTITY = 72;
+const TSV_COL_CODE = 0;
+const TSV_COL_QUANTITY = 13;
+const TSV_COL_PRODUCT_QUANTITY = 72;
 
 const INSERT_BATCH = 5000;
 
-/** 'ml' for volume-labeled packages, 'g' for weight-labeled, null if unclear. */
-function inferUnit(quantityStr: string): 'g' | 'ml' | null {
-    const s = quantityStr.toLowerCase();
-    if (/\d\s*(ml|cl|dl|l|litre|liter|fl\s*\.?\s*oz)\b/.test(s)) return 'ml';
-    if (/\d\s*(g|gr|grams?|kg|mg|oz|lbs?|pounds?)\b/.test(s)) return 'g';
-    return null;
+/**
+ * Two input shapes are accepted, chosen by sniffing the header line:
+ *
+ *  - `tsv`: OFF's own full CSV export (tab-separated, ~200 columns, fixed
+ *    positions above). What the original 2026-07-19 backfill consumed.
+ *  - `csv`: a narrow comma-separated extract with a
+ *    `code,product_quantity,product_quantity_unit,quantity` header, produced
+ *    by a DuckDB SELECT straight off the Parquet export. Far cheaper than
+ *    re-downloading the 9GB CSV when only these fields are wanted.
+ *
+ * Columns are located BY NAME in csv mode, so extra/reordered columns are fine.
+ */
+type Layout = { split: (line: string) => string[]; code: number; qty: number; label: number };
+
+/** RFC4180-ish field splitter: honours "quoted, fields" and "" escapes. */
+function splitCsv(line: string): string[] {
+    const out: string[] = [];
+    let field = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const c = line[i];
+        if (inQuotes) {
+            if (c === '"') {
+                if (line[i + 1] === '"') { field += '"'; i++; } else { inQuotes = false; }
+            } else field += c;
+        } else if (c === '"') inQuotes = true;
+        else if (c === ',') { out.push(field); field = ''; }
+        else field += c;
+    }
+    out.push(field);
+    return out;
+}
+
+function detectLayout(header: string): Layout {
+    if (header.includes('\t')) {
+        return {
+            split: (l) => l.split('\t'),
+            code: TSV_COL_CODE, qty: TSV_COL_PRODUCT_QUANTITY, label: TSV_COL_QUANTITY,
+        };
+    }
+    const cols = splitCsv(header).map(c => c.trim().replace(/^﻿/, ''));
+    const at = (name: string) => {
+        const i = cols.indexOf(name);
+        if (i < 0) throw new Error(`CSV header is missing required column "${name}" (saw: ${cols.join(', ')})`);
+        return i;
+    };
+    return { split: splitCsv, code: at('code'), qty: at('product_quantity'), label: at('quantity') };
 }
 
 async function main() {
-    const csvPath = process.argv[2];
+    const args = process.argv.slice(2);
+    const dryRun = args.includes('--dry-run');
+    const csvPath = args.find(a => !a.startsWith('--'));
     if (!csvPath || !fs.existsSync(csvPath)) {
-        console.error('Usage: backfill-off-package-quantity.ts <openfoodfacts.csv[.gz]>');
+        console.error('Usage: backfill-off-package-quantity.ts <off-export.csv[.gz]> [--dry-run]');
         process.exit(1);
     }
 
@@ -53,27 +107,33 @@ async function main() {
     // Collect qualifying rows first (tiny objects; ~1.3M rows ≈ manageable),
     // then load in one transaction so the temp table stays on one connection.
     const rows: Array<{ barcode: string; qty: number; unit: string | null }> = [];
+    let layout: Layout | null = null;
     let lineNo = 0;
     for await (const line of rl) {
         lineNo++;
-        if (lineNo === 1) continue; // header
-        const cols = line.split('\t');
-        const barcode = cols[COL_CODE];
-        const pq = Number(cols[COL_PRODUCT_QUANTITY]);
-        if (!barcode || !Number.isFinite(pq) || pq <= 0 || pq > 100000) continue;
-        const quantityStr = cols[COL_QUANTITY] ?? '';
-        // Multipacks ("6 x 355 ml"): product_quantity is the TOTAL, which
-        // would overbill "1 bottle" by the pack count. Skip them.
-        if (/\d\s*[x×*]\s*\d/i.test(quantityStr)) continue;
+        if (lineNo === 1) { layout = detectLayout(line); continue; }
+        const cols = layout!.split(line);
+        const barcode = cols[layout!.code];
+        if (!barcode) continue;
+        // Qualification (bounds + the multipack rejection) is shared with the
+        // ingest so the two writers of this column cannot drift apart.
+        const pkg = parsePackageQuantity(cols[layout!.qty], cols[layout!.label] ?? '');
+        if (!pkg) continue;
         // Buffer round-trip detaches the barcode from its parent line: V8's
         // split() returns sliced strings that pin the ENTIRE multi-KB CSV line
         // in memory — retaining 1M+ of those OOMs a 4GB heap.
-        rows.push({ barcode: Buffer.from(barcode).toString(), qty: pq, unit: inferUnit(quantityStr) });
+        rows.push({ barcode: Buffer.from(barcode).toString(), qty: pkg.quantity, unit: pkg.unit });
         if (rows.length % 200000 === 0) console.log(`collected ${rows.length.toLocaleString()} (scanned ${lineNo.toLocaleString()})`);
     }
     console.log(`CSV done: ${rows.length.toLocaleString()} rows with product_quantity (of ${lineNo.toLocaleString()} scanned).`);
 
-    const updated = await prisma.$transaction(async (tx) => {
+    // Dry run executes the real UPDATE and then aborts the transaction, so the
+    // reported count is the actual join result, not an estimate of it.
+    class DryRunAbort extends Error { constructor(readonly count: number) { super('dry-run'); } }
+
+    let updated: number;
+    try {
+        updated = await prisma.$transaction(async (tx) => {
         await tx.$executeRawUnsafe(
             `CREATE TEMP TABLE pkg_tmp (barcode TEXT PRIMARY KEY, qty DOUBLE PRECISION, unit TEXT) ON COMMIT DROP`);
         for (let i = 0; i < rows.length; i += INSERT_BATCH) {
@@ -86,8 +146,17 @@ async function main() {
             UPDATE "OffFood" f
             SET "packageQuantity" = t.qty, "packageQuantityUnit" = t.unit
             FROM pkg_tmp t WHERE f.barcode = t.barcode`);
+        if (dryRun) throw new DryRunAbort(n);
         return n;
-    }, { timeout: 1000 * 60 * 30 });
+        }, { timeout: 1000 * 60 * 30 });
+    } catch (err) {
+        if (err instanceof DryRunAbort) {
+            console.log(`\n🔎 DRY RUN — rolled back. ${err.count.toLocaleString()} OffFood rows WOULD be updated.`);
+            await prisma.$disconnect();
+            return;
+        }
+        throw err;
+    }
 
     console.log(`\n✅ Done. ${updated.toLocaleString()} OffFood rows now carry packageQuantity.`);
     await prisma.$disconnect();

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Doc-claims registry. Every entry: the claim as its owner doc states it, the ONE doc that owns the fact, the command that re-derives it, the expected value, and the date last measured. Run: npm run doc-check (or npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts). A failing claim means the DOC is now wrong \u2014 fix the owner doc AND this entry together, with a fresh date. Contexts: backend = this repo, mobile = KindaHealthyMobile repo, box = the OptiPlex (ssh when not local). The box has no copy of the mobile repo, so its nightly run uses --where backend,box; mobile claims are covered from the Mac.",
+  "$comment": "Doc-claims registry. Every entry: the claim as its owner doc states it, the ONE doc that owns the fact, the command that re-derives it, the expected value, and the date last measured. Run: npm run doc-check (or npx ts-node --project tsconfig.scripts.json --transpile-only scripts/doc-check/run-doc-check.ts). A failing claim means the DOC is now wrong — fix the owner doc AND this entry together, with a fresh date. Contexts: backend = this repo, mobile = KindaHealthyMobile repo, box = the OptiPlex (ssh when not local). The box has no copy of the mobile repo, so its nightly run uses --where backend,box; mobile claims are covered from the Mac.",
   "claims": [
     {
       "id": "attribution-client-sources",
@@ -99,7 +99,7 @@
     },
     {
       "id": "search-route-key-only",
-      "claim": "/api/foods/search has no bearer-token path \u2014 key-only auth (part of why item #23 is not a one-liner)",
+      "claim": "/api/foods/search has no bearer-token path — key-only auth (part of why item #23 is not a one-liner)",
       "ownerDoc": "mobile:sync-docs/sprint_execution_progress.md",
       "where": "backend",
       "command": "grep -cE 'Authorization|Bearer' src/app/api/foods/search/route.ts",
@@ -159,7 +159,7 @@
     },
     {
       "id": "search-uses-gathercandidates",
-      "claim": "Manual search calls the same gatherCandidates() as the mapper \u2014 retrieval is shared; the pick layer is the gap",
+      "claim": "Manual search calls the same gatherCandidates() as the mapper — retrieval is shared; the pick layer is the gap",
       "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
       "where": "backend",
       "command": "grep -c 'gatherCandidates' src/app/api/foods/search/route.ts",
@@ -171,7 +171,7 @@
     },
     {
       "id": "coverage-dominance-not-implemented",
-      "claim": "No CODE implements a coverage-dominance partition \u2014 the term exists only in golden-set case notes as a PROPOSED fix (it was once misdocumented as shipped)",
+      "claim": "No CODE implements a coverage-dominance partition — the term exists only in golden-set case notes as a PROPOSED fix (it was once misdocumented as shipped)",
       "ownerDoc": "mobile:sync-docs/reports/2026-07-29_search-unification-plan.md",
       "where": "backend",
       "command": "grep -rl 'coverage-dominance' src --include='*.ts' --include='*.tsx' | wc -l",
@@ -195,7 +195,7 @@
     },
     {
       "id": "tsc-baseline-30-total-0-src",
-      "claim": "Mobile `npx tsc --noEmit` exits non-zero on exactly 30 pre-existing errors, 0 of them under src/ \u2014 all backend probe scripts Syncthing'd into sync-docs/. Needs an installed toolchain, so it runs on a dev machine, not the box.",
+      "claim": "Mobile `npx tsc --noEmit` exits non-zero on exactly 30 pre-existing errors, 0 of them under src/ — all backend probe scripts Syncthing'd into sync-docs/. Needs an installed toolchain, so it runs on a dev machine, not the box.",
       "ownerDoc": "mobile:CLAUDE.md#ci",
       "where": "devmachine",
       "command": "npx tsc --noEmit 2>&1 | awk '/error TS/{t++} /^src\\// {s++} END{print t\":\"s+0}'",
@@ -208,7 +208,7 @@
     },
     {
       "id": "mobile-no-ci",
-      "claim": "The mobile repo has no CI \u2014 no .github directory at all; every gate is local",
+      "claim": "The mobile repo has no CI — no .github directory at all; every gate is local",
       "ownerDoc": "mobile:CLAUDE.md#ci",
       "where": "mobile",
       "command": "test -d .github && echo present || echo none",
@@ -232,7 +232,7 @@
     },
     {
       "id": "resolve-default-serving-five-sites",
-      "claim": "resolveDefaultServing() is called at exactly 5 sites in logging.tsx \u2014 the ONE way to pick a card's starting weight",
+      "claim": "resolveDefaultServing() is called at exactly 5 sites in logging.tsx — the ONE way to pick a card's starting weight",
       "ownerDoc": "mobile:CLAUDE.md#logging-traps",
       "where": "mobile",
       "command": "grep -c 'resolveDefaultServing(' 'src/app/(tabs)/logging.tsx'",
@@ -244,7 +244,7 @@
     },
     {
       "id": "resolve-watcher-gate",
-      "claim": "The resolve watcher is gated on status==='loading' && !item.foodId \u2014 mapped items must be constructed as 'success'",
+      "claim": "The resolve watcher is gated on status==='loading' && !item.foodId — mapped items must be constructed as 'success'",
       "ownerDoc": "mobile:CLAUDE.md#logging-traps",
       "where": "mobile",
       "command": "grep -c \"status === 'loading' && !item.foodId\" 'src/app/(tabs)/logging.tsx'",
@@ -256,7 +256,7 @@
     },
     {
       "id": "parsed-to-staged-wired",
-      "claim": "handleParse routes mapper output through stagedItemsFromParsed (src/lib/parsed-to-staged.ts) \u2014 never spreads a parse item onto a card",
+      "claim": "handleParse routes mapper output through stagedItemsFromParsed (src/lib/parsed-to-staged.ts) — never spreads a parse item onto a card",
       "ownerDoc": "mobile:plans/v1/api-contract.md",
       "where": "mobile",
       "command": "grep -c 'stagedItemsFromParsed' 'src/app/(tabs)/logging.tsx'",
@@ -280,7 +280,7 @@
     },
     {
       "id": "source-check-nullable",
-      "claim": "food_log_items.source is CHECK-constrained but nullable (no NOT NULL) \u2014 the basis of the toDbSource total-function safety argument",
+      "claim": "food_log_items.source is CHECK-constrained but nullable (no NOT NULL) — the basis of the toDbSource total-function safety argument",
       "ownerDoc": "mobile:plans/v1/api-contract.md",
       "where": "mobile",
       "command": "grep -c 'source TEXT CHECK' supabase/migrations/001_mobile_schema.sql",
@@ -292,7 +292,7 @@
     },
     {
       "id": "sprint-s4-total",
-      "claim": "Sprint plan \u00a74 numbered items: 54 (re-derive, never trust the prose total)",
+      "claim": "Sprint plan §4 numbered items: 54 (re-derive, never trust the prose total)",
       "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
       "where": "mobile",
       "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\.'",
@@ -304,7 +304,7 @@
     },
     {
       "id": "sprint-s4-struck",
-      "claim": "Sprint plan \u00a74 struck items: 6 (struck \u00a74 items are 'N. ~~' list lines, NOT '| ~~' table rows \u2014 that pattern only fits \u00a75)",
+      "claim": "Sprint plan §4 struck items: 6 (struck §4 items are 'N. ~~' list lines, NOT '| ~~' table rows — that pattern only fits §5)",
       "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
       "where": "mobile",
       "command": "awk '/^## 4\\. Open/,/^## 5\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^[0-9]+\\. ~~'",
@@ -316,7 +316,7 @@
     },
     {
       "id": "sprint-s5-struck",
-      "claim": "Sprint plan \u00a75 struck rows: 11",
+      "claim": "Sprint plan §5 struck rows: 11",
       "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
       "where": "mobile",
       "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| ~~'",
@@ -328,7 +328,7 @@
     },
     {
       "id": "citations-zero-normative-docs",
-      "claim": "Zero file.ts:123-style line citations in normative docs (CLAUDE.md, plans/v1, sync-docs top level, log/README, the search plan) \u2014 symbols, not line numbers",
+      "claim": "Zero file.ts:123-style line citations in normative docs (CLAUDE.md, plans/v1, sync-docs top level, log/README, the search plan) — symbols, not line numbers",
       "ownerDoc": "mobile:CLAUDE.md#doc-rules",
       "where": "mobile",
       "command": "grep -roE '[a-zA-Z0-9_/.-]+\\.(ts|tsx|sql|json|js):[0-9]+' CLAUDE.md plans/v1 sync-docs/*.md sync-docs/log/README.md sync-docs/reports/2026-07-29_search-unification-plan.md 2>/dev/null | wc -l",
@@ -340,7 +340,7 @@
     },
     {
       "id": "banners-zero-normative-docs",
-      "claim": "No blanket verification banners in normative docs \u2014 they are how stale pointers survive",
+      "claim": "No blanket verification banners in normative docs — they are how stale pointers survive",
       "ownerDoc": "mobile:CLAUDE.md#doc-rules",
       "where": "mobile",
       "command": "grep -riE 'every [a-z ]+ below (was|were) (re-)?verified' CLAUDE.md plans/v1 sync-docs/*.md 2>/dev/null | wc -l",
@@ -364,7 +364,7 @@
     },
     {
       "id": "fatsecret-live-wire",
-      "claim": "Live search returns FatSecret rows (consumer-side proof the lane runs \u2014 verify at the consumer, not just the producer)",
+      "claim": "Live search returns FatSecret rows (consumer-side proof the lane runs — verify at the consumer, not just the producer)",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "key=$(grep \"^DEV_API_KEY=\" /home/owner/Recipe-App/.env | cut -d= -f2- | tr -d '\"'); best=0; for i in 1 2 3; do n=$(curl -s --max-time 30 \"http://localhost:3000/api/foods/search?s=chobani+greek+yogurt&local=true&api_key=${key:-adminAPI_dev_key_bypass}\" | grep -c '\"source\":\"fatsecret\"'); [ \"$n\" -gt \"$best\" ] && best=$n; [ \"$best\" -gt 0 ] && break; sleep 10; done; echo $best",
@@ -401,7 +401,7 @@
     },
     {
       "id": "aigen-zero-fatsecret-rows",
-      "claim": "AiGeneratedFood contains zero FatSecret-derived rows \u2014 why the fatsecret-cache label must render NO badge",
+      "claim": "AiGeneratedFood contains zero FatSecret-derived rows — why the fatsecret-cache label must render NO badge",
       "ownerDoc": "mobile:CLAUDE.md#attribution",
       "where": "box",
       "command": "docker exec mealspire-db psql -U postgres -d mealspire -t -A -c 'SELECT COUNT(*) FROM \"AiGeneratedFood\" WHERE \"aiModel\" ILIKE $$%fatsecret%$$'",
@@ -413,7 +413,7 @@
     },
     {
       "id": "box-git-stignored",
-      "claim": "The box's .stignore excludes .git \u2014 why the box's git state is meaningless and content hashes are the only comparison",
+      "claim": "The box's .stignore excludes .git — why the box's git state is meaningless and content hashes are the only comparison",
       "ownerDoc": "mobile:CLAUDE.md#deploy",
       "where": "box",
       "command": "grep -c '\\.git' /home/owner/Recipe-App/.stignore",
@@ -425,7 +425,7 @@
     },
     {
       "id": "claude-md-doc-pointers-resolve",
-      "claim": "Every sync-docs/ or plans/ markdown path cited in CLAUDE.md exists in this repo \u2014 a dead pointer in the read-now tier sends the next reader nowhere",
+      "claim": "Every sync-docs/ or plans/ markdown path cited in CLAUDE.md exists in this repo — a dead pointer in the read-now tier sends the next reader nowhere",
       "ownerDoc": "mobile:CLAUDE.md#doc-rules",
       "where": "mobile",
       "command": "grep -oE '`(sync-docs|plans)/[A-Za-z0-9_/.-]+\\.md`' CLAUDE.md | tr -d '`' | sort -u | while read p; do [ -e \"$p\" ] || echo \"$p\"; done | wc -l",
@@ -437,7 +437,7 @@
     },
     {
       "id": "read-now-tier-within-budget",
-      "claim": "The read-now tier (CLAUDE.md + the newest 2 files in sync-docs/log/) is at most 1,500 lines \u2014 the agreed reading budget",
+      "claim": "The read-now tier (CLAUDE.md + the newest 2 files in sync-docs/log/) is at most 1,500 lines — the agreed reading budget",
       "ownerDoc": "mobile:CLAUDE.md#reading",
       "where": "mobile",
       "command": "{ cat CLAUDE.md; ls -1t sync-docs/log/2026-*.md | head -2 | xargs cat; } | wc -l",
@@ -449,7 +449,7 @@
     },
     {
       "id": "handoff-format-retired",
-      "claim": "No handoff_*.md survives at the sync-docs top level \u2014 sync-docs/log/README.md declares that format replaced by session write-offs, and the 7 that remained were archived 2026-07-30",
+      "claim": "No handoff_*.md survives at the sync-docs top level — sync-docs/log/README.md declares that format replaced by session write-offs, and the 7 that remained were archived 2026-07-30",
       "ownerDoc": "mobile:sync-docs/log/README.md",
       "where": "mobile",
       "command": "ls sync-docs/handoff_*.md 2>/dev/null | wc -l",
@@ -461,7 +461,7 @@
     },
     {
       "id": "eval-golden-npm-script",
-      "claim": "npm run eval:golden runs the golden-set harness (scripts/eval/run-eval.ts) \u2014 the command CLAUDE.md's read-now tier names for running the eval",
+      "claim": "npm run eval:golden runs the golden-set harness (scripts/eval/run-eval.ts) — the command CLAUDE.md's read-now tier names for running the eval",
       "ownerDoc": "mobile:CLAUDE.md#commands",
       "where": "backend",
       "command": "node -e \"const s=require('./package.json').scripts['eval:golden']||'';process.stdout.write(String(s.includes('scripts/eval/run-eval.ts')?1:0))\"",
@@ -473,7 +473,7 @@
     },
     {
       "id": "doc-check-timer-installed-on-box",
-      "claim": "The nightly doc-claims checker is installed and enabled on the box (doc-check.timer, 04:50) \u2014 installed 2026-07-30 and verified by a manual run that exited 0",
+      "claim": "The nightly doc-claims checker is installed and enabled on the box (doc-check.timer, 04:50) — installed 2026-07-30 and verified by a manual run that exited 0",
       "ownerDoc": "mobile:CLAUDE.md#deploying-the-backend",
       "where": "box",
       "command": "systemctl --user is-enabled doc-check.timer 2>/dev/null",
@@ -485,7 +485,7 @@
     },
     {
       "id": "sprint-s5-total",
-      "claim": "Sprint plan \u00a75 numbered rows: 51 \u2014 the doc states this at the head of \u00a75 and it moves with every edit",
+      "claim": "Sprint plan §5 numbered rows: 51 — the doc states this at the head of §5 and it moves with every edit",
       "ownerDoc": "mobile:sync-docs/sprint_plan_2026-07-28_queue_execution.md",
       "where": "mobile",
       "command": "awk '/^## 5\\./,/^## 6\\./' sync-docs/sprint_plan_2026-07-28_queue_execution.md | grep -cE '^\\| (~~)?\\*?\\*?[0-9]'",
@@ -497,7 +497,7 @@
     },
     {
       "id": "log-writeoffs-under-50-lines",
-      "claim": "Every session write-off in sync-docs/log/ is within the 50-line hard cap its README sets \u2014 the rule most likely to erode, since the pressure to exceed it is highest on the sessions worth recording",
+      "claim": "Every session write-off in sync-docs/log/ is within the 50-line hard cap its README sets — the rule most likely to erode, since the pressure to exceed it is highest on the sessions worth recording",
       "ownerDoc": "mobile:sync-docs/log/README.md",
       "where": "mobile",
       "command": "for f in sync-docs/log/2026-*.md; do n=$(wc -l < \"$f\"); [ \"$n\" -gt 50 ] && echo \"$f:$n\"; done | wc -l",
@@ -509,7 +509,7 @@
     },
     {
       "id": "off-ingest-timers-enabled",
-      "claim": "Both OFF ingest timers are enabled on the box \u2014 off-delta.timer (weekly) and off-parquet-refresh.timer (quarterly), installed 2026-07-30 after the Mini-PC retirement left the corpus with no refresh path at all",
+      "claim": "Both OFF ingest timers are enabled on the box — off-delta.timer (weekly) and off-parquet-refresh.timer (quarterly), installed 2026-07-30 after the Mini-PC retirement left the corpus with no refresh path at all",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "systemctl --user is-enabled off-delta.timer off-parquet-refresh.timer 2>/dev/null | sort -u | tr -d '\\n'",
@@ -521,7 +521,7 @@
     },
     {
       "id": "off-delta-cursor-fresh",
-      "claim": "The OFF delta cursor is inside its ~14-day retention window \u2014 outside it, un-ingested changes are only recoverable by a full Parquet re-ingest",
+      "claim": "The OFF delta cursor is inside its ~14-day retention window — outside it, un-ingested changes are only recoverable by a full Parquet re-ingest",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "node -e \"const s=require(process.env.HOME+'/Recipe-App/data/off-delta-state.json');process.stdout.write(String(Math.floor((Date.now()/1000-s.lastProcessedEnd)/86400)))\"",
@@ -533,7 +533,7 @@
     },
     {
       "id": "parquet-refresh-preflight-passes",
-      "claim": "The quarterly Parquet refresh's preflight passes on the box (duckdb, both TS entrypoints, ts-node, DATABASE_URL, >=15GB free, correct host) \u2014 the destructive run cannot be rehearsed, so this is the only advance warning that it would abort",
+      "claim": "The quarterly Parquet refresh's preflight passes on the box (duckdb, both TS entrypoints, ts-node, DATABASE_URL, >=15GB free, correct host) — the destructive run cannot be rehearsed, so this is the only advance warning that it would abort",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh --preflight-only >/dev/null 2>&1 && echo ok || echo broken",
@@ -545,7 +545,7 @@
     },
     {
       "id": "box-has-mobile-repo",
-      "claim": "The box holds a receive-only copy of the mobile repo at ~/KindaHealthyMobile (Syncthing folder msmwx-9fkha, added 2026-07-30) \u2014 this is what lets its nightly check mobile-context claims instead of skipping 15 of them",
+      "claim": "The box holds a receive-only copy of the mobile repo at ~/KindaHealthyMobile (Syncthing folder msmwx-9fkha, added 2026-07-30) — this is what lets its nightly check mobile-context claims instead of skipping 15 of them",
       "ownerDoc": "mobile:CLAUDE.md#machines--repos",
       "where": "box",
       "command": "test -f $HOME/KindaHealthyMobile/CLAUDE.md && test -d $HOME/KindaHealthyMobile/sync-docs/log && echo ok || echo missing",
@@ -557,7 +557,7 @@
     },
     {
       "id": "box-mobile-copy-stays-small",
-      "claim": "The box's mobile copy stays under 200MB \u2014 its ignores drop ios/, android/, assets/, node_modules and the sync-docs data dirs; without them it would pull the 2.4GB working tree",
+      "claim": "The box's mobile copy stays under 200MB — its ignores drop ios/, android/, assets/, node_modules and the sync-docs data dirs; without them it would pull the 2.4GB working tree",
       "ownerDoc": "mobile:CLAUDE.md#machines--repos",
       "where": "box",
       "command": "du -sm $HOME/KindaHealthyMobile 2>/dev/null | cut -f1",
@@ -569,7 +569,7 @@
     },
     {
       "id": "parquet-refresh-refuses-without-ack",
-      "claim": "The quarterly OFF refresh refuses (exit 3, nothing downloaded or written) unless a human sets OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 \u2014 it destroys ~1.07M pgvector embeddings and NULLs the OFF pointer on ~81% of FoodMapping cache rows, so the timer must never run it unattended",
+      "claim": "The quarterly OFF refresh refuses (exit 3, nothing downloaded or written) unless a human sets OFF_REFRESH_I_ACCEPT_DATA_LOSS=1 — it destroys ~1.07M pgvector embeddings and NULLs the OFF pointer on ~81% of FoodMapping cache rows, so the timer must never run it unattended",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "$HOME/Recipe-App/scripts/refresh-off-from-parquet.sh >/dev/null 2>&1; echo $?",
@@ -618,7 +618,7 @@
     },
     {
       "id": "off-refresh-does-not-preserve-marks",
-      "claim": "KNOWN DEFECT tripwire: refresh-off-from-parquet.sh does not snapshot/restore OffFood.corruptReason, so a --fresh rebuild silently destroys every curation mark (6,822 lost on 2026-07-30). When this claim FAILS the restore has been added \u2014 update the owner doc's 'The marks are data' section and delete this entry.",
+      "claim": "KNOWN DEFECT tripwire: refresh-off-from-parquet.sh does not snapshot/restore OffFood.corruptReason, so a --fresh rebuild silently destroys every curation mark (6,822 lost on 2026-07-30). When this claim FAILS the restore has been added — update the owner doc's 'The marks are data' section and delete this entry.",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "backend",
       "command": "grep -c 'corruptReason' scripts/refresh-off-from-parquet.sh || true",
@@ -665,32 +665,44 @@
       "verified": "2026-07-31"
     },
     {
-      "id": "off-package-quantity-wiped",
-      "claim": "KNOWN DEFECT tripwire: OffFood.packageQuantity is 0 rows after the 2026-07-30 refresh, which kills borrowSiblingPackageGrams() and with it the whole-package-count serving tier \u2014 branded unitless counts fall through to a flat 100 g floor. When this claim FAILS the backfill has been rerun; re-date the owner doc and delete this entry.",
+      "id": "off-package-quantity-restored",
+      "claim": "OffFood.packageQuantity was restored to 216,773 of 1,085,525 rows on 2026-07-31 (0 before), re-enabling borrowSiblingPackageGrams() and the whole-package-count serving tier. Restored by scripts/backfill-off-package-quantity.ts from a DuckDB Parquet extract; the dry run and the write both reported 216,773. Floor allows for later ingest growth.",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "box",
       "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT count(*) FROM \"OffFood\" WHERE \"packageQuantity\" IS NOT NULL;'",
       "expect": {
-        "kind": "count",
-        "value": "0"
+        "kind": "min",
+        "value": "200000"
       },
       "verified": "2026-07-31"
     },
     {
-      "id": "off-ingest-never-writes-package-quantity",
-      "claim": "STRUCTURAL DEFECT tripwire: ingest-off.ts contains no reference to quantity at all, so packageQuantity/packageQuantityUnit are written ONLY by the out-of-band CSV backfill and every --fresh rebuild destroys them permanently. The Parquet export does carry code/product_quantity/product_quantity_unit/quantity (verified remotely via duckdb parquet_schema 2026-07-31); the fix is to add them to off-parquet-to-jsonl.sh's SELECT and to the ingest. When this claim FAILS the pipeline regenerates the column itself.",
+      "id": "off-ingest-writes-package-quantity",
+      "claim": "STRUCTURAL FIX (2026-07-31): ingest-off.ts writes packageQuantity/packageQuantityUnit from parseOffProduct(), and off-parquet-to-jsonl.sh selects product_quantity + quantity, so a --fresh rebuild now REGENERATES the column instead of destroying it permanently. Before this the column was written only by the out-of-band CSV backfill, which is why the 2026-07-30 refresh left it at 0. If this claim FAILS the pipeline has regressed to destroying the column.",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "backend",
-      "command": "grep -ci 'quantity' scripts/ingest-off.ts || true",
+      "command": "grep -c 'packageQuantity' scripts/ingest-off.ts",
+      "expect": {
+        "kind": "min",
+        "value": "1"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-parquet-select-keeps-package-fields",
+      "claim": "off-parquet-to-jsonl.sh's SELECT emits both product_quantity and quantity. These are the ONLY source of OffFood.packageQuantity in the normal pipeline; dropping them from the SELECT is what made the 2026-07-30 refresh unrecoverable without an out-of-band backfill.",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
+      "where": "backend",
+      "command": "grep -cE '^[[:space:]]*(product_quantity|quantity),' scripts/off-parquet-to-jsonl.sh",
       "expect": {
         "kind": "count",
-        "value": "0"
+        "value": "2"
       },
       "verified": "2026-07-31"
     },
     {
       "id": "off-fresh-deletes-derived-servings",
-      "claim": "STRUCTURAL DEFECT tripwire: ingest-off.ts --fresh runs DELETE FROM \"OffServing\", which destroys the DERIVED servings (source ai / sibling_borrow), not just the OFF label rows. No snapshot covers them. This is the n-svk-05 mechanism: a cached 150 g 'sleeve' was deleted, the estimator redrew 200 g, and upsertServing persisted it \u2014 turning an intermittent bad sample into a permanent red.",
+      "claim": "STRUCTURAL DEFECT tripwire: ingest-off.ts --fresh runs DELETE FROM \"OffServing\", which destroys the DERIVED servings (source ai / sibling_borrow), not just the OFF label rows. No snapshot covers them. This is the n-svk-05 mechanism: a cached 150 g 'sleeve' was deleted, the estimator redrew 200 g, and upsertServing persisted it — turning an intermittent bad sample into a permanent red.",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",
       "where": "backend",
       "command": "grep -c 'DELETE FROM \"OffServing\"' scripts/ingest-off.ts",
@@ -702,7 +714,7 @@
     },
     {
       "id": "corrupt-detector-reachability-gap",
-      "claim": "Sibling grouping in detect-corrupt-panel.ts is a coverage decision: rows in exact-name groups below MIN_GROUP=4 are never signature-tested. Measured 2026-07-31: 661,150 of 1,083,139 kcal-bearing rows (61.0%). The axis is NAME LENGTH, not brandedness \u2014 25.5% unreachable at 1 token rising monotonically to 98.3% at 8+ tokens (branded 61.8% vs unbranded 58.9%). The scan prints these counters on every run so the number re-derives itself.",
+      "claim": "Sibling grouping in detect-corrupt-panel.ts is a coverage decision: rows in exact-name groups below MIN_GROUP=4 are never signature-tested. Measured 2026-07-31: 661,150 of 1,083,139 kcal-bearing rows (61.0%). The axis is NAME LENGTH, not brandedness — 25.5% unreachable at 1 token rising monotonically to 98.3% at 8+ tokens (branded 61.8% vs unbranded 58.9%). The scan prints these counters on every run so the number re-derives itself.",
       "ownerDoc": "mobile:sync-docs/mapping_investigation_playbook.md",
       "where": "backend",
       "command": "grep -c 'UNREACHABLE by tier 1' scripts/eval/detect-corrupt-panel.ts",

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -2530,8 +2530,7 @@
         20,
         30
       ],
-      "knownIssue": true,
-      "notes": "Multi-unit double-count is FIXED (2026-07-18): buildOffResult now divides a label serving by its unit-count (serving-resolver returns unitCount), so a '2 scoops (Xg)' label no longer bills Xg to one scoop. Residual 🟡 is a PRODUCT-SELECTION nuance, not a serving bug: the query now maps to the 'Orgain Organic Protein + Oatmilk' SKU (~45g/scoop per its own label) rather than the base 'Orgain Organic Protein Powder' (~23g/scoop) this range was written for. Both are real Orgain SKUs; 45g is per-label-correct for the one chosen. Revisit if we add product-line disambiguation."
+      "notes": "PROMOTED to a hard assertion 2026-07-31: now maps to the base 'Orgain Organic Protein Powder' SKU at 23g/scoop, inside the [20,30] band. | Previously: multi-unit double-count was FIXED (2026-07-18) — buildOffResult divides a label serving by its unit-count (serving-resolver returns unitCount), so a '2 scoops (Xg)' label no longer bills Xg to one scoop. The residual was a PRODUCT-SELECTION nuance, not a serving bug: the query mapped to the 'Orgain Organic Protein + Oatmilk' SKU (~45g/scoop per its own label) rather than the base SKU this range was written for. The product-line pick tightened after the 2026-07-31 query-pooling fix and packageQuantity restore."
     },
     {
       "id": "n-svg-01",
@@ -6144,7 +6143,7 @@
         ]
       ],
       "knownIssue": true,
-      "notes": "DEFECT (DETECTION + INGEST-BLOCKED). Bare 'c4' is NOT in brand-lexicon.json (only 'c4 energy'/'cellucor c4'), so isBranded/targetBrand never fire; degrades to generic 'fruit punch' (off_03855334, brand ''). No C4 SKU surfaced either. Needs a lexicon entry AND ingest before ranking could engage. knownIssue, non-gating."
+      "notes": "DEFECT (DETECTION + INGEST-BLOCKED). Bare 'c4' is NOT in brand-lexicon.json (only 'c4 energy'/'cellucor c4'), so isBranded/targetBrand never fire and no C4 SKU surfaces. Needs a lexicon entry AND ingest before ranking could engage. The MISS improved on 2026-07-31 (pooling fix + packageQuantity restore): it now lands on off_0810076291826 'Fruit Punch Pre Workout' (Jocko, labeled 19.8g scoop, 50.5 kcal/100g) instead of the brandless generic off_0041387322170 'Fruit Punch' billed at a flat 100g / 409 kcal. Right category, wrong brand — the assertion still fails on 'c4'. knownIssue, non-gating."
     },
     {
       "id": "n-brand-06",

--- a/scripts/eval/known-issue-baseline.json
+++ b/scripts/eval/known-issue-baseline.json
@@ -1,6 +1,6 @@
 {
   "_readme": "Recorded state of each knownIssue case. run-eval compares against this and reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the new values are understood to be the intended state. Writes MERGE: a filtered (--only/--grep) run refreshes only the pins it ran and leaves the rest intact.",
-  "writtenAt": "2026-07-30T17:12:09.410Z",
+  "writtenAt": "2026-07-31T18:07:08.000Z",
   "cases": {
     "s-typo-08": {
       "foodId": "off_9310653104835",
@@ -9,7 +9,7 @@
       "kcal100": 73.69999694824219,
       "abstained": false,
       "errored": false,
-      "itemCount": 20
+      "itemCount": 21
     },
     "s-typo-14": {
       "foodId": "off_5060929632145",
@@ -18,7 +18,7 @@
       "kcal100": 80,
       "abstained": false,
       "errored": false,
-      "itemCount": 22
+      "itemCount": 27
     },
     "n-supp-06": {
       "foodId": "off_0851770007795",
@@ -32,7 +32,7 @@
     "n-supp-12": {
       "foodId": "off_0810169607039",
       "foodName": "Ghost Clear Whey Blue Raspberry",
-      "grams": 22,
+      "grams": 21.5,
       "kcal100": 312.5,
       "abstained": false,
       "errored": false,
@@ -93,10 +93,10 @@
       "itemCount": 1
     },
     "n-brand-05": {
-      "foodId": "off_0041387322170",
-      "foodName": "Fruit Punch",
-      "grams": 100,
-      "kcal100": 409.0909118652344,
+      "foodId": "off_0810076291826",
+      "foodName": "Fruit Punch Pre Workout",
+      "grams": 19.8,
+      "kcal100": 50.5,
       "abstained": false,
       "errored": false,
       "itemCount": 1

--- a/scripts/ingest-off.ts
+++ b/scripts/ingest-off.ts
@@ -128,6 +128,8 @@ async function main() {
           },
           servingSize: d.servingSize,
           servingGrams: d.servingGrams,
+          packageQuantity: d.packageQuantity,
+          packageQuantityUnit: d.packageQuantityUnit,
         });
 
         // If a standard serving size was extracted, prepare an OffServing record

--- a/scripts/lib/off-parse.package-quantity.test.ts
+++ b/scripts/lib/off-parse.package-quantity.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Package-quantity extraction (OffFood.packageQuantity / packageQuantityUnit).
+ *
+ * These columns feed the whole-package-count serving tier. The 2026-07-30
+ * refresh left them at 0 of 1,085,525 rows because NOTHING in the ingest wrote
+ * them — the column existed only as a side effect of an out-of-band backfill.
+ * The end-to-end cases at the bottom exist specifically to fail if that wiring
+ * is ever removed again; the unit cases pin the qualification rules that the
+ * ingest and the backfill now share.
+ *
+ * Label strings are verbatim rows from the 2026-07-31 Parquet extract.
+ */
+
+import { parsePackageQuantity, inferPackageUnit, parseOffProduct } from './off-parse';
+
+describe('inferPackageUnit', () => {
+    it.each([
+        ['591 ml', 'ml'],
+        ['1.75 L', 'ml'],
+        ['33 cl', 'ml'],
+        ['8 fl oz', 'ml'],
+        ['12 fl. oz.', 'ml'],
+        ['350 g', 'g'],
+        ['2,5 kg', 'g'],
+        ['1 lb', 'g'],
+        ['16 oz', 'g'],
+    ])('reads %s as %s', (label, expected) => {
+        expect(inferPackageUnit(label)).toBe(expected);
+    });
+
+    it('returns null rather than guessing when the label carries no unit', () => {
+        // A wrong unit is worse than no unit: 'ml' and 'g' route to different
+        // package bands downstream.
+        expect(inferPackageUnit('1 piece')).toBeNull();
+        expect(inferPackageUnit('')).toBeNull();
+    });
+});
+
+describe('parsePackageQuantity', () => {
+    it('accepts a plain single-package row', () => {
+        expect(parsePackageQuantity(350, '350 g')).toEqual({ quantity: 350, unit: 'g' });
+    });
+
+    it('accepts a numeric string (CSV columns arrive as text)', () => {
+        expect(parsePackageQuantity('2500.0', '2,5 kg')).toEqual({ quantity: 2500, unit: 'g' });
+    });
+
+    it('keeps the quantity when the unit is unreadable', () => {
+        // Quantity is still useful on its own; the unit is separately nullable.
+        expect(parsePackageQuantity(120, 'family size')).toEqual({ quantity: 120, unit: null });
+    });
+
+    describe('rejects', () => {
+        it('multipacks — product_quantity is the pack TOTAL', () => {
+            // Serving these as one package overbills "1 bottle" by the pack count.
+            expect(parsePackageQuantity(250, '2 x 125 g')).toBeNull();
+            expect(parsePackageQuantity(1474.17, '10 x 5.2 OZ (150 g)')).toBeNull();
+            expect(parsePackageQuantity(2130, '6 × 355 ml')).toBeNull();
+        });
+
+        it('a parenthesised pack count even when the total is correct', () => {
+            // "26.6 g (14 x 1.9 g)" — 26.6 IS the true net weight, so this is a
+            // deliberate false negative. Losing a row is cheap; overbilling 14x
+            // is not. Pinned so the conservatism is a decision, not an accident.
+            expect(parsePackageQuantity(26.6, '26.6 g (14 x 1.9 g)')).toBeNull();
+        });
+
+        it('zero and negative quantities', () => {
+            expect(parsePackageQuantity(0, '0 g')).toBeNull();
+            expect(parsePackageQuantity(-5, '5 g')).toBeNull();
+        });
+
+        it('quantities above the 100kg sanity bound', () => {
+            expect(parsePackageQuantity(100001, '100001 g')).toBeNull();
+            expect(parsePackageQuantity(100000, '100000 g')).not.toBeNull(); // bound is inclusive
+        });
+
+        it('missing and unparseable values', () => {
+            expect(parsePackageQuantity(undefined, '')).toBeNull();
+            expect(parsePackageQuantity(null, '')).toBeNull();
+            expect(parsePackageQuantity('', '')).toBeNull();
+            expect(parsePackageQuantity('n/a', '')).toBeNull();
+            expect(parsePackageQuantity(NaN, '')).toBeNull();
+        });
+    });
+});
+
+describe('parseOffProduct wiring (the 2026-07-30 regression)', () => {
+    // Minimal product that clears the country, category, macro and Atwater
+    // gates, so these cases isolate the package-quantity fields.
+    const base = {
+        code: '0012345678905',
+        product_name: 'Test Crackers',
+        brands: 'Testco',
+        countries_tags: ['en:united-states'],
+        nutriments: {
+            'energy-kcal_100g': 400,
+            proteins_100g: 8,
+            carbohydrates_100g: 70,
+            fat_100g: 10,
+            fiber_100g: 3,
+        },
+    };
+
+    function parsed(extra: Record<string, unknown>) {
+        const r = parseOffProduct({ ...base, ...extra });
+        if (r.skip) throw new Error(`fixture was skipped: ${r.reason}`);
+        return r.data;
+    }
+
+    it('carries product_quantity/quantity through to the parsed row', () => {
+        const d = parsed({ product_quantity: 453.592, quantity: '1 lb' });
+        expect(d.packageQuantity).toBeCloseTo(453.592);
+        expect(d.packageQuantityUnit).toBe('g');
+    });
+
+    it('leaves both null when OFF has no package fields', () => {
+        const d = parsed({});
+        expect(d.packageQuantity).toBeNull();
+        expect(d.packageQuantityUnit).toBeNull();
+    });
+
+    it('leaves both null for a multipack', () => {
+        const d = parsed({ product_quantity: 2130, quantity: '6 x 355 ml' });
+        expect(d.packageQuantity).toBeNull();
+        expect(d.packageQuantityUnit).toBeNull();
+    });
+
+    it('does not confuse serving weight with package weight', () => {
+        // servingGrams and packageQuantity are independent tiers; a row can
+        // have both, and swapping them bills a serving as a whole package.
+        const d = parsed({
+            serving_size: '30 g', serving_quantity: 30,
+            product_quantity: 453.592, quantity: '1 lb',
+        });
+        expect(d.servingGrams).toBe(30);
+        expect(d.packageQuantity).toBeCloseTo(453.592);
+    });
+});

--- a/scripts/lib/off-parse.ts
+++ b/scripts/lib/off-parse.ts
@@ -72,6 +72,44 @@ export function parseServingGrams(servingQuantity: any, servingSize: string): nu
   return null;
 }
 
+// --- Package net quantity ------------------------------------------------
+// OFF's `product_quantity` is the normalized net contents (g or ml) and
+// `quantity` is the raw label string ("591 ml", "1.75 L", "6 x 355 ml").
+// Together they populate OffFood.packageQuantity(+Unit), which feeds the
+// whole-package-count serving tier (borrowSiblingPackageGrams() in
+// src/lib/mapping/map-ingredient-with-fallback.ts).
+//
+// These live here, shared by the ingest and by
+// scripts/backfill-off-package-quantity.ts, because the two paths must agree
+// on what qualifies — the 2026-07-30 refresh proved that a column only one
+// path knows how to write is a column the other path silently destroys.
+
+/** "6 x 355 ml", "2×125 g" — product_quantity is the pack TOTAL for these. */
+const MULTIPACK_LABEL = /\d\s*[x×*]\s*\d/i;
+
+/** 'ml' for volume-labeled packages, 'g' for weight-labeled, null if unclear. */
+export function inferPackageUnit(quantityLabel: string): 'g' | 'ml' | null {
+  const s = quantityLabel.toLowerCase();
+  if (/\d\s*(ml|cl|dl|l|litre|liter|fl\s*\.?\s*oz)\b/.test(s)) return 'ml';
+  if (/\d\s*(g|gr|grams?|kg|mg|oz|lbs?|pounds?)\b/.test(s)) return 'g';
+  return null;
+}
+
+/**
+ * Net package contents, or null when unusable. Multipacks are REJECTED
+ * rather than divided: product_quantity is the total across the pack, so
+ * serving it as one package would overbill "1 bottle" by the pack count.
+ */
+export function parsePackageQuantity(
+  productQuantity: unknown,
+  quantityLabel: string,
+): { quantity: number; unit: 'g' | 'ml' | null } | null {
+  const pq = typeof productQuantity === 'number' ? productQuantity : parseFloat(String(productQuantity ?? ''));
+  if (!Number.isFinite(pq) || pq <= 0 || pq > 100000) return null;
+  if (MULTIPACK_LABEL.test(quantityLabel)) return null;
+  return { quantity: pq, unit: inferPackageUnit(quantityLabel) };
+}
+
 /** Atwater check: labeled kcal should be within [0.65x, 1.40x] of the
  * macro-derived estimate. (Was 0.7–1.3; widened 2026-07-13 to admit label
  * rounding / alcohol / sugar-alcohol discrepancies while still rejecting
@@ -122,6 +160,9 @@ export interface ParsedOffProduct {
   fiber: number;
   sugar: number;
   sodium: number;
+  /** Net package contents (g or ml per packageQuantityUnit); null if absent/multipack. */
+  packageQuantity: number | null;
+  packageQuantityUnit: 'g' | 'ml' | null;
   /** true if per-100g macros were back-calculated from `_serving` fields */
   derivedFromServing: boolean;
 }
@@ -173,6 +214,7 @@ export function parseOffProduct(product: any): ParseResult {
   }
 
   const servingGrams = parseServingGrams(servingQuantity, servingSize);
+  const pkg = parsePackageQuantity(product.product_quantity, stripNul(String(product.quantity || '')));
   const nutriments = product.nutriments || {};
 
   let kcal = parseMacro(nutriments['energy-kcal_100g'] ?? nutriments['energy_100g']);
@@ -223,6 +265,8 @@ export function parseOffProduct(product: any): ParseResult {
       servingSize: servingSize || null,
       servingGrams,
       kcal, fat, carbs, protein, fiber, sugar, sodium,
+      packageQuantity: pkg?.quantity ?? null,
+      packageQuantityUnit: pkg?.unit ?? null,
       derivedFromServing,
     },
   };

--- a/scripts/off-parquet-to-jsonl.sh
+++ b/scripts/off-parquet-to-jsonl.sh
@@ -44,6 +44,13 @@ COPY (
     categories,
     serving_size,
     serving_quantity,
+    -- Net package contents. These two feed OffFood.packageQuantity(+Unit) and
+    -- with it the whole-package-count serving tier. They were MISSING from this
+    -- SELECT until 2026-07-31, so the column was only ever written by the
+    -- out-of-band CSV backfill and every --fresh rebuild destroyed it (it read
+    -- 0 of 1,085,525 rows after the 2026-07-30 refresh). Do not drop them again.
+    product_quantity,
+    quantity,
     countries_tags,
     {
       'energy-kcal_100g':     list_filter(nutriments, lambda n: n.name = 'energy-kcal')[1]."100g",


### PR DESCRIPTION
## What

The 2026-07-30 `--fresh` refresh left `OffFood.packageQuantity` at **0 of 1,085,525 rows**, killing the whole-package-count serving tier so every branded unitless count billed a flat 100 g. That was 3 of the 4 remaining golden-eval failures.

The column was only ever written by an out-of-band CSV backfill, and `off-parquet-to-jsonl.sh`'s `SELECT` never emitted `product_quantity`/`quantity` — so **no refresh could regenerate it, only destroy it.** This fixes both the data and the pipeline.

## Durable half (stops the next refresh destroying it)

- `off-parquet-to-jsonl.sh` selects `product_quantity` + `quantity`
- `parseOffProduct()` reads them into `packageQuantity`/`packageQuantityUnit`
- `ingest-off.ts` writes both columns

## Repair half (fixes the corpus we have)

- `backfill-off-package-quantity.ts` accepts a narrow DuckDB-extract CSV alongside OFF's raw TSV export — layout sniffed from the header, columns located **by name**
- New `--dry-run` executes the real `UPDATE` then rolls back, so a 1M-row production write can be counted before it is committed

Qualification (bounds + the multipack rejection, where `product_quantity` is the pack **total**) moves into `off-parse.ts` so the two writers cannot drift apart. A column only one writer understands is a column the other silently destroys — which is precisely how this defect happened.

## Executed

Run on the box 2026-07-31. Dry run and write both reported **216,773 rows** (0 → 216,773), landing on the historical ~207k magnitude.

## Gate

Golden eval is **green on both axes: 0 real failures (was 5) and 0 drift.** Both matter — the warm runner reds on drift too.

- `n-supp-06` **promoted to a hard assertion**: now maps to the base Orgain SKU at 23 g/scoop, inside its `[20,30]` band
- `n-brand-05` / `s-typo-14` stay known issues with refreshed baselines. `n-brand-05`'s miss *improved* — from a brandless generic billed at flat 100 g / 409 kcal to a real pre-workout with a labeled 19.8 g scoop — but still misses on brand, root cause unchanged (bare `c4` absent from the lexicon)

`npm run doc-check`: **60/60**. Two fired tripwires replaced by their inverse claims, plus a new one pinning the Parquet `SELECT`.

## Tests

22 new tests. They pin the **wiring** (the thing that actually broke) and the multipack rejection. Both mutations — unwiring `parseOffProduct` and deleting the multipack guard — were verified to fail the suite, so the tests aren't vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu