### PR TITLE
feat(eval): pin builder + agent-screen reconciler for the two-phase warm screen

### DIFF
--- a/scripts/eval/__tests__/agent-screen-reconcile.test.ts
+++ b/scripts/eval/__tests__/agent-screen-reconcile.test.ts
@@ -1,0 +1,271 @@
+/**
+ * agent-screen-reconcile.test.ts — FAIL INJECTION for the two-phase agent screen.
+ *
+ * The phase-A/phase-C split exists because a shell script cannot spawn a Claude Code
+ * agent, and it introduces a gap the single-process screen never had: a SESSION sits
+ * between the row dump and the DELETE. Everything below is a way that gap can produce
+ * a plausible, green-looking, WRONG evict list:
+ *
+ *   - an agent dies mid-batch          -> short verdict set -> its rows silently KEPT
+ *   - a fan-out driver double-counts   -> totals inflated by an unknown amount
+ *   - an off-by-one in the driver      -> every row judged, none of them its own
+ *   - an unrecognised verdict string   -> falls through as "not a REJECT" = keep
+ *   - a serving-axis REJECT            -> a DELETE that cannot fix the defect
+ *   - policy drift back to `strict`    -> D1 rides in at 73.8% live false-evict
+ *
+ * Every block carries a POSITIVE CONTROL, per fail-closed.test.ts: a guard that
+ * refuses everything is a tautology, not a test.
+ *
+ * NO NETWORK, NO DATABASE — only the pure exported functions run here.
+ */
+
+import {
+    reconcile,
+    VALID_AXES,
+    VALID_VERDICTS,
+    NON_EVICTING_RULES,
+    type AgentVerdict,
+} from '../_agent_screen_reconcile';
+import { buildPins, pinOutcome, PIN_VOID_EXIT, parseAddedKeys, parseSeedLines } from '../_pin_batch_seeds';
+
+const ROWS = [{ key: 'a lays' }, { key: 'b oreo' }, { key: 'c sprite' }];
+
+const ok = (over: Partial<AgentVerdict> & { idx: number; key: string }): AgentVerdict => ({
+    verdict: 'ACCEPT', axis: 'none', confidence: 0.9, reason: 'fine', ...over,
+});
+
+const fullAccept = (): AgentVerdict[] => ROWS.map((r, i) => ok({ idx: i, key: r.key }));
+
+// ===========================================================================
+// 1. Coverage — the fleet must account for every dumped row
+// ===========================================================================
+
+describe('reconcile: the fleet must account for every row exactly once', () => {
+    it('POSITIVE CONTROL — a complete, well-formed verdict set reconciles', () => {
+        const r = reconcile(ROWS, fullAccept(), []);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.result.counts.rows).toBe(3);
+        expect(r.result.counts.accept).toBe(3);
+        expect(r.result.evict).toEqual([]);
+    });
+
+    it('a DEAD AGENT (missing verdicts) refuses — never "those rows are fine"', () => {
+        const short = fullAccept().slice(0, 2);
+        const r = reconcile(ROWS, short, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        const text = r.reasons.join(' ');
+        expect(text).toContain('MISSING 1 of 3');
+        expect(text).toContain('silently KEEPS');
+    });
+
+    it('DUPLICATE verdicts refuse — a twice-judged batch has unknown totals', () => {
+        const dup = [...fullAccept(), ok({ idx: 1, key: 'b oreo', verdict: 'REJECT', axis: 'identity' })];
+        const r = reconcile(ROWS, dup, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('DUPLICATE');
+    });
+
+    it('an OFF-BY-ONE driver refuses even though every row got a verdict', () => {
+        // Coverage counting alone cannot see this: 3 rows, 3 verdicts, all present.
+        const shifted = ROWS.map((_, i) => ok({ idx: i, key: ROWS[(i + 1) % ROWS.length].key }));
+        const r = reconcile(ROWS, shifted, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('MISALIGNED');
+    });
+
+    it('verdicts for a DIFFERENT dump (out-of-range idx) refuse', () => {
+        const stray = [...fullAccept(), ok({ idx: 47, key: 'z from another batch' })];
+        const r = reconcile(ROWS, stray, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('OUT-OF-RANGE');
+    });
+});
+
+// ===========================================================================
+// 2. Shape — an unrecognised judgement must not become a silent KEEP
+// ===========================================================================
+
+describe('reconcile: an unreadable judgement is not an ACCEPT', () => {
+    it('a verdict carrying an error field refuses', () => {
+        const v = fullAccept();
+        v[1] = { ...v[1], error: 'agent returned truncated JSON' };
+        const r = reconcile(ROWS, v, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('not an ACCEPT');
+    });
+
+    it('an unrecognised verdict string refuses rather than defaulting to keep', () => {
+        const v = fullAccept();
+        v[0] = { ...v[0], verdict: 'PROBABLY_FINE' as unknown as AgentVerdict['verdict'] };
+        const r = reconcile(ROWS, v, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('a decision nobody made');
+    });
+
+    it('an unknown axis refuses — it could smuggle a serving reject into a DELETE', () => {
+        const v = fullAccept();
+        v[0] = { ...v[0], verdict: 'REJECT', axis: 'portion' };
+        const r = reconcile(ROWS, v, []);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('axis');
+    });
+
+    it('the valid sets are exactly the shipped LLM_SYSTEM contract', () => {
+        expect([...VALID_VERDICTS].sort()).toEqual(['ACCEPT', 'REJECT', 'UNSURE']);
+        expect([...VALID_AXES].sort()).toEqual(['identity', 'key', 'none', 'nutrition', 'serving']);
+    });
+});
+
+// ===========================================================================
+// 3. The evict set — what a REJECT is allowed to delete
+// ===========================================================================
+
+describe('reconcile: building the evict list', () => {
+    it('UNSURE never evicts — it is the human queue, not a delete', () => {
+        const v = fullAccept();
+        v[0] = { ...v[0], verdict: 'UNSURE', axis: 'identity' };
+        const r = reconcile(ROWS, v, []);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.result.evict).toEqual([]);
+        expect(r.result.counts.unsure).toBe(1);
+    });
+
+    it('a SERVING-axis REJECT is held back — deleting the row cannot fix a serving', () => {
+        const v = fullAccept();
+        v[0] = { ...v[0], verdict: 'REJECT', axis: 'serving' };
+        v[1] = { ...v[1], verdict: 'REJECT', axis: 'identity' };
+        const r = reconcile(ROWS, v, []);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.result.evict).toEqual(['b oreo']);              // identity reject only
+        expect(r.result.servingAxisRejects).toEqual(['a lays']);  // reported, not deleted
+        expect(r.result.counts.reject).toBe(2);
+    });
+
+    it('the list is the UNION of Tier D and the agents, deduplicated and sorted', () => {
+        const v = fullAccept();
+        v[2] = { ...v[2], verdict: 'REJECT', axis: 'identity' };
+        const r = reconcile(ROWS, v, ['a lays', 'c sprite']);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.result.evict).toEqual(['a lays', 'c sprite']);
+        expect(r.result.counts.tierDEvict).toBe(2);
+        expect(r.result.counts.agentEvict).toBe(1);
+        expect(r.result.counts.overlap).toBe(1);
+    });
+
+    it('a Tier-D list from a DIFFERENT run refuses', () => {
+        const r = reconcile(ROWS, fullAccept(), ['not in this dump']);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('different runs');
+    });
+});
+
+// ===========================================================================
+// 4. Policy drift — D1/D5/D6 must not evict behind the agents' reputation
+// ===========================================================================
+
+describe('reconcile: rules demoted for cause cannot carry an eviction alone', () => {
+    const hit = (rule: string) => ({ rule: rule as never, severity: 'EVICT' as const, detail: '' });
+
+    it('an eviction resting ONLY on D1 refuses (73.8% live false-evict)', () => {
+        const r = reconcile(ROWS, fullAccept(), ['a lays'], [{ key: 'a lays', tierD: [hit('D1')] }]);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.reasons.join(' ')).toContain('demoted for cause');
+    });
+
+    it('POSITIVE CONTROL — the same row evicting on D3 as well is allowed through', () => {
+        const r = reconcile(ROWS, fullAccept(), ['a lays'], [{ key: 'a lays', tierD: [hit('D1'), hit('D3')] }]);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.result.evict).toEqual(['a lays']);
+    });
+
+    it('the demoted set is exactly D1, D5, D6', () => {
+        expect([...NON_EVICTING_RULES].sort()).toEqual(['D1', 'D5', 'D6']);
+    });
+});
+
+// ===========================================================================
+// 5. Pins — zero pins is VOID, and a pin must never be a guess
+// ===========================================================================
+
+describe('_pin_batch_seeds: pin coverage IS screen coverage', () => {
+    // A stand-in for canonicalizeCacheKey: lowercase, token-sort. The real one is
+    // imported by the script itself; re-deriving it HERE would test the stand-in.
+    const canon = (s: string) => s.toLowerCase().split(/\s+/).sort().join(' ');
+
+    // NOTE the shapes below: the KEY is token-sorted ('chips lays'), the seed phrase is
+    // not ('lays chips'). That asymmetry is the reason pins exist at all — handing the
+    // judge the key instead of the phrase reads as a different product name.
+    it('POSITIVE CONTROL — seeds that canonicalize onto added keys pin at 100%', () => {
+        const b = buildPins(['chips lays', 'oreo'], ['lays chips', 'oreo'], canon);
+        expect(b.pins.get('chips lays')).toBe('lays chips');
+        expect(b.pins.get('oreo')).toBe('oreo');
+        expect(b.unpinned).toEqual([]);
+    });
+
+    it('a seed the normalizer renamed simply MISSES — it never mispins another row', () => {
+        // "bell pepper" is rewritten to "capsicum" before keying, so its seed cannot
+        // reach the row; the row stays unpinned rather than borrowing a neighbour.
+        const b = buildPins(['capsicum'], ['bell pepper'], canon);
+        expect(b.pins.size).toBe(0);
+        expect(b.unpinned).toEqual(['capsicum']);
+        expect(b.seedsOffTarget).toBe(1);
+    });
+
+    it('two seeds landing on one key are REPORTED, not silently resolved', () => {
+        const b = buildPins(['chips lays'], ['lays chips', 'chips lays'], canon);
+        expect(b.collisions).toHaveLength(1);
+        expect(b.collisions[0].key).toBe('chips lays');
+        expect(b.pins.get('chips lays')).toBe('lays chips');   // first wins, deterministically
+    });
+
+    it('--merge fills only the gaps, and seed pins WIN where both have a phrase', () => {
+        const merged = new Map([['chips lays', 'telemetry phrase'], ['oreo', 'oreo cookies']]);
+        const b = buildPins(['chips lays', 'oreo'], ['lays chips'], canon, merged);
+        expect(b.pins.get('chips lays')).toBe('lays chips');    // the seed, not telemetry
+        expect(b.pins.get('oreo')).toBe('oreo cookies');        // gap filled
+        expect(b.fromMerge).toBe(1);
+    });
+
+    it('--merge never pins a key the batch did not add', () => {
+        const merged = new Map([['some other key', 'phrase']]);
+        const b = buildPins(['chips lays'], ['lays chips'], canon, merged);
+        expect(b.pins.has('some other key')).toBe(false);
+    });
+
+    it('pinning NOTHING is VOID, distinct from success and from error', () => {
+        const o = pinOutcome(0, 107);
+        expect(o.code).toBe(PIN_VOID_EXIT);
+        expect(o.code).not.toBe(0);
+        expect(o.code).not.toBe(2);
+        expect(o.lines.join(' ')).toContain('0 / 107');
+        expect(o.lines.join(' ')).toContain('produced NOTHING');
+    });
+
+    it('POSITIVE CONTROL — one pin is a result', () => {
+        expect(pinOutcome(1, 107).code).toBe(0);
+    });
+
+    it('added.txt is key<TAB>details — the details are never mistaken for a key', () => {
+        expect(parseAddedKeys('a lays\tLays | openfoodfacts | ai\nb oreo\tOreo | off | ai\n'))
+            .toEqual(['a lays', 'b oreo']);
+    });
+
+    it('a batch seed file drops comments and blanks', () => {
+        expect(parseSeedLines('# domain: chains\n\nolive garden breadstick\n  \nchipotle bowl\n'))
+            .toEqual(['olive garden breadstick', 'chipotle bowl']);
+    });
+});

--- a/scripts/eval/_agent_screen_reconcile.ts
+++ b/scripts/eval/_agent_screen_reconcile.ts
@@ -1,0 +1,320 @@
+/**
+ * _agent_screen_reconcile.ts — turn a fleet of Claude Code agent verdicts into the
+ * batch's `screen-evict.txt`, and REFUSE if the fleet did not actually judge the batch.
+ *
+ * WHERE THIS SITS: `run-batches.sh --screen agent <B>` runs Tier D alone, dumps the rows
+ * and the byte-identical Tier-L record cards, and exits 10. A session fans Sonnet agents
+ * over the cards and writes `agent-verdicts.json`. Then `--resume` calls THIS, which is
+ * the only producer of the evict list. The session does not write the evict file: a
+ * hand-assembled list is a transcription step between the judgement and the DELETE, and
+ * this whole campaign exists because transcription steps are where the truth goes.
+ *
+ * THE RECONCILE IS THE POINT (playbook §10): assert 0 missing, 0 duplicate, 0 failed
+ * before believing any total. The 2026-07-27 audit's rule was that silent truncation
+ * reads as "covered everything" when it did not — an agent that dies mid-batch returns
+ * fewer verdicts, and a union built from a short list quietly keeps every row the dead
+ * agent would have flagged. So: every row in rows.json must come back exactly once, at
+ * the right index, with a verdict this script recognises, or nothing is written at all.
+ *
+ * THE EVICT SET is `Tier-D EVICT  ∪  agent REJECT`, minus serving-axis rejects.
+ *   - UNSURE never evicts. It is a first-class outcome that routes a row to a human
+ *     (the full audit returned 104 of them); folding it into the delete list would
+ *     convert "I cannot tell" into "destroy it".
+ *   - Serving-axis rejects are excluded because an evictor must be actionable by
+ *     deleting the row (playbook §2). FoodMapping is identity-only — there is no grams
+ *     column — so deleting a row cannot fix a serving weight; it discards a correct
+ *     identity and re-resolves the same bad weight. This is the same reasoning that
+ *     demoted D5 and D6, and the same 17 rows the whole-cache audit held back.
+ *
+ * Read-only with respect to the database. Writes only the two output files.
+ *
+ * Exit codes:
+ *   0 = reconciled, nothing to evict
+ *   1 = reconciled, rows flagged for withholding (evict file written, non-empty)
+ *   2 = REFUSED — the fleet's output does not account for the batch, or an input is
+ *       malformed. Nothing is written. A screen that could not be reconciled must never
+ *       be read as a clean batch.
+ */
+import * as fs from 'fs';
+import type { ScreenRow, Verdict, RuleId } from './correctness-screen';
+
+// ---------------------------------------------------------------------------
+// Pure, unit-testable core (scripts/eval/__tests__/agent-screen-reconcile.test.ts)
+// ---------------------------------------------------------------------------
+
+export type AgentDecision = 'ACCEPT' | 'UNSURE' | 'REJECT';
+
+/** One agent verdict, matching the shipped LlmVerdict shape plus the card's idx. */
+export interface AgentVerdict {
+    idx: number;
+    key: string;
+    verdict: AgentDecision;
+    axis: string;
+    confidence?: number;
+    reason?: string;
+    error?: string;
+}
+
+export const VALID_VERDICTS: ReadonlySet<string> = new Set(['ACCEPT', 'UNSURE', 'REJECT']);
+export const VALID_AXES: ReadonlySet<string> = new Set(['identity', 'nutrition', 'serving', 'key', 'none']);
+
+/**
+ * Rules that may NOT carry an eviction on their own. `balanced` already excludes all
+ * three, so this is a tripwire on policy drift rather than a filter that fires today —
+ * if someone runs the agent path at `--policy strict`, D1's measured 73.8% live
+ * false-evict rate must not ride in behind the agents' reputation.
+ */
+export const NON_EVICTING_RULES: ReadonlySet<RuleId> = new Set<RuleId>(['D1', 'D5', 'D6']);
+
+export type Reconcile =
+    | { ok: true; result: ReconcileResult }
+    | { ok: false; reasons: string[] };
+
+export interface ReconcileResult {
+    evict: string[];
+    /** Agent REJECTs held back because deleting the row cannot fix the defect. */
+    servingAxisRejects: string[];
+    counts: {
+        rows: number;
+        accept: number;
+        unsure: number;
+        reject: number;
+        tierDEvict: number;
+        agentEvict: number;
+        overlap: number;
+    };
+}
+
+/**
+ * Reconcile agent verdicts against the exact row set that was dumped, then build the
+ * evict list. Every failure mode below was chosen because it can happen QUIETLY.
+ */
+export function reconcile(
+    rows: Pick<ScreenRow, 'key'>[],
+    verdicts: AgentVerdict[],
+    tierDEvictKeys: string[],
+    tierDVerdicts?: Pick<Verdict, 'key' | 'tierD'>[],
+): Reconcile {
+    const reasons: string[] = [];
+
+    // --- 1. Coverage: exactly one verdict per row, at the right index.
+    const byIdx = new Map<number, AgentVerdict[]>();
+    for (const v of verdicts) {
+        const list = byIdx.get(v.idx);
+        if (list) list.push(v); else byIdx.set(v.idx, [v]);
+    }
+    const missing: number[] = [];
+    const duplicated: number[] = [];
+    const misaligned: string[] = [];
+    for (let i = 0; i < rows.length; i++) {
+        const got = byIdx.get(i);
+        if (!got || got.length === 0) { missing.push(i); continue; }
+        if (got.length > 1) duplicated.push(i);
+        // idx AND key must agree. An off-by-one in a fan-out driver produces a full
+        // set of verdicts attached to the wrong rows, which coverage counting alone
+        // cannot see — every row is judged, just not the one it says.
+        for (const v of got) {
+            if (v.key !== rows[i].key) {
+                misaligned.push(`idx ${i}: card key "${rows[i].key}" but verdict carries "${v.key}"`);
+            }
+        }
+    }
+    const stray = [...byIdx.keys()].filter(i => i < 0 || i >= rows.length);
+
+    if (missing.length) {
+        reasons.push(`MISSING ${missing.length} of ${rows.length} verdict(s) — expected one per row, `
+            + `observed none for idx ${missing.slice(0, 10).join(', ')}${missing.length > 10 ? ', ...' : ''}. `
+            + 'A short verdict set silently KEEPS every row the dead agent would have flagged.');
+    }
+    if (duplicated.length) {
+        reasons.push(`DUPLICATE verdicts for idx ${duplicated.slice(0, 10).join(', ')}`
+            + `${duplicated.length > 10 ? ', ...' : ''} — a batch file was judged twice and the totals are `
+            + 'inflated by an unknown amount.');
+    }
+    if (misaligned.length) {
+        reasons.push(`MISALIGNED ${misaligned.length} verdict(s): ${misaligned.slice(0, 5).join(' | ')}`
+            + `${misaligned.length > 5 ? ' | ...' : ''}. The fleet judged rows other than the ones named.`);
+    }
+    if (stray.length) {
+        reasons.push(`OUT-OF-RANGE idx ${stray.slice(0, 10).join(', ')} for a ${rows.length}-row dump — `
+            + 'these verdicts belong to a different dump.');
+    }
+
+    // --- 2. Shape: an unrecognised verdict must not fall through as "not a REJECT".
+    const errored = verdicts.filter(v => v.error);
+    if (errored.length) {
+        reasons.push(`${errored.length} verdict(s) carry an error field (e.g. idx ${errored[0].idx}: `
+            + `${JSON.stringify(String(errored[0].error).slice(0, 80))}). A failed judgement is not an ACCEPT.`);
+    }
+    const badVerdict = verdicts.filter(v => !VALID_VERDICTS.has(v.verdict));
+    if (badVerdict.length) {
+        reasons.push(`${badVerdict.length} verdict(s) are not ACCEPT/UNSURE/REJECT `
+            + `(e.g. idx ${badVerdict[0].idx}: ${JSON.stringify(badVerdict[0].verdict)}). An unrecognised value `
+            + 'would default to "keep", which is a decision nobody made.');
+    }
+    const badAxis = verdicts.filter(v => VALID_VERDICTS.has(v.verdict) && !VALID_AXES.has(v.axis));
+    if (badAxis.length) {
+        reasons.push(`${badAxis.length} verdict(s) carry an axis outside identity/nutrition/serving/key/none `
+            + `(e.g. idx ${badAxis[0].idx}: ${JSON.stringify(badAxis[0].axis)}). The serving-axis exclusion is `
+            + 'applied by matching this field, so an unknown axis could smuggle a serving reject into a DELETE.');
+    }
+
+    // --- 3. Tier-D evictions must rest on a rule that is allowed to evict.
+    const rowKeys = new Set(rows.map(r => r.key));
+    const tierDStray = tierDEvictKeys.filter(k => !rowKeys.has(k));
+    if (tierDStray.length) {
+        reasons.push(`Tier D flagged ${tierDStray.length} key(s) that are not in the row dump `
+            + `(${tierDStray.slice(0, 5).join(', ')}) — the two inputs are from different runs.`);
+    }
+    if (tierDVerdicts) {
+        const hits = new Map(tierDVerdicts.map(v => [v.key, v.tierD]));
+        const restsOnDemoted: string[] = [];
+        for (const k of tierDEvictKeys) {
+            const h = hits.get(k);
+            if (!h) continue;
+            const evicting = h.filter(x => x.severity === 'EVICT').map(x => x.rule);
+            if (evicting.length && evicting.every(r => NON_EVICTING_RULES.has(r))) {
+                restsOnDemoted.push(`${k} (${evicting.join(',')})`);
+            }
+        }
+        if (restsOnDemoted.length) {
+            reasons.push(`${restsOnDemoted.length} Tier-D eviction(s) rest ONLY on rules demoted for cause `
+                + `(D1 false-evicts at 73.8% on the live cache; D5/D6 are serving-stage defects a delete cannot fix): `
+                + `${restsOnDemoted.slice(0, 5).join(', ')}. Run the agent path at --policy balanced.`);
+        }
+    }
+
+    if (reasons.length) return { ok: false, reasons };
+
+    // --- 4. Build the list. Only reached when the fleet accounts for the batch.
+    const rejects = verdicts.filter(v => v.verdict === 'REJECT');
+    const servingAxisRejects = rejects.filter(v => v.axis === 'serving').map(v => v.key);
+    const agentEvict = rejects.filter(v => v.axis !== 'serving').map(v => v.key);
+    const tierD = new Set(tierDEvictKeys);
+    const union = new Set<string>([...tierD, ...agentEvict]);
+    // Deterministic order: same inputs, same file, so a diff between two runs is a
+    // real difference and not a set-iteration artefact.
+    const evict = [...union].sort();
+
+    return {
+        ok: true,
+        result: {
+            evict,
+            servingAxisRejects: [...new Set(servingAxisRejects)].sort(),
+            counts: {
+                rows: rows.length,
+                accept: verdicts.filter(v => v.verdict === 'ACCEPT').length,
+                unsure: verdicts.filter(v => v.verdict === 'UNSURE').length,
+                reject: rejects.length,
+                tierDEvict: tierD.size,
+                agentEvict: new Set(agentEvict).size,
+                overlap: agentEvict.filter(k => tierD.has(k)).length,
+            },
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function readJson<T>(p: string): T {
+    return JSON.parse(fs.readFileSync(p, 'utf8')) as T;
+}
+
+function main(): number {
+    const args = process.argv.slice(2);
+    const val = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+    const rowsPath = val('--rows');
+    const verdictsPath = val('--verdicts');
+    const tierDEvictPath = val('--tier-d-evict');
+    const tierDJsonPath = val('--tier-d-json');
+    const outPath = val('--out');
+    const reportPath = val('--report');
+    if (!rowsPath || !verdictsPath || !outPath) {
+        console.error('usage: _agent_screen_reconcile.ts --rows <rows.json> --verdicts <agent-verdicts.json> '
+            + '--out <screen-evict.txt> [--tier-d-evict <screen-d-evict.txt>] [--tier-d-json <screen-d.json>] '
+            + '[--report <reconcile.json>]');
+        return 2;
+    }
+
+    const rows = readJson<ScreenRow[]>(rowsPath);
+    if (!Array.isArray(rows) || rows.length === 0) {
+        console.error(`REFUSING: ${rowsPath} holds ${Array.isArray(rows) ? 0 : 'no'} row(s). A screen over zero rows `
+            + 'is not a clean batch.');
+        return 2;
+    }
+
+    const rawVerdicts = readJson<unknown>(verdictsPath);
+    // Accept either a bare array or {verdicts:[...]}, because both shapes come back
+    // from a fan-out depending on how the session assembled them. Anything else is
+    // refused rather than coerced.
+    const verdicts: AgentVerdict[] = Array.isArray(rawVerdicts)
+        ? rawVerdicts as AgentVerdict[]
+        : ((rawVerdicts as { verdicts?: AgentVerdict[] })?.verdicts ?? null) as AgentVerdict[];
+    if (!Array.isArray(verdicts)) {
+        console.error(`REFUSING: ${verdictsPath} is neither an array of verdicts nor {"verdicts":[...]}.`);
+        return 2;
+    }
+
+    let tierDEvictKeys: string[] = [];
+    if (tierDEvictPath) {
+        if (!fs.existsSync(tierDEvictPath)) {
+            // Tier D writes this file whenever --out was passed, empty when it flagged
+            // nothing. Absent means the screen did not get that far.
+            console.error(`REFUSING: --tier-d-evict ${tierDEvictPath} does not exist. Tier D writes this file `
+                + 'even when it flags nothing, so an absent file means the Tier-D screen did not complete.');
+            return 2;
+        }
+        tierDEvictKeys = fs.readFileSync(tierDEvictPath, 'utf8').split('\n').map(l => l.trim()).filter(Boolean);
+    }
+    const tierDVerdicts = tierDJsonPath && fs.existsSync(tierDJsonPath)
+        ? readJson<{ verdicts: Verdict[] }>(tierDJsonPath).verdicts
+        : undefined;
+
+    const r = reconcile(rows, verdicts, tierDEvictKeys, tierDVerdicts);
+    if (!r.ok) {
+        // Remove any evict file a PREVIOUS attempt left behind. Refusing while a stale
+        // list sits at the path the caller reads is the fail-open shape this whole
+        // script exists to avoid: a second run's refusal would look like a first run's
+        // verdict, and the DELETE would be built from verdicts nobody re-checked.
+        if (fs.existsSync(outPath)) {
+            fs.unlinkSync(outPath);
+            console.error(`(removed a stale ${outPath} from an earlier attempt)`);
+        }
+        console.error('\nRECONCILE REFUSED — nothing written. The fleet does not account for this batch:\n');
+        for (const reason of r.reasons) console.error(`  * ${reason}`);
+        console.error('');
+        return 2;
+    }
+
+    const { evict, servingAxisRejects, counts } = r.result;
+    fs.writeFileSync(outPath, evict.join('\n') + (evict.length ? '\n' : ''));
+    if (reportPath) {
+        fs.writeFileSync(reportPath, JSON.stringify({ ...counts, evict, servingAxisRejects }, null, 1));
+    }
+
+    console.log(`reconciled ${counts.rows} row(s): ACCEPT ${counts.accept} · UNSURE ${counts.unsure} · REJECT ${counts.reject}`);
+    console.log(`  0 missing, 0 duplicate, 0 misaligned, 0 failed — the fleet accounts for every row.`);
+    console.log(`evict = Tier-D ${counts.tierDEvict} u agent ${counts.agentEvict} (overlap ${counts.overlap}) = ${evict.length}`);
+    if (servingAxisRejects.length) {
+        console.log(`held back ${servingAxisRejects.length} serving-axis REJECT(s) — deleting an identity-only row `
+            + `cannot fix a serving weight: ${servingAxisRejects.slice(0, 6).join(', ')}`);
+    }
+    console.log(`UNSURE rows are NOT evicted; they are the human queue for this batch.`);
+    console.log(`wrote ${outPath}${reportPath ? ` and ${reportPath}` : ''}`);
+
+    return evict.length ? 1 : 0;
+}
+
+if (require.main === module) {
+    try {
+        process.exit(main());
+    } catch (e) {
+        console.error(e);
+        process.exit(2);
+    }
+}

--- a/scripts/eval/_pin_batch_seeds.ts
+++ b/scripts/eval/_pin_batch_seeds.ts
@@ -1,0 +1,240 @@
+/**
+ * _pin_batch_seeds.ts — build the `key<TAB>phrase` pin file for ONE warm batch.
+ *
+ * WHY THIS EXISTS: attribution in the correctness screen is PINS ONLY (playbook §10).
+ * The Jaccard fallback false-evicts at 44.8% vs 26.8% for pinned rows, so an unpinned
+ * row is judged with an EMPTY shopper phrase and the seed-dependent rules abstain.
+ * The whole-cache audit could only recover ~48% of phrases from telemetry. A warm batch
+ * is in a strictly better position: THE PHRASE IS KNOWN. Every key the batch added was
+ * written by warming one of the seed lines sitting in the batch file.
+ *
+ * The mapping from phrase to key is `canonicalizeCacheKey`, and this script IMPORTS it
+ * rather than re-deriving it — the same rule _recover_seeds.ts follows for the same
+ * reason. A transcription of that function is the exact bug class this whole exercise
+ * is about (playbook §1: a probe that reimplements the caller is a different function).
+ *
+ * WHAT IT DOES NOT ASSUME: that `canonicalizeCacheKey(seed)` is always the key the row
+ * landed under. It is not. The pipeline's AI normalize step rewrites names before the
+ * key is computed — `bell pepper` -> `capsicum`, `shrimp` -> `prawns`, `fresh ginger` ->
+ * `ginger` (measured 2026-07-20; the same finding that made repoint keys come from
+ * MappingEventLog rather than from the seed). So a seed pin can MISS. It cannot be
+ * WRONG in the dangerous direction unless two different seeds canonicalize to one key,
+ * which is reported as a collision rather than silently resolved.
+ *
+ * The residue is filled by _recover_seeds.ts from MappingEventLog and merged in via
+ * --merge, with SEED PINS WINNING: for a warm batch the seed is what was actually sent,
+ * whereas the telemetry line is the most FREQUENT raw line for that key and may belong
+ * to a real user's differently-worded query that canonicalizes to the same place.
+ *
+ * THE SEED LIST IS assembleSeeds(), NOT THE BATCH FILE. `warm-cache.ts --seed <file>`
+ * ADDS the batch to the ~264-name standard corpus rather than replacing it, so a batch
+ * run writes rows the batch file never names. Pinning from the batch file alone was
+ * MEASURED at 83.0% / 84.8% / 90.9% on batches 03 / 02 / 04 (2026-08-01), and every
+ * inspected miss was a standard-corpus row: `blackberry`, `cranberry`, `egg`,
+ * `cheese gouda`, `and creamer half`. Calling the warmer's own seed assembly closes
+ * that gap at the source instead of guessing at a second list.
+ *
+ * Read-only. No DB, no network.
+ *
+ * Exit codes:
+ *   0 = wrote >= 1 pin
+ *   4 = VOID — zero pins. Playbook §11 class B: an empty pin file is not a result, and
+ *       downstream _dump_cache_prompts.ts would refuse it (or, before that guard,
+ *       silently un-pin every row). A run that produced nothing must not exit like a
+ *       run that produced something.
+ *   2 = error / refused
+ */
+import * as fs from 'fs';
+import { canonicalizeCacheKey } from '../../src/lib/mapping/normalization-rules';
+import { assembleSeeds } from './warm-cache';
+
+// ---------------------------------------------------------------------------
+// Pure, unit-testable core (scripts/eval/__tests__/cache-ops-void-exits.test.ts)
+// ---------------------------------------------------------------------------
+
+export const PIN_VOID_EXIT = 4;
+
+export interface PinBuild {
+    /** key -> phrase, seed pins layered over merged pins. */
+    pins: Map<string, string>;
+    /** Added keys with no pin from any source — judged with an EMPTY phrase. */
+    unpinned: string[];
+    /** Two seeds canonicalizing onto one added key: reported, never silently resolved. */
+    collisions: { key: string; kept: string; dropped: string }[];
+    /** Seeds whose canonical key is not among the added keys (normalizer rewrote it). */
+    seedsOffTarget: number;
+    /** Pins taken from --merge because no seed reached that key. */
+    fromMerge: number;
+}
+
+/**
+ * Build the pin set for a batch.
+ *
+ * `addedKeys` bounds the whole thing: pinning a key the batch did not add would put a
+ * phrase on a row this screen is not judging, and the screen pulls rows from added.txt.
+ */
+export function buildPins(
+    addedKeys: string[],
+    seeds: string[],
+    canon: (s: string) => string,
+    merged?: Map<string, string>,
+): PinBuild {
+    const added = new Set(addedKeys);
+    const pins = new Map<string, string>();
+    const collisions: PinBuild['collisions'] = [];
+    let seedsOffTarget = 0;
+
+    for (const seed of seeds) {
+        let k: string;
+        try { k = canon(seed); } catch { seedsOffTarget++; continue; }
+        if (!added.has(k)) { seedsOffTarget++; continue; }
+        const prior = pins.get(k);
+        if (prior && prior !== seed) {
+            // Do not pick a winner on a guess. Keep the first, report the second: a
+            // collision means two shopper phrases share one cached row, which is a
+            // finding about the key space, not a detail to smooth over.
+            collisions.push({ key: k, kept: prior, dropped: seed });
+            continue;
+        }
+        pins.set(k, seed);
+    }
+
+    let fromMerge = 0;
+    if (merged) {
+        for (const [k, phrase] of merged) {
+            if (!added.has(k) || pins.has(k)) continue;
+            pins.set(k, phrase);
+            fromMerge++;
+        }
+    }
+
+    const unpinned = addedKeys.filter(k => !pins.has(k));
+    return { pins, unpinned, collisions, seedsOffTarget, fromMerge };
+}
+
+/** Zero pins is a distinct, loud, nonzero outcome — never a quiet green. */
+export function pinOutcome(pinned: number, wanted: number): { code: number; lines: string[] } {
+    if (pinned === 0) {
+        return {
+            code: PIN_VOID_EXIT,
+            lines: [
+                `VOID: pinned 0 / ${wanted} added key(s) — this run produced NOTHING.`,
+                'Attribution is pins-only, so an empty pin file means every row would be judged with an',
+                'EMPTY shopper phrase and the seed-dependent rules would abstain (playbook §11 class B:',
+                'absence encoded as a pass). Wrong added.txt, wrong seed file, or canonicalizeCacheKey',
+                'landing nowhere near the warmed keys — find out which before using the output.',
+            ],
+        };
+    }
+    return { code: 0, lines: [] };
+}
+
+/** added.txt is `key<TAB>details` (gate.py). Take field 0 and nothing else. */
+export function parseAddedKeys(text: string): string[] {
+    return text.split('\n')
+        .map(l => l.split('\t')[0].trim())
+        .filter(Boolean);
+}
+
+/** A batch seed file is bare phrases, `#` comments, blank lines. */
+export function parseSeedLines(text: string): string[] {
+    return text.split('\n')
+        .map(l => l.replace(/\r$/, '').trim())
+        .filter(l => l && !l.startsWith('#'));
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main(): number {
+    const args = process.argv.slice(2);
+    const val = (flag: string): string | undefined => {
+        const i = args.indexOf(flag);
+        return i >= 0 ? args[i + 1] : undefined;
+    };
+    const addedPath = val('--added');
+    const seedsPath = val('--seeds');
+    const outPath = val('--out');
+    const mergePath = val('--merge');
+    const batchOnly = args.includes('--batch-seeds-only');
+    if (!addedPath || !seedsPath || !outPath) {
+        console.error('usage: _pin_batch_seeds.ts --added <added.txt> --seeds <batch.txt> --out <pins.tsv> '
+            + '[--merge <telemetry-pins.tsv>] [--batch-seeds-only]');
+        return 2;
+    }
+
+    const addedKeys = parseAddedKeys(fs.readFileSync(addedPath, 'utf8'));
+    // The warmer's own seed assembly, so the pin source is the list that actually ran.
+    // --batch-seeds-only exists to REPRODUCE the 83-91% measurement above, not for
+    // production use: it is the narrower list, and its coverage gap is the finding.
+    const seeds = batchOnly
+        ? parseSeedLines(fs.readFileSync(seedsPath, 'utf8'))
+        : assembleSeeds({ seedFile: seedsPath });
+    console.log(batchOnly
+        ? `seed source: BATCH FILE ONLY — ${seeds.length} phrase(s)`
+        : `seed source: assembleSeeds({seedFile}) — ${seeds.length} phrase(s) (standard corpus + batch)`);
+    if (!addedKeys.length) {
+        console.error(`REFUSING: ${addedPath} lists 0 keys. There is nothing to pin, and a screen over 0 rows `
+            + 'is not a clean batch.');
+        return 2;
+    }
+
+    let merged: Map<string, string> | undefined;
+    if (mergePath) {
+        // A missing merge file is fine (the telemetry pass may legitimately have found
+        // nothing); an unreadable-but-present one is not, and is not guessed at.
+        if (fs.existsSync(mergePath)) {
+            merged = new Map();
+            for (const line of fs.readFileSync(mergePath, 'utf8').split('\n')) {
+                if (!line.trim()) continue;
+                const tab = line.indexOf('\t');
+                if (tab < 0) continue;
+                const k = line.slice(0, tab).trim();
+                const p = line.slice(tab + 1).trim();
+                if (k && p) merged.set(k, p);
+            }
+            console.log(`merge source: ${merged.size} telemetry pin(s) from ${mergePath}`);
+        } else {
+            console.log(`merge source: ${mergePath} absent — seed pins only`);
+        }
+    }
+
+    const b = buildPins(addedKeys, seeds, canonicalizeCacheKey, merged);
+
+    const lines: string[] = [];
+    for (const k of addedKeys) {
+        const p = b.pins.get(k);
+        if (p) lines.push(`${k}\t${p}`);
+    }
+    fs.writeFileSync(outPath, lines.join('\n') + (lines.length ? '\n' : ''));
+
+    const pct = (100 * b.pins.size) / addedKeys.length;
+    console.log(`pinned ${b.pins.size} / ${addedKeys.length} added key(s) (${pct.toFixed(1)}%)`
+        + `  [seed ${b.pins.size - b.fromMerge}, telemetry ${b.fromMerge}] -> ${outPath}`);
+    if (b.seedsOffTarget) {
+        console.log(`NOTE ${b.seedsOffTarget} of ${seeds.length} seed(s) canonicalized to a key this batch did not add `
+            + '— expected: the pipeline normalizes names before keying (bell pepper -> capsicum), and warming '
+            + 'also HITS existing rows rather than adding them.');
+    }
+    for (const c of b.collisions) {
+        console.log(`COLLISION key "${c.key}": kept "${c.kept}", dropped "${c.dropped}" — two phrases, one cached row.`);
+    }
+    if (b.unpinned.length) {
+        console.log(`WARN ${b.unpinned.length} added key(s) have NO phrase and will be judged with an empty seed: `
+            + b.unpinned.slice(0, 8).join(', ') + (b.unpinned.length > 8 ? ', ...' : ''));
+    }
+
+    const outcome = pinOutcome(b.pins.size, addedKeys.length);
+    for (const l of outcome.lines) console.error(l);
+    return outcome.code;
+}
+
+if (require.main === module) {
+    try {
+        process.exit(main());
+    } catch (e) {
+        console.error(e);
+        process.exit(2);
+    }
+}


### PR DESCRIPTION
Two backend scripts the warm campaign's two-phase agent screen needs. The screener is Claude Code Sonnet agents (decided 2026-07-31); `run-batches.sh` is unattended and a shell script cannot spawn one, so the runner splits into screen-and-stop (`--screen agent`, exits 10) and resume (`--resume`). These are the pieces that split calls.

## `_pin_batch_seeds.ts`

Builds the `key<TAB>phrase` pin file for one batch. **Pin coverage is screen coverage** — an unpinned row is judged with an empty phrase, so D1/D2/D3/D4/D10/D11 abstain, and D3 alone carries 15 of 23 measured BAD catches. Imports `canonicalizeCacheKey` and the warmer's own `assembleSeeds` rather than transcribing either.

**The handoff spec predicted seed pins would reach ~100%. Measured by replaying batches 02/03/04, they don't:**

| source | 02 | 03 | 04 |
|---|---|---|---|
| seed pins alone | 92.0% | 84.0% | 91.8% |
| telemetry alone | 98.2% | 96.0% | 97.3% |
| merged, seed-first | **98.2%** | **97.0%** | **97.3%** |

Two causes. `warm-cache --seed` *adds* to the ~264-name standard corpus, so `added.txt` holds rows the batch file never names — fixed here by pinning from `assembleSeeds`. And the AI normalize step renames a query *before* the key is computed, so `canonicalizeCacheKey(seed)` is not the stored key (`gouda cheese slices` → `cheese gouda`, `egg beaters` → `beater`). The second is unfixable from the seed side, hence `--merge` folding in telemetry pins recovered from `MappingEventLog.normalizedForm`. Both sources are load-bearing — batch 03 reaches 97 from 84 + 96.

## `_agent_screen_reconcile.ts`

The only producer of `screen-evict.txt` in the agent path. The session writes **verdicts**; this derives the evict list, so no transcription step sits between a judgement and a `DELETE`.

Refuses on: a row missing, duplicated, or returned at an index whose key doesn't match; out-of-range index; error field; unrecognised verdict or axis; Tier-D keys from a different run; an eviction resting only on D1/D5/D6. Serving-axis rejects are held back — `FoodMapping` is identity-only, so an evictor must be actionable by deleting the row, and D1/D5/D6 are demoted for cause (D1 false-evicts at 73.8% live; D5/D6 are serving-stage defects a delete cannot fix). A refusal unlinks any stale out file so it cannot be misread as a prior verdict.

## Tests

25 fail-injection tests, each paired with a positive control, covering the ways a session-shaped gap yields a green-looking wrong evict list: dead agent, double-count, off-by-one driver, unrecognised verdict, serving-axis reject, policy drift to `strict`.

## Verification

`npm run typecheck` clean; `lint:ci` 0 errors; full `scripts/eval/__tests__` suite 20 suites / 1084 tests pass. The runner split itself is **built but has never run end to end** — batch 10 is the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu