### PR TITLE
docs(doc-check): claims for the hand-authored corruptReason marks lost in the refresh

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -749,6 +749,30 @@
       "verified": "2026-07-31"
     },
     {
+      "id": "off-triage-marks-have-no-producer",
+      "claim": "No code in the backend repo produces the triage-bigwarm-2026-07-21 corruptReason mark (the registry itself is excluded, or the check matches its own text), so a refresh that re-derives marks cannot bring the 2026-07-21 hand-authored batch back",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md#the-hand-authored-marks",
+      "where": "backend",
+      "command": "grep -rIl 'triage-bigwarm' src scripts --exclude-dir=results --exclude-dir=doc-check | wc -l",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-07-31"
+    },
+    {
+      "id": "off-triage-verdicts-mostly-untargeted",
+      "claim": "triage-verdicts-2026-07-21.json holds 50 nutrition mark-corrupt verdicts of which only 7 carry a targetId; the other 43 name a row by seed and prose only, which no restore tool can consume",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md#the-hand-authored-marks",
+      "where": "backend",
+      "command": "python3 -c \"import json;d=json.load(open('scripts/eval/results/triage-verdicts-2026-07-21.json'));n=[r for r in d['confirmed'] if r['cls']=='nutrition'];print(len(n), sum(1 for r in n if r.get('targetId')))\"",
+      "expect": {
+        "kind": "equals",
+        "value": "50 7"
+      },
+      "verified": "2026-07-31"
+    },
+    {
       "id": "corrupt-detector-reachability-gap",
       "claim": "Sibling grouping in detect-corrupt-panel.ts is a coverage decision: rows in exact-name groups below MIN_GROUP=4 are never signature-tested. Measured 2026-07-31: 661,150 of 1,083,139 kcal-bearing rows (61.0%). The axis is NAME LENGTH, not brandedness — 25.5% unreachable at 1 token rising monotonically to 98.3% at 8+ tokens (branded 61.8% vs unbranded 58.9%). The scan prints these counters on every run so the number re-derives itself.",
       "ownerDoc": "mobile:sync-docs/mapping_investigation_playbook.md",


### PR DESCRIPTION
The 2026-07-30 OFF refresh destroyed a fourth curation population nobody enumerated: the 50 hand-authored `triage-bigwarm-2026-07-21:panel` marks. The re-derive design shipped in #202 cannot bring them back, because no rule produces them.

The argument that closed B3 — "every mark in the live table traces to a detector rule" — was tested against the live `corruptReason` table, which holds only re-derived marks *by construction*. It measured the survivors and concluded about the population.

**Measured 2026-07-31:** zero `triage-bigwarm` marks survive (`panel-low` 5,362 / `panel-inflated` 1,539 / `panel-inflated-family` 4); 7 of 50 verdicts carry a `targetId`; 5 of those are OFF barcodes and all 5 read NULL today; the other 2 name FDC rows, which have no `corruptReason` column.

## Claims added

- `off-triage-marks-have-no-producer` — no code writes the mark string, so a re-deriving refresh can never regenerate it. The grep excludes `doc-check/` because the claim's own text otherwise matches it; the checker caught this on first run.
- `off-triage-verdicts-mostly-untargeted` — 50 verdicts, 7 targeted, so 43 name a row by `seed` and prose that no restore tool can consume.

`npm run doc-check` → 66/66.

Owner doc is the mobile repo's `sync-docs/backend_integration_guide.md`, new section "The hand-authored marks did not come back" (committed there as `31fba27`). That section also records why the 5 targeted rows should **not** simply be re-marked: re-checked against the live corpus, 2 of the 5 verdicts are now false, so replaying them would mark two good rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu