### PR TITLE
docs(doc-check): a box-context claim on the rules file Syncthing never delivers

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -954,6 +954,19 @@
       },
       "verified": "2026-08-01",
       "timeoutMs": 60000
+    },
+    {
+      "id": "box-rules-file-has-no-cooking-verbs",
+      "claim": "THE DELIVERED HALF of PR #211, and the only check that can see it. data/ is in the box's .stignore, so Syncthing has NEVER carried data/fatsecret/normalization-rules.json to /home/owner/Recipe-App — the box held the 2026-07-24 content until an scp on 2026-08-01 — and readRulesFile() in src/lib/mapping/normalization-rules.ts prefers that on-disk JSON over DEFAULT_RULES. A stale copy therefore reinstates the cooking-state key collapse on the LIVE service while every Mac-side gate stays green, including the backend-context twin cooking-verbs-out-of-prep-phrases-and-cache-bumped, which reads the Mac's file. Asserts zero of the verbs PR #211 removed (grilled/roasted/baked/broiled/scrambled/steamed/poached/boiled — the last also covering the hard[-\\s]?boiled and soft[-\\s]?boiled forms — /sauteed/sautéed/smoked), matched on word boundaries so the deliberately RETAINED parboiled, blanched and microwaved do not trip it. Output is verbCount@prepPhraseCount: a missing, unreadable or unparseable file emits nothing and FAILS, never passes.",
+      "ownerDoc": "mobile:CLAUDE.md#deploying-the-backend",
+      "where": "box",
+      "command": "node -e \"const p='/home/owner/Recipe-App/data/fatsecret/normalization-rules.json';const r=JSON.parse(require('fs').readFileSync(p,'utf8'));const V=['grilled','roasted','baked','broiled','scrambled','steamed','poached','boiled','sauteed','saut\\u00e9ed','smoked'];const re=new RegExp('[^a-z]('+V.join('|')+')[^a-z]','i');const h=r.prep_phrases.filter(x=>re.test(' '+String(x).toLowerCase()+' '));process.stdout.write(h.length+'@'+r.prep_phrases.length)\"",
+      "expect": {
+        "kind": "matches",
+        "value": "^0@[1-9][0-9]*$"
+      },
+      "verified": "2026-08-01",
+      "timeoutMs": 60000
     }
   ]
 }


### PR DESCRIPTION
## Why

`data/` is in the box's Syncthing `.stignore`. `data/fatsecret/normalization-rules.json` had **never** synced to `/home/owner/Recipe-App` — the box sat on the 2026-07-24 content until an `scp` on 2026-08-01.

`readRulesFile()` in `src/lib/mapping/normalization-rules.ts` prefers that on-disk JSON over `DEFAULT_RULES`. So the PR #211 cooking-state fix was **fully inert on the live service while every Mac-side gate was green** — including the backend-context twin claim `cooking-verbs-out-of-prep-phrases-and-cache-bumped`, which reads the *Mac's* copy and therefore cannot see this.

That is why the new claim's context is `box`: the drift is invisible from the Mac by construction.

## The verb set is derived, not remembered

Taken from `git show 3ed8a7a -- data/fatsecret/normalization-rules.json` (the PR #211 commit): `grilled`, `roasted`, `baked`, `broiled`, `scrambled`, `steamed`, `poached`, `boiled` (plus the `hard[-\s]?boiled` / `soft[-\s]?boiled` forms), `sauteed`, `sautéed`, `smoked`.

PR #211 deliberately **kept** `blanched`, `microwaved`, `parboiled` — the word-boundary match is what stops `parboiled` tripping on `boiled`.

## Fail-closed, tested in the failure direction

Against doctored copies in the box's `/tmp` (the real file untouched; its `sha256` is unchanged and matches the Mac's):

| variant | stdout | verdict |
|---|---|---|
| real file | `0@55` | PASS |
| `+ "grilled"` | `1@56` | FAIL |
| `+ "Grilled"` | `1@56` | FAIL |
| `+ "hard[-\s]?boiled"` | `1@56` | FAIL |
| `+ "sautéed"` | `1@56` | FAIL |
| nonexistent path | *(empty)*, exit 1 | FAIL |
| unparseable JSON | *(empty)*, exit 1 | FAIL |

The `verbCount@prepPhraseCount` output shape exists so an empty-but-parsing file cannot read as green.

`npm run doc-check`: **80/80 claims hold**, unfiltered, on the Mac — no "OUT OF SCOPE" line, so the `box` claims genuinely executed over ssh rather than being skipped.

## Companion

The owner doc for this fact is the mobile repo's `CLAUDE.md` §Deploying the backend, which gains the matching note that `data/` never syncs. That is a separate commit in the mobile repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu