### PR TITLE
docs(doc-check): swap the fired nutrition tripwire for its inverse

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -773,16 +773,16 @@
       "verified": "2026-07-31"
     },
     {
-      "id": "off-nutrition-tier-never-marked",
-      "claim": "No nutrition-tier corruptReason mark exists in the corpus: every live mark carries a panel-tier prefix, so detect-corrupt-nutrition.ts output has never been applied",
-      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md#the-nutrition-detectors-marks-have-never-been-applied",
+      "id": "off-no-impossible-rows-unmarked",
+      "claim": "No live unmarked OffFood row exceeds MAX_KCAL_100G (905 kcal/100g). The nutrition-tier physics marks were applied 2026-08-01 (22,087 rows); this goes RED if a refresh wipes them, which it will until the refresh re-runs detect-corrupt-nutrition.ts",
+      "ownerDoc": "mobile:sync-docs/backend_integration_guide.md#the-nutrition-detector-tier",
       "where": "box",
-      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc \"SELECT count(*) FROM \\\"OffFood\\\" WHERE \\\"corruptReason\\\" IS NOT NULL AND split_part(\\\"corruptReason\\\", ':', 1) NOT LIKE 'panel-%'\"",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc \"SELECT count(*) FROM \\\"OffFood\\\" WHERE \\\"corruptReason\\\" IS NULL AND \\\"duplicateOfBarcode\\\" IS NULL AND (\\\"nutrientsPer100g\\\"->>'calories')::float > 905\"",
       "expect": {
         "kind": "count",
         "value": "0"
       },
-      "verified": "2026-07-31"
+      "verified": "2026-08-01"
     },
     {
       "id": "off-refresh-omits-nutrition-detector",


### PR DESCRIPTION
The nutrition detector's physics tiers were applied to the corpus on 2026-08-01 (22,087 marks, Diego approving each write), so the tripwire added in #205 is now false — **by design**. It was written knowing the fix would break it, so that the owner doc had to be re-dated in the same commit.

## Run summary

| | before | after |
|---|---|---|
| `corruptReason` marks | 6,905 | **28,992** |
| rows >905 kcal/100g unmarked | 14,315 | **0** |
| Typesense `off_foods` | 985,254 | **963,167** (== Postgres eligible, exact) |
| `eval:golden` | 0 failures / 0 drift | **0 failures / 0 drift** |

The dry run reported no `FoodMapping` row pointing at any marked record, so no existing cache pick changed — this is preventive for the warm campaign.

## Claim change

- **removed** `off-nutrition-tier-never-marked` (fired as intended)
- **added** `off-no-impossible-rows-unmarked` — no live unmarked row exceeds `MAX_KCAL_100G` (905). Goes RED if a refresh wipes the marks, which it will until the refresh re-runs the detector.
- **unchanged** `off-refresh-omits-nutrition-detector` — still passing, i.e. that gap is still open and the next rebuild destroys all 22,087 marks.

## What was deliberately not applied

Of 24,203 flags, 2,116 were held: `sodium-implausible` (971), `sodium-sibling-outlier` (1,034) and `panel-inflated-serving` (111). The last would have marked correct rows — it fires when implied per-serving kcal exceeds `MIN_IMPLIED_SERVING_KCAL` (1,500), which assumes `servingGrams` is a single eating occasion. `8000500273296` "Ferrero" stores 603 kcal / 42.7 fat / 44.4 carbs / 8.2 protein — Ferrero Rocher's real panel to the decimal — and fires only because the serving is the 375 g box. A scan file is not a mark list.

`npm run doc-check` → 68/68. Owner doc: mobile `sync-docs/backend_integration_guide.md` §"The nutrition detector tier" (mobile `a3c92e5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu