### PR TITLE
docs(doc-check): tripwire for the unmigrated per-batch warm screen

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -759,6 +759,18 @@
         "value": "1"
       },
       "verified": "2026-07-31"
+    },
+    {
+      "id": "warm-runner-still-hardcodes-llm",
+      "claim": "TRIPWIRE. The per-batch screen in warm-plan-2026-07-25/run-batches.sh still routes to the OpenRouter --llm tier; the agent migration (handoff §3, two-phase runner split) is specified but NOT built. When this claim FAILS, the split has shipped — update the handoff, CLAUDE.md and this entry together. The file lives in a gitignored sync-docs data dir the box does not receive, so this is a devmachine claim.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-07-31_warm-push-handoff.md#3-the-warm-push",
+      "where": "devmachine",
+      "command": "grep -c -- 'correctness-screen.ts .*--llm ' sync-docs/warm-plan-2026-07-25/run-batches.sh",
+      "expect": {
+        "kind": "equals",
+        "value": "1"
+      },
+      "verified": "2026-07-31"
     }
   ]
 }


### PR DESCRIPTION
Adds one `devmachine` claim, `warm-runner-still-hardcodes-llm`.

Diego decided the per-batch warm screen moves to Claude Code Sonnet agents for all nine remaining batches. `run-batches.sh` still passes `--llm`, so this claim asserts the *current* state and goes red the day the migration ships — at which point the handoff report, `CLAUDE.md` and this entry get re-dated together.

`devmachine` context because the runner lives in `sync-docs/warm-plan-2026-07-25/`, a gitignored data dir the box's Syncthing ignores drop.

`npm run doc-check` → 64/64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu