### PR TITLE
Bare query: a declared serving outranks a derived whole piece

### DIFF
--- a/src/lib/mapping/__tests__/build-fatsecret-result-demoted-default.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-demoted-default.test.ts
@@ -183,3 +183,93 @@ describe('a non-bare request is unaffected', () => {
         expect(r!.grams).toBe(200);
     });
 });
+
+/**
+ * The lexicon-free trailing-token fallback yields to a declared serving.
+ *
+ * Golden eval `n-mq-47` drift, 2026-08-02: `trader joes chicken breast` moved
+ * 112g -> 236g. `fs_4881229` has NO 236g serving — its largest is 135g. The
+ * number comes from `1/2 breast, bone and skin removed`, grams 118 with
+ * numberOfUnits **0.5**, so per-unit is 118 / 0.5 = 236: one whole breast,
+ * derived correctly and answering the wrong question. The record states its own
+ * serving on a row reading `1 serving (90 g)`.
+ *
+ * The fix is a priority rule, not a size ceiling. A ceiling would be a threshold
+ * picked to exclude one food, and would still choose the wrong row for records
+ * whose pieces are legitimately large.
+ */
+function makeBreastRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '4881229', name: 'Skinless Chicken Breast', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { kcal: 110, protein: 23, carbs: 0, fat: 2 },
+        defaultServingId: '4751539',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            serving('4751536', '1 oz boneless, cooked, skinless', 28),
+            serving('4751538', '1 serving (90 g)', 90),
+            { ...serving('4751539', '100 g', 100), numberOfUnits: 100 },
+            { ...serving('4751525', '1/2 breast, bone and skin removed', 118), numberOfUnits: 0.5 },
+            serving('4751533', '1 cup cooked, diced', 135),
+        ],
+        ...over,
+    };
+}
+
+describe('n-mq-47 — a declared serving outranks a derived whole piece', () => {
+    it('bare "chicken breast" bills the record\'s 90g serving, not the derived 236g breast', async () => {
+        // MUTATION: drop the `declaredOneServing` guard -> 236g, outside [80,200].
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeBreastRow());
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_4881229', name: 'Skinless Chicken Breast' }),
+            parsedLine({ name: 'chicken breast' }), 0.9, 'chicken breast'
+        );
+        expect(r!.grams).toBe(90);
+        expect(r!.grams).toBeGreaterThanOrEqual(80);
+        expect(r!.grams).toBeLessThanOrEqual(200);
+    });
+
+    it('the 0.5-unit arithmetic itself is untouched — it is the PRIORITY that changed', async () => {
+        // Same record, same row, no "1 serving" to yield to: the fallback still
+        // derives one whole breast. This pins that the fix did not delete the
+        // fallback or break numberOfUnits handling.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeBreastRow({
+            servings: makeBreastRow().servings.filter(s => s.servingId !== '4751538'),
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_4881229', name: 'Skinless Chicken Breast' }),
+            parsedLine({ name: 'chicken breast' }), 0.9, 'chicken breast'
+        );
+        expect(r!.grams).toBe(236);
+    });
+
+    it('a NON-bare count still uses the fallback — the rule is bare-only', async () => {
+        // "2 chicken breasts" is an explicit count of pieces; the declared
+        // single serving must not answer it.
+        // MUTATION: drop `bareSingular ?` from declaredOneServing -> 180g.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeBreastRow());
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_4881229', name: 'Skinless Chicken Breast' }),
+            parsedLine({ qty: 2, name: 'chicken breasts' }), 0.9, '2 chicken breasts'
+        );
+        expect(r!.grams).toBe(472);
+    });
+
+    it('the curated lexicon path is NOT affected — "1 bar" still beats a serving row', async () => {
+        // MUTATION: apply the yield to the lexicon path too -> 30g, and a
+        // protein bar stops billing as a bar.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeBreastRow({
+            name: 'Protein Bar', defaultServingId: 'svPanel',
+            servings: [
+                serving('svBar', '1 bar', 60),
+                serving('svServing', '1 serving (30 g)', 30),
+                { ...serving('svPanel', '100 g', 100), numberOfUnits: 100 },
+            ],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_9', name: 'Protein Bar' }),
+            parsedLine({ name: 'protein bar' }), 0.9, 'protein bar'
+        );
+        expect(r!.grams).toBe(60);
+        expect(r!.servingTier).toBe('fs_label_count');
+    });
+});

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -469,13 +469,53 @@ export async function buildFatSecretResult(
         // contains the request's trailing token ("1 pretzel (Include nuggets)")
         // is itself proof the token is a countable piece of THIS food. Only
         // fires when such a serving exists, so no false discrete billing.
+        //
+        // BUT IT YIELDS TO A DECLARED SERVING ON A BARE REQUEST. This fallback is
+        // lexicon-free by design — it accepts whatever trailing token happens to
+        // appear in some serving label — so it is the weakest evidence in this
+        // branch, and on a bare query it was outranking the record's own answer.
+        //
+        // `trader joes chicken breast` (golden eval n-mq-47, drift measured
+        // 2026-08-02) resolved trailing token `breast` against
+        // `1/2 breast, bone and skin removed` on `fs_4881229`. That row carries
+        // grams 118 and **numberOfUnits 0.5**, so the per-unit arithmetic below
+        // derives 118 / 0.5 = 236 g — one whole breast. The arithmetic is
+        // correct; the ANSWER is wrong, because a bare request asks what one
+        // serving is and that record says so itself, on a row reading
+        // `1 serving (90 g)`. 236 g is outside the case's [80, 200] band; 90 g
+        // is inside it.
+        //
+        // Note what this is NOT: a size ceiling. A ceiling was the obvious read
+        // (the floor `BARE_MIN_PIECE_SERVING_GRAMS` has no upper twin) and it
+        // would be a magic number chosen to exclude one food, and would still
+        // pick the wrong row for every record whose pieces are legitimately
+        // large. Preferring an explicit declaration over an inference is a rule
+        // with a reason, and it needs no threshold.
+        //
+        // Scoped to the lexicon-free path deliberately. The curated
+        // `DISCRETE_ITEM_UNIT_RE` path is strong evidence — "1 bar" on a protein
+        // bar SHOULD outrank a generic serving row — and is left alone.
         if (!match && !unit && !barePlural) {
             const lastToken = (parsed?.name || foodName)
                 .toLowerCase().trim().split(/\s+/).pop() ?? '';
             const fallbackNoun = singularizeUnit(lastToken);
             if (fallbackNoun && fallbackNoun.length >= 3) {
                 const fallbackMatch = usableServings.find(s => servingMatchesNoun(s, fallbackNoun));
-                if (fallbackMatch) {
+                const declaredOneServing = bareSingular
+                    ? usableServings.find(s =>
+                        EXPLICIT_ONE_SERVING_RE.test(s.description)
+                        && usableBareLabelServing(
+                            s.grams, extractLabelServingUnit(s.description)) != null)
+                    : undefined;
+                if (fallbackMatch && declaredOneServing) {
+                    logger.info('fs.build_result.bare_fallback_yielded_to_declared_serving', {
+                        foodId: candidate.id,
+                        fallbackNoun,
+                        fallbackServing: fallbackMatch.description,
+                        declaredServing: declaredOneServing.description,
+                    });
+                }
+                if (fallbackMatch && !declaredOneServing) {
                     noun = fallbackNoun;
                     match = fallbackMatch;
                 }


### PR DESCRIPTION
Closes the `n-mq-47` drift that #214 introduced, and which was blocking the warm campaign — `run-batches.sh:702` reds on any `knownIssueDrift`.

## The defect

`trader joes chicken breast` moved 112g → **236g**, outside its [80, 200] band.

`fs_4881229` has **no 236g serving** — its largest is 135g:

```
4751536  1 oz boneless, cooked, skinless        28    numberOfUnits 1
4751538  1 serving (90 g)                       90    numberOfUnits 1
4751539  100 g                                 100    numberOfUnits 100
4751525  1/2 breast, bone and skin removed     118    numberOfUnits 0.5
4751533  1 cup cooked, diced                   135    numberOfUnits 1
```

The lexicon-free trailing-token fallback resolved `breast` against `1/2 breast, bone and skin removed`, and the per-unit arithmetic did `118 / 0.5 = 236` — one whole breast. **The arithmetic is correct.** The answer is wrong, because a bare request asks what one serving is, and the record says so itself on row `4751538`: `1 serving (90 g)`.

## Why not a ceiling

A size ceiling was the obvious read — `BARE_MIN_PIECE_SERVING_GRAMS` (20g) has no upper twin, and that missing-second-bound asymmetry has now bitten three times. It is still the wrong fix: it would be a threshold picked to exclude one food, and it would keep choosing the wrong row for every record whose pieces are legitimately large. Preferring an explicit declaration over an inference needs no threshold.

## Scope

- **Lexicon-free path only.** The curated `DISCRETE_ITEM_UNIT_RE` path is strong evidence — `1 bar` on a protein bar *should* outrank a generic serving row — and is untouched.
- **Bare-only.** `2 chicken breasts` is an explicit count and still derives 472g.

## Gate

Noise floor **0/20 and 0/250 on both trees**; winners **93 / 156**, unchanged across runs 5–8. Deterministic movers **66**, same as run 7 — this adds none.

| query | before | run 7 | run 8 |
|---|---|---|---|
| `chicken breast` | 112g | 236g | **90g** |
| `chicken` | 113.4g | 85g | 85g |
| `1 handful almonds` | 30g | 28g | 30g |

4 tests; M1 (ignore the declared serving) and M2 (drop the bare-only scope) verified red.

## Read this before trusting either instrument

Measured 2026-08-02: **118 of 139 mapping events in a full golden eval run (84.9%) are `funnelStage='cache_hit'`.** The eval mostly does not reach the mapper. `n-mq-22` stayed byte-identically red after #214 deployed because it is cache-served; evicting one `FoodMapping` row turned it green with no code change. `n-cook-06`'s drift is the same shape.

And `winner-diff` is the mirror image — it replays a frozen gather snapshot, so it **bypasses the cache entirely**. Every gate number above is a claim about **cold retrieval only**.

`/api/nlp/parse` already honours `nocache=1` and `run-eval.ts` has never passed it. A cold golden run is the obvious next instrument and is not in this PR.