### PR TITLE
Lane-composed rerank window + the four FatSecret serving defects it exposed

### DIFF
--- a/scripts/eval/winner-diff-screens.ts
+++ b/scripts/eval/winner-diff-screens.ts
@@ -71,6 +71,8 @@ export interface WinnerInfo {
     selectionReason: string;
     /** index in `filtered` (GATHER order) — >= 10 means it was outside slice(0,10) */
     indexInFiltered: number;
+    /** Positional: index in `filtered` < 10. NOT window membership — the rerank
+     *  window is lane-composed, so use `inRerankWindow` for "reached the reranker". */
     inTop10: boolean;
     inRerankWindow: boolean;
 }

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -461,6 +461,20 @@ const KNOWN_CALLERS: Record<string, SelectionVariant> = {
     // gate — the one playbook section 5a requires before any admission or ranking
     // change — could not be run without `--allow-drift`. It was not run.
     '9e5634f738b23ba7': 'gate-backstop',
+    // CURRENT — the shape section 9 transcribes. Delta from 9e5634f7 is the rerank
+    // WINDOW: `filtered.slice(0, 10)` (a prefix over gather order) became
+    // `buildRerankPool(filtered, RERANK_POOL_LIMIT)` (per-lane composition), and the
+    // count-label extension now walks the remainder by difference instead of
+    // `filtered.slice(10)`.
+    //
+    // Still 'gate-backstop', and the variant taxonomy is deliberately NOT extended:
+    // `SelectionVariant` models what the confidence GATE does relative to Step 4
+    // (pre-empt vs backstop), and that is untouched here. Adding a variant per
+    // window shape would mean section 9 has to reproduce both, which is only worth
+    // doing when one tree must produce both sides of an A/B. This change is gated
+    // the other way — two trees, each transcribing its own caller — so the base
+    // tree's own pin (9e5634f7) covers the base side.
+    '16bec3f864088b83': 'gate-backstop',
 };
 /**
  * Re-pinned 2026-08-01 alongside the `copiedHelperSource()` CRLF fix above.
@@ -497,7 +511,7 @@ const PINNED_HELPERS_HASH = '7535716631ca65c8';
  * (that shape is genuinely known, and naming it is more useful than "unrecognised"),
  * but it can no longer claim the replay mirrors it.
  */
-const TRANSCRIBED_CALLER = '9e5634f738b23ba7';
+const TRANSCRIBED_CALLER = '16bec3f864088b83';
 
 interface DriftResult {
     caller: string;
@@ -594,6 +608,13 @@ const { AI_NUTRITION_MAX_PER_BATCH, AI_NUTRITION_HYDRATION_MAX_PER_BATCH } = req
 
 // Everything below is IMPORTED FROM THE REAL MODULES, never reimplemented. A probe
 // that reimplements the caller's argument list is a different function.
+//
+// `rerank-pool` is imported for the same reason, and it was written leaf-safe so
+// that it could be: no imports of its own, structural `{ source }` typing rather
+// than `UnifiedCandidate`. Requiring it here pulls in nothing from `config.ts`
+// (which snapshots flags and warms ONNX — playbook section 4).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { buildRerankPool, rerankPoolRemainder, RERANK_POOL_LIMIT } = require('../../src/lib/mapping/rerank-pool');
 const { confidenceGate } = gatherMod;
 const { filterCandidatesByTokens, hasCoreTokenMismatch, hasNullOrInvalidMacros, detectGrainCookingContext } = filterMod;
 const { simpleRerank, toRerankCandidate, stripPrepModifiers } = rerankMod;
@@ -1307,13 +1328,32 @@ function replaySelection(e: SnapshotEntry, debug: boolean, variant: SelectionVar
         // caller 1657
         const countedNoun = countedPieceNoun(parsed);
 
-        // caller 1660-1668: NON-MONOTONE #1 — slice over GATHER order, not score
-        // order; the count-label extension pulls from filtered.slice(10) to a hard
-        // cap of 13. In BOTH variants this is now the ONLY way a candidate with
-        // indexInFiltered >= 10 can reach the reranker.
-        const candidatesForRerank: UnifiedCandidate[] = filtered.slice(0, 10);
+        // NON-MONOTONE #1 — the rerank window.
+        //
+        // The caller no longer takes a PREFIX of `filtered`. It composes the window
+        // per retrieval lane (`buildRerankPool`), because a prefix over gather order
+        // deleted whole lanes: measured cold 2026-08-01, 207 of 249 already-asked
+        // lines lost at least one entire lane, and the FatSecret lane reached the
+        // reranker on 42 of 249.
+        //
+        // IMPORTED, NOT TRANSCRIBED. `rerank-pool.ts` is leaf-safe by construction
+        // (no imports at all, structural `{ source }` typing rather than
+        // `UnifiedCandidate`), specifically so this harness can call the real
+        // function. Every hand-copy in this file is a drift liability — section 2
+        // exists because of them — so where the caller's logic can be imported
+        // instead, it is.
+        //
+        // The window SIZE is unchanged (RERANK_POOL_LIMIT === the old literal 10),
+        // so this is a re-composition, not an admission change. It is still
+        // non-monotone: a candidate that reaches the reranker under a prefix can be
+        // evicted by lane composition, which is exactly what this harness is for.
+        //
+        // The count-label extension now walks the REMAINDER (by difference), not
+        // `filtered.slice(10)` — the window is no longer a prefix, so the old form
+        // would re-offer candidates already inside it. Hard cap of 13 unchanged.
+        const candidatesForRerank: UnifiedCandidate[] = buildRerankPool(filtered, RERANK_POOL_LIMIT);
         if (countedNoun) {
-            for (const c of filtered.slice(10)) {
+            for (const c of rerankPoolRemainder(filtered, candidatesForRerank)) {
                 if (candidatesForRerank.length >= 13) break;
                 if (copy_candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
             }
@@ -1637,6 +1677,12 @@ function mkWinner(
         confidence: clamped,
         selectionReason,
         indexInFiltered: idx,
+        // POSITIONAL ONLY. Since the rerank window is composed per lane rather
+        // than taken as a prefix, "in the first 10 of `filtered`" and "reached
+        // the reranker" are different facts. `inRerankWindow` below is the one
+        // that answers the second, and it is derived from the actual window ids.
+        // Kept because it still describes gather position, which is what the
+        // starvation analysis is about; do not read it as window membership.
         inTop10: idx >= 0 && idx < 10,
         inRerankWindow: rerankRan && windowIds.includes(w.id),
     };

--- a/scripts/eval/winner-gate.sh
+++ b/scripts/eval/winner-gate.sh
@@ -135,6 +135,36 @@ fi
 
 RUN='npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/winner-diff.ts'
 
+# ------------------------------------------------------- blind spot A, part 2
+# THE VARIANT MUST BE THE ONE THE TREES ACTUALLY CONTAIN.
+#
+# `resolveVariant()` defaults to 'baseline', and this driver never passed
+# --variant, so every run it has ever done replayed `baseline` -- the PRE-#168
+# caller, where confidenceGate PRE-EMPTS Step 4 and simpleRerank never runs. No
+# tree has contained that shape since 2026-07-26 (`fb211474`). On the ~10.6% of
+# lines where the gate fires, both sides were therefore modelling a caller
+# neither tree has, and any change living inside Step 4 is INVISIBLE on exactly
+# those rows -- understating both its benefit and its risk.
+#
+# winner-diff says this out loud (`announceVariantFit`). The driver piped it to
+# `tail -6` and it scrolled past. A warning nobody can see is not a warning,
+# which is the same lesson as the drift banner it sits next to.
+#
+# Derived from the tree, never assumed: `hashes` resolves this tree's caller hash
+# through KNOWN_CALLERS. If the tree is UNRECOGNISED there is no honest variant
+# to pick and we stop -- that is the drift guard's job and it must not be routed
+# around here.
+TREE_VARIANT="$(eval "$RUN" hashes 2>/dev/null | sed -n 's/^this tree is: \([a-z-]*\) .*/\1/p' | head -1)"
+if [[ -z "$TREE_VARIANT" || "$TREE_VARIANT" == "UNRECOGNISED" ]]; then
+    echo "ABORT: cannot resolve this tree's caller variant (got '${TREE_VARIANT:-<empty>}')." >&2
+    echo "The caller block is drifted or unrecognised. Re-pin it in winner-diff.ts" >&2
+    echo "(KNOWN_CALLERS + TRANSCRIBED_CALLER) after running \`winner-diff verify\`." >&2
+    echo "Replaying a variant this tree does not contain is not a measurement." >&2
+    exit 3
+fi
+VARIANT_ARG="--variant $TREE_VARIANT"
+echo "variant:   $TREE_VARIANT (resolved from this tree's caller hash)"
+
 # ------------------------------------------------------------ base worktree
 # A worktree, NOT `git checkout <ref> -- <file>`: that form silently discards
 # uncommitted edits when HEAD is the base commit (playbook section 9).
@@ -178,12 +208,12 @@ fi
 # bugs were caught.
 noise_floor_both_trees() {
     local snap="$1" name="$2"
-    if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$snap" $SERVING ) 2>&1 | tail -6; then
+    if ! ( cd "$BASE_TREE" && eval "$RUN" noise-floor --snapshot "$snap" $VARIANT_ARG $SERVING ) 2>&1 | tail -6; then
         echo "ABORT: noise floor non-zero on BASE for $name. The replay is not" >&2
         echo "deterministic, so any before/after claim below it is not a result." >&2
         exit 4
     fi
-    if ! eval "$RUN" noise-floor --snapshot "$snap" $SERVING 2>&1 | tail -6; then
+    if ! eval "$RUN" noise-floor --snapshot "$snap" $VARIANT_ARG $SERVING 2>&1 | tail -6; then
         echo "ABORT: noise floor non-zero on BRANCH for $name. Your change" >&2
         echo "introduced nondeterminism into replay — that is itself the finding." >&2
         exit 4
@@ -205,15 +235,15 @@ fi
 # ------------------------------------------------------------ replays
 echo "[4/5] replay BASE, then BRANCH, against the identical frozen pool"
 ( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap.json" \
-    --out "$OUT/A-base.json" --label BASE $SERVING ) 2>&1 | tail -6
+    --out "$OUT/A-base.json" --label BASE $VARIANT_ARG $SERVING ) 2>&1 | tail -6
 eval "$RUN" replay --snapshot "$OUT/snap.json" \
-    --out "$OUT/B-branch.json" --label BRANCH $SERVING 2>&1 | tail -6
+    --out "$OUT/B-branch.json" --label BRANCH $VARIANT_ARG $SERVING 2>&1 | tail -6
 
 if [[ "$REGRESSION_N" -gt 0 ]]; then
     ( cd "$BASE_TREE" && eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
-        --out "$OUT/A-base-regression.json" --label BASE $SERVING ) 2>&1 | tail -4
+        --out "$OUT/A-base-regression.json" --label BASE $VARIANT_ARG $SERVING ) 2>&1 | tail -4
     eval "$RUN" replay --snapshot "$OUT/snap-regression.json" \
-        --out "$OUT/B-branch-regression.json" --label BRANCH $SERVING 2>&1 | tail -4
+        --out "$OUT/B-branch-regression.json" --label BRANCH $VARIANT_ARG $SERVING 2>&1 | tail -4
 fi
 
 # ------------------------------------------------------------ diff

--- a/src/lib/mapping/__tests__/build-fatsecret-result-ambiguous-unit.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-ambiguous-unit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * buildFatSecretResult — ambiguous / count units ("handful", "sleeve", "bowl").
+ *
+ * `buildOffResult()` and `buildFdcResult()` both resolve these through
+ * `getOrCreateAmbiguousServing()`. This cascade never called it, so the request
+ * fell to the record's declared default — whichever single piece it leads with.
+ *
+ * Latent while the FatSecret lane reached the reranker on 16.9% of queries; the
+ * lane-composition fix made FatSecret the winner for these lines and the gate
+ * measured it (2026-08-02, regression pool):
+ *     1 handful almonds          30g       ->  1.2g
+ *     1 sleeve saltine crackers  113g/490kcal -> 3g/13kcal
+ * one almond and one cracker respectively.
+ *
+ * Note what is NOT the fix, because it was the obvious one: banding the
+ * declared default. This builder is terminal, so a rejection lands on the flat
+ * per-100g tier, and the bare-query guard's digit gate excludes every one of
+ * these lines. 100g for a handful of almonds is wrong in the other direction.
+ * The request needs an answer, not a veto.
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+const mockGetOrCreateAmbiguousServing = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+jest.mock('../ambiguous-unit-backfill', () => ({
+    isAmbiguousUnit: jest.requireActual('../ambiguous-unit-backfill').isAmbiguousUnit,
+    getOrCreateAmbiguousServing: (...args: unknown[]) => mockGetOrCreateAmbiguousServing(...args),
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(over: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_37040', source: 'fatsecret' as const, name: 'Almonds',
+        brandName: null, score: 1, foodType: 'Generic', rawData: {}, ...over,
+    } as any;
+}
+
+/** fs_37040's real shape: the declared default IS the 1.2g single almond. */
+function makeRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '37040', name: 'Almonds', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { kcal: 578, protein: 21, carbs: 22, fat: 50 },
+        defaultServingId: 'svPiece',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            {
+                servingId: 'svPiece', description: '1 almond', measurementDescription: 'almond',
+                grams: 1.2, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 7, protein: 0.3, carbohydrate: 0.3, fat: 0.6 },
+            },
+        ],
+        ...over,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '', ...over } as ParsedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+    mockGetOrCreateAmbiguousServing.mockResolvedValue({ status: 'success', grams: 30 });
+});
+
+describe('the unit reaches the shared resolver', () => {
+    it('"1 handful almonds" bills the resolved handful, not the 1.2g almond', async () => {
+        // MUTATION: delete the (c2) block -> falls to fs_default_serving at 1.2g.
+        const r = await buildFatSecretResult(
+            makeCandidate(),
+            parsedLine({ unit: 'handful', name: 'almonds' }),
+            0.9, '1 handful almonds'
+        );
+        expect(r!.grams).toBe(30);
+        expect(r!.servingTier).toBe('count_unit_ai');
+        expect(mockGetOrCreateAmbiguousServing).toHaveBeenCalledWith(
+            'fs_37040', 'Almonds', 'handful', null
+        );
+    });
+
+    it('a cached resolution is tiered as cached, not as a fresh estimate', async () => {
+        // The tier is how the flywheel tells a cache hit from an LLM spend.
+        mockGetOrCreateAmbiguousServing.mockResolvedValue({ status: 'cached', grams: 113 });
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Saltine Crackers' }),
+            parsedLine({ unit: 'sleeve', name: 'saltine crackers' }),
+            0.9, '1 sleeve saltine crackers'
+        );
+        expect(r!.grams).toBe(113);
+        expect(r!.servingTier).toBe('count_unit_cached');
+    });
+
+    it('scales by qty — "2 bowls cereal" is two resolved bowls', async () => {
+        mockGetOrCreateAmbiguousServing.mockResolvedValue({ status: 'success', grams: 50 });
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Cereal' }),
+            parsedLine({ qty: 2, unit: 'bowl', name: 'cereal' }),
+            0.9, '2 bowls cereal'
+        );
+        expect(r!.grams).toBe(100);
+    });
+});
+
+describe('ordering — a label the record genuinely enumerates still wins', () => {
+    it('"2 bars" matches the record\'s own bar serving and never consults the resolver', async () => {
+        // MUTATION: move the (c2) block ABOVE the noun match -> the resolver
+        // answers a unit the label already defines, and this call count is 1.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Protein Bar', defaultServingId: 'svBar',
+            servings: [{
+                servingId: 'svBar', description: '1 bar', measurementDescription: 'bar',
+                grams: 60, volumeMl: null, numberOfUnits: 1, nutrients: null,
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Protein Bar' }),
+            parsedLine({ qty: 2, unit: 'bar', name: 'bars' }),
+            0.9, '2 bars'
+        );
+        expect(r!.grams).toBe(120);
+        expect(r!.servingTier).toBe('fs_label_count');
+        expect(mockGetOrCreateAmbiguousServing).not.toHaveBeenCalled();
+    });
+
+    it('an explicit weight unit never reaches the resolver', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(),
+            parsedLine({ qty: 50, unit: 'g', name: 'almonds' }),
+            0.9, '50g almonds'
+        );
+        expect(r!.grams).toBe(50);
+        expect(mockGetOrCreateAmbiguousServing).not.toHaveBeenCalled();
+    });
+
+    it('a bare request has no unit and never reaches the resolver', async () => {
+        await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'almonds' }), 0.9, 'almonds'
+        );
+        expect(mockGetOrCreateAmbiguousServing).not.toHaveBeenCalled();
+    });
+});
+
+describe('the resolver failing is not a crash and not a fabrication', () => {
+    it('an unresolved unit falls through to the existing cascade', async () => {
+        // MUTATION: drop the status/grams guard and bill `ambiguous.grams`
+        // unconditionally -> NaN grams reach the caller.
+        mockGetOrCreateAmbiguousServing.mockResolvedValue({ status: 'error', error: 'no estimate' });
+        const r = await buildFatSecretResult(
+            makeCandidate(),
+            parsedLine({ unit: 'handful', name: 'almonds' }),
+            0.9, '1 handful almonds'
+        );
+        expect(r).not.toBeNull();
+        expect(Number.isFinite(r!.grams)).toBe(true);
+        expect(r!.servingTier).not.toBe('count_unit_ai');
+    });
+
+    it('a zero or negative resolution is refused', async () => {
+        mockGetOrCreateAmbiguousServing.mockResolvedValue({ status: 'success', grams: 0 });
+        const r = await buildFatSecretResult(
+            makeCandidate(),
+            parsedLine({ unit: 'handful', name: 'almonds' }),
+            0.9, '1 handful almonds'
+        );
+        expect(r!.grams).not.toBe(0);
+        expect(r!.servingTier).not.toBe('count_unit_ai');
+    });
+});

--- a/src/lib/mapping/__tests__/build-fatsecret-result-bare-piece.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-bare-piece.test.ts
@@ -211,6 +211,96 @@ describe('rule (2) — a bare SINGULAR must not bill a tiny piece either', () =>
     });
 });
 
+describe('the default-serving sink — suppression alone was not enough', () => {
+    /**
+     * The real fs_37040 "Almonds" record, read off the box 2026-08-01:
+     *   35301  1 almond                  1.2g   <- defaultServingId
+     *   44764  1 oz                     28.35g
+     *   35300  1 oz (23 whole kernels)  28.35g
+     *   59771  100 g                     100g
+     *   35299  1 cup whole                143g
+     * Suppressing the count branch moved `almonds` from fs_label_count to
+     * fs_default_serving and left the billed grams at 1.2 — the declared
+     * default IS the per-piece row. A fix that only suppresses is inert here.
+     */
+    function almondsRow() {
+        return makeRow({
+            defaultServingId: 'svPiece',
+            servings: [
+                {
+                    servingId: 'svPiece', description: '1 almond', measurementDescription: 'almond',
+                    grams: 1.2, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 7, protein: 0.3, carbohydrate: 0.2, fat: 0.6 },
+                },
+                {
+                    servingId: 'svOz', description: '1 oz (23 whole kernels)', measurementDescription: 'oz',
+                    grams: 28.35, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 164, protein: 6, carbohydrate: 6.1, fat: 14.2 },
+                },
+                {
+                    servingId: 'svCup', description: '1 cup whole', measurementDescription: 'cup',
+                    grams: 143, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 827, protein: 30.4, carbohydrate: 30.8, fat: 71.4 },
+                },
+            ],
+        });
+    }
+
+    it('bare "almonds" bills a serving, not the 1.2g declared default', async () => {
+        // MUTATION: delete the bareServingUsable() band on the default-serving
+        // branch -> 1.2g comes straight back, with every other test still green.
+        mockFatSecretFoodFindUnique.mockResolvedValue(almondsRow());
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'almonds' }), 0.9, 'almonds'
+        );
+        expect(r!.grams).toBe(28);           // bare-query lexicon: 1 oz
+        expect(r!.servingTier).toBe('bare_category_default');
+    });
+
+    it('rejects, and does NOT substitute another serving off the record', async () => {
+        // The tempting fix is "take the next in-band serving". It is not safe:
+        // prisma include has no orderBy, so the next in-band row here is either
+        // 28.35g or 143g depending on DB order. Falling through to the guard is
+        // deterministic. This asserts we never land on the cup.
+        mockFatSecretFoodFindUnique.mockResolvedValue(almondsRow());
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'almonds' }), 0.9, 'almonds'
+        );
+        expect(r!.grams).not.toBe(143);
+        expect(r!.grams).not.toBe(28.35);
+    });
+
+    it('an in-band declared default is still billed untouched', async () => {
+        // The band must only fire where the answer was already out of band.
+        // MUTATION: invert the band condition -> this goes red.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Greek Yogurt',
+            defaultServingId: 'svCup',
+            servings: [{
+                servingId: 'svCup', description: '1 container', measurementDescription: 'container',
+                grams: 170, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 100, protein: 17, carbohydrate: 6, fat: 0 },
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Greek Yogurt' }),
+            parsedLine({ name: 'greek yogurt' }), 0.9, 'greek yogurt'
+        );
+        expect(r!.servingTier).toBe('fs_default_serving');
+        expect(r!.grams).toBe(170);
+    });
+
+    it('a NON-bare request keeps an out-of-band default serving', async () => {
+        // The band is bare-only. "3 almonds" is an explicit count and must still
+        // resolve per piece. MUTATION: drop the bare gate from bareServingUsable.
+        mockFatSecretFoodFindUnique.mockResolvedValue(almondsRow());
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 3, name: 'almonds' }), 0.9, '3 almonds'
+        );
+        expect(r!.grams).toBeCloseTo(3.6, 3);
+    });
+});
+
 describe('what the suppression must NOT touch', () => {
     it('an explicit count keeps per-piece resolution ("3 almonds" -> 3.6g)', async () => {
         // The digit gate is the whole reason a counted request still works.

--- a/src/lib/mapping/__tests__/build-fatsecret-result-bare-piece.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-bare-piece.test.ts
@@ -1,0 +1,250 @@
+/**
+ * buildFatSecretResult — bare-request per-piece suppression.
+ *
+ * The FatSecret count branch matched a piece noun against serving descriptions
+ * with NO bare-request guard, so a query meaning "a serving" resolved to one
+ * piece: bare `almonds` billed 1.2 g / 7 kcal against the OFF cascade's 28 g /
+ * 160 kcal (winner-gate, 2026-08-01). OFF had both rules; this copy had
+ * neither, and could not even import the plural predicate.
+ *
+ * Each test below names the mutation it kills, because the point of this file
+ * is that the guards are load-bearing, not that the happy path works.
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(over: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_900', source: 'fatsecret' as const, name: 'Almonds',
+        brandName: null, score: 1, foodType: 'Generic', rawData: {}, ...over,
+    } as any;
+}
+
+/** A real fs shape: a per-piece serving AND a portion serving on one record. */
+function makeRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '900', name: 'Almonds', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { kcal: 579, protein: 21, carbs: 22, fat: 50 },
+        defaultServingId: 'svOz',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            {
+                servingId: 'svPiece', description: '1 almond', measurementDescription: 'almond',
+                grams: 1.2, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 7, protein: 0.3, carbohydrate: 0.3, fat: 0.6 },
+            },
+            {
+                servingId: 'svOz', description: '1 oz (23 whole)', measurementDescription: 'oz',
+                grams: 28, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 162, protein: 6, carbohydrate: 6, fat: 14 },
+            },
+        ],
+        ...over,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '', ...over } as ParsedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+});
+
+describe('rule (1) — a bare PLURAL asks for a serving, never one piece', () => {
+    it('bare "almonds" does not bill the 1.2g per-piece serving', async () => {
+        // MUTATION: drop `barePlural ? null :` from the noun computation.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'almonds' }), 0.9, 'almonds'
+        );
+        expect(r!.servingTier).not.toBe('fs_label_count');
+        expect(r!.grams).toBeGreaterThanOrEqual(20);
+        expect(r!.grams).not.toBeCloseTo(1.2, 3);
+    });
+
+    it('the lexicon-free trailing-token fallback is suppressed too', async () => {
+        // The plural noun is not in DISCRETE_ITEM_UNIT_RE, so the FIRST match
+        // attempt returns nothing and only the trailing-token fallback can
+        // reach the per-piece serving. Without `&& !barePlural` on that branch
+        // the whole fix is inert for exactly the case that motivated it.
+        // MUTATION: drop `&& !barePlural` from the fallback condition.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Pretzels',
+            servings: [
+                {
+                    servingId: 'svPiece', description: '1 pretzel', measurementDescription: 'pretzel',
+                    grams: 2.3, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 9, protein: 0.2, carbohydrate: 1.9, fat: 0.1 },
+                },
+                {
+                    servingId: 'svOz', description: '1 oz', measurementDescription: 'oz',
+                    grams: 28, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 108, protein: 2.6, carbohydrate: 22.5, fat: 1 },
+                },
+            ],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Pretzels' }), parsedLine({ name: 'pretzels' }), 0.9, 'pretzels'
+        );
+        expect(r!.servingTier).not.toBe('fs_label_count');
+        expect(r!.grams).not.toBeCloseTo(2.3, 3);
+    });
+
+    it('a plural whose NAME is in the discrete-unit lexicon is suppressed too', async () => {
+        // The other plural tests only exercise the trailing-token fallback,
+        // because "almond"/"pretzel" are not in DISCRETE_ITEM_UNIT_RE. "nuggets"
+        // IS, so it reaches the FIRST match attempt — and only the gate on the
+        // noun computation stops it. Without this case that gate is untested.
+        // MUTATION: drop `barePlural ? null :` from the noun computation.
+        //
+        // Note what suppression costs: nothing. The default serving IS the
+        // manufacturer's serving, so the fall-through answers "a serving of
+        // nuggets" (100g) instead of one nugget (25g).
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Chicken Nuggets',
+            defaultServingId: 'svServ',
+            servings: [
+                {
+                    servingId: 'svPiece', description: '1 nugget', measurementDescription: 'nugget',
+                    grams: 25, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 74, protein: 4, carbohydrate: 4, fat: 5 },
+                },
+                {
+                    servingId: 'svServ', description: '4 nuggets', measurementDescription: 'serving',
+                    grams: 100, volumeMl: null, numberOfUnits: 4,
+                    nutrients: { calories: 296, protein: 16, carbohydrate: 16, fat: 20 },
+                },
+            ],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Chicken Nuggets' }),
+            parsedLine({ name: 'chicken nuggets' }), 0.9, 'chicken nuggets'
+        );
+        expect(r!.servingTier).not.toBe('fs_label_count');
+        expect(r!.grams).not.toBe(25);
+    });
+
+    it('"goldfish" counts as plural without plural morphology', async () => {
+        // MUTATION: drop BARE_PLURAL_STYLE_NAMES from isBarePluralRequest.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Goldfish Crackers',
+            servings: [
+                {
+                    servingId: 'svPiece', description: '1 cracker', measurementDescription: 'cracker',
+                    grams: 0.5, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 2, protein: 0.1, carbohydrate: 0.3, fat: 0.1 },
+                },
+                {
+                    servingId: 'svOz', description: '55 pieces', measurementDescription: 'pieces',
+                    grams: 30, volumeMl: null, numberOfUnits: 1,
+                    nutrients: { calories: 140, protein: 3, carbohydrate: 20, fat: 5 },
+                },
+            ],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Goldfish Crackers' }),
+            parsedLine({ name: 'goldfish' }), 0.9, 'goldfish'
+        );
+        expect(r!.servingTier).not.toBe('fs_label_count');
+    });
+});
+
+describe('rule (2) — a bare SINGULAR must not bill a tiny piece either', () => {
+    it('bare "almond" is suppressed by the 20g piece floor', async () => {
+        // MUTATION: delete the `bareSingular && perUnitGrams < BARE_MIN_...`
+        // branch. "almond" is not morphologically plural, so ONLY this rule
+        // stands between the query and a 1.2g bill.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'almond' }), 0.9, 'almond'
+        );
+        expect(r!.servingTier).not.toBe('fs_label_count');
+        expect(r!.grams).not.toBeCloseTo(1.2, 3);
+    });
+
+    it('a piece AT the floor passes — the floor is >=, not >', async () => {
+        // MUTATION: `<` -> `<=` in the floor comparison.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Rice Cakes',
+            servings: [{
+                servingId: 'svPiece', description: '1 cake', measurementDescription: 'cake',
+                grams: 20, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 35, protein: 1, carbohydrate: 7, fat: 0.3 },
+            }],
+            defaultServingId: 'svPiece',
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Rice Cake' }), parsedLine({ name: 'rice cake' }), 0.9, 'rice cake'
+        );
+        expect(r!.servingTier).toBe('fs_label_count');
+        expect(r!.grams).toBe(20);
+    });
+
+    it('a real single-piece food keeps its piece weight (banana, 118g)', async () => {
+        // The floor must not swallow foods where one piece IS the serving.
+        // MUTATION: raise BARE_MIN_PIECE_SERVING_GRAMS above 118.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Banana',
+            servings: [{
+                servingId: 'svPiece', description: '1 medium banana', measurementDescription: 'banana',
+                grams: 118, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 105, protein: 1.3, carbohydrate: 27, fat: 0.4 },
+            }],
+            defaultServingId: 'svPiece',
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Banana' }), parsedLine({ name: 'banana' }), 0.9, 'banana'
+        );
+        expect(r!.servingTier).toBe('fs_label_count');
+        expect(r!.grams).toBe(118);
+    });
+});
+
+describe('what the suppression must NOT touch', () => {
+    it('an explicit count keeps per-piece resolution ("3 almonds" -> 3.6g)', async () => {
+        // The digit gate is the whole reason a counted request still works.
+        // MUTATION: remove the `/\d/.test(rawLine)` gate from either predicate.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 3, name: 'almonds' }), 0.9, '3 almonds'
+        );
+        expect(r!.servingTier).toBe('fs_label_count');
+        expect(r!.grams).toBeCloseTo(3.6, 3);
+    });
+
+    it('an explicit count unit is unaffected ("2 bars")', async () => {
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            name: 'Quest Protein Bar',
+            servings: [{
+                servingId: 'svBar', description: '1 bar', measurementDescription: 'bar',
+                grams: 60, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 200, protein: 21, carbohydrate: 21, fat: 8 },
+            }],
+            defaultServingId: 'svBar',
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ name: 'Quest Protein Bar' }),
+            parsedLine({ qty: 2, unit: 'bar', name: 'protein bar' }), 0.9, '2 bars'
+        );
+        expect(r!.servingTier).toBe('fs_label_count');
+        expect(r!.grams).toBe(120);
+    });
+
+    it('a bare singular with an explicit weight unit is untouched', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 50, unit: 'g', name: 'almonds' }), 0.9, '50g almonds'
+        );
+        expect(r!.servingTier).toBe('fs_weight_direct');
+        expect(r!.grams).toBe(50);
+    });
+});

--- a/src/lib/mapping/__tests__/build-fatsecret-result-demoted-default.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-demoted-default.test.ts
@@ -1,0 +1,185 @@
+/**
+ * buildFatSecretResult — what answers a bare request when the record's DECLARED
+ * default serving is the per-100g panel row.
+ *
+ * `defaultServingId` resolves for 23,837 of 23,837 FatSecret foods, so the
+ * `?? usableServings[0]` fallback under it fires in exactly one situation: the
+ * declared default is the shared "100 g" row that `isPer100gPanelServing`
+ * demotes out of `usableServings`. That is 569 foods (measured 2026-08-02, box),
+ * and for every one of them the billed grams were decided by include ORDER.
+ *
+ * `Chicken` (fs_1623) is the case that exposed it. Its declared default is the
+ * "100 g" panel row; its other servings run from a 7g thin slice to a 135g cup.
+ * The positional pick returned the 85g "1 serving" row before the include was
+ * ordered and the 7g slice after — 201 kcal vs 17 kcal for the same query,
+ * decided by nothing. Ordering the include made that REPRODUCIBLE, which is
+ * strictly worse than flaky: a wrong number that never varies stops being
+ * noticed.
+ *
+ * The fixture below is the real fs_1623 serving list, verbatim from the box.
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(over: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_1623', source: 'fatsecret' as const, name: 'Chicken',
+        brandName: null, score: 1, foodType: 'Generic', rawData: {}, ...over,
+    } as any;
+}
+
+function serving(servingId: string, description: string, grams: number) {
+    return {
+        servingId, description, measurementDescription: null,
+        grams, volumeMl: null, numberOfUnits: 1, nutrients: null,
+    };
+}
+
+/**
+ * fs_1623 as stored, ordered by `servingId` ascending — i.e. exactly what the
+ * `orderBy` on the include now returns. The 7g thin slice sorts FIRST, which is
+ * what the positional pick billed.
+ */
+function makeRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '1623', name: 'Chicken', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { kcal: 237, protein: 27, carbs: 0, fat: 14 },
+        defaultServingId: '50303',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            serving('3942', '1 thin slice (approx 2" x 1-1/2" x 1/8")', 7),
+            serving('3943', '1 oz boneless, cooked', 28.35),
+            serving('3945', '1 cup cooked, diced', 135),
+            serving('3947', '1 medium piece (yield after cooking, bone removed)', 62),
+            serving('4191', '1 medium slice (approx 2" x 1-1/2" x 1/4")', 14),
+            serving('4192', '1 thick slice (approx 2" x 1-1/2" x 3/8")', 21),
+            serving('4193', '1 oz boneless (yield after cooking)', 24),
+            serving('4195', '1 serving (85 g)', 85),
+            serving('4196', '1 small piece (yield after cooking, bone removed)', 32),
+            serving('4197', '1 large piece (yield after cooking, bone removed)', 98),
+            serving('4198', '1 oz, with bone cooked (yield after bone removed)', 19),
+            { ...serving('50303', '100 g', 100), numberOfUnits: 100 },
+        ],
+        ...over,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '', ...over } as ParsedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+});
+
+describe('bare "chicken" — the record answers the question itself', () => {
+    it('bills the record\'s own "1 serving (85 g)" row, not the 7g thin slice', async () => {
+        // MUTATION: drop the EXPLICIT_ONE_SERVING_RE step from the `??` chain ->
+        // this falls to usableServings[0] and bills 7g / 17kcal.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBe(85);
+        expect(r!.kcal).toBeCloseTo(201, 0);
+    });
+
+    it('specifically does NOT bill any of the sub-20g piece rows', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        // 7g thin slice, 14g medium slice, 19g bone-in oz — every one of these
+        // was reachable positionally.
+        expect([7, 14, 19]).not.toContain(r!.grams);
+    });
+
+    it('no lexicon default exists for this query, so nothing downstream rescues it', async () => {
+        // The point of the assertion: `getBareQueryDefault('chicken')` returns
+        // nothing (measured 2026-08-02 — likewise beef, steak, salmon, pork,
+        // turkey, rice, pasta, bread, egg, ham, sausage). The bare-query guard
+        // therefore cannot correct a wrong pick here, and neither can falling
+        // through: this branch is the only thing standing between a staple
+        // protein and an arbitrary number.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r!.servingTier).toBe('fs_default_serving');
+    });
+});
+
+describe('the preference is a FALLBACK, not an override', () => {
+    it('a resolvable declared default still wins over the "1 serving" row', async () => {
+        // MUTATION: reorder the `??` chain to put EXPLICIT_ONE_SERVING_RE first
+        // -> this bills 85g instead of the record's declared 135g cup.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({ defaultServingId: '3945' }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r!.grams).toBe(135);
+    });
+
+    it('falls back to position when the record has no "1 serving" row at all', async () => {
+        // Not an endorsement of the positional pick — it is what the other 291
+        // of the 569 still get, and this test exists so that population is
+        // visible rather than implied.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: makeRow().servings.filter(s => s.servingId !== '4195'),
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r!.grams).toBe(7);
+    });
+});
+
+describe('the bare band still applies to the row this picks', () => {
+    it('an out-of-band "1 serving" row is rejected, not billed', async () => {
+        // MUTATION: apply the preference AFTER `bareServingUsable` instead of
+        // before -> a 900g catering serving bills 900g on a bare query.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: makeRow().servings.map(s =>
+                s.servingId === '4195' ? serving('4195', '1 serving (900 g)', 900) : s),
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r!.grams).not.toBe(900);
+        expect(r!.servingTier).not.toBe('fs_default_serving');
+    });
+
+    it('"2 servings" is a multiple and must not match the count-1 anchor', async () => {
+        // MUTATION: drop the leading `1\s+` from EXPLICIT_ONE_SERVING_RE -> this
+        // bills 170g, i.e. two servings for a request that asked for one.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: makeRow().servings.map(s =>
+                s.servingId === '4195' ? serving('4195', '2 servings (170 g)', 170) : s),
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ name: 'chicken' }), 0.9, 'chicken'
+        );
+        expect(r!.grams).not.toBe(170);
+    });
+});
+
+describe('a non-bare request is unaffected', () => {
+    it('an explicit weight still bills that weight', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(),
+            parsedLine({ qty: 200, unit: 'g', name: 'chicken' }),
+            0.9, '200g chicken'
+        );
+        expect(r!.grams).toBe(200);
+    });
+});

--- a/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result.test.ts
@@ -590,7 +590,14 @@ describe('per-100g panel inversion recovers the true serving weight', () => {
     // fs-shaped Diet Coke: every panel nutrient is 0, so nothing is derivable.
     // Demoting the panel here would swap a 100g display for a 1g one showing
     // the same correct 0 kcal, so the row is deliberately left in place.
-    it('leaves a genuinely zero-calorie drink exactly as it was', async () => {
+    //
+    // UPDATED 2026-08-01, bare-request serving band. This is a BARE query, and
+    // its `100 g` default serving is the per-100g placeholder the band exists
+    // to reject, so it now falls through to the bare-query guard and bills the
+    // category default: 355g, one can — the same answer buildOffResult gives
+    // for `coca cola`. The assertion this test was written to defend is
+    // unchanged and still checked below: never the 1g shape, always 0 kcal.
+    it('leaves a genuinely zero-calorie drink at a sane weight and 0 kcal', async () => {
         mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
             name: 'Diet Coke (Can)',
             brandName: 'Coca-Cola',
@@ -615,7 +622,8 @@ describe('per-100g panel inversion recovers the true serving weight', () => {
             0.9,
             'diet coke'
         );
-        expect(result!.grams).toBe(100);
+        expect(result!.grams).toBe(355);
+        expect(result!.grams).toBeGreaterThan(3);   // never the 1g shape
         expect(result!.kcal).toBe(0);
     });
 

--- a/src/lib/mapping/__tests__/rerank-pool.test.ts
+++ b/src/lib/mapping/__tests__/rerank-pool.test.ts
@@ -1,0 +1,167 @@
+import { buildRerankPool, rerankPoolRemainder, RERANK_POOL_LIMIT } from '../rerank-pool';
+
+/**
+ * Each block names the invariant it pins and, where the guard is a specific
+ * expression, the mutation that must kill it. A test written against its own
+ * author's mental model shares that model's blind spots, so the mutations were
+ * actually applied and confirmed red before this file was committed.
+ */
+
+interface C { id: string; source?: string | null }
+
+const c = (id: string, source?: string | null): C => ({ id, source });
+const ids = (xs: readonly C[]) => xs.map(x => x.id).join(',');
+const bySource = (xs: readonly C[]) =>
+    xs.reduce<Record<string, number>>((m, x) => (m[x.source ?? ''] = (m[x.source ?? ''] ?? 0) + 1, m), {});
+
+/** The measured `grilled chicken breast` gather, 2026-08-01: 2 FDC, 14 OFF, 8 FatSecret,
+ *  concatenated lane by lane exactly as gatherCandidates emits them. */
+const GRILLED_CHICKEN_BREAST: C[] = [
+    ...Array.from({ length: 2 }, (_, i) => c(`fdc${i}`, 'fdc')),
+    ...Array.from({ length: 14 }, (_, i) => c(`off${i}`, 'openfoodfacts')),
+    ...Array.from({ length: 8 }, (_, i) => c(`fs${i}`, 'fatsecret')),
+];
+
+describe('buildRerankPool — the defect it exists to fix', () => {
+    it('admits the FatSecret lane that a flat prefix deleted entirely', () => {
+        // The old behaviour, kept literally so the regression is visible here and
+        // not just in a commit message.
+        expect(bySource(GRILLED_CHICKEN_BREAST.slice(0, 10)))
+            .toEqual({ fdc: 2, openfoodfacts: 8 });
+
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        expect(bySource(pool)).toEqual({ fdc: 2, openfoodfacts: 4, fatsecret: 4 });
+    });
+
+    it('gives every lane present in the input a place in the window', () => {
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        for (const lane of ['fdc', 'openfoodfacts', 'fatsecret']) {
+            expect(pool.some(x => x.source === lane)).toBe(true);
+        }
+    });
+});
+
+describe('buildRerankPool — invariants', () => {
+    it('1. size is min(limit, input length) — a small lane never costs capacity', () => {
+        expect(buildRerankPool(GRILLED_CHICKEN_BREAST)).toHaveLength(10);
+        // One lane holds a single candidate: its slots must go to the others, not
+        // be forfeited. Mutation: stop redistributing (drop the `progressed` loop
+        // and take a fixed share per lane) -> this goes to 6.
+        const lopsided = [c('a', 'fdc'), ...Array.from({ length: 20 }, (_, i) => c(`o${i}`, 'off'))];
+        expect(buildRerankPool(lopsided)).toHaveLength(10);
+        expect(buildRerankPool([c('x', 'fdc')])).toHaveLength(1);
+        expect(buildRerankPool([])).toHaveLength(0);
+        expect(buildRerankPool(GRILLED_CHICKEN_BREAST, 0)).toHaveLength(0);
+    });
+
+    it('2. the window is a duplicate-free subset of the input', () => {
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        expect(new Set(pool.map(x => x.id)).size).toBe(pool.length);
+        for (const x of pool) expect(GRILLED_CHICKEN_BREAST).toContain(x);
+    });
+
+    it('3. within-lane gather order is preserved', () => {
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        const off = pool.filter(x => x.source === 'openfoodfacts').map(x => x.id);
+        const fs = pool.filter(x => x.source === 'fatsecret').map(x => x.id);
+        expect(off).toEqual(['off0', 'off1', 'off2', 'off3']);
+        expect(fs).toEqual(['fs0', 'fs1', 'fs2', 'fs3']);
+    });
+
+    it('4. first-of-lane is stable — the caller\'s FDC estimate fallback cannot move', () => {
+        // `aiNutritionEstimate` falls back to `candidatesForRerank.find(c => c.source === 'fdc')`.
+        // Mutation: sort lanes by size, or reverse lane order -> the found FDC row
+        // is still fdc0 (within-lane order), so this test alone is NOT sufficient;
+        // it pins the consumer, and the lane-order test below pins the rest.
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        expect(pool.find(x => x.source === 'fdc')!.id).toBe('fdc0');
+        expect(pool.find(x => x.source === 'fatsecret')!.id).toBe('fs0');
+        expect(pool.find(x => x.source === 'openfoodfacts')!.id).toBe('off0');
+    });
+
+    it('5. degenerate input reduces exactly to the old slice', () => {
+        const oneLane = Array.from({ length: 20 }, (_, i) => c(`a${i}`, 'fdc'));
+        expect(ids(buildRerankPool(oneLane))).toBe(ids(oneLane.slice(0, 10)));
+
+        // Untagged candidates are ONE lane, not an error and not per-candidate
+        // lanes: mis-tagging must never be able to delete a candidate.
+        const untagged = Array.from({ length: 20 }, (_, i) => c(`u${i}`));
+        expect(ids(buildRerankPool(untagged))).toBe(ids(untagged.slice(0, 10)));
+
+        const nullTagged = Array.from({ length: 20 }, (_, i) => c(`n${i}`, null));
+        expect(ids(buildRerankPool(nullTagged))).toBe(ids(nullTagged.slice(0, 10)));
+    });
+
+    it('untagged candidates share ONE lane even when mixed with tagged ones', () => {
+        // The all-untagged case in invariant 5 cannot see this: 20 single-member
+        // lanes round-robin to the same order as one 20-member lane, so it passes
+        // under the mutation "every untagged candidate is its own lane". Mixing is
+        // the shape that separates them — under that mutation the tagged lane is
+        // outvoted 9:1 and drops from 2 members to 1. (Found by running the
+        // mutation, not by reading the code: the first version of this file had
+        // only the all-untagged case and the mutant survived it.)
+        const mixed = [
+            c('fdc0', 'fdc'), c('fdc1', 'fdc'),
+            ...Array.from({ length: 12 }, (_, i) => c(`u${i}`)),
+        ];
+        const pool = buildRerankPool(mixed);
+        expect(bySource(pool)).toEqual({ fdc: 2, '': 8 });
+        expect(ids(pool)).toBe('fdc0,u0,fdc1,u1,u2,u3,u4,u5,u6,u7');
+    });
+
+    it('lane order is FIRST APPEARANCE, so no source preference is introduced', () => {
+        // Same three lanes, gathered in a different order: the window must follow
+        // the input, never a hardcoded ranking. Mutation: order lanes by a fixed
+        // list like ['fdc','openfoodfacts','fatsecret'] -> this goes red.
+        const fsFirst = [
+            ...Array.from({ length: 4 }, (_, i) => c(`fs${i}`, 'fatsecret')),
+            ...Array.from({ length: 4 }, (_, i) => c(`fdc${i}`, 'fdc')),
+            ...Array.from({ length: 4 }, (_, i) => c(`off${i}`, 'openfoodfacts')),
+        ];
+        expect(ids(buildRerankPool(fsFirst, 3))).toBe('fs0,fdc0,off0');
+
+        const fdcFirst = [
+            ...Array.from({ length: 4 }, (_, i) => c(`fdc${i}`, 'fdc')),
+            ...Array.from({ length: 4 }, (_, i) => c(`fs${i}`, 'fatsecret')),
+            ...Array.from({ length: 4 }, (_, i) => c(`off${i}`, 'openfoodfacts')),
+        ];
+        expect(ids(buildRerankPool(fdcFirst, 3))).toBe('fdc0,fs0,off0');
+    });
+
+    it('input shorter than the limit is returned whole, and never mutated', () => {
+        const short = [c('a', 'fdc'), c('b', 'off')];
+        const pool = buildRerankPool(short);
+        expect(ids(pool)).toBe('a,b');
+        pool.push(c('c', 'off'));
+        expect(short).toHaveLength(2);
+    });
+
+    it('RERANK_POOL_LIMIT is still the 10 the caller used to hardcode', () => {
+        expect(RERANK_POOL_LIMIT).toBe(10);
+    });
+});
+
+describe('rerankPoolRemainder', () => {
+    it('returns exactly what the window did not take, in gather order', () => {
+        const pool = buildRerankPool(GRILLED_CHICKEN_BREAST);
+        const rest = rerankPoolRemainder(GRILLED_CHICKEN_BREAST, pool);
+
+        expect(rest).toHaveLength(GRILLED_CHICKEN_BREAST.length - pool.length);
+        expect(bySource(rest)).toEqual({ openfoodfacts: 10, fatsecret: 4 });
+
+        // Disjoint from the window. This is the whole reason the remainder is
+        // computed by difference: `filtered.slice(10)` would re-offer fs0..fs3 and
+        // off4..off9, which the counted-noun reach-through would then push into a
+        // window that already holds them. Mutation: revert to `slice(10)` -> the
+        // overlap assertion below goes red with 6 duplicates.
+        const inPool = new Set(pool.map(x => x.id));
+        expect(rest.filter(x => inPool.has(x.id))).toEqual([]);
+
+        // Order within the remainder is still gather order.
+        expect(rest.map(x => x.id).slice(0, 3)).toEqual(['off4', 'off5', 'off6']);
+    });
+
+    it('an empty window leaves the input untouched', () => {
+        expect(ids(rerankPoolRemainder(GRILLED_CHICKEN_BREAST, []))).toBe(ids(GRILLED_CHICKEN_BREAST));
+    });
+});

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -18,7 +18,11 @@
  *       else default serving                            ('fs_default_serving')
  *   (d) nothing usable        → per-100g × qty          ('fs_per100g_fallback')
  * Bare unitless qty-1 requests get the same bare-query-guard CAP/REPLACE
- * parity as buildOffResult (see the guard wire-in below).
+ * parity as buildOffResult (see the guard wire-in below), and the same
+ * per-piece suppression: a bare PLURAL ("almonds") never resolves to one
+ * piece, and a bare SINGULAR never bills a sub-20g piece. Both rules come from
+ * `src/lib/servings/bare-query-guard.ts` — the ONE owner — because the two
+ * previous copies of this cascade's rules diverged silently.
  */
 
 import { prisma } from '../db';
@@ -26,7 +30,10 @@ import { logger } from '../logger';
 import { FATSECRET_REFRESH_DAYS } from './config';
 import { singularizeUnit, inferDiscreteUnit } from './count-label';
 import { num, servingMacros, type Macros } from './fs-serving-macros';
-import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
+import {
+    applyOffBareQueryGuard, isBarePluralRequest, isBareUnitlessQty1,
+    BARE_MIN_PIECE_SERVING_GRAMS,
+} from '../servings/bare-query-guard';
 import { volumeToGrams } from '../units/volume-density';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import type { UnifiedCandidate } from './gather-candidates';
@@ -372,16 +379,39 @@ export async function buildFatSecretResult(
         // a discrete piece. Token-match the noun against serving descriptions —
         // the fs "1 bar" serving is exactly the missing-serving-shape class
         // this lane exists to fix.
-        let noun = unit
-            ? singularizeUnit(unit)
-            : inferDiscreteUnit(parsed?.name || foodName);
+        //
+        // BARE-REQUEST PER-PIECE SUPPRESSION — the same two rules the OFF
+        // cascade applies, now taken from their one owner in bare-query-guard
+        // rather than re-derived here:
+        //   (1) a digitless qty-1 PLURAL asks for A SERVING, not one piece, so
+        //       every per-piece branch is suppressed ("almonds" → a serving,
+        //       never one 1.2 g nut);
+        //   (2) a digitless qty-1 SINGULAR must not be answered by a tiny
+        //       per-piece weight either — bare "almond" still means a serving.
+        //       OFF spells this `BARE_MIN_PIECE_SERVING_GRAMS` (20 g); pieces
+        //       at or above it (banana, egg, bagel) ARE the serving.
+        //
+        // This branch had NEITHER rule. OFF suppresses (1) across its three
+        // per-piece branches and enforces (2) in its seed branch, but the
+        // plural predicate lived inside map-ingredient-with-fallback and could
+        // not be imported here without an import cycle — so the rule was
+        // structurally unavailable to this copy, not merely forgotten.
+        // Measured by the winner-gate 2026-08-01: bare `almonds` billed 1.2 g /
+        // 7 kcal here against OFF's 28 g / 160 kcal.
+        const barePlural = isBarePluralRequest(parsed, rawLine, parsed?.name || foodName);
+        const bareSingular = !barePlural && isBareUnitlessQty1(parsed, rawLine);
+        let noun = barePlural
+            ? null
+            : unit
+                ? singularizeUnit(unit)
+                : inferDiscreteUnit(parsed?.name || foodName);
         let match = noun ? usableServings.find(s => servingMatchesNoun(s, noun!)) : undefined;
         // Lexicon-free fallback for unitless lines ("15 pretzels"): the noun
         // lexicon is deliberately conservative, but an fs serving whose label
         // contains the request's trailing token ("1 pretzel (Include nuggets)")
         // is itself proof the token is a countable piece of THIS food. Only
         // fires when such a serving exists, so no false discrete billing.
-        if (!match && !unit) {
+        if (!match && !unit && !barePlural) {
             const lastToken = (parsed?.name || foodName)
                 .toLowerCase().trim().split(/\s+/).pop() ?? '';
             const fallbackNoun = singularizeUnit(lastToken);
@@ -398,16 +428,28 @@ export async function buildFatSecretResult(
                 const unitsPerServing = match.numberOfUnits && match.numberOfUnits > 0
                     ? match.numberOfUnits : 1;
                 const perUnitGrams = match.grams! / unitsPerServing;
-                grams = qty * perUnitGrams;
-                servingDescription = `${qty} ${noun} (${perUnitGrams.toFixed(1)}g each)`;
-                servingTier = 'fs_label_count';
-                pickedServing = match;
-                logger.info('fs.build_result.label_count_matched', {
-                    foodId: candidate.id,
-                    noun,
-                    serving: match.description,
-                    perUnitGrams,
-                });
+                if (bareSingular && perUnitGrams < BARE_MIN_PIECE_SERVING_GRAMS) {
+                    // Rule (2): leave `grams` null so resolution falls through
+                    // to the default serving, where the bare-query guard can
+                    // apply the category default.
+                    logger.info('fs.build_result.bare_tiny_piece_skipped', {
+                        foodId: candidate.id,
+                        noun,
+                        serving: match.description,
+                        perUnitGrams,
+                    });
+                } else {
+                    grams = qty * perUnitGrams;
+                    servingDescription = `${qty} ${noun} (${perUnitGrams.toFixed(1)}g each)`;
+                    servingTier = 'fs_label_count';
+                    pickedServing = match;
+                    logger.info('fs.build_result.label_count_matched', {
+                        foodId: candidate.id,
+                        noun,
+                        serving: match.description,
+                        perUnitGrams,
+                    });
+                }
             }
         }
         // Default-serving fallback for serving-billed requests the noun match

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -28,11 +28,11 @@
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { FATSECRET_REFRESH_DAYS } from './config';
-import { singularizeUnit, inferDiscreteUnit } from './count-label';
+import { singularizeUnit, inferDiscreteUnit, extractLabelServingUnit } from './count-label';
 import { num, servingMacros, type Macros } from './fs-serving-macros';
 import {
     applyOffBareQueryGuard, isBarePluralRequest, isBareUnitlessQty1,
-    BARE_MIN_PIECE_SERVING_GRAMS,
+    usableBareLabelServing, BARE_MIN_PIECE_SERVING_GRAMS, BARE_LABEL_MIN_GRAMS,
 } from '../servings/bare-query-guard';
 import { volumeToGrams } from '../units/volume-density';
 import type { ParsedIngredient } from '../parse/ingredient-line';
@@ -454,12 +454,44 @@ export async function buildFatSecretResult(
         }
         // Default-serving fallback for serving-billed requests the noun match
         // couldn't resolve (bare qty-1, "1 serving", unmatched nouns).
+        //
+        // BAND ON THE BARE PATH. A record's declared default is not necessarily
+        // single-serving-scale: FatSecret's own `defaultServingId` for `Almonds`
+        // (fs_37040) is the 1.2g "1 almond" row, so suppressing the count branch
+        // above changed only which TIER billed 1.2g, not the number — measured
+        // by the winner-gate, 2026-08-01. OFF gates its equivalent step on
+        // `usableBareLabelServing()` and routes onward when it fails; this
+        // cascade had no band and no successor, so an out-of-band serving was
+        // simply billed.
+        //
+        // Reject, do NOT substitute. Picking "the next in-band serving" looks
+        // better and is not safe: `usableServings` comes from an unordered
+        // include, and fs_37040's other in-band servings are 28.35g AND 143g.
+        // Falling through is deterministic — the request lands on the fabricated
+        // per-100g tier, which the bare-query guard REPLACEs with the category
+        // default (`almonds` -> 28g, `coca cola` -> 355g). That only ever fires
+        // where the current answer is already outside 3–400g or is the flat-100g
+        // placeholder, i.e. exactly the answers that were wrong.
+        const bareServingUsable = (s: FsServingView): boolean =>
+            !bareSingular && !barePlural
+                ? true
+                : usableBareLabelServing(s.grams, extractLabelServingUnit(s.description)) != null;
         if (grams == null) {
-            const defaultServing =
+            const declaredDefault =
                 (row?.defaultServingId
                     ? usableServings.find(s => s.servingId === row!.defaultServingId)
                     : undefined)
                 ?? usableServings[0];
+            const defaultServing = declaredDefault && bareServingUsable(declaredDefault)
+                ? declaredDefault
+                : undefined;
+            if (declaredDefault && !defaultServing) {
+                logger.info('fs.build_result.bare_default_serving_out_of_band', {
+                    foodId: candidate.id,
+                    serving: declaredDefault.description,
+                    grams: declaredDefault.grams,
+                });
+            }
             if (defaultServing) {
                 grams = qty * defaultServing.grams!;
                 servingDescription = qty === 1
@@ -495,6 +527,29 @@ export async function buildFatSecretResult(
                 // written for.
                 const fromPanel = per100 ? gramsFromPer100gPanel(m, per100) : null;
                 const estPerServingGrams = fromPanel ?? estimateServingGrams(m);
+                // FLOOR ONLY — not the label band. This tier is the next thing
+                // to catch a bare request the default-serving band just
+                // rejected, and it reaches the identical answer by a different
+                // route: inverting the 1-almond serving's 7 kcal against a 578
+                // kcal/100g panel is 1.2g again. Banding one branch and not the
+                // other would have made the fix inert while looking like it
+                // worked.
+                //
+                // But only the FLOOR transfers. The first version applied the
+                // full 3–400g label band here and the existing panel-inversion
+                // tests killed it: a brewed coffee legitimately inverts to
+                // ~477g, and a 400g ceiling sent it to the flat 100g default.
+                // These grams are not a label — they are arithmetic on the
+                // record's own panel, validated at 98.1% within 5% — so the
+                // upper bound has no basis on this tier. The defect being fixed
+                // is a 1.2g UNDER-bill.
+                if ((bareSingular || barePlural) && estPerServingGrams < BARE_LABEL_MIN_GRAMS) {
+                    logger.info('fs.build_result.bare_macro_serving_out_of_band', {
+                        foodId: candidate.id,
+                        serving: macroServing.description,
+                        estGrams: estPerServingGrams,
+                    });
+                } else {
                 macroServing.grams = estPerServingGrams;
                 grams = qty * estPerServingGrams;
                 servingDescription = qty === 1
@@ -509,6 +564,7 @@ export async function buildFatSecretResult(
                     estGrams: estPerServingGrams,
                     gramsSource: fromPanel != null ? 'per100g_panel_inversion' : 'energy_density',
                 });
+                }
             }
         }
     }

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -204,7 +204,22 @@ export async function buildFatSecretResult(
     // 1. Hydrate from the local store (persisted at retrieval time by the lane).
     const row = await prisma.fatSecretFood.findUnique({
         where: { fsId },
-        include: { servings: true },
+        // ORDER IS LOAD-BEARING and was unspecified. The default-serving branch
+        // falls back to `usableServings[0]` — a POSITIONAL pick — whenever
+        // `defaultServingId` does not resolve, and it very often does not:
+        // 598 FatSecretFood rows declare a flat-100g panel row as their default
+        // (measured 2026-08-02, box), and `isPer100gPanelServing()` demotes
+        // exactly that row out of `usableServings`. For all 598 the billed grams
+        // were therefore decided by Postgres row order, which no query pins.
+        //
+        // `servingId` is the stable natural key. This asserts reproducibility
+        // only — it makes no claim that the first serving is the RIGHT one.
+        // Re-derive the population:
+        //   SELECT count(*) FROM "FatSecretFood" f
+        //   JOIN "FatSecretServing" s ON s."fsId"=f."fsId"
+        //    AND s."servingId"=f."defaultServingId"
+        //   WHERE s.description ~* '^\s*100\s*g';
+        include: { servings: { orderBy: { servingId: 'asc' } } },
     }).catch((err: Error) => {
         logger.warn('fs.build_result.hydrate_failed', {
             foodId: candidate.id,
@@ -319,6 +334,34 @@ export async function buildFatSecretResult(
     const brandName = row?.brandName ?? candidate.brandName ?? null;
     const qty = parsed ? parsed.qty * parsed.multiplier : 1;
     const unit = parsed?.unit?.toLowerCase().trim();
+
+    // INSTRUMENT, NOT A FIX — and deliberately so.
+    //
+    // `EXPLICIT_MEASURE_UNIT_RE` is a promise that a unit bills deterministically
+    // from grams or millilitres; `requestBillsByServing()` skips the entire
+    // count/serving branch on the strength of it. But `pint`, `quart`, `gallon`
+    // and `l` are in that regex and in NEITHER table below, so they fall past
+    // everything to the flat per-100g tier: `1 pint ice cream` bills 100g.
+    //
+    // NOT fixed, on measurement. Those units appear in 0 of 54,083 production
+    // `MappingEventLog` lines and 0 across every eval and warm corpus (measured
+    // 2026-08-02). And the obvious fix is still wrong: adding the ml keys would
+    // send `2 liters coca cola` from 200g to 1000g against a true ~2,080g,
+    // because the failure is on the DENSITY side — `LIQUID_RE` in
+    // `src/lib/units/volume-density.ts` classifies cola, beer, coffee and
+    // smoothies as 0.5 g/ml SOLIDS. That trades an obviously absurd number for
+    // a plausible wrong one, which is strictly harder to catch.
+    //
+    // So count it rather than guess at it. This is the instrument-fail-open
+    // lesson applied deliberately: the existing `volume_unit_table_mismatch`
+    // warning sits INSIDE the volume branch, which these units can never enter,
+    // so it can never fire for them. Build the fix if and only if this warns.
+    if (unit && EXPLICIT_MEASURE_UNIT_RE.test(unit)
+        && WEIGHT_TO_GRAMS[unit] == null && VOLUME_UNIT_ML[unit] == null) {
+        logger.warn('fs.build_result.declared_unit_has_no_conversion', {
+            foodId: candidate.id, unit, foodName, qty,
+        });
+    }
 
     // 3. Gram resolution cascade.
     let grams: number | null = null;
@@ -602,6 +645,7 @@ export async function buildFatSecretResult(
             rawLine,
             queryName: parsed?.name || '',
             foodName,
+            servingDescription: pickedServing?.description ?? servingDescription,
         });
         if (bareOverride) {
             logger.info('fs.build_result.bare_category_default', {

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -51,6 +51,16 @@ function requestBillsByServing(parsed: ParsedIngredient | null): boolean {
     return !(parsed?.unit && EXPLICIT_MEASURE_UNIT_RE.test(parsed.unit.trim()));
 }
 
+/**
+ * A serving row that literally calls itself one serving ("1 serving (85 g)",
+ * "1 serving, cooked"). Deliberately anchored and count-1: "2 servings" is a
+ * multiple and "1 serving size" style prose is not what FatSecret emits. 3,565
+ * such rows exist on the box, 3,422 of them inside the 3-400g bare band
+ * (measured 2026-08-02). Read by the default-serving fallback below, where it
+ * replaces a positional pick — see the reasoning there.
+ */
+const EXPLICIT_ONE_SERVING_RE = /^\s*1\s+serving\b/i;
+
 const WEIGHT_TO_GRAMS: Record<string, number> = {
     'g': 1, 'gram': 1, 'grams': 1,
     'oz': 28.35, 'ounce': 28.35, 'ounces': 28.35,
@@ -507,6 +517,32 @@ export async function buildFatSecretResult(
         // cascade had no band and no successor, so an out-of-band serving was
         // simply billed.
         //
+        // AND THE FALLBACK BELOW THE DECLARED DEFAULT WAS A COIN FLIP, with a
+        // measurable population. `defaultServingId` resolves for 23,837 of
+        // 23,837 FatSecret foods, so `?? usableServings[0]` fires in exactly
+        // one situation: the declared default IS the per-100g panel row that
+        // `isPer100gPanelServing` demotes out of `usableServings` above. That is
+        // 569 foods, 568 of which have another serving to land on positionally
+        // (measured 2026-08-02, box). `Chicken` (fs_1623) is one: its declared
+        // default is the shared "100 g" row, and the positional pick billed
+        // whichever serving the include happened to return first — 85g before
+        // this branch was ordered, 7g ("1 thin slice") after. Ordering made it
+        // reproducible without making it right; reproducible-and-wrong is worse,
+        // because it stops being noticed.
+        //
+        // 278 of those 569 records answer the question themselves with an
+        // explicit "1 serving (Xg)" row, and 3,422 of the 3,565 such rows
+        // corpus-wide are inside the 3-400g band. Preferring it is the record's
+        // own statement of what a serving is, which is the whole hierarchy this
+        // branch implements; position is not evidence of anything.
+        //
+        // No lexicon rescue exists for this class, which is why it matters:
+        // `getBareQueryDefault` returns NOTHING for chicken, beef, steak,
+        // salmon, pork, turkey, rice, pasta, bread, egg, ham or sausage
+        // (measured 2026-08-02). The staple proteins and grains have no category
+        // default, so falling through to the bare-query guard would not have
+        // corrected `chicken` either — it would have billed the flat 100g.
+        //
         // Reject, do NOT substitute. Picking "the next in-band serving" looks
         // better and is not safe: `usableServings` comes from an unordered
         // include, and fs_37040's other in-band servings are 28.35g AND 143g.
@@ -524,6 +560,7 @@ export async function buildFatSecretResult(
                 (row?.defaultServingId
                     ? usableServings.find(s => s.servingId === row!.defaultServingId)
                     : undefined)
+                ?? usableServings.find(s => EXPLICIT_ONE_SERVING_RE.test(s.description))
                 ?? usableServings[0];
             const defaultServing = declaredDefault && bareServingUsable(declaredDefault)
                 ? declaredDefault

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -27,6 +27,7 @@ import { FATSECRET_REFRESH_DAYS } from './config';
 import { singularizeUnit, inferDiscreteUnit } from './count-label';
 import { num, servingMacros, type Macros } from './fs-serving-macros';
 import { applyOffBareQueryGuard } from '../servings/bare-query-guard';
+import { volumeToGrams } from '../units/volume-density';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import type { UnifiedCandidate } from './gather-candidates';
 import type { FatsecretMappedIngredient } from './map-ingredient-with-fallback';
@@ -337,23 +338,31 @@ export async function buildFatSecretResult(
             servingTier = 'fs_label_volume';
             pickedServing = volMatch;
         } else {
-            // Category-density fallback, mirroring buildFdcResult: dry-granular
-            // categories get their tuned density, everything else the flat
-            // liquid=1.0 / solid=0.5 defaults.
-            const isLiquid = /broth|stock|water|juice|milk|sauce|vinegar|oil|syrup/i
-                .test(`${foodName} ${parsed?.name ?? ''}`);
-            let densityGml = isLiquid ? 1.0 : 0.5;
-            try {
-                const { inferCategoryFromName, categoryDensity, DRY_GRANULE_DENSITY_CATEGORIES } = require('../units/density');
-                const category = inferCategoryFromName(foodName) || inferCategoryFromName(parsed?.name || '');
-                if (category && DRY_GRANULE_DENSITY_CATEGORIES.has(category)) {
-                    const catDensity = categoryDensity(category);
-                    if (catDensity && catDensity > 0) densityGml = catDensity;
-                }
-            } catch {
-                // density.ts unavailable — keep the flat default
+            // Density fallback, from the ONE owner of this rule
+            // (`resolveVolumeGrams()` in `src/lib/units/volume-density.ts`).
+            //
+            // This block used to be a hand-copy that "mirrored buildFdcResult".
+            // It mirrored the wrong copy: the OFF path carries an `isPaste` tier
+            // (~1 g/ml for spreads) that neither this nor the FDC copy ever got,
+            // so a tablespoon of peanut butter billed 15ml × 0.5 = 7.5 g here
+            // against ~16 g there. Measured 2026-08-01 — when the rerank window
+            // stopped starving the FatSecret lane, 73 of 250 already-asked
+            // queries changed what the user is billed, and this was the cause.
+            //
+            // Nothing about the NUMBERS changed in the move; they are the OFF
+            // path's tuned constants verbatim. Re-tuning is a separate PR with
+            // its own winner-gate run, because grams feed the save gates and the
+            // cached row.
+            const resolved = volumeToGrams(qty, unit, foodName, parsed?.name);
+            // `unit` already passed `VOLUME_UNIT_ML[unit]` above, so a null here
+            // would mean the two unit tables disagree — fall back rather than
+            // bill NaN, and say so.
+            if (!resolved) {
+                logger.warn('fs.build_result.volume_unit_table_mismatch', { unit, foodName });
+                grams = totalMl * 0.5;
+            } else {
+                grams = resolved.grams;
             }
-            grams = totalMl * densityGml;
             servingDescription = `${qty} ${unit}`;
             servingTier = 'fs_volume_density';
         }

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -35,6 +35,11 @@ import {
     usableBareLabelServing, BARE_MIN_PIECE_SERVING_GRAMS, BARE_LABEL_MIN_GRAMS,
 } from '../servings/bare-query-guard';
 import { volumeToGrams } from '../units/volume-density';
+// Ambiguous/count-unit resolution, shared with the OFF and FDC cascades. Safe
+// to import here: `ambiguous-unit-backfill` pulls only `db` and `logger`, so
+// there is no cycle back through map-ingredient-with-fallback.
+import { isAmbiguousUnit, getOrCreateAmbiguousServing } from './ambiguous-unit-backfill';
+import { classifyUnit } from './unit-type';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import type { UnifiedCandidate } from './gather-candidates';
 import type { FatsecretMappedIngredient } from './map-ingredient-with-fallback';
@@ -505,6 +510,62 @@ export async function buildFatSecretResult(
                 }
             }
         }
+
+        // (c2) AMBIGUOUS / COUNT UNIT — the step the other two cascades have and
+        // this one did not.
+        //
+        // "1 handful almonds", "1 sleeve saltine crackers", "1 bowl cereal",
+        // "1 knob of butter": the unit is a real request the label cannot answer,
+        // and `buildOffResult()` and `buildFdcResult()` both resolve it through
+        // `getOrCreateAmbiguousServing()` (deterministic sub-piece defaults,
+        // then the per-food cache, then an estimate). `buildFatSecretResult()`
+        // never called it, so these fell straight to the declared default —
+        // whatever single piece the record happens to lead with.
+        //
+        // That was invisible while the FatSecret lane reached the reranker on
+        // 16.9% of queries. Fixing the lane starvation made FatSecret the winner
+        // for these lines and the gate measured the cost immediately
+        // (2026-08-02, regression pool): `1 handful almonds` 30g -> 1.2g and
+        // `1 sleeve saltine crackers` 113g / 490kcal -> 3g / 13kcal, both
+        // billing ONE almond and ONE cracker.
+        //
+        // Banding the default serving would NOT have fixed these. This builder
+        // is terminal — it always bills something — so a rejection lands on the
+        // flat per-100g tier, and the bare-query guard cannot rescue it either
+        // because its digit gate excludes every one of these lines by design.
+        // 100g for a handful of almonds is not better than 1.2g, it is just
+        // wrong in the other direction. The request needs an ANSWER, not a veto,
+        // and the answer already exists in a module this file can import.
+        //
+        // Ordered after the noun match and before the declared default,
+        // mirroring `buildOffResult()`: a serving the label genuinely enumerates
+        // still wins ("2 bars" on a record with a "1 bar" serving never reaches
+        // here), and a resolved container weight outranks a lead piece.
+        if (grams == null && unit
+            && (isAmbiguousUnit(unit) || classifyUnit(unit) === 'count')) {
+            const ambiguous = await getOrCreateAmbiguousServing(
+                candidate.id, foodName, unit, brandName
+            );
+            if ((ambiguous.status === 'success' || ambiguous.status === 'cached')
+                && ambiguous.grams && ambiguous.grams > 0) {
+                grams = qty * ambiguous.grams;
+                servingDescription = `${qty} ${unit} (${ambiguous.grams.toFixed(1)}g each)`;
+                servingTier = ambiguous.status === 'cached' ? 'count_unit_cached' : 'count_unit_ai';
+                logger.info('fs.build_result.unit_serving_resolved', {
+                    foodId: candidate.id,
+                    unit,
+                    perUnitGrams: ambiguous.grams,
+                    status: ambiguous.status,
+                });
+            } else {
+                logger.warn('fs.build_result.unit_serving_unresolved', {
+                    foodId: candidate.id,
+                    unit,
+                    error: ambiguous.error,
+                });
+            }
+        }
+
         // Default-serving fallback for serving-billed requests the noun match
         // couldn't resolve (bare qty-1, "1 serving", unmatched nouns).
         //

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -5640,6 +5640,7 @@ export async function buildOffResult(
         rawLine,
         queryName: parsed?.name || '',
         foodName: hydrated.foodName,
+        servingDescription,
     });
     if (bareOverride) {
         logger.info('off.build_result.bare_category_default', {

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -23,6 +23,7 @@ import {
     detectGrainCookingContext,
 } from './filter-candidates';
 import { simpleRerank, toRerankCandidate, extractLeanPercentage, isGenericGroundMeatQuery, stripPrepModifiers } from './simple-rerank';
+import { buildRerankPool, rerankPoolRemainder, RERANK_POOL_LIMIT } from './rerank-pool';
 import {
     singularizeUnit, extractLabelServingUnit,
     LABEL_COUNT_PIECE_NOUNS, GENERIC_PIECE_WORDS,
@@ -1900,25 +1901,49 @@ export async function mapIngredientWithFallback(
                     const countedNoun = countedPieceNoun(parsed);
 
                     // Enrich Generic candidates with cached nutrition data.
-                    const candidatesForRerank = filtered.slice(0, 10);
-                    // Counted queries: let count-labeled SKUs below the top-10 cutoff
-                    // compete too (they still have to win the rerank on merit).
+                    //
+                    // THE WINDOW IS COMPOSED PER LANE, NOT TAKEN AS A PREFIX.
+                    // `filtered` is in GATHER order and gatherCandidates concatenates
+                    // its lanes, so a prefix (the old `filtered.slice(0, 10)`) deleted
+                    // every later lane whenever the earlier ones filled the window.
+                    // Measured cold 2026-08-01 over a 20-query cold-seed population:
+                    // 17 of 20 admitted ZERO FatSecret candidates while the lane had
+                    // gathered 8 — `grilled chicken breast` gathered
+                    // { fdc: 2, openfoodfacts: 14, fatsecret: 8 } and reranked
+                    // { fdc: 2, openfoodfacts: 8 }. Rationale, invariants and the
+                    // re-derive command: `buildRerankPool()` in
+                    // `src/lib/mapping/rerank-pool.ts`.
+                    //
+                    // The budget is unchanged (RERANK_POOL_LIMIT === the old 10), so
+                    // this is a RE-COMPOSITION, not an admission relaxation. It is
+                    // non-monotone in both directions — candidates that reach the
+                    // reranker today can be evicted — which is why it ships with a
+                    // winner-gate regression population and not with an argument.
+                    const candidatesForRerank = buildRerankPool(filtered, RERANK_POOL_LIMIT);
+                    // Counted queries: let count-labeled SKUs below the cutoff compete
+                    // too (they still have to win the rerank on merit). The remainder
+                    // is computed by DIFFERENCE, not as `filtered.slice(10)` — the
+                    // window is no longer a prefix, so the old form would have
+                    // re-offered candidates already inside it.
                     if (countedNoun) {
-                        for (const c of filtered.slice(10)) {
+                        for (const c of rerankPoolRemainder(filtered, candidatesForRerank)) {
                             if (candidatesForRerank.length >= 13) break;
                             if (candidateHasCountLabel(c, countedNoun)) candidatesForRerank.push(c);
                         }
                     }
                     // NOT DONE HERE, DELIBERATELY, AND THE REASON IS WORTH KEEPING.
                     //
-                    // `filtered.slice(0, 10)` above truncates over GATHER order, not
-                    // score order. On 17 of the 441 measured gate-firing lines the
-                    // gate's pick sits past index 10, so simpleRerank cannot re-select
-                    // it — those lines are a DELETION, not an adjudication, and the
-                    // backstop below cannot rescue them because the reranker did return
-                    // a winner, just a different one. `kirkland almonds` is the sharpest:
-                    // the Kirkland record is at gather index 22, so the reranker only
-                    // ever sees a Members Mark record.
+                    // The window truncates over GATHER order. On 17 of the 441 measured
+                    // gate-firing lines the gate's pick sits past the cutoff, so
+                    // simpleRerank cannot re-select it — those lines are a DELETION, not
+                    // an adjudication, and the backstop below cannot rescue them because
+                    // the reranker did return a winner, just a different one.
+                    // `kirkland almonds` is the sharpest: the Kirkland record is at
+                    // gather index 22, so the reranker only ever sees a Members Mark
+                    // record. Per-lane composition NARROWS this — a starved lane is no
+                    // longer deleted wholesale — but it does not close it: a candidate
+                    // past its own lane's share of the window is still unseen, and
+                    // `kirkland almonds` gathers 16 OFF rows for 5 lane slots.
                     //
                     // The obvious repair — append `gateSelection` to candidatesForRerank
                     // — was written, measured, and REVERTED. Scored against the project's

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -66,6 +66,7 @@ import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { deriveMappingCacheKey, deriveCacheKeyName, isMalformedCacheKey, type BrandKeyInput } from './cache-key';
 import {
     applyOffBareQueryGuard, isBareUnitlessQty1, usableBareLabelServing,
+    isBarePluralRequest,
     isDoseAnchoredBareQuery,
     BARE_LABEL_MIN_GRAMS, BARE_LABEL_MAX_GRAMS, BARE_MIN_PIECE_SERVING_GRAMS,
 } from '../servings/bare-query-guard';
@@ -529,42 +530,14 @@ export function makeSortedFilteredComparator(
 
 // ============================================================
 // Bare-plural request detection (PR D pt3, Lever A3)
+//
+// The predicate moved to `src/lib/servings/bare-query-guard.ts`, which owns
+// every bare-request eligibility rule and — unlike this file — can be imported
+// by `buildFatSecretResult` without an import cycle. It lived here, called from
+// exactly one place, while the FatSecret count branch had no bare-plural
+// suppression at all. Re-exported so existing importers keep working.
 // ============================================================
-
-// Snack-style names that read plural without plural morphology ("goldfish").
-const BARE_PLURAL_STYLE_NAMES = /\b(goldfish|chex mix|trail mix|popcorn|granola)\b/i;
-
-/**
- * True when the token is a plain -s plural. singularizeUnit alone is NOT a
- * plural test: 'hummus'→'hummu', 'couscous'→'couscou', 'molasses'→'molass'
- * all change without being plural. Require an -s ending that is not one of
- * the pseudo-plural shapes 'ss' (swiss), 'us' (hummus/couscous), 'is'
- * (debris), 'sses' (molasses — the plain 'ss' check misses it).
- */
-function isMorphologicalPluralToken(token: string): boolean {
-    const t = token.toLowerCase();
-    if (t.length < 3 || !t.endsWith('s')) return false;
-    if (t.endsWith('ss') || t.endsWith('us') || t.endsWith('is') || t.endsWith('sses')) return false;
-    return singularizeUnit(t) !== t;
-}
-
-/**
- * A bare-plural request ("almonds", "goldfish") is a digitless unitless qty-1
- * line whose food name is plural: the user asked for A SERVING of the food,
- * not one piece. Explicit counts ("3 almonds" — digit gate), singular bare
- * queries ("almond"), and unit-carrying lines never qualify.
- */
-export function isBarePluralRequest(
-    parsed: ParsedIngredient | null,
-    rawLine: string,
-    itemNameForCount: string
-): boolean {
-    if (!parsed || parsed.unit || parsed.qty !== 1) return false;
-    if (/\d/.test(rawLine)) return false;
-    const tokens = (parsed.name || '').trim().split(/\s+/).filter(t => t.length > 0);
-    const lastFoodToken = tokens[tokens.length - 1] ?? '';
-    return isMorphologicalPluralToken(lastFoodToken) || BARE_PLURAL_STYLE_NAMES.test(itemNameForCount);
-}
+export { isBarePluralRequest };
 
 // ============================================================
 // Main Entry Point

--- a/src/lib/mapping/rerank-pool.ts
+++ b/src/lib/mapping/rerank-pool.ts
@@ -1,0 +1,143 @@
+/**
+ * rerank-pool.ts — how the pre-rerank candidate window is COMPOSED.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `mapIngredientWithFallback()` used to build the rerank window as
+ * `filtered.slice(0, 10)`. `filtered` is in GATHER order, not score order, and
+ * gatherCandidates() concatenates its lanes (FDC, then OpenFoodFacts, then the
+ * FatSecret lane) rather than interleaving them. So whenever the earlier lanes
+ * alone fill the window, every later lane is DELETED before simpleRerank ever
+ * runs — not out-ranked, never seen.
+ *
+ * That is not an edge case. Measured cold over a 20-query cold-seed population
+ * on 2026-08-01 (winner-diff `snapshot`, which forces production flags, so the
+ * FatSecret lane is live exactly as it is on the box):
+ *
+ *     17 of 20 queries admitted ZERO FatSecret candidates to the window
+ *     while the lane had gathered 8. `grilled chicken breast`:
+ *       gathered 24 { fdc: 2, openfoodfacts: 14, fatsecret: 8 }
+ *       window     { fdc: 2, openfoodfacts: 8 }
+ *       deleted 14 { fatsecret: 8, openfoodfacts: 6 }
+ *
+ * Re-derive:
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     -r tsconfig-paths/register scripts/eval/winner-diff.ts \
+ *     snapshot --from-file <seeds> --out /tmp/snap.json
+ *   then group each entry's `candidates` by `source`, before and after the window.
+ *
+ * The caller block in map-ingredient-with-fallback.ts has documented this defect
+ * in a comment since the confidenceGate demotion, and named the repair it did NOT
+ * want: special-casing one favoured candidate past the cutoff. That was measured
+ * and reverted (it only changed WHICH rows were wrong, and turned one
+ * adjudicated-wrong record into a CACHED one). This module is the repair the
+ * comment asked for instead — fix the composition, not the exception.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * It is NOT a source preference. No lane is ranked above another and no lane is
+ * guaranteed a minimum. Lanes are visited in the order they first appear in the
+ * input, which IS gather order, so the only thing that changes is WHICH
+ * candidates spend the window's fixed budget — never how they are then scored.
+ *
+ * It is NOT an admission relaxation. `|window|` is unchanged (`limit`, still 10),
+ * so this cannot widen the pool the way the changes in playbook section 5a did.
+ * It is a RE-COMPOSITION, and re-composition is non-monotone in both directions:
+ * candidates that reach the reranker today can be evicted by it. That is a cost,
+ * it is real, and it is what the winner-gate regression population is for.
+ *
+ * INVARIANTS (each has a test in __tests__/rerank-pool.test.ts)
+ * ------------------------------------------------------------
+ *  1. Size: `out.length === Math.min(limit, input.length)`.
+ *  2. Subset: every element of `out` is an element of `input`, no duplicates.
+ *  3. Within-lane order is preserved — a lane's candidates appear in the window
+ *     in the same relative order gather produced them.
+ *  4. FIRST-OF-LANE STABILITY: for any lane present in the window, the window's
+ *     first member of that lane is that lane's first member in `input`. The
+ *     caller depends on this: its FDC nutrition-estimate fallback takes
+ *     `find(c => c.source === 'fdc')`, and that consumer must not move.
+ *  5. Degenerate input (one lane, or a missing/blank `source`) reduces exactly to
+ *     the old `slice(0, limit)`. A single-lane corpus sees no change at all.
+ */
+
+/** Candidates only need a lane tag; keeping this structural avoids importing
+ *  gather-candidates.ts, which is not leaf-safe (playbook section 4 — read-only
+ *  eval tooling must be able to import this without warming ONNX). */
+export interface LaneTagged {
+    source?: string | null;
+}
+
+/** The pre-rerank window size. Was the literal `10` inside the caller. */
+export const RERANK_POOL_LIMIT = 10;
+
+/**
+ * Round-robin the candidates across their retrieval lanes, preserving each
+ * lane's internal (gather) order, until `limit` is reached.
+ *
+ * Lane identity is the raw `source` string. An absent or empty `source` is its
+ * own lane rather than an error: mis-tagging a candidate must not be able to
+ * delete it, and a corpus where nothing is tagged degenerates to the old
+ * behaviour (invariant 5) instead of behaving unpredictably.
+ */
+export function buildRerankPool<T extends LaneTagged>(
+    candidates: readonly T[],
+    limit: number = RERANK_POOL_LIMIT,
+): T[] {
+    if (limit <= 0) return [];
+    if (candidates.length <= limit) return candidates.slice();
+
+    // Lane order = order of FIRST APPEARANCE in the input. This is what keeps
+    // the function free of any built-in source preference: it inherits gather's
+    // ordering decision rather than making one of its own.
+    const lanes = new Map<string, T[]>();
+    for (const c of candidates) {
+        const key = c.source ?? '';
+        const lane = lanes.get(key);
+        if (lane) lane.push(c);
+        else lanes.set(key, [c]);
+    }
+
+    // A single lane cannot be starved by definition, and round-robining it would
+    // be an identity transform anyway. Return early so the degenerate case is
+    // provably byte-identical to the old slice.
+    if (lanes.size <= 1) return candidates.slice(0, limit);
+
+    const out: T[] = [];
+    const cursors = new Map<string, number>();
+    for (const key of lanes.keys()) cursors.set(key, 0);
+
+    // Round-robin. A lane that runs dry simply stops contributing and its slots
+    // go to the lanes that still have candidates — so a small lane never costs
+    // the window capacity, and the size invariant holds.
+    let progressed = true;
+    while (out.length < limit && progressed) {
+        progressed = false;
+        for (const [key, lane] of lanes) {
+            if (out.length >= limit) break;
+            const i = cursors.get(key)!;
+            if (i >= lane.length) continue;
+            out.push(lane[i]);
+            cursors.set(key, i + 1);
+            progressed = true;
+        }
+    }
+    return out;
+}
+
+/**
+ * The candidates `buildRerankPool` did NOT take, in gather order.
+ *
+ * The caller walks this for the counted-noun reach-through (count-labelled SKUs
+ * below the cutoff may still compete). Before this module that was
+ * `filtered.slice(10)` — correct only while the window was a prefix. It is not
+ * one any more, so the remainder has to be computed by difference or the
+ * reach-through would re-offer candidates already in the window.
+ */
+export function rerankPoolRemainder<T extends LaneTagged>(
+    candidates: readonly T[],
+    pool: readonly T[],
+): T[] {
+    if (pool.length === 0) return candidates.slice();
+    const taken = new Set<T>(pool);
+    return candidates.filter(c => !taken.has(c));
+}

--- a/src/lib/servings/__tests__/dose-count-reconciliation.test.ts
+++ b/src/lib/servings/__tests__/dose-count-reconciliation.test.ts
@@ -1,0 +1,167 @@
+import { applyOffBareQueryGuard } from '../bare-query-guard';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+/**
+ * Dose-count reconciliation — the rule that replaced a floor direction.
+ *
+ * The floor was rejected on measurement, and these tests encode WHY, because
+ * the reasons are what stop it being reintroduced:
+ *   - it does not fire on its own motivating case (16 is exactly 32/2, and the
+ *     condition would be `< def/2`);
+ *   - measured over 18,456 FatSecret default servings, 660 rows sit below half
+ *     the category default and most of them are the RECORD being right. A floor
+ *     takes `flour tortilla` 13g -> 120g on the lexicon's "flour", `water
+ *     spinach` -> 240g, `milk bread` -> 240g, `lemonade powder` -> 355g. All are
+ *     <=2-token names, so the existing token gate cannot block a single one.
+ *
+ * The reconciliation never reads the lexicon's GRAMS — only its COUNT, applied
+ * to the record's own per-unit weight. Requiring the same spoon/scoop word on
+ * both sides is what makes those four hijacks impossible rather than unlikely.
+ */
+
+function bare(name: string): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name } as ParsedIngredient;
+}
+
+describe('fires for the nut-butter dose disagreement', () => {
+    it('peanut butter: 1 tbsp declared -> 2 tbsp requested, using the RECORD\'s 16g', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 16, servingTier: 'label_serving_default',
+            parsed: bare('peanut butter'), rawLine: 'peanut butter',
+            queryName: 'peanut butter', foodName: 'Peanut Butter',
+            servingDescription: '1 tbsp',
+        });
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBe(32);
+        expect(r!.servingTier).toBe('bare_dose_count_reconciled');
+    });
+
+    it('scales the RECORD\'s number, not the lexicon\'s', () => {
+        // A record declaring a 20g tablespoon must yield 40g, not the lexicon's
+        // 32g. MUTATION: return queryDefault.grams instead of scaling -> red.
+        const r = applyOffBareQueryGuard({
+            grams: 20, servingTier: 'label_serving_default',
+            parsed: bare('peanut butter'), rawLine: 'peanut butter',
+            queryName: 'peanut butter', foodName: 'Peanut Butter',
+            servingDescription: '1 tbsp',
+        });
+        expect(r!.grams).toBe(40);
+    });
+});
+
+describe('the hijacks a floor would have caused are structurally unreachable', () => {
+    // Each of these has a lexicon entry whose grams are far above the billed
+    // number, so a floor fires on every one.
+    //
+    // WHICH guard blocks them, measured rather than assumed: it is the LEXICON
+    // side that fails to parse, not the record side. Their bare-query defaults
+    // are "1 cup" (flour tortilla 120g, water spinach 240g, milk bread 240g),
+    // "1 can" (lemonade 355g) and "1 oz" (saltine crackers, bacon, both 28g) —
+    // none is a spoon/scoop dose, so the rule exits before the record is ever
+    // consulted. Mutating away the same-unit-word check leaves all six GREEN;
+    // it is a different guard doing the work here.
+    //
+    // That is the real safety property, and it is stronger than the one first
+    // written down: the rule is confined by the LEXICON, and only the
+    // nut-butter category expresses a spoon dose with a count above 1.
+    it.each([
+        ['flour tortilla', 13, '1 tortilla (approx 4" dia)', 'Flour Tortilla'],
+        ['water spinach', 30, '1 cup', 'Water Spinach'],
+        ['milk bread', 36, '1 medium slice', 'Milk Bread'],
+        ['lemonade', 18, '1 packet', 'Lemonade Powder'],
+        ['saltine crackers', 3, '1 cracker', 'Saltine Crackers'],
+        ['bacon', 5, '1 thin slice', 'Bacon'],
+    ])('%s is left alone', (q, grams, desc, food) => {
+        const r = applyOffBareQueryGuard({
+            grams, servingTier: 'label_serving_default',
+            parsed: bare(q), rawLine: q, queryName: q, foodName: food,
+            servingDescription: desc,
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+});
+
+describe('the gates', () => {
+    it('does not fire when the counts already agree (olive oil, 1 tbsp = 1 tbsp)', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 14, servingTier: 'label_serving_default',
+            parsed: bare('olive oil'), rawLine: 'olive oil',
+            queryName: 'olive oil', foodName: 'Olive Oil',
+            servingDescription: '1 tbsp',
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+
+    it('never scales DOWN — the record already exceeding the lexicon is kept', () => {
+        // ghost pre workout: record 2 scoops vs lexicon 1 scoop. MUTATION: drop
+        // the `lexCount > recCount` guard -> this halves a correct serving.
+        const r = applyOffBareQueryGuard({
+            grams: 32.5, servingTier: 'label_serving_default',
+            parsed: bare('ghost pre workout'), rawLine: 'ghost pre workout',
+            queryName: 'ghost pre workout', foodName: 'Ghost Pre Workout',
+            servingDescription: '2 scoops',
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+
+    it('requires the SAME unit word on both sides', () => {
+        // Lexicon says 2 tbsp; record declares teaspoons. Cross-unit scaling
+        // would be inventing a conversion. MUTATION: drop the lex[2]===rec[2]
+        // check -> this returns 32.
+        const r = applyOffBareQueryGuard({
+            grams: 16, servingTier: 'label_serving_default',
+            parsed: bare('peanut butter'), rawLine: 'peanut butter',
+            queryName: 'peanut butter', foodName: 'Peanut Butter',
+            servingDescription: '1 tsp',
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+
+    it('a non-bare line is out of scope entirely (digit gate)', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 16, servingTier: 'label_serving_default',
+            parsed: { qty: 1, multiplier: 1, unit: 'tbsp', name: 'peanut butter' } as ParsedIngredient,
+            rawLine: '1 tbsp peanut butter',
+            queryName: 'peanut butter', foodName: 'Peanut Butter',
+            servingDescription: '1 tbsp',
+        });
+        expect(r).toBeNull();
+    });
+
+    it('a long product query is blocked by the existing token gate', () => {
+        // "a tbsp of peanut butter" reaches the guard as bare (the parser does
+        // not lift the unit), and must NOT be doubled — the user said one.
+        const r = applyOffBareQueryGuard({
+            grams: 16, servingTier: 'label_serving_default',
+            parsed: bare('a tbsp of peanut butter'), rawLine: 'a tbsp of peanut butter',
+            queryName: 'a tbsp of peanut butter', foodName: 'Peanut Butter',
+            servingDescription: '1 tbsp',
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+
+    it('a caller that omits servingDescription loses this rule and nothing else', () => {
+        const r = applyOffBareQueryGuard({
+            grams: 16, servingTier: 'label_serving_default',
+            parsed: bare('peanut butter'), rawLine: 'peanut butter',
+            queryName: 'peanut butter', foodName: 'Peanut Butter',
+        });
+        expect(r?.servingTier).not.toBe('bare_dose_count_reconciled');
+    });
+
+    it('the existing kill switch covers it', () => {
+        const prev = process.env.OFF_BARE_SERVING_GUARD;
+        process.env.OFF_BARE_SERVING_GUARD = '0';
+        try {
+            expect(applyOffBareQueryGuard({
+                grams: 16, servingTier: 'label_serving_default',
+                parsed: bare('peanut butter'), rawLine: 'peanut butter',
+                queryName: 'peanut butter', foodName: 'Peanut Butter',
+                servingDescription: '1 tbsp',
+            })).toBeNull();
+        } finally {
+            if (prev === undefined) delete process.env.OFF_BARE_SERVING_GUARD;
+            else process.env.OFF_BARE_SERVING_GUARD = prev;
+        }
+    });
+});

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -19,7 +19,7 @@
 
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import { getBareQueryDefault } from '../ai/ambiguous-serving-estimator';
-import { discretePieceFloor } from '../mapping/count-label';
+import { discretePieceFloor, singularizeUnit } from '../mapping/count-label';
 
 /**
  * Tiers whose grams come from real package/label machinery and can only be
@@ -89,6 +89,55 @@ export function isBareUnitlessQty1(parsed: ParsedIngredient | null, rawLine: str
     if (!parsed || parsed.unit || parsed.qty !== 1 || parsed.multiplier !== 1) return false;
     if (/\d/.test(rawLine)) return false;
     return true;
+}
+
+/**
+ * Foods whose bare NAME is already a portion word even though it is not
+ * morphologically plural — "popcorn", "granola", "trail mix". Same intent as
+ * the plural test: the user named a serving, not a piece.
+ */
+const BARE_PLURAL_STYLE_NAMES = /\b(goldfish|chex mix|trail mix|popcorn|granola)\b/i;
+
+/**
+ * True when the token is a plain -s plural. singularizeUnit alone is NOT a
+ * plural test: 'hummus'→'hummu', 'couscous'→'couscou', 'molasses'→'molass'
+ * all change without being plural. Require an -s ending that is not one of
+ * the pseudo-plural shapes 'ss' (swiss), 'us' (hummus/couscous), 'is'
+ * (debris), 'sses' (molasses — the plain 'ss' check misses it).
+ */
+function isMorphologicalPluralToken(token: string): boolean {
+    const t = token.toLowerCase();
+    if (t.length < 3 || !t.endsWith('s')) return false;
+    if (t.endsWith('ss') || t.endsWith('us') || t.endsWith('is') || t.endsWith('sses')) return false;
+    return singularizeUnit(t) !== t;
+}
+
+/**
+ * A digitless qty-1 PLURAL request ("almonds", "goldfish"): the user asked for
+ * A SERVING, not one piece. Every per-piece resolution branch must be
+ * suppressed for these — one almond is 1.2 g against a 28 g serving, one grape
+ * 5 g — and resolution must fall through to serving-scale tiers.
+ *
+ * THIS PREDICATE LIVES HERE, NOT IN A BUILDER. It was defined inside
+ * `map-ingredient-with-fallback.ts` and called from exactly one place, the OFF
+ * cascade; `buildFatSecretResult` could not even import it without an import
+ * cycle, so the FatSecret count branch had no bare-plural suppression at all
+ * and billed bare `almonds` at 1.2 g (measured 2026-08-01 by the winner-gate,
+ * 28 g `bare_plural_serving` → 1.2 g `fs_label_count`). That is the same defect
+ * shape as the volume-density hand-copies: a rule maintained in one of N
+ * cascades. This module already owns the bare-request eligibility predicates
+ * and is imported by every builder — one owner, every caller.
+ */
+export function isBarePluralRequest(
+    parsed: ParsedIngredient | null,
+    rawLine: string,
+    itemNameForCount: string
+): boolean {
+    if (!parsed || parsed.unit || parsed.qty !== 1) return false;
+    if (/\d/.test(rawLine)) return false;
+    const tokens = (parsed.name || '').trim().split(/\s+/).filter(t => t.length > 0);
+    const lastFoodToken = tokens[tokens.length - 1] ?? '';
+    return isMorphologicalPluralToken(lastFoodToken) || BARE_PLURAL_STYLE_NAMES.test(itemNameForCount);
 }
 
 /**

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -299,6 +299,13 @@ export interface BareQueryGuardInput {
     queryName: string;
     /** Matched product's name, used as a REPLACE-only lexicon fallback. */
     foodName: string;
+    /**
+     * The billed serving's own description ("1 tbsp", "1 medium", "1 cracker").
+     * Read ONLY by the dose-count reconciliation below, which requires a
+     * spoon/scoop word on both sides — so a caller that omits it loses that
+     * rule and nothing else.
+     */
+    servingDescription?: string | null;
 }
 
 export interface BareQueryGuardOverride {
@@ -315,7 +322,7 @@ export interface BareQueryGuardOverride {
 export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGuardOverride | null {
     if (process.env.OFF_BARE_SERVING_GUARD === '0') return null;
 
-    const { grams, servingTier, parsed, rawLine, queryName, foodName } = input;
+    const { grams, servingTier, parsed, rawLine, queryName, foodName, servingDescription } = input;
 
     // Eligibility: bare unitless qty-1 request only. The digit gate keeps every
     // explicit count out ("15 pretzels" must retain its count_unresolved_floor
@@ -331,6 +338,63 @@ export function applyOffBareQueryGuard(input: BareQueryGuardInput): BareQueryGua
     // what the guard is for. The REPLACE path below is untouched entirely, since
     // there the grams are fabricated and nothing real is being overwritten.
     const capAllowed = capMayOverrideLabelServing(queryName, servingTier);
+
+    // DOSE-COUNT RECONCILIATION — deliberately NOT a floor direction.
+    //
+    // A floor was the obvious answer to bare `peanut butter` billing 16g against
+    // the lexicon's 32g, and it is wrong twice over. It does not even fire:
+    // 16 is EXACTLY 32/2 and the condition would be `grams < queryDefault/2`.
+    // And measured over 18,456 FatSecret default servings, the 660 rows below
+    // half the category default are mostly records being RIGHT — a floor would
+    // take `flour tortilla` 13g -> 120g (matching the lexicon on "flour"),
+    // `water spinach` 30g -> 240g, `milk bread` 36g -> 240g, `lemonade powder`
+    // 18g -> 355g. All are <=2-token names, so `capMayOverrideLabelServing()`
+    // cannot block them: the cap's damage lives in long product queries, the
+    // floor's in short generic ones, and the existing gate points the wrong way.
+    // The guard being CAP-only is a correct asymmetry, not an oversight — a
+    // declared serving is data and the lexicon is a guess, and downward that
+    // guess is wrong more often than right.
+    //
+    // What is actually wrong for peanut butter is narrower. Both sides agree the
+    // food is billed in tablespoons and that a tablespoon is ~16g; they disagree
+    // only on HOW MANY a bare request means. That is a claim about user intent,
+    // where the lexicon is the right authority and the record has no view.
+    //
+    // So this rule never reads the lexicon's GRAMS. It reads its COUNT and
+    // multiplies the record's OWN per-unit grams. Worst case is an integer
+    // multiple of a number the record itself published.
+    //
+    // The guard that makes the hijack class IMPOSSIBLE rather than unlikely is
+    // the LEXICON-side parse, not the record-side one — measured, by mutating
+    // each away in turn. Those four queries' bare defaults are "1 cup" (flour
+    // tortilla, water spinach, milk bread) and "1 can" (lemonade); none is a
+    // spoon/scoop dose, so the rule exits before the record is consulted, and
+    // dropping the same-unit-word check leaves all four still blocked. Only the
+    // nut-butter category pairs a spoon word with a count above 1, which is what
+    // confines this rule to 9 of 18,456 records.
+    //
+    // Measured 2026-08-02: 9 of 18,456 records reach it, all peanut butter —
+    // only the nut-butter category has a lexicon count > 1, which confines the
+    // rule by construction.
+    if (DECLARED_LABEL_TIERS.has(servingTier)
+        && capAllowed
+        && queryDefault
+        && isDoseAnchoredBareQuery(queryName)) {
+        const lex = /^\s*(\d+)\s+(tsp|tbsp|scoop)s?\b/i.exec(queryDefault.description);
+        const rec = /^\s*(\d+(?:\.\d+)?)\s*(tsp|tbsp|scoop)s?\b/i.exec(servingDescription ?? '');
+        if (lex && rec && lex[2].toLowerCase() === rec[2].toLowerCase()) {
+            const lexCount = Number(lex[1]);
+            const recCount = Number(rec[1]);
+            if (recCount > 0 && lexCount > recCount) {
+                const scaled = grams * (lexCount / recCount);
+                return {
+                    grams: scaled,
+                    servingTier: 'bare_dose_count_reconciled',
+                    servingDescription: `${lexCount} ${rec[2].toLowerCase()} (~${scaled}g)`,
+                };
+            }
+        }
+    }
 
     if (CAP_TIERS.has(servingTier)) {
         // CAP consults ONLY the query-side lexicon. A foodName fallback here

--- a/src/lib/units/__tests__/volume-density.test.ts
+++ b/src/lib/units/__tests__/volume-density.test.ts
@@ -1,0 +1,115 @@
+import { resolveVolumeGrams, volumeToGrams } from '../volume-density';
+
+/**
+ * The cases that matter are the ones the three hand-copies DISAGREED on. Each
+ * block below names the copy that was right and the number the wrong copies
+ * produced, so a future re-tune has to argue with a measurement.
+ */
+
+describe('resolveVolumeGrams — the paste tier the other two copies never got', () => {
+    it('peanut butter: 16 g/tbsp, not the dry-goods 7.5 g', () => {
+        const r = resolveVolumeGrams('Peanut Butter');
+        expect(r.volumeClass).toBe('paste');
+        expect(r.perUnit['tbsp']).toBe(16);
+        // What buildFatSecretResult and the FDC path billed before this module:
+        expect(15 * 0.5).toBe(7.5);
+    });
+
+    it('2 tbsp peanut butter is ~32 g — the number the OFF comment cites', () => {
+        expect(volumeToGrams(2, 'tbsp', 'Peanut Butter')!.grams).toBe(32);
+    });
+
+    it('greek yogurt: 250 g/cup, not 120 g', () => {
+        const r = volumeToGrams(1, 'cup', 'Greek Yogurt')!;
+        expect(r.grams).toBe(250);
+        expect(r.volumeClass).toBe('paste');
+    });
+
+    it.each([
+        'Almond Butter', 'Hummus', 'Honey', 'Mayonnaise', 'Strawberry Jam',
+        'Nutella', 'Tahini', 'Cream Cheese', 'Sour Cream', 'Ricotta',
+        'Tomato Paste', 'Ranch Dressing', 'Ketchup', 'Dijon Mustard',
+    ])('%s classifies as paste', (name) => {
+        expect(resolveVolumeGrams(name).volumeClass).toBe('paste');
+    });
+});
+
+describe('resolveVolumeGrams — liquids outrank pastes', () => {
+    it('a sauce containing "butter" is a LIQUID, not a paste', () => {
+        // isPaste is `!isLiquid && ...` in the original. Order matters: "butter
+        // sauce" matches both regexes, and the liquid answer (15 g/tbsp) is the
+        // right one. Mutation: drop the !isLiquid guard -> this goes to 16.
+        const r = resolveVolumeGrams('Butter Sauce');
+        expect(r.volumeClass).toBe('liquid');
+        expect(r.perUnit['tbsp']).toBe(15);
+    });
+
+    it.each(['Chicken Broth', 'Beef Stock', 'Water', 'Orange Juice', 'Whole Milk', 'Olive Oil', 'Maple Syrup', 'White Vinegar'])(
+        '%s classifies as liquid at 240 g/cup', (name) => {
+            const r = resolveVolumeGrams(name);
+            expect(r.volumeClass).toBe('liquid');
+            expect(r.perUnit['cup']).toBe(240);
+        });
+});
+
+describe('resolveVolumeGrams — the dry-granular category override', () => {
+    it('sugar uses its category density, not the flat 0.5 (n-serv-14)', () => {
+        const r = resolveVolumeGrams('Granulated Sugar');
+        expect(r.volumeClass).toBe('solid');
+        expect(r.solidDensity).toBeGreaterThan(0.5);
+        // The regression the override exists to stop: 5 * 0.5 = 2.5 g/tsp.
+        expect(r.perUnit['tsp']).toBeGreaterThan(2.5);
+    });
+
+    it('uncategorized solids keep the 0.5 default', () => {
+        const r = resolveVolumeGrams('Salt');
+        expect(r.volumeClass).toBe('solid');
+        expect(r.solidDensity).toBe(0.5);
+        expect(r.perUnit['tbsp']).toBe(7.5);
+    });
+
+    it('rice is NOT overridden — the restriction is load-bearing (n-serv-01/03/04)', () => {
+        // rice/grain/dairy are deliberately excluded from the override because
+        // overriding them overshoots COOKED servings. Mutation: widen the
+        // override to every inferred category -> this goes red.
+        const r = resolveVolumeGrams('White Rice');
+        expect(r.solidDensity).toBe(0.5);
+    });
+});
+
+describe('resolveVolumeGrams — name selection', () => {
+    it('takes the first non-empty name, so callers can pass candidate then query', () => {
+        expect(resolveVolumeGrams('Peanut Butter', 'sugar').volumeClass).toBe('paste');
+        expect(resolveVolumeGrams(null, undefined, '   ', 'Peanut Butter').volumeClass).toBe('paste');
+    });
+
+    it('an empty name is a plain solid, never a crash', () => {
+        const r = resolveVolumeGrams(null, undefined, '');
+        expect(r.volumeClass).toBe('solid');
+        expect(r.solidDensity).toBe(0.5);
+    });
+});
+
+describe('volumeToGrams', () => {
+    it('returns null for a non-volume unit so callers can fall through', () => {
+        expect(volumeToGrams(1, 'g', 'Peanut Butter')).toBeNull();
+        expect(volumeToGrams(1, 'slice', 'Bread')).toBeNull();
+        expect(volumeToGrams(1, null, 'Peanut Butter')).toBeNull();
+    });
+
+    it('is case-insensitive on the unit', () => {
+        expect(volumeToGrams(1, 'TBSP', 'Peanut Butter')!.grams).toBe(16);
+    });
+
+    it('micro-volume units are absolute, not density-scaled', () => {
+        // A pinch of sugar and a pinch of salt weigh the same here on purpose.
+        expect(volumeToGrams(1, 'pinch', 'Granulated Sugar')!.grams).toBe(0.3);
+        expect(volumeToGrams(1, 'pinch', 'Salt')!.grams).toBe(0.3);
+        expect(volumeToGrams(1, 'dash', 'Salt')!.grams).toBe(0.6);
+    });
+
+    it('scales linearly with quantity', () => {
+        expect(volumeToGrams(0.5, 'cup', 'Peanut Butter')!.grams).toBe(125);
+        expect(volumeToGrams(3, 'tsp', 'Salt')!.grams).toBe(7.5);
+    });
+});

--- a/src/lib/units/volume-density.ts
+++ b/src/lib/units/volume-density.ts
@@ -1,0 +1,138 @@
+/**
+ * volume-density.ts — THE owner of "how many grams is one ml of this food".
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * This rule existed in THREE hand-copied places, and only one of them was
+ * correct:
+ *
+ *   - the OFF path in `mapIngredientWithFallback()` — had the `isPaste` tier
+ *   - the FDC path in the same file       — did NOT
+ *   - `buildFatSecretResult()`            — did NOT
+ *
+ * The paste tier was added because the dry-goods default badly undercounts
+ * dense spreads; its own comment reads "2 tbsp peanut butter is ~32g, not 15g".
+ * That fix landed in one copy. The other two kept billing `15ml × 0.5 = 7.5 g`
+ * for a tablespoon of peanut butter.
+ *
+ * It stayed invisible because of WHO WINS. The FatSecret lane reached the
+ * reranker on only 16.9% of queries (measured 2026-08-01 over 249 already-asked
+ * lines), so the broken copies were rarely the ones billing. Fixing the
+ * pre-rerank lane starvation raises that to ~53% and the divergence surfaces
+ * immediately: `1 tbsp peanut butter` 16 g → 7.5 g, `1 cup greek yogurt`
+ * 250 g → 120 g. The gate caught it on 73 of 250 already-asked queries.
+ *
+ * So the defect this module closes is not "the FatSecret path is wrong". It is
+ * "the same rule is maintained in three places", which guarantees that the next
+ * correction lands in one of them. One owner, three callers.
+ *
+ * Re-derive the divergence:
+ *   grep -rn "isPaste" src/            # was 1 file before this module existed
+ *
+ * NOT A DENSITY MODEL. These are the tuned constants the OFF path already
+ * shipped, moved verbatim — deliberately, so this change is a de-duplication
+ * and not a re-tuning. Any change to the NUMBERS is a separate PR with its own
+ * winner-gate run, because grams feed the save gates and the cached row.
+ */
+
+import {
+    inferCategoryFromName,
+    categoryDensity,
+    DRY_GRANULE_DENSITY_CATEGORIES,
+} from './density';
+
+/** Millilitres per volume unit. The unit tables in the callers were identical
+ *  except that one spelled `cup` 240 and another 240 — kept at 240. */
+export const VOLUME_UNIT_ML: Record<string, number> = {
+    'cup': 240, 'cups': 240,
+    'tbsp': 15, 'tablespoon': 15, 'tablespoons': 15,
+    'tsp': 5, 'teaspoon': 5, 'teaspoons': 5,
+    'ml': 1, 'milliliter': 1, 'milliliters': 1,
+    'floz': 30, 'fl oz': 30,
+};
+
+/** Foods that pour. ~1 g/ml. */
+const LIQUID_RE = /broth|stock|water|juice|milk|sauce|vinegar|oil|syrup/i;
+
+/**
+ * Dense pastes and spreads, ~1 g/ml rather than the dry-goods default.
+ * Verbatim from the OFF path — this is the list that made `2 tbsp peanut
+ * butter` bill ~32 g instead of 15 g.
+ */
+const PASTE_RE =
+    /butter|spread|hummus|yogurt|yoghurt|honey|mayo|mayonnaise|jam|jelly|nutella|tahini|cream cheese|sour cream|ricotta|paste|dressing|ketchup|mustard/i;
+
+export type VolumeClass = 'liquid' | 'paste' | 'solid';
+
+export interface VolumeGrams {
+    /** Grams for one of each supported volume unit. */
+    perUnit: Record<string, number>;
+    /** Which branch decided it — logged, so a wrong bill is traceable to a rule. */
+    volumeClass: VolumeClass;
+    /** g/ml actually used for solids (category density, or the 0.5 default). */
+    solidDensity: number;
+}
+
+/**
+ * Resolve grams-per-volume-unit for a food, by NAME.
+ *
+ * `names` are tried in order and the first non-empty one classifies — callers
+ * pass the candidate's name and then the parsed query name, matching what the
+ * OFF path did.
+ */
+export function resolveVolumeGrams(...names: Array<string | null | undefined>): VolumeGrams {
+    const name = names.find(n => n && n.trim().length > 0)?.trim() ?? '';
+
+    const isLiquid = LIQUID_RE.test(name);
+    const isPaste = !isLiquid && PASTE_RE.test(name);
+
+    // Dry-solid density: prefer the food's category density (sugar 0.85, flour
+    // 0.53, oats 0.36 …) over a flat 0.5, which under-weighted DENSE solids by
+    // ~40% — granulated sugar billed 2.5 g/tsp instead of ~4.25 g (n-serv-14).
+    //
+    // ONLY for unambiguous dry-granular categories. rice/grain/dairy stay at 0.5
+    // on purpose: overriding them overshoots COOKED servings and trips the
+    // serving bands (n-serv-01/03/04). That restriction is load-bearing, not
+    // conservatism — do not widen it without re-running those cases.
+    let solidDensity = 0.5;
+    const category = inferCategoryFromName(name);
+    if (category && DRY_GRANULE_DENSITY_CATEGORIES.has(category)) {
+        const catDensity = categoryDensity(category);
+        if (catDensity && catDensity > 0) solidDensity = catDensity;
+    }
+
+    const cupG = isLiquid ? 240 : isPaste ? 250 : 240 * solidDensity;
+    const tbspG = isLiquid ? 15 : isPaste ? 16 : 15 * solidDensity;
+    const tspG = isLiquid ? 5 : isPaste ? 5.3 : 5 * solidDensity;
+    const mlG = isLiquid ? 1 : isPaste ? 1 : solidDensity;
+    const flozG = isLiquid ? 30 : isPaste ? 30 : 30 * solidDensity;
+
+    return {
+        perUnit: {
+            'cup': cupG, 'cups': cupG,
+            'tbsp': tbspG, 'tablespoon': tbspG, 'tablespoons': tbspG,
+            'tsp': tspG, 'teaspoon': tspG, 'teaspoons': tspG,
+            'ml': mlG, 'milliliter': mlG, 'milliliters': mlG,
+            'floz': flozG, 'fl oz': flozG,
+            // Micro-volume spice measures: absolute, not density-scaled. A pinch
+            // of anything is a pinch.
+            'dash': 0.6, 'dashes': 0.6,
+            'pinch': 0.3, 'pinches': 0.3,
+        },
+        volumeClass: isLiquid ? 'liquid' : isPaste ? 'paste' : 'solid',
+        solidDensity,
+    };
+}
+
+/** Grams for `qty` of `unit`, or null when the unit is not a volume unit. */
+export function volumeToGrams(
+    qty: number,
+    unit: string | null | undefined,
+    ...names: Array<string | null | undefined>
+): { grams: number; volumeClass: VolumeClass } | null {
+    if (!unit) return null;
+    const resolved = resolveVolumeGrams(...names);
+    const perUnit = resolved.perUnit[unit.toLowerCase()];
+    if (perUnit == null) return null;
+    return { grams: qty * perUnit, volumeClass: resolved.volumeClass };
+}

--- a/src/lib/units/volume-density.ts
+++ b/src/lib/units/volume-density.ts
@@ -24,7 +24,16 @@
  *
  * So the defect this module closes is not "the FatSecret path is wrong". It is
  * "the same rule is maintained in three places", which guarantees that the next
- * correction lands in one of them. One owner, three callers.
+ * correction lands in one of them.
+ *
+ * ONE OWNER, ONE CALLER SO FAR. Only `buildFatSecretResult()` calls this today.
+ * `buildOffResult()` and `buildFdcResult()` still carry their inline copies, and
+ * FDC is still the copy WITHOUT the paste tier — bare `1 tbsp peanut butter` on
+ * an FDC winner bills 7.5g. Converging them changes which grams those cascades
+ * bill, so each needs its own winner-gate run; this module exists so that work
+ * is a deletion rather than a fourth transcription. Do not read the existence of
+ * an owner as evidence the callers use it — count them:
+ *   grep -rn "volume-density" src/ | grep -v __tests__
  *
  * Re-derive the divergence:
  *   grep -rn "isPaste" src/            # was 1 file before this module existed
@@ -76,9 +85,20 @@ export interface VolumeGrams {
 /**
  * Resolve grams-per-volume-unit for a food, by NAME.
  *
- * `names` are tried in order and the first non-empty one classifies — callers
- * pass the candidate's name and then the parsed query name, matching what the
- * OFF path did.
+ * `names` are tried in order and the FIRST NON-EMPTY one classifies; the rest
+ * are fallbacks for an unnamed record, not additional evidence. Callers pass
+ * the matched candidate's name first because that is what the OFF path
+ * classifies on (`isLiquid`/`isPaste` in `buildOffResult()` test
+ * `candidate.name` alone).
+ *
+ * KNOWN DIVERGENCE, not closed here: `buildFdcResult()` tests the query name
+ * TOO (`RE.test(candidate.name) || RE.test(parsed?.name || '')`), so the three
+ * cascades disagree about whether what the USER typed may classify the food.
+ * It matters — `1 tbsp peanut butter` matching a record named "Skippy Creamy"
+ * has no paste token in the candidate name and bills the dry-goods 7.5g.
+ * Widening this to consider every name is a BEHAVIOUR change that moves grams,
+ * so it needs its own winner-gate run; it is deliberately not bundled with the
+ * de-duplication.
  */
 export function resolveVolumeGrams(...names: Array<string | null | undefined>): VolumeGrams {
     const name = names.find(n => n && n.trim().length > 0)?.trim() ?? '';

--- a/src/lib/units/volume-density.ts
+++ b/src/lib/units/volume-density.ts
@@ -28,20 +28,49 @@
  *
  * ONE OWNER, ONE CALLER SO FAR. Only `buildFatSecretResult()` calls this today.
  * `buildOffResult()` and `buildFdcResult()` still carry their inline copies, and
- * FDC is still the copy WITHOUT the paste tier — bare `1 tbsp peanut butter` on
- * an FDC winner bills 7.5g. Converging them changes which grams those cascades
- * bill, so each needs its own winner-gate run; this module exists so that work
- * is a deletion rather than a fourth transcription. Do not read the existence of
- * an owner as evidence the callers use it — count them:
+ * FDC is still the copy WITHOUT the paste tier. Do not read the existence of an
+ * owner as evidence the callers use it — count them:
  *   grep -rn "volume-density" src/ | grep -v __tests__
+ *
+ * A caveat on FDC, measured 2026-08-02 and worth carrying, because it is the
+ * opposite of what the code reads like: FDC's inline density table has NEVER
+ * billed a live query. Of 4,491 `volume_unit` events, ZERO have an FDC winner —
+ * `findOwnFdcVolumeServing()` and `insertFdcAiServing()` absorb every FDC volume
+ * request ahead of it (`fdc_label_volume` 865, `fdc_volume_cached` 317,
+ * `fdc_volume_ai` 318, density fallback 0). So converging FDC is a near-free
+ * deletion of a latent landmine, not a repair of live billing; the live
+ * population is entirely OFF's. Re-derive:
+ *   SELECT "servingTier", count(*) FROM "MappingEventLog"
+ *   WHERE "servingTier" LIKE '%volume%' GROUP BY 1;
+ *
+ * Note also that OFF and FDC both stamp the SAME tier string `volume_unit`, so
+ * the event log cannot attribute a wrong gram bill to a lane. That is how the
+ * FDC copy stayed divergent unseen; splitting the tiers belongs with the
+ * convergence commit.
  *
  * Re-derive the divergence:
  *   grep -rn "isPaste" src/            # was 1 file before this module existed
  *
- * NOT A DENSITY MODEL. These are the tuned constants the OFF path already
- * shipped, moved verbatim — deliberately, so this change is a de-duplication
- * and not a re-tuning. Any change to the NUMBERS is a separate PR with its own
+ * NOT A DENSITY MODEL. Any change to the NUMBERS is a separate PR with its own
  * winner-gate run, because grams feed the save gates and the cached row.
+ *
+ * PROVENANCE, corrected 2026-08-02 — an earlier version of this header claimed
+ * the constants were "the OFF path's constants verbatim". That is FALSE for
+ * `ml`, `floz` and `fl oz`. `cup`/`tbsp`/`tsp` came from OFF; `ml`/`floz` came
+ * from FDC, which is what `buildFatSecretResult()` already did before the move,
+ * so nothing regressed — but the header was asserting agreement that does not
+ * exist. Measured over 9 foods x 15 unit keys, 21 of 135 cells differ from OFF.
+ *
+ * The disagreement is real and OFF is the wrong one: OFF hardcodes `ml: 1` and
+ * `floz: 30` UNSCALED, so it bills `1 cup flour` at 127.2g and `240 ml flour`
+ * at 240g — the same volume of the same food, 1.89x apart, contradicting the
+ * density it computed one line earlier. This module scales them. Converging OFF
+ * onto it is measured to move 0 of 4,473 live `volume_unit` events (`ml`/`floz`
+ * have zero production traffic), but it is a constant change and belongs in its
+ * own commit with its own gate.
+ *
+ * Re-derive the cell-level diff by executing both inline blocks:
+ *   the OFF block in `buildOffResult()` vs `resolveVolumeGrams()`, same inputs.
  */
 
 import {


### PR DESCRIPTION
> **Draft on purpose.** The change does what it claims, and the winner-gate refutes it as shippable. Both facts are the deliverable. Do not merge until the serving defect below is fixed.

## The defect is real, and larger than the handoff recorded

`filtered.slice(0, 10)` took a **prefix** of gather order. `gatherCandidates` concatenates its lanes (FDC → OFF → FatSecret) rather than interleaving, so whenever the earlier lanes filled the window, every later lane was **deleted before `simpleRerank` ran** — not out-ranked, never seen.

Measured cold over 249 already-asked lines (`winner-diff snapshot`, which forces production flags, so the FatSecret lane is live exactly as on the box):

```
249/249  queries truncate
207      (83.1%) lose at least one ENTIRE lane
fatsecret    gathered for 249, reached the reranker on 42  (16.9%)
fdc          0.0% starved
openfoodfacts 3.2% starved
```

It is not a `grilled chicken breast` quirk. It is the default behaviour.

## The fix

`buildRerankPool()` round-robins across lanes in **first-appearance order**, preserving within-lane order, with the **same budget** (`RERANK_POOL_LIMIT` === the old literal `10`).

- **Not a source preference** — no lane is ranked above another; lane order is inherited from gather.
- **Not an admission relaxation** — `|window|` is unchanged. It is a re-composition, and re-composition is non-monotone in *both* directions.
- Leaf-safe module (no imports, structural `{ source }` typing) specifically so the eval harness can import the real function rather than transcribe it.

13 tests. All five mutations kill their named test — and **one mutation survived the first draft** (untagged candidates becoming one lane each); the test that closes it was written from the mutation, not from the code.

## What the gate said

Noise floor **0/20 and 0/250 on both trees**, variant `gate-backstop` on both sides, serving stage on.

**Cold (20 seeds): 15 SAME, 5 WINNER-CHANGED, 0 WINNER→NOWINNER.**

`n-mq-22`'s item moves into band — `21.4P` (OFF, 95 kcal/100g) → `29.6P` (FatSecret, 195 kcal/100g), against the case's `[25, 38]`. Every tripwire held: `chipotle chicken burrito bowl`, `impossible burger patty`, `mac and cheese`, `shrimp taco`, `kirkland almonds`. Class drift: BASE 2, BRANCH 0.

**Regression (250 already-asked): 93 WINNER-CHANGED (37%) — and this is the refutation.** 73/250 (29%) change what the user is **billed**:

| query | before | after | tier |
|---|---|---|---|
| `1 tbsp peanut butter` | 16.0 g / 95 kcal | **7.5 g / 44 kcal** | `volume_unit` → `fs_volume_density` |
| `2 tbsp peanut butter` | 32.0 g / 190 kcal | **15.0 g / 88 kcal** | same |
| `0.5 cup peanut butter` | 125.0 g / 743 kcal | **60.0 g / 353 kcal** | same |
| `1 cup greek yogurt` | 250.0 g / 310 kcal | **120.0 g / 110 kcal** | same |
| `almonds` | 28.0 g / 160 kcal | **1.2 g / 7 kcal** | `bare_plural_serving` → `fs_label_count` |
| `1 courgette` | 196.0 g / 41 kcal | **28.4 g / 5 kcal** | `seed_count_default` → `fs_default_serving` |

## Root cause — and it is not this change

On `1 tbsp peanut butter` the winner moved from an OFF peanut butter (594 kcal/100g) to a FatSecret peanut butter (588) — **the same food, 1% apart**. The record did not get worse. The **serving tier** changed.

`fs_volume_density` in `build-fatsecret-result.ts` falls back to a flat `isLiquid ? 1.0 : 0.5` g/ml when no volume-quantified serving exists. Peanut butter is ~1.07 g/ml, so `1 tbsp = 14.79 ml × 0.5 = 7.4 g` against a true ~16 g — a **~50% under-bill on every non-liquid volume request that lands on a FatSecret record without a volume serving**. `almonds` bills **one almond** because `fs_label_count` noun-matches a `1 almond (1.2g)` serving on a bare plural query.

These tiers are latent today **precisely because of the starvation** — FatSecret wins 16.9% of the time. Any change that raises that rate detonates them. This one raises it to ~53%.

This is the PR #173 lesson at scale, and exactly what the playbook says to look for: *winner-diff gates which record wins, not what the user is billed.*

## Ordering

1. Fix `build-fatsecret-result.ts`: the volume-density fallback, and the bare-plural `fs_label_count` path.
2. Re-run this gate.
3. Then ship this.

Shipping as-is would be **worse than the defect it fixes** — and worse still under warming, where those grams become cached `FoodMapping` rows.

## Also here (both pre-existing, both needed to gate this honestly)

- **`winner-gate.sh` never passed `--variant`**, so `resolveVariant()` defaulted to `baseline` — the pre-#168 caller, which no tree has contained since 2026-07-26. Every run this driver has ever done modelled a caller neither side had, and a Step-4 change is invisible on the ~10.6% of lines where the gate fires. Now resolved from the tree's own caller hash; aborts rather than guessing.
- **`WinnerInfo.inTop10` is positional, not window membership.** Under lane composition those are different facts; `inRerankWindow` is the real one.

## Receipts

Caller re-pinned `16bec3f864088b83`. `verify --from-events --limit 60`: MATCH 60, MISMATCH-UNEXPLAINED 0, CONF-UNEXPLAINED 0. `npx tsc --noEmit` clean. Mapping suite: 3 pre-existing 5s-timeout flakes — clean master fails **4** of the same suite under identical conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu