### PR TITLE
chore(eval): refresh the n-mq-47 and n-cook-06 pins

### DIFF
--- a/scripts/eval/known-issue-baseline.json
+++ b/scripts/eval/known-issue-baseline.json
@@ -1,6 +1,6 @@
 {
   "_readme": "Recorded state of each knownIssue case. run-eval compares against this and reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the new values are understood to be the intended state. Writes MERGE: a filtered (--only/--grep) run refreshes only the pins it ran and leaves the rest intact.",
-  "writtenAt": "2026-07-31T18:07:08.000Z",
+  "writtenAt": "2026-08-02T13:58:42.245Z",
   "cases": {
     "s-typo-08": {
       "foodId": "off_9310653104835",
@@ -84,10 +84,10 @@
       "itemCount": 1
     },
     "n-cook-06": {
-      "foodId": "cmrs5ej1z00002qaag5mhai74",
+      "foodId": "off_9348219004831",
       "foodName": "Rolled Oats",
-      "grams": 90,
-      "kcal100": 361,
+      "grams": 86.39999999999999,
+      "kcal100": 400,
       "abstained": false,
       "errored": false,
       "itemCount": 1
@@ -138,10 +138,10 @@
       "itemCount": 1
     },
     "n-mq-47": {
-      "foodId": "off_0261638011855",
+      "foodId": "fs_4881229",
       "foodName": "Skinless Chicken Breast",
-      "grams": 112,
-      "kcal100": 125,
+      "grams": 90,
+      "kcal100": 110,
       "abstained": false,
       "errored": false,
       "itemCount": 1


### PR DESCRIPTION
Unblocks the warm campaign — `run-batches.sh:702` reds on any `knownIssueDrift`, and these two were the last blockers.

**n-mq-47** is the state #215 was written to produce: grams 112 → 90, the grams assertion now **passes** (previously 236, outside [80,200]). The case remains a knownIssue only for its pre-existing name mismatch.

**n-cook-06** is refreshed with a caveat that should not be lost: **it is cache-served** (`cacheHit='early'`, `funnelStage='cache_hit'`), so the pin records a cache-derived value, not mapper behaviour. Old and new records are both dry rolled-oats panels against a [45,95] cooked band — the case fails identically in kind, and this is not a regression from #214/#215. The honest alternative was to evict the cached row as was done for n-mq-22; that is a production write and was out of scope.

Wider: **118 of 139 mapping events in a full golden run (84.9%) are cache hits.** Most pins may be recording cache state. `/api/nlp/parse` honours `nocache=1` and `run-eval.ts` has never passed it — a cold golden run is the obvious next instrument.

Verified after: `0 real failures, 15 known issues`, no DRIFT section.