### PR TITLE
feat(coverage): cut coverage-corpus-2026-08-02 with the branded-CPG arm

### DIFF
--- a/scripts/eval/_cut_coverage_corpus.ts
+++ b/scripts/eval/_cut_coverage_corpus.ts
@@ -1,0 +1,128 @@
+/**
+ * Cut a NEW coverage corpus from an existing one plus a set of additions.
+ *
+ * Why this exists as a script rather than an edit: `cache-coverage.ts` says the
+ * committed corpus is the fixed denominator and that "changing it breaks
+ * comparability with every earlier reading — cut a new file under a new name
+ * instead, and restate the baseline." Appending to the live corpus silently
+ * invalidates every prior coverage/growth number in the logs. This produces the
+ * new file, leaves the old one untouched, and prints the restated baseline.
+ *
+ * `baseline` is recomputed for EVERY seed against the live cache at cut time, so
+ * `growth` on the new corpus restarts at 0% by construction and measures work
+ * done from this cut forward. The old file keeps its own baseline and its own
+ * history stays readable.
+ *
+ * Additions are deduped by CACHE KEY against the base corpus, not by raw string:
+ * "fage total 0 plain" and "Fage Total 0% plain" are one seed to the coverage
+ * reader, and admitting both would inflate the denominator with a row that can
+ * never be independently cached. Rows already in the base are dropped, and the
+ * base itself is copied through untouched (deduping it would change the
+ * denominator this script exists to preserve).
+ *
+ * Usage:
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register \
+ *     scripts/eval/_cut_coverage_corpus.ts \
+ *       --base scripts/eval/coverage-corpus.tsv \
+ *       --add  /tmp/additions.tsv        # domain \t seed, no header
+ *       --out  scripts/eval/coverage-corpus-2026-08-02.tsv
+ */
+import * as fs from 'fs';
+import { PrismaClient } from '@prisma/client';
+import { canonicalizeCacheKey } from '../../src/lib/mapping/normalization-rules';
+
+const args = process.argv.slice(2);
+const argValue = (f: string) => {
+    const i = args.indexOf(f);
+    return i >= 0 ? args[i + 1] : undefined;
+};
+
+const BASE = argValue('--base');
+const ADD = argValue('--add');
+const OUT = argValue('--out');
+
+if (!BASE || !OUT) {
+    console.error('usage: --base <corpus.tsv> [--add <domain\\tseed.tsv>] --out <new.tsv>');
+    process.exit(2);
+}
+if (fs.existsSync(OUT)) {
+    // Fail closed. Overwriting a cut corpus is the same comparability break the
+    // whole script exists to avoid, just one level up.
+    console.error(`!! ${OUT} already exists. Cutting over it would break comparability. Refusing.`);
+    process.exit(2);
+}
+
+interface Row { domain: string; seed: string }
+
+function readBase(p: string): Row[] {
+    const out: Row[] = [];
+    for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+        const t = line.trim();
+        if (!t) continue;
+        const [domain, , ...rest] = t.split('\t');
+        const seed = rest.join('\t').trim();
+        if (!seed || domain === 'domain') continue;   // header
+        out.push({ domain, seed });
+    }
+    return out;
+}
+
+function readAdditions(p: string): Row[] {
+    const out: Row[] = [];
+    for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+        const t = line.trim();
+        if (!t || t.startsWith('#')) continue;
+        const [domain, ...rest] = t.split('\t');
+        const seed = rest.join('\t').trim();
+        if (!seed) continue;
+        out.push({ domain: domain.trim(), seed });
+    }
+    return out;
+}
+
+async function main() {
+    const base = readBase(BASE!);
+    const additions = ADD ? readAdditions(ADD) : [];
+
+    const baseKeys = new Set(base.map(r => canonicalizeCacheKey(r.seed)));
+    const seenAdd = new Set<string>();
+    const kept: Row[] = [];
+    let dupBase = 0, dupAdd = 0;
+    for (const r of additions) {
+        const k = canonicalizeCacheKey(r.seed);
+        if (baseKeys.has(k)) { dupBase++; continue; }
+        if (seenAdd.has(k)) { dupAdd++; continue; }
+        seenAdd.add(k);
+        kept.push(r);
+    }
+
+    const all = [...base, ...kept];
+
+    const prisma = new PrismaClient();
+    let cachedKeys: Set<string>;
+    try {
+        const rows = await prisma.foodMapping.findMany({ select: { normalizedForm: true } });
+        cachedKeys = new Set(rows.map(r => r.normalizedForm));
+    } finally {
+        await prisma.$disconnect().catch(() => {});
+    }
+
+    let cached = 0;
+    const lines = ['domain\tbaseline\tseed'];
+    for (const r of all) {
+        const isCached = cachedKeys.has(canonicalizeCacheKey(r.seed));
+        if (isCached) cached++;
+        lines.push(`${r.domain}\t${isCached ? 'cached' : 'new'}\t${r.seed}`);
+    }
+    fs.writeFileSync(OUT!, lines.join('\n') + '\n');
+
+    const pct = (n: number, d: number) => (d ? Math.round((n / d) * 1000) / 10 : 0);
+    console.log(`base            ${base.length}`);
+    console.log(`additions       ${additions.length} offered, ${kept.length} kept ` +
+        `(${dupBase} already in base by cache key, ${dupAdd} duplicate within additions)`);
+    console.log(`NEW CORPUS      ${all.length} seeds -> ${OUT}`);
+    console.log(`RESTATED BASELINE  cached ${cached}/${all.length} = ${pct(cached, all.length)}%`);
+    console.log(`growth restarts at 0% by construction (every seed's baseline is its state right now)`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/eval/coverage-corpus-2026-08-02.tsv
+++ b/scripts/eval/coverage-corpus-2026-08-02.tsv
@@ -1,0 +1,3755 @@
+domain	baseline	seed
+unlabeled	cached	oatmeal
+breakfast	cached	steel cut oats
+breakfast	cached	rolled oats
+breakfast	new	instant oatmeal
+breakfast	new	quaker instant oatmeal maple brown sugar
+breakfast	new	quaker oats old fashioned
+breakfast	new	quaker instant oatmeal apple cinnamon
+breakfast	new	overnight oats
+breakfast	new	cream of wheat
+breakfast	cached	grits
+breakfast	cached	cheese grits
+breakfast	new	shrimp and grits
+unlabeled	cached	cereal
+unlabeled	cached	corn flakes
+breakfast	cached	bran flakes
+breakfast	new	shredded wheat
+breakfast	cached	puffed rice cereal
+unlabeled	cached	cheerios
+unlabeled	cached	honey nut cheerios
+unlabeled	cached	frosted flakes
+unlabeled	cached	froot loops
+unlabeled	cached	cinnamon toast crunch
+unlabeled	cached	lucky charms
+breakfast	cached	special k red berries
+breakfast	cached	special k original
+breakfast	new	honey bunches of oats
+unlabeled	cached	raisin bran
+unlabeled	cached	cocoa puffs
+breakfast	cached	corn pops
+unlabeled	cached	rice krispies
+unlabeled	cached	cap'n crunch
+breakfast	cached	reese's puffs
+unlabeled	cached	fruity pebbles
+unlabeled	cached	cocoa pebbles
+breakfast	new	grape nuts
+breakfast	cached	life cereal
+breakfast	cached	kix
+breakfast	cached	chex
+breakfast	cached	cinnamon chex
+breakfast	cached	total cereal
+unlabeled	cached	all bran
+breakfast	cached	wheaties
+breakfast	cached	golden grahams
+unlabeled	cached	trix
+unlabeled	cached	granola
+unlabeled	cached	granola bar
+unlabeled	cached	nature valley granola bar
+breakfast	cached	quaker chewy granola bar
+breakfast	cached	kind granola bar
+breakfast	cached	kashi granola
+breakfast	cached	granola with yogurt
+unlabeled	cached	pancakes
+unlabeled	cached	buttermilk pancakes
+breakfast	cached	blueberry pancakes
+unlabeled	cached	eggo waffles
+breakfast	cached	eggo homestyle waffles
+unlabeled	cached	belgian waffle
+unlabeled	cached	waffles
+unlabeled	cached	french toast
+unlabeled	cached	french toast sticks
+unlabeled	cached	breakfast sandwich
+breakfast	new	egg mcmuffin
+breakfast	cached	sausage egg and cheese biscuit
+unlabeled	cached	breakfast burrito
+breakfast	cached	bacon egg and cheese sandwich
+breakfast	new	sausage mcmuffin
+breakfast	cached	bacon egg and cheese bagel
+breakfast	new	egg white breakfast sandwich
+unlabeled	cached	bacon
+unlabeled	cached	turkey bacon
+breakfast	new	sausage links
+breakfast	new	sausage patty
+breakfast	new	breakfast sausage
+breakfast	cached	scrambled eggs
+unlabeled	cached	fried egg
+breakfast	new	poached egg
+breakfast	new	hard boiled egg
+unlabeled	cached	egg whites
+unlabeled	new	omelette
+breakfast	new	western omelette
+unlabeled	new	cheese omelette
+unlabeled	new	veggie omelette
+breakfast	new	eggs benedict
+unlabeled	cached	over easy eggs
+breakfast	new	sunny side up eggs
+unlabeled	cached	bagel
+unlabeled	cached	plain bagel
+unlabeled	cached	everything bagel
+breakfast	new	blueberry bagel
+unlabeled	cached	bagel with cream cheese
+unlabeled	cached	cinnamon raisin bagel
+unlabeled	cached	muffin
+breakfast	new	blueberry muffin
+unlabeled	cached	english muffin
+unlabeled	cached	croissant
+unlabeled	cached	chocolate croissant
+breakfast	new	danish
+unlabeled	cached	cheese danish
+unlabeled	cached	cinnamon roll
+breakfast	new	pop tarts frosted brown sugar cinnamon
+unlabeled	cached	toaster strudel
+unlabeled	cached	toast
+breakfast	new	white toast
+unlabeled	cached	wheat toast
+unlabeled	cached	avocado toast
+breakfast	new	buttered toast
+breakfast	new	toast with peanut butter
+breakfast	new	sourdough toast
+breakfast	new	breakfast bowl
+unlabeled	cached	yogurt parfait
+breakfast	new	chobani oat vanilla
+unlabeled	cached	greek yogurt with granola
+unlabeled	cached	acai bowl
+breakfast	new	egg and potato breakfast bowl
+breakfast	new	ham
+unlabeled	cached	canadian bacon
+unlabeled	cached	hash browns
+unlabeled	cached	breakfast potatoes
+breakfast	new	biscuit
+breakfast	cached	biscuits and gravy
+unlabeled	cached	black coffee
+unlabeled	cached	coffee
+unlabeled	cached	espresso
+coffee-tea	new	double espresso
+unlabeled	cached	americano
+coffee-tea	new	iced americano
+unlabeled	cached	latte
+unlabeled	cached	iced latte
+unlabeled	cached	cappuccino
+coffee-tea	new	macchiato
+coffee-tea	new	cortado
+unlabeled	cached	flat white
+unlabeled	cached	cold brew
+coffee-tea	new	nitro cold brew
+unlabeled	cached	iced coffee
+unlabeled	cached	mocha
+coffee-tea	new	iced mocha
+unlabeled	cached	vanilla latte
+coffee-tea	new	caramel latte
+unlabeled	cached	pumpkin spice latte
+coffee-tea	new	decaf coffee
+unlabeled	cached	starbucks caramel macchiato
+coffee-tea	cached	starbucks pumpkin spice latte
+coffee-tea	cached	starbucks pike place roast
+coffee-tea	cached	starbucks caffe latte
+coffee-tea	cached	starbucks cappuccino
+unlabeled	cached	starbucks cold brew
+unlabeled	cached	starbucks vanilla sweet cream cold brew
+coffee-tea	cached	starbucks nitro cold brew
+unlabeled	cached	starbucks caramel frappuccino
+unlabeled	cached	starbucks mocha frappuccino
+coffee-tea	new	starbucks iced brown sugar oatmilk shaken espresso
+coffee-tea	cached	starbucks white chocolate mocha
+coffee-tea	new	starbucks blonde vanilla latte
+coffee-tea	cached	starbucks flat white
+coffee-tea	cached	starbucks chai tea latte
+coffee-tea	cached	starbucks matcha latte
+coffee-tea	cached	starbucks london fog
+coffee-tea	cached	starbucks americano
+unlabeled	new	dunkin iced coffee
+coffee-tea	cached	dunkin hot coffee
+coffee-tea	new	dunkin caramel craze latte
+coffee-tea	cached	dunkin iced caramel craze latte
+coffee-tea	new	dunkin cold brew
+coffee-tea	new	dunkin macchiato
+coffee-tea	new	dunkin frozen coffee
+coffee-tea	cached	dunkin matcha latte
+coffee-tea	cached	dunkin chai latte
+coffee-tea	new	dunkin midnight coffee
+coffee-tea	new	dunkin french vanilla coffee
+coffee-tea	new	peet's coffee
+coffee-tea	new	peet's cold brew
+coffee-tea	new	peet's caffe mocha
+coffee-tea	new	caribou coffee
+coffee-tea	new	caribou coffee cooler
+coffee-tea	new	caribou northern lite latte
+coffee-tea	new	dutch bros iced coffee
+coffee-tea	new	dutch bros golden eagle
+coffee-tea	new	dutch bros americano
+coffee-tea	new	dutch bros caramelizer
+coffee-tea	new	tim hortons double double
+coffee-tea	new	tim hortons iced capp
+coffee-tea	new	tim hortons french vanilla
+coffee-tea	new	panera hazelnut coffee
+coffee-tea	cached	panera dark roast coffee
+coffee-tea	new	starbucks frappuccino bottle
+coffee-tea	cached	starbucks doubleshot espresso can
+coffee-tea	cached	starbucks triple shot energy
+coffee-tea	new	la colombe draft latte
+coffee-tea	new	la colombe cold brew
+coffee-tea	new	chameleon cold brew
+coffee-tea	new	stok cold brew
+coffee-tea	cached	califia farms cold brew coffee
+coffee-tea	new	high brew cold brew
+coffee-tea	new	coffee mate french vanilla creamer
+coffee-tea	new	coffee mate hazelnut creamer
+coffee-tea	new	coffee mate original creamer
+coffee-tea	new	coffee mate sweet italian creme creamer
+coffee-tea	new	half and half
+coffee-tea	new	heavy cream in coffee
+unlabeled	cached	oat milk latte
+coffee-tea	new	almond milk latte
+coffee-tea	new	coconut milk coffee
+unlabeled	cached	coffee with cream and sugar
+coffee-tea	cached	coffee with milk
+coffee-tea	new	black coffee with sugar
+coffee-tea	new	sugar free vanilla latte
+unlabeled	cached	black tea
+unlabeled	cached	green tea
+coffee-tea	new	herbal tea
+coffee-tea	new	chamomile tea
+coffee-tea	new	chai tea
+coffee-tea	new	masala chai
+coffee-tea	new	earl grey tea
+coffee-tea	new	peppermint tea
+coffee-tea	new	ginger tea
+coffee-tea	new	oolong tea
+coffee-tea	new	white tea
+coffee-tea	new	rooibos tea
+unlabeled	new	iced tea
+unlabeled	cached	sweet tea
+unlabeled	cached	unsweetened iced tea
+coffee-tea	new	arizona iced tea
+unlabeled	cached	arizona green tea
+coffee-tea	cached	arizona arnold palmer
+coffee-tea	new	pure leaf iced tea
+coffee-tea	new	pure leaf unsweetened tea
+unlabeled	cached	gold peak sweet tea
+coffee-tea	new	gold peak unsweetened tea
+coffee-tea	new	snapple lemon tea
+unlabeled	cached	snapple peach tea
+coffee-tea	new	lipton iced tea
+unlabeled	cached	lipton green tea
+unlabeled	cached	matcha latte
+coffee-tea	new	iced matcha latte
+coffee-tea	new	matcha green tea
+coffee-tea	cached	starbucks iced matcha latte
+unlabeled	cached	bubble tea
+coffee-tea	new	boba tea
+coffee-tea	new	taro milk tea
+coffee-tea	new	brown sugar boba milk tea
+unlabeled	cached	thai iced tea
+coffee-tea	new	honeydew milk tea
+coffee-tea	new	jasmine milk tea
+unlabeled	cached	hot chocolate
+coffee-tea	new	hot cocoa
+coffee-tea	cached	starbucks hot chocolate
+coffee-tea	new	swiss miss hot chocolate
+coffee-tea	new	peppermint hot chocolate
+unlabeled	cached	coca-cola
+unlabeled	new	diet coke
+unlabeled	cached	coke zero
+sodas-energy	cached	coca-cola classic
+unlabeled	cached	pepsi
+sodas-energy	new	diet pepsi
+sodas-energy	new	pepsi zero sugar
+sodas-energy	new	dr pepper
+sodas-energy	new	diet dr pepper
+unlabeled	cached	sprite
+sodas-energy	new	sprite zero
+unlabeled	cached	mountain dew
+sodas-energy	cached	diet mountain dew
+sodas-energy	new	mountain dew zero sugar
+sodas-energy	cached	mountain dew baja blast
+unlabeled	cached	7up
+unlabeled	cached	fanta orange
+unlabeled	cached	root beer
+unlabeled	cached	ginger ale
+sodas-energy	new	club soda
+sodas-energy	new	tonic water
+unlabeled	cached	monster energy
+unlabeled	cached	monster ultra zero
+sodas-energy	cached	monster mango loco
+unlabeled	cached	red bull
+sodas-energy	new	red bull sugar free
+sodas-energy	cached	celsius sparkling kiwi guava
+unlabeled	cached	celsius sparkling orange
+sodas-energy	new	celsius arctic vibe
+unlabeled	cached	bang energy
+sodas-energy	cached	bang cotton candy
+unlabeled	cached	alani nu energy drink
+unlabeled	cached	alani nu cosmic stardust
+sodas-energy	new	c4 energy drink
+sodas-energy	new	c4 original carbonated
+sodas-energy	cached	ghost energy
+sodas-energy	cached	ghost energy sour patch kids
+unlabeled	cached	reign total body fuel
+unlabeled	cached	rockstar energy
+sodas-energy	new	5-hour energy
+unlabeled	cached	gatorade
+unlabeled	cached	gatorade zero
+unlabeled	cached	gatorade fruit punch
+unlabeled	new	gatorade cool blue
+unlabeled	cached	powerade
+sodas-energy	new	powerade zero
+unlabeled	cached	bodyarmor
+unlabeled	new	bodyarmor lyte
+unlabeled	cached	prime hydration
+sodas-energy	new	prime hydration blue raspberry
+sodas-energy	cached	liquid iv hydration multiplier
+sodas-energy	new	pedialyte
+sodas-energy	cached	pedialyte freezer pops
+sodas-energy	cached	nuun hydration tablets
+sodas-energy	cached	lmnt electrolyte drink mix
+sodas-energy	new	la croix sparkling water
+sodas-energy	new	la croix pamplemousse
+unlabeled	cached	bubly sparkling water
+sodas-energy	new	bubly lime
+sodas-energy	new	waterloo sparkling water
+sodas-energy	new	topo chico mineral water
+sodas-energy	cached	spindrift sparkling water
+sodas-energy	cached	spindrift grapefruit
+sodas-energy	new	perrier sparkling water
+sodas-energy	new	san pellegrino sparkling water
+sodas-energy	new	sparkling water
+unlabeled	cached	orange juice
+unlabeled	cached	apple juice
+unlabeled	cached	tropicana orange juice
+unlabeled	cached	simply orange
+sodas-energy	cached	simply lemonade
+sodas-energy	cached	ocean spray cranberry juice
+sodas-energy	new	ocean spray cran-grape
+unlabeled	cached	capri sun
+unlabeled	cached	capri sun pacific cooler
+sodas-energy	cached	minute maid orange juice
+sodas-energy	cached	minute maid fruit punch
+sodas-energy	cached	v8 vegetable juice
+sodas-energy	cached	v8 splash
+sodas-energy	new	naked juice green machine
+sodas-energy	new	naked juice mighty mango
+unlabeled	cached	grape juice
+unlabeled	cached	pineapple juice
+unlabeled	cached	cranberry juice
+unlabeled	cached	grapefruit juice
+unlabeled	cached	lemonade
+sodas-energy	cached	pink lemonade
+sodas-energy	cached	country time lemonade
+sodas-energy	cached	minute maid lemonade
+unlabeled	cached	kombucha
+unlabeled	cached	gt's kombucha
+sodas-energy	new	gt's kombucha gingerade
+unlabeled	cached	health-ade kombucha
+sodas-energy	cached	health-ade pink lady apple
+unlabeled	cached	chocolate milk
+sodas-energy	new	yoo-hoo
+sodas-energy	cached	crystal light
+sodas-energy	new	mio water enhancer
+unlabeled	cached	propel water
+sodas-energy	cached	propel fitness water
+unlabeled	cached	vitamin water
+sodas-energy	new	smartwater
+sodas-energy	cached	sparkling ice
+sodas-energy	cached	sparkling ice black raspberry
+sodas-energy	cached	fruit punch
+sodas-energy	new	hi-c
+sodas-energy	new	tampico
+sodas-energy	cached	sunny d
+sodas-energy	new	coconut water
+sodas-energy	cached	vita coco coconut water
+unlabeled	cached	sports drink
+unlabeled	new	energy drink
+sodas-energy	new	diet soda
+unlabeled	cached	soda
+sodas-energy	cached	starbucks doubleshot energy
+sodas-energy	new	celsius on-the-go
+sodas-energy	cached	bang keto coffee
+sodas-energy	new	gatorlyte
+alcohol	new	bud light
+alcohol	new	michelob ultra
+alcohol	new	coors light
+alcohol	new	miller lite
+alcohol	new	modelo especial
+alcohol	new	corona extra
+alcohol	new	stella artois
+alcohol	new	guinness stout
+alcohol	new	heineken
+alcohol	new	budweiser
+alcohol	new	pbr
+alcohol	new	yuengling
+alcohol	new	sam adams boston lager
+alcohol	new	blue moon belgian white
+alcohol	new	ipa
+alcohol	new	hazy ipa
+alcohol	new	double ipa
+alcohol	new	pilsner
+unlabeled	cached	lager
+unlabeled	cached	stout
+alcohol	new	porter
+alcohol	new	sour beer
+alcohol	new	wheat beer
+alcohol	new	amber ale
+alcohol	new	white claw black cherry
+alcohol	new	white claw mango
+alcohol	new	white claw natural lime
+alcohol	new	truly wild berry
+alcohol	new	truly lemonade
+alcohol	new	truly strawberry lemonade
+alcohol	new	high noon watermelon
+alcohol	new	high noon peach
+alcohol	new	high noon pineapple
+alcohol	new	nutrl vodka seltzer
+alcohol	new	bud light seltzer
+alcohol	new	smirnoff ice
+alcohol	new	twisted tea original
+alcohol	new	twisted tea half and half
+alcohol	new	mike's hard lemonade
+alcohol	new	angry orchard hard cider
+alcohol	new	strongbow hard cider
+unlabeled	new	red wine
+alcohol	new	cabernet sauvignon
+alcohol	new	pinot noir
+alcohol	new	merlot
+alcohol	new	malbec
+alcohol	new	zinfandel
+alcohol	new	shiraz
+alcohol	new	white wine
+alcohol	new	chardonnay
+alcohol	new	sauvignon blanc
+alcohol	new	pinot grigio
+alcohol	new	riesling
+alcohol	new	moscato
+unlabeled	cached	rose wine
+unlabeled	cached	prosecco
+unlabeled	cached	champagne
+alcohol	new	sparkling wine
+unlabeled	cached	white claw
+alcohol	new	truly
+alcohol	new	vodka
+alcohol	new	titos vodka
+alcohol	new	grey goose vodka
+alcohol	new	smirnoff vodka
+alcohol	new	absolut vodka
+alcohol	new	whiskey
+alcohol	new	jack daniels
+alcohol	new	jameson irish whiskey
+alcohol	new	crown royal
+alcohol	new	bourbon
+alcohol	new	makers mark
+alcohol	new	jim beam
+alcohol	new	woodford reserve
+alcohol	new	tequila
+alcohol	new	casamigos tequila
+alcohol	new	patron tequila
+alcohol	new	jose cuervo
+alcohol	new	gin
+alcohol	new	tanqueray gin
+alcohol	new	bombay sapphire
+alcohol	new	rum
+alcohol	new	bacardi rum
+alcohol	new	captain morgan
+alcohol	new	malibu rum
+alcohol	new	scotch
+alcohol	new	johnnie walker
+alcohol	new	glenlivet
+alcohol	new	sake
+unlabeled	cached	margarita
+unlabeled	cached	old fashioned
+unlabeled	cached	moscow mule
+unlabeled	cached	mojito
+unlabeled	cached	martini
+alcohol	new	espresso martini
+alcohol	new	negroni
+alcohol	new	whiskey sour
+alcohol	new	long island iced tea
+unlabeled	cached	pina colada
+alcohol	new	aperol spritz
+alcohol	new	daiquiri
+alcohol	new	cosmopolitan
+alcohol	new	manhattan
+unlabeled	cached	bloody mary
+alcohol	new	paloma
+unlabeled	cached	mimosa
+unlabeled	cached	sangria
+alcohol	new	white claw surge
+alcohol	new	high noon
+alcohol	new	truly punch
+alcohol	new	cutwater vodka soda
+alcohol	new	cutwater margarita
+alcohol	new	on the rocks cocktails margarita
+alcohol	new	crown royal peach
+alcohol	new	fireball whiskey
+alcohol	new	malibu black
+alcohol	new	seagrams 7
+alcohol	new	skinny margarita
+alcohol	new	irish coffee
+alcohol	new	mudslide
+alcohol	new	white russian
+alcohol	new	tequila sunrise
+alcohol	new	kahlua
+unlabeled	cached	mcdonalds big mac
+unlabeled	cached	mcdonalds quarter pounder with cheese
+burger-fastfood	new	mcdonalds double quarter pounder with cheese
+burger-fastfood	cached	mcdonalds mcdouble
+burger-fastfood	new	mcdonalds cheeseburger
+burger-fastfood	new	mcdonalds hamburger
+unlabeled	cached	mcdonalds mcchicken
+unlabeled	cached	mcdonalds filet o fish
+burger-fastfood	new	mcdonalds 10 piece chicken mcnuggets
+burger-fastfood	new	mcdonalds 20 piece chicken mcnuggets
+unlabeled	cached	mcdonalds egg mcmuffin
+burger-fastfood	cached	mcdonalds sausage mcmuffin with egg
+burger-fastfood	new	mcdonalds bacon egg and cheese biscuit
+burger-fastfood	new	mcdonalds hotcakes
+unlabeled	cached	mcdonalds hash browns
+burger-fastfood	new	mcdonalds french fries
+unlabeled	cached	mcdonalds mcflurry
+burger-fastfood	new	mcdonalds apple pie
+burger-fastfood	new	mcdonalds sausage burrito
+unlabeled	cached	burger king whopper
+burger-fastfood	new	burger king whopper jr
+burger-fastfood	new	burger king double whopper
+burger-fastfood	new	burger king bacon king
+burger-fastfood	cached	burger king chicken fries
+burger-fastfood	new	burger king original chicken sandwich
+unlabeled	new	burger king impossible whopper
+burger-fastfood	new	burger king croissan'wich
+burger-fastfood	new	burger king onion rings
+burger-fastfood	new	burger king french fries
+unlabeled	new	wendys dave's single
+unlabeled	cached	wendys baconator
+burger-fastfood	new	wendys son of baconator
+unlabeled	cached	wendys spicy chicken sandwich
+burger-fastfood	new	wendys crispy chicken sandwich
+unlabeled	cached	wendys jr bacon cheeseburger
+unlabeled	new	wendys frosty
+unlabeled	cached	wendys chili
+burger-fastfood	new	wendys biggie fries
+burger-fastfood	new	wendys grilled chicken sandwich
+unlabeled	cached	taco bell crunchwrap supreme
+unlabeled	new	taco bell chalupa supreme
+burger-fastfood	new	taco bell crunchy taco
+burger-fastfood	new	taco bell soft taco
+burger-fastfood	new	taco bell doritos locos tacos
+burger-fastfood	new	taco bell beefy 5 layer burrito
+unlabeled	new	taco bell quesarito
+unlabeled	cached	taco bell cheesy gordita crunch
+burger-fastfood	new	taco bell mexican pizza
+burger-fastfood	new	taco bell nachos bellgrande
+burger-fastfood	new	jack in the box jumbo jack
+burger-fastfood	new	jack in the box sourdough jack
+burger-fastfood	cached	jack in the box curly fries
+unlabeled	cached	jack in the box tacos
+burger-fastfood	new	jack in the box bacon ultimate cheeseburger
+burger-fastfood	new	jack in the box breakfast jack
+unlabeled	cached	sonic cheeseburger
+burger-fastfood	new	sonic chili cheese tots
+unlabeled	cached	sonic mozzarella sticks
+unlabeled	cached	sonic corn dog
+unlabeled	cached	sonic slush
+burger-fastfood	new	sonic tater tots
+unlabeled	new	whataburger burger
+unlabeled	cached	whataburger patty melt
+unlabeled	new	whataburger honey butter chicken biscuit
+burger-fastfood	new	whataburger taquito
+burger-fastfood	new	whataburger onion rings
+burger-fastfood	new	in-n-out double double
+burger-fastfood	new	in-n-out cheeseburger
+burger-fastfood	new	in-n-out animal style fries
+burger-fastfood	new	in-n-out neapolitan shake
+burger-fastfood	new	five guys cheeseburger
+burger-fastfood	new	five guys bacon burger
+burger-fastfood	new	five guys little cheeseburger
+burger-fastfood	new	five guys cajun fries
+burger-fastfood	new	five guys hot dog
+unlabeled	cached	shake shack shackburger
+burger-fastfood	new	shake shack smokeshack
+burger-fastfood	new	shake shack chicken shack
+burger-fastfood	new	shake shack crinkle cut fries
+burger-fastfood	new	shake shack shroom burger
+unlabeled	cached	culvers butterburger
+burger-fastfood	new	culvers cheese curds
+burger-fastfood	new	culvers concrete mixer
+burger-fastfood	new	culvers crinkle cut fries
+burger-fastfood	new	steak n shake steakburger
+burger-fastfood	new	steak n shake double steakburger
+burger-fastfood	new	steak n shake frisco melt
+burger-fastfood	new	steak n shake chili
+burger-fastfood	new	checkers big buford
+burger-fastfood	new	checkers baconzilla
+burger-fastfood	new	checkers famous seasoned fries
+burger-fastfood	new	rallys big buford
+unlabeled	cached	white castle slider
+burger-fastfood	new	white castle cheese slider
+burger-fastfood	new	white castle chicken slider
+burger-fastfood	new	white castle onion rings
+unlabeled	cached	arbys classic roast beef
+burger-fastfood	new	arbys beef n cheddar
+burger-fastfood	cached	arbys curly fries
+burger-fastfood	new	arbys jamocha shake
+burger-fastfood	new	arbys chicken tenders
+burger-fastfood	new	arbys reuben
+unlabeled	cached	dairy queen blizzard
+burger-fastfood	new	dairy queen dilly bar
+burger-fastfood	new	dairy queen gravy fries
+burger-fastfood	new	dairy queen chicken strip basket
+burger-fastfood	new	dairy queen deluxe cheeseburger
+burger-fastfood	new	hardees thickburger
+burger-fastfood	new	hardees famous star
+burger-fastfood	new	hardees biscuit
+burger-fastfood	new	carls jr famous star
+burger-fastfood	new	carls jr western bacon cheeseburger
+burger-fastfood	new	carls jr criss cut fries
+burger-fastfood	new	carls jr big carl
+burger-fastfood	new	mcdonalds mcrib
+burger-fastfood	new	mcdonalds mccafe latte
+burger-fastfood	new	mcdonalds sausage biscuit
+burger-fastfood	new	burger king double cheeseburger
+burger-fastfood	new	wendys 4 for 4
+burger-fastfood	new	taco bell power menu bowl
+burger-fastfood	new	taco bell baja blast freeze
+burger-fastfood	new	jack in the box egg rolls
+burger-fastfood	new	sonic footlong quarter pound coney
+burger-fastfood	new	whataburger dr pepper shake
+burger-fastfood	new	five guys milkshake
+burger-fastfood	cached	shake shack cheese fries
+burger-fastfood	new	culvers walleye sandwich
+burger-fastfood	new	steak n shake three way chili
+burger-fastfood	new	arbys market fresh sandwich
+burger-fastfood	new	white castle fish slider
+burger-fastfood	new	dairy queen blizzard oreo
+burger-fastfood	new	hardees made from scratch biscuit
+burger-fastfood	new	carls jr the six dollar burger
+burger-fastfood	new	mcdonalds mccrispy
+burger-fastfood	new	burger king ch'king sandwich
+burger-fastfood	new	wendys asiago ranch chicken club
+burger-fastfood	new	sonic ocean water
+burger-fastfood	new	whataburger green chile double
+burger-fastfood	new	in-n-out grilled cheese
+burger-fastfood	new	five guys veggie sandwich
+burger-fastfood	new	jack in the box teriyaki bowl
+chicken-chains	new	chick-fil-a chicken sandwich
+chicken-chains	new	chick-fil-a spicy chicken sandwich
+chicken-chains	new	chick-fil-a spicy deluxe sandwich
+chicken-chains	new	chick-fil-a deluxe sandwich
+chicken-chains	new	chick-fil-a grilled chicken sandwich
+unlabeled	cached	chick-fil-a chicken nuggets
+chicken-chains	new	chick-fil-a grilled nuggets
+chicken-chains	new	chick-fil-a chick-n-strips
+chicken-chains	cached	chick-fil-a waffle fries
+unlabeled	cached	chick-fil-a mac and cheese
+unlabeled	cached	chick-fil-a cobb salad
+chicken-chains	new	chick-fil-a market salad
+unlabeled	cached	chick-fil-a chicken biscuit
+chicken-chains	new	chick-fil-a chicken minis
+chicken-chains	new	chick-fil-a polynesian sauce
+chicken-chains	new	chick-fil-a chick-fil-a sauce
+chicken-chains	new	popeyes chicken sandwich
+unlabeled	new	popeyes spicy chicken sandwich
+chicken-chains	new	popeyes classic chicken sandwich
+chicken-chains	new	popeyes blackened chicken sandwich
+chicken-chains	new	popeyes chicken tenders
+chicken-chains	cached	popeyes red beans and rice
+chicken-chains	cached	popeyes cajun fries
+chicken-chains	new	popeyes mashed potatoes with cajun gravy
+chicken-chains	new	popeyes buttermilk biscuit
+chicken-chains	new	popeyes coleslaw
+unlabeled	cached	popeyes mac and cheese
+chicken-chains	new	popeyes bonafide chicken
+unlabeled	cached	popeyes wings
+chicken-chains	new	kfc original recipe chicken
+chicken-chains	new	kfc extra crispy chicken
+chicken-chains	new	kfc chicken sandwich
+chicken-chains	new	kfc spicy chicken sandwich
+unlabeled	new	kfc chicken tenders
+unlabeled	cached	kfc famous bowl
+unlabeled	new	kfc mashed potatoes and gravy
+chicken-chains	new	kfc coleslaw
+chicken-chains	new	kfc mac and cheese
+unlabeled	cached	kfc biscuit
+chicken-chains	new	kfc pot pie
+chicken-chains	new	kfc popcorn nuggets
+chicken-chains	new	kfc wings
+unlabeled	cached	raising canes chicken fingers
+chicken-chains	new	raising canes 3 finger combo
+chicken-chains	new	raising canes texas toast
+chicken-chains	new	raising canes coleslaw
+chicken-chains	new	raising canes crinkle cut fries
+chicken-chains	new	raising canes cane's sauce
+chicken-chains	new	raising canes caniac combo
+chicken-chains	new	zaxbys chicken fingers
+chicken-chains	new	zaxbys wings
+chicken-chains	new	zaxbys boneless wings
+chicken-chains	new	zaxbys chicken sandwich
+chicken-chains	new	zaxbys coleslaw
+chicken-chains	new	zaxbys texas toast
+chicken-chains	new	zaxbys fried pickles
+chicken-chains	new	zaxbys zax sauce
+chicken-chains	new	zaxbys crinkle fries
+chicken-chains	new	zaxbys kickin chicken sandwich
+chicken-chains	new	bojangles chicken supremes
+unlabeled	cached	bojangles cajun filet biscuit
+chicken-chains	new	bojangles dirty rice
+chicken-chains	new	bojangles seasoned fries
+chicken-chains	new	bojangles biscuit
+chicken-chains	new	bojangles chicken supreme sandwich
+chicken-chains	new	bojangles mashed potatoes with gravy
+chicken-chains	new	bojangles bo-berry biscuit
+chicken-chains	new	churchs chicken tenders
+chicken-chains	new	churchs original chicken
+chicken-chains	new	churchs spicy chicken
+chicken-chains	new	churchs mashed potatoes and gravy
+chicken-chains	new	churchs jalapeno cheese bombers
+chicken-chains	new	churchs honey biscuit
+chicken-chains	new	churchs mac and cheese
+chicken-chains	new	churchs coleslaw
+chicken-chains	new	wingstop classic wings
+chicken-chains	new	wingstop boneless wings
+chicken-chains	new	wingstop 10 piece wings
+chicken-chains	new	wingstop lemon pepper wings
+chicken-chains	new	wingstop atomic wings
+chicken-chains	new	wingstop garlic parmesan wings
+chicken-chains	new	wingstop mango habanero wings
+chicken-chains	new	wingstop hawaiian wings
+chicken-chains	new	wingstop cajun fries
+chicken-chains	new	wingstop seasoned fries
+chicken-chains	new	wingstop ranch
+chicken-chains	new	wingstop chicken sandwich
+chicken-chains	new	buffalo wild wings traditional wings
+chicken-chains	new	buffalo wild wings boneless wings
+chicken-chains	new	buffalo wild wings honey bbq wings
+chicken-chains	new	buffalo wild wings mango habanero wings
+chicken-chains	new	buffalo wild wings parmesan garlic wings
+chicken-chains	new	buffalo wild wings asian zing wings
+chicken-chains	new	buffalo wild wings chicken tenders
+chicken-chains	new	buffalo wild wings potato wedges
+unlabeled	new	buffalo wild wings mozzarella sticks
+chicken-chains	new	buffalo wild wings chicken sandwich
+chicken-chains	new	hooters wings
+chicken-chains	new	hooters boneless wings
+chicken-chains	new	hooters daytona wings
+chicken-chains	new	hooters original buffalo wings
+chicken-chains	new	hooters chicken tenders
+chicken-chains	new	hooters curly fries
+chicken-chains	new	hooters hooters sauce
+chicken-chains	new	el pollo loco pollo bowl
+chicken-chains	new	el pollo loco chicken tacos
+chicken-chains	new	el pollo loco chicken burrito
+chicken-chains	new	el pollo loco pollo asado
+chicken-chains	new	el pollo loco chicken quesadilla
+chicken-chains	new	el pollo loco original pollo bowl
+chicken-chains	new	el pollo loco fiesta salad
+chicken-chains	new	nandos peri peri chicken
+chicken-chains	new	nandos chicken sandwich
+chicken-chains	new	nandos chicken wings
+chicken-chains	new	nandos chicken thigh
+chicken-chains	new	nandos peri fries
+chicken-chains	new	nandos coleslaw
+chicken-chains	new	nandos garlic bread
+chicken-chains	new	daves hot chicken tenders
+chicken-chains	new	daves hot chicken slider
+chicken-chains	new	daves hot chicken mac and cheese
+chicken-chains	new	daves hot chicken kale slaw
+chicken-chains	new	daves hot chicken fries
+chicken-chains	new	slim chickens chicken tenders
+chicken-chains	new	slim chickens wings
+chicken-chains	new	slim chickens chicken sandwich
+chicken-chains	new	slim chickens mac and cheese
+chicken-chains	new	slim chickens fries
+chicken-chains	new	slim chickens texas toast
+chicken-chains	new	slim chickens coleslaw
+unlabeled	cached	chipotle chicken burrito bowl
+fast-casual	cached	chipotle chicken burrito
+fast-casual	cached	chipotle steak burrito bowl
+fast-casual	new	chipotle carnitas burrito
+unlabeled	new	chipotle barbacoa bowl
+unlabeled	new	chipotle sofritas bowl
+unlabeled	cached	chipotle chips and guacamole
+unlabeled	new	chipotle guacamole
+fast-casual	cached	chipotle white rice
+fast-casual	cached	chipotle brown rice
+fast-casual	cached	chipotle black beans
+fast-casual	cached	chipotle pinto beans
+fast-casual	cached	chipotle fajita veggies
+fast-casual	cached	chipotle chicken quesadilla
+fast-casual	cached	chipotle queso blanco
+unlabeled	cached	chipotle chips and queso
+fast-casual	new	chipotle tortilla on the side
+fast-casual	cached	chipotle salad
+fast-casual	new	chipotle kids quesadilla
+fast-casual	cached	chipotle mild salsa
+fast-casual	new	chipotle corn salsa
+fast-casual	cached	chipotle sour cream
+fast-casual	cached	chipotle lettuce
+fast-casual	new	qdoba chicken burrito
+fast-casual	new	qdoba chicken bowl
+fast-casual	new	qdoba steak bowl
+fast-casual	new	qdoba three cheese queso
+fast-casual	new	qdoba pulled pork bowl
+fast-casual	new	qdoba chips and queso
+fast-casual	cached	qdoba guacamole
+fast-casual	new	qdoba loaded tortilla soup
+fast-casual	new	qdoba cilantro lime rice
+fast-casual	cached	qdoba black beans
+fast-casual	new	qdoba chicken taco
+fast-casual	new	moe's homewrecker burrito
+fast-casual	new	moe's joey bag of donuts
+fast-casual	new	moe's earmuffs bowl
+fast-casual	new	moe's stack
+fast-casual	new	moe's queso
+fast-casual	new	moe's guac
+fast-casual	cached	moe's chips
+fast-casual	new	moe's kid cutie quesadilla
+fast-casual	new	moe's art vandelay
+unlabeled	cached	panera broccoli cheddar soup
+fast-casual	cached	panera chicken noodle soup
+fast-casual	new	panera you pick two
+fast-casual	cached	panera fuji apple chicken salad
+unlabeled	new	panera greek salad
+fast-casual	new	panera bacon turkey bravo sandwich
+fast-casual	new	panera napa almond chicken salad sandwich
+fast-casual	new	panera baked potato soup
+unlabeled	cached	panera mac and cheese
+unlabeled	cached	panera bread bowl
+fast-casual	new	panera green goddess cobb salad
+fast-casual	cached	panera turkey chili
+unlabeled	cached	panera caesar salad
+fast-casual	cached	panera cinnamon crunch bagel
+fast-casual	cached	panera ten vegetable soup
+unlabeled	cached	subway footlong italian bmt
+fast-casual	new	subway turkey breast sandwich
+unlabeled	new	subway chicken teriyaki sub
+fast-casual	new	subway meatball marinara sub
+fast-casual	new	subway tuna sandwich
+fast-casual	cached	subway veggie delite
+unlabeled	cached	subway spicy italian
+unlabeled	new	subway steak and cheese footlong
+fast-casual	new	subway cold cut combo
+fast-casual	new	subway chicken bacon ranch melt
+fast-casual	cached	subway footlong club
+unlabeled	new	subway sweet onion chicken teriyaki
+fast-casual	new	jersey mike's original italian
+fast-casual	new	jersey mike's club supreme
+fast-casual	new	jersey mike's chipotle cheese steak
+fast-casual	new	jersey mike's turkey and provolone
+fast-casual	new	jersey mike's big kahuna cheese steak
+fast-casual	cached	jersey mike's club sub
+fast-casual	new	jimmy john's italian night club
+fast-casual	new	jimmy john's turkey tom
+fast-casual	new	jimmy john's beach club
+fast-casual	new	jimmy john's vito
+fast-casual	new	jimmy john's gargantuan
+fast-casual	new	jimmy john's ultimate porker
+fast-casual	new	jimmy john's country club
+fast-casual	cached	firehouse subs hook and ladder
+fast-casual	cached	firehouse subs italian
+fast-casual	cached	firehouse subs meatball
+fast-casual	cached	firehouse subs turkey bacon ranch
+fast-casual	cached	firehouse subs smokehouse beef and cheddar brisket
+fast-casual	new	firehouse subs engine company sub
+fast-casual	cached	potbelly turkey breast sandwich
+fast-casual	cached	potbelly wreck sandwich
+fast-casual	cached	potbelly italian sandwich
+fast-casual	cached	potbelly mama's meatball sandwich
+fast-casual	cached	potbelly turkey club sandwich
+fast-casual	new	potbelly mac and cheese
+fast-casual	new	potbelly chicken salad sandwich
+fast-casual	cached	sweetgreen harvest bowl
+fast-casual	new	sweetgreen kale caesar
+fast-casual	cached	sweetgreen chicken pesto parm
+fast-casual	cached	sweetgreen guacamole greens
+fast-casual	cached	sweetgreen shroomami bowl
+fast-casual	new	sweetgreen spicy sabzi
+fast-casual	cached	sweetgreen curry cauliflower
+fast-casual	cached	sweetgreen buffalo chicken ranch
+fast-casual	cached	cava harissa avocado bowl
+fast-casual	new	cava greek salad
+fast-casual	cached	cava spicy lamb meatballs bowl
+fast-casual	new	cava chicken pita
+fast-casual	new	cava braised lamb bowl
+fast-casual	new	cava roasted vegetable bowl
+fast-casual	cached	cava spicy hummus
+fast-casual	cached	cava harissa honey chicken
+fast-casual	cached	cava falafel bowl
+unlabeled	new	panda express orange chicken
+unlabeled	cached	panda express beijing beef
+unlabeled	cached	panda express kung pao chicken
+unlabeled	cached	panda express chow mein
+fast-casual	cached	panda express fried rice
+unlabeled	cached	panda express broccoli beef
+unlabeled	new	panda express honey walnut shrimp
+fast-casual	new	panda express string bean chicken breast
+fast-casual	cached	panda express super greens
+fast-casual	cached	panda express black pepper chicken
+fast-casual	new	noodles and company mac and cheese
+fast-casual	cached	noodles and company pad thai
+fast-casual	new	noodles and company wisconsin mac and cheese
+fast-casual	new	noodles and company japanese pan noodles
+fast-casual	new	noodles and company penne rosa
+fast-casual	new	noodles and company buttered noodles
+fast-casual	new	noodles and company zucchini noodles
+fast-casual	new	noodles and company thai curry soup
+fast-casual	new	blaze pizza build your own pizza
+fast-casual	new	blaze pizza the red vine
+fast-casual	new	blaze pizza pepperoni pizza
+fast-casual	new	blaze pizza white top pizza
+fast-casual	new	blaze pizza keto crust pizza
+fast-casual	cached	portillo's italian beef sandwich
+fast-casual	cached	portillo's chicago style hot dog
+fast-casual	new	portillo's chopped salad
+fast-casual	cached	portillo's chocolate cake shake
+fast-casual	new	portillo's italian sausage sandwich
+fast-casual	cached	boston market rotisserie chicken
+fast-casual	new	boston market mashed potatoes
+fast-casual	cached	boston market chicken pot pie
+fast-casual	cached	boston market cornbread
+fast-casual	cached	boston market mac and cheese
+fast-casual	cached	boston market meatloaf
+fast-casual	new	pret a manger chicken caesar wrap
+fast-casual	new	pret a manger avocado and tomato sandwich
+fast-casual	new	pret a manger egg salad sandwich
+unlabeled	cached	dominos pepperoni pizza
+unlabeled	cached	dominos cheese pizza
+pizza	new	dominos hand tossed pizza
+pizza	new	dominos brooklyn style pizza
+pizza	new	dominos thin crust pizza
+pizza	new	dominos extravaganzza pizza
+pizza	new	dominos philly cheese steak pizza
+pizza	new	dominos deluxe pizza
+pizza	new	dominos meatzza pizza
+pizza	new	dominos ultimate pepperoni pizza
+unlabeled	cached	dominos parmesan bread bites
+pizza	new	dominos breadsticks
+pizza	new	dominos cheesy bread
+pizza	new	dominos cinnamon twists
+pizza	new	dominos garlic knots
+pizza	new	dominos boneless chicken wings
+pizza	new	dominos buffalo wings
+pizza	new	dominos marinara dipping cup
+pizza	new	dominos ranch dipping cup
+pizza	new	pizza hut pepperoni pizza
+pizza	new	pizza hut cheese pizza
+pizza	new	pizza hut pan pizza
+pizza	new	pizza hut thin n crispy pizza
+pizza	new	pizza hut hand tossed pizza
+pizza	new	pizza hut stuffed crust pizza
+pizza	new	pizza hut original stuffed crust pizza
+pizza	new	pizza hut supreme pizza
+pizza	new	pizza hut meat lovers pizza
+pizza	new	pizza hut veggie lovers pizza
+unlabeled	cached	pizza hut breadsticks
+pizza	new	pizza hut cheese sticks
+pizza	new	pizza hut cinnamon sticks
+pizza	new	pizza hut wings
+pizza	new	pizza hut garlic parmesan wings
+pizza	new	pizza hut honey bbq wings
+unlabeled	cached	papa johns pepperoni pizza
+unlabeled	cached	papa johns cheese pizza
+pizza	new	papa johns original crust pizza
+pizza	new	papa johns thin crust pizza
+pizza	new	papa johns works pizza
+pizza	new	papa johns garden fresh pizza
+pizza	new	papa johns bbq chicken bacon pizza
+pizza	new	papa johns papadia
+pizza	new	papa johns breadsticks
+pizza	new	papa johns cheesesticks
+unlabeled	cached	papa johns garlic knots
+pizza	new	papa johns chicken wings
+pizza	new	papa johns garlic parmesan wings
+pizza	new	papa johns papa bowl
+unlabeled	cached	little caesars pepperoni pizza
+pizza	new	little caesars hot n ready pizza
+pizza	new	little caesars cheese pizza
+pizza	new	little caesars deep dish pizza
+pizza	new	little caesars extramostbestest pizza
+pizza	new	little caesars stuffed crazy bread
+pizza	new	little caesars crazy bread
+pizza	new	little caesars crazy sauce
+pizza	new	little caesars caesar wings
+pizza	new	little caesars italian cheese bread
+pizza	new	marcos pepperoni pizza
+pizza	new	marcos cheese pizza
+pizza	new	marcos deluxe pizza
+pizza	new	marcos pepperoni magnifico pizza
+pizza	new	marcos cheezybread
+pizza	new	marcos garlic dip
+pizza	new	casey's pepperoni pizza
+pizza	new	casey's taco pizza
+pizza	cached	casey's breakfast pizza
+pizza	new	casey's bacon cheeseburger pizza
+pizza	new	mod pizza mini pizza
+pizza	new	mod pizza calexico pizza
+pizza	new	cicis pepperoni pizza
+pizza	new	cicis cheese pizza
+pizza	new	cicis buffalo chicken pizza
+pizza	new	cicis breadsticks
+pizza	new	cicis cinnamon rolls
+pizza	new	new york style pizza slice
+pizza	new	new york cheese pizza slice
+pizza	new	chicago deep dish pizza
+pizza	new	detroit style pizza
+pizza	new	neapolitan pizza
+pizza	new	sicilian pizza slice
+pizza	new	thin crust cheese pizza
+pizza	new	pepperoni pizza slice
+pizza	new	plain cheese pizza slice
+pizza	new	supreme pizza slice
+pizza	new	veggie pizza slice
+pizza	new	white pizza slice
+pizza	new	buffalo chicken pizza slice
+pizza	new	hawaiian pizza slice
+pizza	new	digiorno rising crust pepperoni pizza
+pizza	new	digiorno rising crust four cheese pizza
+pizza	new	digiorno thin crispy crust pizza
+pizza	new	digiorno stuffed crust pizza
+pizza	new	digiorno pizza and cheesy breadsticks
+pizza	new	digiorno croissant crust pizza
+pizza	cached	red baron classic crust pepperoni pizza
+pizza	new	red baron four cheese pizza
+pizza	new	red baron thin and crispy pizza
+pizza	cached	tombstone original pepperoni pizza
+pizza	new	tombstone four meat pizza
+pizza	cached	totinos party pizza pepperoni
+pizza	new	totinos party pizza cheese
+pizza	new	totinos pizza rolls pepperoni
+unlabeled	cached	totinos pizza rolls cheese
+pizza	new	california pizza kitchen margherita frozen pizza
+pizza	new	california pizza kitchen bbq chicken frozen pizza
+pizza	new	screamin sicilian pizza
+pizza	new	newmans own thin and crispy pepperoni pizza
+unlabeled	cached	amys cheese pizza
+pizza	new	amys margherita pizza
+unlabeled	cached	amys spinach pizza
+pizza	new	home run inn cheese pizza
+pizza	new	home run inn sausage pizza
+pizza	new	jacks original pizza
+pizza	new	jacks pepperoni pizza
+pizza	cached	freschetta four cheese pizza
+pizza	new	freschetta brick oven crust pepperoni pizza
+salty-snacks	new	potato chips
+unlabeled	cached	lays classic
+salty-snacks	cached	lays barbecue
+unlabeled	cached	ruffles cheddar and sour cream
+salty-snacks	new	kettle brand sea salt
+salty-snacks	new	cape cod original
+salty-snacks	cached	utz crab chips
+salty-snacks	cached	lays wavy
+unlabeled	cached	pringles original
+unlabeled	cached	pringles sour cream and onion
+salty-snacks	new	miss vickies jalapeno
+salty-snacks	new	sea salt potato chips
+unlabeled	cached	tortilla chips
+unlabeled	cached	doritos nacho cheese
+unlabeled	cached	doritos cool ranch
+unlabeled	cached	tostitos scoops
+salty-snacks	cached	fritos original
+unlabeled	cached	takis fuego
+salty-snacks	cached	santitas tortilla chips
+salty-snacks	new	late july sea salt
+salty-snacks	new	corn chips
+unlabeled	cached	cheetos crunchy
+unlabeled	cached	cheetos puffs
+salty-snacks	cached	cheez it original
+salty-snacks	cached	goldfish cheddar
+salty-snacks	cached	pirates booty
+salty-snacks	cached	whisps parmesan crisps
+salty-snacks	new	cheese crackers
+unlabeled	cached	ritz crackers
+unlabeled	cached	triscuit original
+unlabeled	cached	wheat thins original
+unlabeled	cached	club crackers
+unlabeled	cached	saltine crackers
+salty-snacks	cached	sea salt crackers
+unlabeled	cached	pretzels
+salty-snacks	new	snyders of hanover pretzels
+unlabeled	cached	rold gold pretzels
+salty-snacks	new	dots pretzels
+salty-snacks	cached	pretzel sticks
+salty-snacks	new	popcorn
+salty-snacks	new	skinnypop popcorn
+salty-snacks	cached	boom chicka pop popcorn
+unlabeled	cached	smartfood white cheddar popcorn
+salty-snacks	new	orville redenbacher popcorn
+salty-snacks	cached	movie theater popcorn
+salty-snacks	cached	kettle corn
+unlabeled	cached	veggie straws
+salty-snacks	cached	puffed cheese balls
+unlabeled	cached	trail mix
+salty-snacks	cached	planters mixed nuts
+salty-snacks	cached	blue diamond almonds
+salty-snacks	cached	wonderful pistachios
+salty-snacks	new	sahale snacks trail mix
+unlabeled	cached	cashews
+unlabeled	cached	almonds
+salty-snacks	cached	mixed nuts
+salty-snacks	cached	roasted peanuts
+unlabeled	cached	beef jerky
+unlabeled	cached	jack links beef jerky
+salty-snacks	new	chomps meat stick
+unlabeled	cached	slim jim
+salty-snacks	cached	country archer beef jerky
+salty-snacks	cached	dukes smoked shorty sausages
+salty-snacks	cached	pork rinds
+salty-snacks	cached	seaweed snacks
+salty-snacks	cached	roasted seaweed
+salty-snacks	new	hummus cup
+salty-snacks	cached	guacamole cup
+unlabeled	cached	string cheese
+salty-snacks	cached	cheese stick
+salty-snacks	cached	mozzarella string cheese
+salty-snacks	new	olives
+salty-snacks	cached	kalamata olives
+salty-snacks	new	pickles
+salty-snacks	cached	dill pickle spear
+salty-snacks	new	pickle chips
+unlabeled	cached	lays sour cream and onion
+unlabeled	cached	ruffles original
+salty-snacks	cached	kettle brand jalapeno
+salty-snacks	new	cape cod sea salt and vinegar
+salty-snacks	cached	utz sour cream and onion
+unlabeled	cached	pringles bbq
+salty-snacks	cached	miss vickies sea salt
+unlabeled	cached	doritos spicy sweet chili
+salty-snacks	cached	tostitos original
+unlabeled	cached	fritos chili cheese
+salty-snacks	new	takis original
+salty-snacks	cached	late july multigrain
+unlabeled	cached	cheetos flamin hot
+salty-snacks	cached	cheez it white cheddar
+salty-snacks	cached	goldfish original
+unlabeled	cached	crackers
+unlabeled	cached	ritz peanut butter crackers
+salty-snacks	cached	wheat thins toasted chips
+salty-snacks	new	saltines
+salty-snacks	new	snyders honey mustard pretzels
+salty-snacks	cached	rold gold tiny twists
+unlabeled	cached	skinnypop white cheddar popcorn
+salty-snacks	cached	kettle corn popcorn
+salty-snacks	new	veggie chips
+salty-snacks	cached	planters peanuts
+salty-snacks	cached	blue diamond wasabi almonds
+salty-snacks	cached	sahale almonds
+unlabeled	cached	pistachios
+unlabeled	cached	walnuts
+unlabeled	cached	pecans
+unlabeled	cached	jack links teriyaki beef jerky
+salty-snacks	new	slim jim smoked snack sticks
+unlabeled	cached	turkey jerky
+salty-snacks	new	salmon jerky
+salty-snacks	cached	pork rinds spicy
+salty-snacks	new	nori snack
+salty-snacks	cached	seaweed crisps
+salty-snacks	new	hummus and pretzels snack pack
+salty-snacks	new	babybel cheese
+unlabeled	cached	mozzarella sticks
+salty-snacks	cached	green olives
+salty-snacks	cached	sweet pickles
+salty-snacks	cached	pickle spears
+salty-snacks	cached	tortilla strips
+salty-snacks	new	takis xplosion
+salty-snacks	cached	doritos flamas
+unlabeled	cached	tostitos hint of lime
+salty-snacks	cached	fritos scoops
+salty-snacks	cached	cheetos crunchy flamin hot
+salty-snacks	cached	cheez it grooves
+salty-snacks	cached	goldfish flavor blasted
+salty-snacks	cached	ritz bits
+salty-snacks	cached	triscuit thin crisps
+salty-snacks	cached	wheat thins sundried tomato
+salty-snacks	new	club crackers original
+salty-snacks	new	sesame crackers
+salty-snacks	new	snyders pretzel pieces
+salty-snacks	cached	dots honey mustard pretzels
+salty-snacks	new	mini pretzels
+salty-snacks	new	angies boomchickapop sweet and salty
+salty-snacks	cached	orville redenbacher kettle corn
+salty-snacks	cached	white cheddar popcorn
+salty-snacks	new	caramel popcorn
+salty-snacks	cached	sour cream and onion chips
+salty-snacks	cached	salt and vinegar chips
+salty-snacks	new	kettle brand honey dijon
+salty-snacks	new	cape cod jalapeno
+salty-snacks	cached	utz ripples
+unlabeled	cached	pringles cheddar cheese
+salty-snacks	cached	lays limon
+salty-snacks	new	sabritas chips
+salty-snacks	new	harvest snaps snap pea crisps
+salty-snacks	cached	quaker rice cakes
+salty-snacks	new	popcorners
+candy	cached	reeses peanut butter cups
+candy	cached	reeses miniatures
+candy	new	reeses pieces
+candy	cached	hersheys milk chocolate bar
+unlabeled	cached	hersheys kisses
+candy	cached	hersheys special dark
+candy	new	snickers bar
+candy	cached	snickers minis
+candy	new	twix bars
+candy	cached	twix minis
+candy	cached	kit kat bar
+candy	cached	kit kat minis
+candy	cached	milky way bar
+unlabeled	cached	3 musketeers bar
+unlabeled	cached	butterfinger bar
+unlabeled	cached	baby ruth bar
+unlabeled	cached	almond joy bar
+candy	new	mounds bar
+unlabeled	cached	crunch bar
+candy	new	take 5 bar
+unlabeled	cached	whatchamacallit bar
+candy	cached	toblerone milk chocolate
+candy	new	toblerone dark chocolate
+unlabeled	cached	lindt lindor truffles
+candy	new	lindt excellence dark chocolate
+candy	new	ghirardelli dark chocolate squares
+candy	cached	ghirardelli milk chocolate squares
+candy	cached	dove dark chocolate
+candy	cached	dove milk chocolate
+unlabeled	cached	haribo goldbears
+candy	cached	haribo sour goldbears
+unlabeled	cached	haribo twin snakes
+unlabeled	cached	sour patch kids
+candy	new	sour patch kids watermelon
+unlabeled	cached	swedish fish
+unlabeled	cached	skittles original
+unlabeled	cached	skittles sour
+unlabeled	cached	starburst original
+candy	cached	starburst sour
+candy	cached	airheads bars
+candy	cached	airheads xtremes
+candy	cached	trolli sour brite crawlers
+candy	cached	trolli sour bites
+candy	cached	albanese gummy bears
+candy	cached	albanese gummy worms
+unlabeled	cached	nerds gummy clusters
+candy	cached	jolly rancher hard candy
+candy	cached	jolly rancher gummies
+candy	cached	werthers original caramel
+candy	cached	life savers mints
+candy	cached	life savers gummies
+candy	cached	altoids peppermint mints
+candy	cached	altoids curiously strong mints
+candy	cached	tic tac mints
+candy	new	tic tac orange
+candy	cached	mentos mint
+candy	cached	mentos fruit
+candy	cached	m and ms peanut
+candy	new	m and ms milk chocolate
+candy	new	m and ms pretzel
+candy	cached	m and ms crispy
+candy	new	m and ms peanut butter
+candy	cached	reeses peanut butter eggs
+candy	cached	candy corn
+candy	cached	cadbury creme egg
+candy	cached	cadbury mini eggs
+candy	new	twizzlers strawberry twists
+candy	cached	twizzlers pull n peel
+candy	new	red vines original red
+candy	cached	kraft caramels
+candy	new	werthers caramel chews
+candy	new	jelly belly jelly beans
+candy	new	marshmallows
+candy	cached	mini marshmallows
+candy	cached	jet puffed marshmallows
+candy	cached	chocolate covered almonds
+candy	cached	chocolate covered pretzels
+candy	cached	chocolate covered raisins
+candy	cached	chocolate covered peanuts
+candy	new	extra spearmint gum
+candy	new	extra peppermint gum
+candy	cached	trident spearmint gum
+candy	new	trident original bubblegum
+candy	new	5 gum cobalt
+candy	cached	orbit spearmint gum
+candy	cached	orbit peppermint gum
+candy	new	lindt dark chocolate 70%
+candy	cached	ghirardelli intense dark chocolate
+candy	new	halva
+candy	cached	sesame halva
+unlabeled	cached	york peppermint pattie
+candy	new	whoppers malted milk balls
+unlabeled	cached	milk duds
+unlabeled	cached	junior mints
+candy	new	raisinets
+candy	new	goobers
+candy	new	sweettarts
+unlabeled	cached	laffy taffy
+candy	cached	now and later
+candy	cached	bit o honey
+unlabeled	cached	tootsie roll
+candy	cached	tootsie pop
+candy	cached	charleston chew
+candy	cached	pixy stix
+candy	new	dum dum lollipops
+candy	cached	ring pop
+candy	cached	warheads sour hard candy
+candy	cached	big league chew
+candy	new	chewy sprees
+candy	new	runts candy
+candy	new	nerds candy
+candy	cached	pop rocks
+candy	cached	crunch bar dark chocolate
+candy	cached	hersheys cookies n creme
+candy	new	hersheys gold bar
+candy	new	100 grand bar
+candy	new	payday candy bar
+candy	cached	mr goodbar
+candy	new	skor toffee bar
+candy	new	heath toffee bar
+unlabeled	cached	whey protein
+unlabeled	cached	protein shake
+unlabeled	cached	protein bar
+unlabeled	cached	protein powder
+unlabeled	cached	protein cookie
+unlabeled	cached	optimum nutrition gold standard whey
+protein-supplements	cached	optimum nutrition gold standard whey chocolate
+protein-supplements	new	optimum nutrition gold standard whey vanilla
+unlabeled	cached	dymatize iso100
+protein-supplements	new	dymatize iso100 chocolate
+protein-supplements	cached	ghost whey protein
+protein-supplements	new	ghost whey protein chocolate
+unlabeled	cached	ryse loaded protein
+protein-supplements	cached	ryse whey protein
+protein-supplements	new	legion whey protein
+protein-supplements	new	legion whey protein chocolate
+protein-supplements	new	transparent labs whey protein isolate
+protein-supplements	cached	muscle milk protein powder
+protein-supplements	cached	premier protein powder
+protein-supplements	cached	orgain protein powder
+unlabeled	cached	orgain organic protein powder
+protein-supplements	cached	vega protein powder
+protein-supplements	new	vega sport protein powder
+protein-supplements	new	isopure whey protein isolate
+unlabeled	cached	isopure zero carb
+unlabeled	cached	quest protein powder
+protein-supplements	cached	ascent whey protein
+protein-supplements	cached	nutricost whey protein
+protein-supplements	cached	body fortress whey protein
+protein-supplements	new	six star whey protein
+unlabeled	cached	premier protein shake
+unlabeled	cached	premier protein shake chocolate
+protein-supplements	new	premier protein shake vanilla
+protein-supplements	cached	fairlife core power shake
+protein-supplements	cached	fairlife core power elite
+protein-supplements	cached	muscle milk rtd shake
+unlabeled	cached	orgain protein shake
+protein-supplements	cached	ensure protein shake
+unlabeled	cached	ensure max protein
+unlabeled	cached	boost high protein
+protein-supplements	new	boost protein drink
+unlabeled	cached	owyn protein shake
+unlabeled	cached	koia protein shake
+protein-supplements	new	shakeology shake
+unlabeled	cached	quest bar
+unlabeled	cached	quest bar chocolate chip cookie dough
+unlabeled	cached	quest bar cookies and cream
+protein-supplements	new	rxbar
+unlabeled	cached	rxbar chocolate sea salt
+unlabeled	cached	rxbar peanut butter
+unlabeled	cached	clif bar
+protein-supplements	cached	clif builders bar
+protein-supplements	cached	clif builders bar chocolate peanut butter
+protein-supplements	cached	kind protein bar
+unlabeled	cached	pure protein bar
+unlabeled	cached	pure protein bar chocolate deluxe
+unlabeled	cached	built bar
+protein-supplements	new	built bar chocolate
+protein-supplements	new	one bar
+protein-supplements	new	one bar birthday cake
+protein-supplements	cached	barebells protein bar
+protein-supplements	cached	barebells protein bar chocolate dough
+protein-supplements	cached	david protein bar
+protein-supplements	new	david protein bar chocolate chip cookie dough
+protein-supplements	cached	no cow protein bar
+protein-supplements	new	perfect bar
+unlabeled	cached	perfect bar peanut butter
+protein-supplements	cached	think protein bar
+protein-supplements	cached	think high protein bar
+protein-supplements	cached	power crunch protein bar
+protein-supplements	new	met-rx big 100 bar
+unlabeled	cached	gatorade protein bar
+protein-supplements	cached	nature valley protein bar
+protein-supplements	cached	nature valley protein bar chocolate peanut butter
+protein-supplements	cached	lenny and larrys protein cookie
+protein-supplements	new	lenny and larrys protein puffs
+protein-supplements	cached	quest protein chips
+protein-supplements	cached	quest chips nacho cheese
+protein-supplements	new	wilde chips
+protein-supplements	cached	wilde protein chips
+unlabeled	cached	greek yogurt
+unlabeled	cached	chobani greek yogurt
+protein-supplements	cached	fage greek yogurt
+protein-supplements	cached	oikos triple zero greek yogurt
+protein-supplements	new	two good greek yogurt
+protein-supplements	cached	collagen peptides
+protein-supplements	cached	vital proteins collagen peptides
+protein-supplements	cached	vital proteins collagen powder
+protein-supplements	cached	collagen protein powder
+unlabeled	cached	creatine monohydrate
+protein-supplements	new	optimum nutrition creatine monohydrate
+protein-supplements	new	creatine powder
+protein-supplements	cached	c4 pre workout
+protein-supplements	cached	c4 original pre workout
+unlabeled	cached	ghost pre workout
+unlabeled	cached	ghost legend pre workout
+protein-supplements	cached	bucked up pre workout
+protein-supplements	new	alani nu pre workout
+unlabeled	cached	bcaa powder
+protein-supplements	new	scivation xtend bcaa
+protein-supplements	new	eaa powder
+protein-supplements	new	kaged aminos eaa
+protein-supplements	new	ag1 greens powder
+protein-supplements	cached	athletic greens ag1
+protein-supplements	cached	bloom greens powder
+protein-supplements	new	bloom nutrition greens
+protein-supplements	cached	mass gainer
+protein-supplements	cached	optimum nutrition serious mass
+protein-supplements	new	true mass gainer
+protein-supplements	cached	muscle milk mass gainer
+unlabeled	cached	meal replacement shake
+protein-supplements	cached	huel meal replacement shake
+protein-supplements	new	soylent meal replacement shake
+protein-supplements	new	electrolyte powder
+protein-supplements	cached	liquid iv electrolyte powder
+protein-supplements	new	nuun electrolyte tablets
+protein-supplements	cached	gatorade electrolyte powder
+protein-supplements	new	skratch labs electrolyte powder
+protein-supplements	cached	whey protein isolate
+protein-supplements	cached	whey protein concentrate
+protein-supplements	cached	casein protein powder
+protein-supplements	cached	optimum nutrition gold standard casein
+protein-supplements	cached	plant protein powder
+unlabeled	cached	vegan protein powder
+protein-supplements	cached	pea protein powder
+protein-supplements	new	egg white protein powder
+protein-supplements	cached	premier protein bar
+protein-supplements	cached	quest protein shake
+protein-supplements	new	muscle milk genuine protein shake
+protein-supplements	new	optimum nutrition amino energy
+protein-supplements	new	cellucor c4 sport pre workout
+protein-supplements	cached	kaged pre workout
+protein-supplements	cached	protein pancake mix
+unlabeled	new	kodiak cakes protein pancake mix
+unlabeled	cached	whole milk
+dairy	new	2% milk
+dairy	new	1% milk
+unlabeled	cached	skim milk
+dairy	cached	fairlife whole milk
+dairy	new	fairlife 2% milk
+unlabeled	cached	lactaid whole milk
+dairy	cached	lactaid fat free milk
+unlabeled	cached	a2 whole milk
+dairy	new	raw milk
+unlabeled	cached	buttermilk
+unlabeled	cached	evaporated milk
+unlabeled	cached	sweetened condensed milk
+unlabeled	cached	heavy cream
+unlabeled	cached	oatly oat milk
+unlabeled	cached	chobani oat milk
+dairy	cached	silk almond milk
+dairy	cached	silk soy milk
+dairy	cached	silk oat milk
+dairy	new	almond breeze almond milk
+dairy	cached	ripple pea milk
+unlabeled	cached	califia farms almond milk
+dairy	cached	califia farms oat milk
+unlabeled	cached	coconut milk
+unlabeled	cached	cashew milk
+dairy	cached	chobani flip yogurt
+dairy	cached	fage total 0% greek yogurt
+dairy	new	fage total 2% greek yogurt
+dairy	cached	oikos triple zero yogurt
+unlabeled	cached	oikos greek yogurt
+dairy	cached	yoplait original yogurt
+dairy	new	yoplait light yogurt
+dairy	new	dannon greek yogurt
+dairy	new	dannon activia yogurt
+dairy	new	siggi's icelandic yogurt
+dairy	new	siggi's 4% yogurt
+dairy	new	noosa yogurt
+unlabeled	cached	activia probiotic yogurt
+dairy	cached	icelandic provisions skyr
+dairy	new	plain yogurt
+dairy	new	vanilla yogurt
+unlabeled	cached	skyr
+unlabeled	cached	kefir
+unlabeled	cached	lifeway kefir
+dairy	new	yogurt drink
+unlabeled	cached	cottage cheese
+dairy	cached	good culture cottage cheese
+dairy	cached	daisy cottage cheese
+dairy	cached	breakstone's cottage cheese
+unlabeled	cached	sour cream
+unlabeled	cached	daisy sour cream
+unlabeled	cached	cream cheese
+unlabeled	cached	philadelphia cream cheese
+dairy	new	philadelphia strawberry cream cheese
+dairy	cached	philadelphia chive and onion cream cheese
+unlabeled	cached	butter
+dairy	cached	salted butter
+unlabeled	cached	unsalted butter
+dairy	cached	kerrygold butter
+dairy	cached	land o lakes butter
+dairy	new	country crock spread
+unlabeled	cached	ghee
+dairy	new	margarine
+unlabeled	cached	cheddar cheese
+dairy	cached	sharp cheddar cheese
+dairy	cached	mild cheddar cheese
+dairy	cached	mozzarella cheese
+dairy	new	shredded mozzarella cheese
+dairy	new	fresh mozzarella cheese
+dairy	cached	parmesan cheese
+dairy	new	grated parmesan cheese
+dairy	new	swiss cheese
+dairy	new	provolone cheese
+dairy	new	gouda cheese
+dairy	new	brie cheese
+unlabeled	cached	feta cheese
+dairy	cached	crumbled feta cheese
+unlabeled	cached	goat cheese
+unlabeled	cached	blue cheese
+dairy	cached	blue cheese crumbles
+dairy	new	american cheese slices
+dairy	cached	pepper jack cheese
+dairy	cached	colby jack cheese
+unlabeled	cached	queso fresco
+dairy	new	cotija cheese
+dairy	new	halloumi cheese
+dairy	new	ricotta cheese
+dairy	new	mascarpone cheese
+dairy	cached	laughing cow cheese wedge
+dairy	new	shredded mexican blend cheese
+dairy	new	whole egg
+dairy	new	liquid egg whites
+dairy	new	egg beaters
+unlabeled	cached	whipped cream
+unlabeled	cached	cool whip
+unlabeled	cached	reddi wip
+dairy	cached	violife cheddar shreds
+dairy	cached	violife cream cheese
+dairy	cached	kite hill almond milk yogurt
+dairy	cached	kite hill cream cheese
+dairy	cached	forager cashewmilk yogurt
+dairy	cached	forager cashew milk
+dairy	cached	oatly oat milk barista
+dairy	cached	silk almond milk unsweetened
+dairy	new	almond breeze unsweetened vanilla almond milk
+dairy	cached	chobani oat milk barista
+dairy	cached	dannon light and fit yogurt
+dairy	new	yoplait greek yogurt
+dairy	new	fage yogurt honey
+dairy	new	noosa mango yogurt
+dairy	new	oikos triple zero vanilla yogurt
+dairy	new	two good vanilla yogurt
+dairy	new	siggi's vanilla yogurt
+dairy	cached	lactose free milk
+dairy	new	whole milk powder
+dairy	cached	nonfat dry milk
+unlabeled	cached	goat milk
+dairy	cached	low fat cottage cheese
+unlabeled	cached	whipped cream cheese
+unlabeled	cached	neufchatel cheese
+dairy	new	laughing cow light cheese wedge
+dairy	cached	babybel light cheese
+dairy	new	egg substitute
+dairy	cached	liquid eggs
+dairy	new	pasteurized egg whites
+dairy	new	gouda cheese slices
+dairy	new	swiss cheese slices
+dairy	new	provolone cheese slices
+dairy	new	shredded cheddar cheese
+dairy	new	shredded parmesan cheese
+dairy	new	block cheddar cheese
+unlabeled	cached	almond milk
+unlabeled	new	soy milk
+unlabeled	cached	oat milk
+dairy	cached	coconut milk creamer
+dairy	new	half and half creamer
+frozen	new	frozen lean cuisine chicken fettuccine alfredo
+frozen	new	lean cuisine baked chicken
+frozen	new	stouffer's lasagna
+frozen	cached	stouffer's mac and cheese
+frozen	cached	stouffer's meatloaf
+unlabeled	cached	healthy choice power bowl
+frozen	cached	healthy choice cafe steamers
+frozen	new	amy's kitchen burrito
+frozen	cached	amy's kitchen bowl
+frozen	cached	marie callender's chicken pot pie
+frozen	new	marie callender's turkey dinner
+unlabeled	cached	banquet chicken pot pie
+unlabeled	cached	banquet salisbury steak
+frozen	cached	hungry-man salisbury steak dinner
+frozen	new	michelangelo's chicken parmesan
+frozen	new	real good foods chicken breast strips
+frozen	cached	kevin's natural foods korean bbq chicken
+frozen	cached	sweet earth veggie bowl
+frozen	cached	evol burrito
+frozen	cached	life cuisine cauliflower pizza bowl
+frozen	cached	jimmy dean sausage biscuit sandwich
+frozen	cached	jimmy dean croissant breakfast sandwich
+frozen	new	eggo blueberry waffles
+frozen	new	kodiak cakes frozen waffles
+frozen	new	frozen breakfast burrito
+unlabeled	cached	tyson chicken nuggets
+frozen	cached	tyson chicken strips
+frozen	cached	perdue chicken tenders
+frozen	new	just bare chicken nuggets
+frozen	cached	applegate chicken nuggets
+frozen	new	frozen chicken patties
+frozen	cached	gorton's fish fillets
+frozen	cached	gorton's fish sticks
+frozen	new	van de kamp's fish sticks
+frozen	new	frozen salmon fillet
+frozen	new	frozen shrimp
+frozen	new	frozen fish sticks
+frozen	new	ore-ida tater tots
+frozen	new	ore-ida french fries
+frozen	cached	ore-ida hash browns
+frozen	cached	alexia sweet potato fries
+frozen	cached	alexia waffle fries
+frozen	new	frozen broccoli
+frozen	new	frozen mixed vegetables
+frozen	new	frozen corn
+frozen	new	frozen edamame
+frozen	new	frozen spinach
+frozen	new	frozen blueberries
+frozen	new	frozen strawberries
+frozen	new	frozen mango chunks
+frozen	cached	sambazon acai packs
+frozen	new	frozen mozzarella sticks
+frozen	new	frozen egg rolls
+frozen	new	frozen potstickers
+frozen	cached	bibigo chicken dumplings
+frozen	cached	bibigo pork dumplings
+frozen	cached	tgi fridays mozzarella sticks
+frozen	cached	tgi fridays potato skins
+frozen	new	el monterey beef and bean burrito
+frozen	cached	el monterey breakfast burrito
+frozen	cached	amy's kitchen bean and cheese burrito
+frozen	cached	trader joe's orange chicken
+frozen	cached	trader joe's chicken tikka masala
+frozen	cached	trader joe's mandarin orange chicken
+frozen	cached	trader joe's soyaki vegetable stir fry
+unlabeled	cached	trader joe's cauliflower gnocchi
+frozen	new	beyond meat burger patty
+frozen	cached	beyond meat sausage
+frozen	cached	impossible burger patty
+frozen	cached	impossible sausage patty
+frozen	cached	boca veggie burger
+frozen	cached	boca chicken patties
+frozen	cached	morningstar farms veggie burger
+frozen	cached	morningstar farms chik'n patty
+frozen	new	morningstar farms sausage links
+frozen	cached	gardein chick'n tenders
+frozen	new	gardein beefless burger
+frozen	new	frozen rice bowl
+frozen	new	frozen chicken fried rice bowl
+frozen	new	frozen teriyaki chicken bowl
+frozen	new	frozen quinoa bowl
+frozen	new	frozen buttermilk pancakes
+frozen	new	frozen chocolate chip pancakes
+frozen	cached	lean cuisine spaghetti with meat sauce
+frozen	cached	lean cuisine sweet and sour chicken
+frozen	cached	stouffer's chicken alfredo
+frozen	cached	stouffer's french bread pizza
+frozen	cached	amy's kitchen mac and cheese
+frozen	cached	amy's kitchen enchilada
+frozen	cached	healthy choice fettuccine alfredo
+frozen	cached	marie callender's beef pot pie
+frozen	cached	banquet chicken fried steak
+frozen	new	hungry-man boneless fried chicken
+frozen	cached	real good foods pizza bowl
+frozen	cached	kevin's natural foods chicken tikka masala
+frozen	cached	sweet earth breakfast burrito
+frozen	cached	evol chicken burrito
+frozen	new	life cuisine spinach artichoke pizza bowl
+frozen	cached	jimmy dean stuffed hash browns
+frozen	cached	eggo minis waffles
+frozen	new	frozen breakfast sandwich
+frozen	new	tyson any'tizers chicken wings
+frozen	new	tyson chicken breast fillets
+frozen	new	just bare chicken breast strips
+frozen	new	applegate turkey burger
+frozen	new	frozen fish fillets
+frozen	new	frozen calamari rings
+frozen	cached	ore-ida crinkle cut fries
+frozen	new	ore-ida onion rings
+frozen	new	frozen brussels sprouts
+frozen	new	frozen peas
+frozen	new	frozen green beans
+frozen	new	frozen cauliflower rice
+frozen	new	frozen raspberries
+frozen	new	frozen cherries
+frozen	new	frozen samosas
+frozen	cached	bibigo mandu
+frozen	cached	totino's pizza rolls
+frozen	cached	el monterey chicken and cheese burrito
+frozen	cached	trader joe's vegetable gyoza
+frozen	new	beyond meat chicken tenders
+frozen	cached	impossible chicken nuggets
+frozen	cached	morningstar farms buffalo wings
+frozen	cached	gardein meatless meatballs
+frozen	new	frozen shepherd's pie
+frozen	new	frozen chicken fajita bowl
+frozen	new	frozen teriyaki vegetables
+frozen	new	frozen churros
+frozen	new	frozen naan bread
+frozen	new	frozen garlic bread
+frozen	new	frozen pierogies
+frozen	new	frozen falafel
+unlabeled	cached	white bread
+unlabeled	cached	whole wheat bread
+bread-bakery	new	whole grain bread
+unlabeled	cached	sourdough bread
+unlabeled	cached	rye bread
+unlabeled	cached	pumpernickel bread
+unlabeled	cached	multigrain bread
+bread-bakery	new	brioche bread
+unlabeled	cached	texas toast
+unlabeled	cached	italian bread
+unlabeled	cached	french bread
+unlabeled	cached	potato bread
+unlabeled	cached	oat bread
+unlabeled	cached	dave's killer bread
+bread-bakery	new	dave's killer bread 21 whole grains and seeds
+bread-bakery	new	dave's killer bread white bread done right
+bread-bakery	new	nature's own whole wheat bread
+bread-bakery	cached	nature's own honey wheat bread
+bread-bakery	cached	nature's own butterbread
+bread-bakery	cached	sara lee white bread
+unlabeled	cached	sara lee whole wheat bread
+bread-bakery	new	pepperidge farm white bread
+bread-bakery	cached	pepperidge farm cinnamon swirl bread
+bread-bakery	new	pepperidge farm whole grain bread
+unlabeled	cached	wonder bread
+bread-bakery	new	wonder classic white bread
+bread-bakery	new	arnold whole wheat bread
+bread-bakery	new	oroweat whole wheat bread
+bread-bakery	cached	oroweat country white bread
+unlabeled	cached	ezekiel bread
+bread-bakery	new	ezekiel sprouted grain bread
+bread-bakery	new	canyon bakehouse gluten free bread
+bread-bakery	new	hamburger bun
+bread-bakery	new	whole wheat hamburger bun
+unlabeled	cached	hot dog bun
+unlabeled	cached	hawaiian rolls
+bread-bakery	new	king's hawaiian rolls
+bread-bakery	cached	king's hawaiian hot dog buns
+unlabeled	cached	brioche bun
+unlabeled	cached	dinner roll
+unlabeled	cached	pretzel bun
+bread-bakery	new	sub roll
+bread-bakery	new	hoagie roll
+bread-bakery	new	ciabatta roll
+unlabeled	cached	kaiser roll
+bread-bakery	cached	thomas' plain bagel
+bread-bakery	cached	thomas' everything bagel
+bread-bakery	new	dave's killer bread bagel
+bread-bakery	new	mini bagel
+bread-bakery	new	bagel thins
+bread-bakery	cached	thomas' english muffin
+bread-bakery	cached	thomas' cinnamon raisin english muffin
+unlabeled	cached	flour tortilla
+unlabeled	cached	corn tortilla
+bread-bakery	new	whole wheat tortilla
+bread-bakery	cached	mission flour tortilla
+bread-bakery	cached	mission corn tortilla
+bread-bakery	cached	la banderita flour tortilla
+unlabeled	cached	low carb tortilla
+bread-bakery	new	tortilla wrap
+bread-bakery	new	spinach tortilla wrap
+bread-bakery	new	flatout wrap
+bread-bakery	new	flatout flatbread
+unlabeled	cached	pita bread
+bread-bakery	new	whole wheat pita bread
+unlabeled	cached	naan
+unlabeled	cached	garlic naan
+unlabeled	cached	lavash
+bread-bakery	new	butter croissant
+bread-bakery	new	pillsbury croissant
+bread-bakery	new	pillsbury biscuits
+bread-bakery	new	pillsbury grands biscuits
+bread-bakery	new	canned biscuits
+unlabeled	cached	buttermilk biscuit
+unlabeled	cached	chocolate chip muffin
+bread-bakery	new	otis spunkmeyer muffin
+bread-bakery	new	costco muffin
+unlabeled	cached	bran muffin
+unlabeled	cached	glazed donut
+bread-bakery	new	boston creme donut
+unlabeled	cached	chocolate donut
+bread-bakery	new	cake donut
+bread-bakery	new	krispy kreme glazed donut
+unlabeled	cached	dunkin donut
+unlabeled	cached	dunkin munchkins
+bread-bakery	new	entenmann's donuts
+bread-bakery	new	entenmann's crumb donuts
+bread-bakery	new	pillsbury cinnamon rolls
+bread-bakery	new	cinnabon cinnamon roll
+bread-bakery	new	apple turnover
+bread-bakery	new	cherry turnover
+unlabeled	cached	scone
+bread-bakery	new	blueberry scone
+unlabeled	cached	pop tarts
+bread-bakery	new	pop tarts frosted strawberry
+unlabeled	cached	cornbread
+bread-bakery	new	jiffy cornbread
+bread-bakery	new	focaccia bread
+unlabeled	cached	baguette
+bread-bakery	new	french baguette
+unlabeled	cached	soft pretzel
+bread-bakery	new	auntie anne's pretzel
+bread-bakery	new	croutons
+bread-bakery	new	caesar croutons
+bread-bakery	new	breadcrumbs
+bread-bakery	new	panko breadcrumbs
+bread-bakery	new	italian breadcrumbs
+bread-bakery	new	pancake mix
+bread-bakery	new	bisquick pancake mix
+unlabeled	cached	kodiak cakes pancake mix
+bread-bakery	new	waffle mix
+unlabeled	cached	flatbread
+bread-bakery	new	sandwich thins
+bread-bakery	new	arnold sandwich thins
+bread-bakery	new	potato roll
+meat-seafood	cached	grilled chicken breast
+meat-seafood	new	baked chicken breast
+meat-seafood	new	roasted chicken breast
+meat-seafood	new	raw chicken breast
+unlabeled	cached	chicken thigh
+meat-seafood	new	grilled chicken thigh
+meat-seafood	new	baked chicken thigh
+meat-seafood	new	boneless skinless chicken thigh
+unlabeled	cached	chicken wing
+meat-seafood	new	buffalo chicken wing
+unlabeled	cached	chicken drumstick
+unlabeled	cached	chicken tenderloin
+meat-seafood	new	whole roasted chicken
+unlabeled	cached	rotisserie chicken
+meat-seafood	new	shredded chicken
+meat-seafood	new	ground chicken
+meat-seafood	new	chicken sausage
+meat-seafood	new	fried chicken
+meat-seafood	new	air fried chicken breast
+unlabeled	cached	chicken liver
+meat-seafood	new	ground beef 93/7
+meat-seafood	new	ground beef 80/20
+meat-seafood	new	ground beef 85/15
+unlabeled	cached	ground beef 90/10
+meat-seafood	new	93% lean ground beef
+meat-seafood	new	lean ground beef
+unlabeled	cached	ribeye steak
+meat-seafood	new	grilled ribeye
+unlabeled	cached	sirloin steak
+meat-seafood	new	top sirloin steak
+unlabeled	cached	filet mignon
+unlabeled	cached	new york strip steak
+unlabeled	cached	flank steak
+unlabeled	cached	skirt steak
+unlabeled	cached	brisket
+meat-seafood	new	smoked brisket
+unlabeled	cached	chuck roast
+meat-seafood	new	short rib
+meat-seafood	new	beef stew meat
+unlabeled	cached	corned beef
+unlabeled	cached	prime rib
+meat-seafood	new	hamburger patty
+meat-seafood	new	grilled hamburger patty
+meat-seafood	new	london broil
+unlabeled	cached	beef tenderloin
+unlabeled	cached	pork chop
+meat-seafood	new	grilled pork chop
+meat-seafood	new	baked pork chop
+unlabeled	cached	pork tenderloin
+meat-seafood	new	pork loin
+unlabeled	cached	pulled pork
+unlabeled	cached	pork belly
+unlabeled	new	crispy bacon
+meat-seafood	new	spiral ham
+meat-seafood	new	honey baked ham
+unlabeled	cached	prosciutto
+unlabeled	cached	pancetta
+unlabeled	cached	italian sausage
+unlabeled	cached	bratwurst
+unlabeled	cached	chorizo
+unlabeled	cached	hot dog
+meat-seafood	new	beef hot dog
+unlabeled	new	kielbasa
+meat-seafood	new	polish sausage
+meat-seafood	new	andouille sausage
+unlabeled	cached	turkey breast
+unlabeled	cached	roasted turkey breast
+meat-seafood	new	ground turkey
+unlabeled	cached	deli turkey
+meat-seafood	new	deli turkey breast
+meat-seafood	new	whole roast turkey
+meat-seafood	new	smoked turkey
+unlabeled	cached	lamb chop
+meat-seafood	new	grilled lamb chop
+meat-seafood	new	ground lamb
+meat-seafood	new	leg of lamb
+meat-seafood	new	rack of lamb
+unlabeled	cached	salmon
+meat-seafood	cached	grilled salmon
+meat-seafood	new	baked salmon
+meat-seafood	new	atlantic salmon
+meat-seafood	new	sockeye salmon
+unlabeled	cached	smoked salmon
+unlabeled	cached	lox
+meat-seafood	new	tuna steak
+meat-seafood	new	seared tuna steak
+meat-seafood	new	canned tuna in water
+meat-seafood	new	canned tuna in oil
+unlabeled	cached	tilapia
+meat-seafood	new	grilled tilapia
+meat-seafood	new	baked tilapia
+unlabeled	cached	cod
+meat-seafood	new	baked cod
+unlabeled	cached	halibut
+meat-seafood	new	mahi mahi
+unlabeled	cached	swordfish
+unlabeled	cached	sardines
+meat-seafood	new	canned sardines
+unlabeled	cached	anchovies
+unlabeled	cached	mackerel
+unlabeled	cached	trout
+unlabeled	cached	rainbow trout
+unlabeled	cached	shrimp
+meat-seafood	new	grilled shrimp
+meat-seafood	new	boiled shrimp
+unlabeled	cached	prawns
+meat-seafood	new	crab
+unlabeled	cached	crab legs
+meat-seafood	new	snow crab legs
+meat-seafood	new	king crab legs
+unlabeled	cached	lobster tail
+unlabeled	cached	scallops
+meat-seafood	new	seared scallops
+unlabeled	cached	mussels
+meat-seafood	new	steamed mussels
+unlabeled	new	clams
+unlabeled	new	oysters
+meat-seafood	new	raw oysters
+unlabeled	cached	calamari
+meat-seafood	new	fried calamari
+unlabeled	cached	octopus
+meat-seafood	new	grilled octopus
+unlabeled	cached	imitation crab
+meat-seafood	cached	boar's head turkey breast
+meat-seafood	new	boar's head ham
+meat-seafood	new	applegate turkey
+meat-seafood	new	applegate chicken breast
+meat-seafood	new	oscar mayer bacon
+meat-seafood	new	oscar mayer turkey bacon
+unlabeled	cached	oscar mayer deli ham
+meat-seafood	new	hillshire farm smoked sausage
+meat-seafood	new	hillshire farm deli turkey
+meat-seafood	new	land o'frost ham
+meat-seafood	new	land o'frost turkey
+unlabeled	cached	carne asada
+meat-seafood	new	beef fajita strips
+meat-seafood	new	pork carnitas
+meat-seafood	new	chicken carnitas
+meat-seafood	new	smoked pork shoulder
+meat-seafood	new	beef short ribs braised
+unlabeled	cached	apple
+unlabeled	cached	honeycrisp apple
+unlabeled	cached	gala apple
+unlabeled	cached	granny smith apple
+unlabeled	cached	banana
+unlabeled	cached	orange
+unlabeled	cached	clementine
+unlabeled	cached	grapes
+unlabeled	cached	strawberries
+unlabeled	cached	blueberries
+unlabeled	cached	raspberries
+unlabeled	cached	blackberries
+unlabeled	cached	watermelon
+unlabeled	cached	cantaloupe
+produce	new	honeydew
+unlabeled	cached	pineapple
+unlabeled	cached	mango
+unlabeled	cached	peach
+unlabeled	cached	nectarine
+unlabeled	cached	plum
+unlabeled	cached	pear
+unlabeled	cached	kiwi
+unlabeled	cached	cherries
+unlabeled	cached	pomegranate
+unlabeled	cached	papaya
+unlabeled	cached	dragon fruit
+unlabeled	cached	guava
+unlabeled	cached	passion fruit
+unlabeled	cached	apricot
+unlabeled	cached	fig
+unlabeled	cached	date
+unlabeled	cached	medjool dates
+unlabeled	cached	grapefruit
+unlabeled	cached	lemon
+unlabeled	cached	lime
+unlabeled	cached	avocado
+produce	new	coconut
+produce	cached	star fruit
+unlabeled	cached	persimmon
+unlabeled	cached	lychee
+unlabeled	cached	jackfruit
+unlabeled	cached	prunes
+unlabeled	cached	raisins
+produce	new	dried cranberries
+produce	new	dried mango
+produce	new	banana chips
+produce	new	applesauce
+produce	cached	fruit cup
+produce	new	freeze dried strawberries
+unlabeled	cached	broccoli
+unlabeled	cached	cauliflower
+unlabeled	cached	spinach
+unlabeled	cached	kale
+unlabeled	cached	arugula
+unlabeled	cached	romaine lettuce
+unlabeled	cached	iceberg lettuce
+produce	cached	spring mix
+unlabeled	cached	cabbage
+unlabeled	cached	brussels sprouts
+unlabeled	cached	asparagus
+produce	new	green beans
+produce	cached	peas
+unlabeled	cached	snap peas
+unlabeled	cached	carrots
+unlabeled	cached	baby carrots
+unlabeled	cached	celery
+unlabeled	cached	cucumber
+unlabeled	cached	tomato
+unlabeled	cached	cherry tomatoes
+unlabeled	cached	roma tomato
+unlabeled	cached	red bell pepper
+produce	cached	green bell pepper
+unlabeled	cached	yellow bell pepper
+unlabeled	cached	jalapeno
+produce	new	serrano pepper
+unlabeled	cached	poblano pepper
+unlabeled	cached	yellow onion
+unlabeled	cached	red onion
+produce	cached	white onion
+unlabeled	cached	shallot
+unlabeled	cached	garlic
+unlabeled	cached	leek
+produce	new	scallion
+unlabeled	cached	zucchini
+produce	cached	yellow squash
+unlabeled	cached	butternut squash
+unlabeled	cached	acorn squash
+unlabeled	cached	spaghetti squash
+unlabeled	cached	pumpkin
+unlabeled	cached	eggplant
+unlabeled	cached	mushrooms
+produce	new	cremini mushrooms
+unlabeled	cached	portobello mushroom
+unlabeled	cached	shiitake mushrooms
+unlabeled	cached	sweet potato
+unlabeled	cached	russet potato
+produce	cached	red potato
+unlabeled	cached	yukon gold potato
+unlabeled	cached	beet
+unlabeled	cached	radish
+unlabeled	cached	turnip
+unlabeled	cached	parsnip
+unlabeled	cached	corn on the cob
+unlabeled	cached	artichoke
+unlabeled	cached	okra
+unlabeled	cached	bok choy
+unlabeled	cached	swiss chard
+produce	cached	collard greens
+produce	new	seaweed
+produce	new	sprouts
+produce	new	hearts of palm
+unlabeled	cached	jicama
+produce	cached	roasted vegetables
+produce	cached	steamed broccoli
+produce	new	air fried brussels sprouts
+unlabeled	cached	mashed potatoes
+produce	new	sauteed spinach
+produce	new	grilled asparagus
+unlabeled	cached	side salad
+unlabeled	cached	coleslaw
+unlabeled	cached	guacamole
+unlabeled	cached	pico de gallo
+unlabeled	cached	salsa
+unlabeled	cached	sauerkraut
+unlabeled	cached	kimchi
+produce	new	canned corn
+produce	new	canned green beans
+produce	cached	bartlett pear
+produce	cached	red grapes
+produce	cached	green grapes
+produce	cached	mandarin orange
+produce	new	cara cara orange
+unlabeled	cached	blood orange
+produce	new	mini cucumbers
+produce	cached	english cucumber
+produce	new	heirloom tomato
+produce	new	sun dried tomatoes
+produce	cached	green cabbage
+unlabeled	cached	red cabbage
+produce	cached	napa cabbage
+unlabeled	cached	purple sweet potato
+produce	new	white mushrooms
+unlabeled	cached	pearl onions
+produce	cached	pumpkin puree
+produce	cached	mixed berries
+unlabeled	cached	tangerine
+grains-pantry	cached	dry white rice
+unlabeled	cached	cooked white rice
+grains-pantry	cached	dry brown rice
+grains-pantry	cached	cooked brown rice
+grains-pantry	cached	dry jasmine rice
+grains-pantry	new	cooked jasmine rice
+grains-pantry	cached	dry basmati rice
+grains-pantry	new	cooked basmati rice
+grains-pantry	new	sushi rice
+grains-pantry	new	cooked sushi rice
+unlabeled	cached	wild rice
+grains-pantry	cached	cooked wild rice
+unlabeled	cached	arborio rice
+unlabeled	cached	cauliflower rice
+grains-pantry	new	minute rice
+grains-pantry	new	uncle ben's ready rice
+grains-pantry	new	ben's original ready rice
+unlabeled	cached	spanish rice
+unlabeled	cached	fried rice
+grains-pantry	new	coconut rice
+unlabeled	cached	rice pilaf
+unlabeled	cached	spaghetti
+grains-pantry	new	cooked spaghetti
+grains-pantry	new	penne
+grains-pantry	cached	cooked penne
+grains-pantry	new	rigatoni
+unlabeled	cached	fettuccine
+unlabeled	cached	linguine
+grains-pantry	new	farfalle
+grains-pantry	new	rotini
+unlabeled	cached	macaroni
+grains-pantry	cached	cooked macaroni
+unlabeled	cached	orzo
+unlabeled	cached	angel hair pasta
+grains-pantry	new	lasagna noodles
+unlabeled	cached	ravioli
+grains-pantry	cached	cheese ravioli
+unlabeled	cached	tortellini
+grains-pantry	cached	cheese tortellini
+unlabeled	cached	gnocchi
+grains-pantry	new	egg noodles
+grains-pantry	cached	ramen noodles
+grains-pantry	cached	instant ramen noodles
+grains-pantry	cached	rice noodles
+grains-pantry	cached	soba noodles
+grains-pantry	cached	udon noodles
+grains-pantry	new	whole wheat pasta
+grains-pantry	new	chickpea pasta
+grains-pantry	new	banza pasta
+grains-pantry	new	protein pasta
+grains-pantry	cached	shirataki noodles
+unlabeled	cached	quinoa
+unlabeled	cached	cooked quinoa
+grains-pantry	cached	dry quinoa
+unlabeled	cached	couscous
+grains-pantry	cached	cooked couscous
+unlabeled	cached	farro
+grains-pantry	new	cooked farro
+unlabeled	cached	barley
+grains-pantry	cached	pearl barley
+unlabeled	cached	bulgur
+unlabeled	cached	millet
+grains-pantry	new	buckwheat
+unlabeled	cached	buckwheat groats
+unlabeled	cached	polenta
+unlabeled	cached	cornmeal
+grains-pantry	new	instant oats
+grains-pantry	cached	oat bran
+grains-pantry	new	wheat berries
+grains-pantry	new	freekeh
+grains-pantry	cached	black beans
+grains-pantry	new	canned black beans
+grains-pantry	cached	pinto beans
+grains-pantry	new	canned pinto beans
+grains-pantry	new	kidney beans
+grains-pantry	cached	canned kidney beans
+unlabeled	cached	chickpeas
+grains-pantry	new	canned chickpeas
+grains-pantry	cached	garbanzo beans
+grains-pantry	cached	navy beans
+grains-pantry	new	cannellini beans
+grains-pantry	cached	great northern beans
+grains-pantry	cached	lima beans
+unlabeled	cached	black eyed peas
+unlabeled	cached	red lentils
+grains-pantry	cached	green lentils
+grains-pantry	cached	brown lentils
+grains-pantry	cached	cooked lentils
+grains-pantry	new	split peas
+grains-pantry	cached	refried beans
+grains-pantry	new	baked beans
+unlabeled	cached	edamame
+grains-pantry	cached	shelled edamame
+grains-pantry	new	canned diced tomatoes
+grains-pantry	new	canned crushed tomatoes
+unlabeled	cached	tomato paste
+unlabeled	cached	tomato sauce
+grains-pantry	new	canned tuna
+grains-pantry	new	canned chicken
+grains-pantry	cached	campbell's chicken noodle soup
+grains-pantry	cached	campbell's tomato soup
+grains-pantry	cached	progresso chicken noodle soup
+grains-pantry	new	amy's minestrone soup
+grains-pantry	new	chicken broth
+grains-pantry	new	beef broth
+grains-pantry	cached	bone broth
+grains-pantry	new	canned coconut milk
+unlabeled	cached	canned pumpkin
+grains-pantry	new	all purpose flour
+grains-pantry	cached	bread flour
+unlabeled	cached	almond flour
+unlabeled	cached	coconut flour
+unlabeled	cached	oat flour
+grains-pantry	new	sugar
+unlabeled	cached	brown sugar
+grains-pantry	new	powdered sugar
+grains-pantry	cached	bisquick baking mix
+grains-pantry	new	cornstarch
+grains-pantry	new	yeast
+unlabeled	cached	cocoa powder
+unlabeled	cached	white rice
+unlabeled	cached	brown rice
+grains-pantry	new	long grain rice
+grains-pantry	new	short grain rice
+unlabeled	cached	ketchup
+unlabeled	cached	heinz ketchup
+unlabeled	cached	yellow mustard
+unlabeled	cached	dijon mustard
+unlabeled	new	spicy brown mustard
+unlabeled	cached	honey mustard
+unlabeled	cached	mayonnaise
+unlabeled	cached	hellmanns mayonnaise
+condiments	cached	dukes mayonnaise
+condiments	cached	kewpie mayonnaise
+condiments	cached	light mayonnaise
+condiments	new	relish
+condiments	new	horseradish
+unlabeled	cached	tartar sauce
+unlabeled	cached	cocktail sauce
+unlabeled	cached	ranch dressing
+condiments	cached	hidden valley ranch dressing
+unlabeled	cached	blue cheese dressing
+unlabeled	cached	thousand island dressing
+unlabeled	cached	caesar dressing
+unlabeled	cached	italian dressing
+condiments	new	balsamic vinaigrette
+condiments	new	greek dressing
+condiments	cached	honey mustard dressing
+condiments	cached	bolthouse farms yogurt dressing
+condiments	new	skinnygirl dressing
+unlabeled	cached	sriracha
+unlabeled	cached	tabasco
+condiments	new	cholula hot sauce
+condiments	cached	franks redhot
+condiments	new	valentina hot sauce
+condiments	new	tapatio hot sauce
+condiments	new	crystal hot sauce
+condiments	new	truff hot sauce
+condiments	cached	chili crisp
+unlabeled	cached	gochujang
+condiments	cached	sambal oelek
+unlabeled	cached	harissa
+unlabeled	cached	soy sauce
+condiments	new	low sodium soy sauce
+unlabeled	cached	teriyaki sauce
+unlabeled	cached	hoisin sauce
+unlabeled	cached	oyster sauce
+unlabeled	cached	fish sauce
+condiments	new	ponzu sauce
+unlabeled	cached	sweet chili sauce
+condiments	new	peanut sauce
+condiments	cached	curry paste
+unlabeled	cached	miso paste
+unlabeled	cached	sweet baby rays bbq sauce
+condiments	new	kc masterpiece bbq sauce
+unlabeled	cached	bbq sauce
+unlabeled	cached	marinara sauce
+condiments	cached	raos marinara sauce
+unlabeled	cached	prego pasta sauce
+condiments	cached	classico pasta sauce
+unlabeled	cached	alfredo sauce
+unlabeled	cached	vodka sauce
+unlabeled	cached	pesto
+condiments	new	bolognese sauce
+unlabeled	cached	salsa verde
+unlabeled	cached	queso dip
+unlabeled	cached	hummus
+unlabeled	cached	sabra hummus
+unlabeled	cached	tzatziki
+condiments	cached	french onion dip
+unlabeled	cached	buffalo sauce
+condiments	new	ranch dip
+unlabeled	cached	olive oil
+condiments	new	extra virgin olive oil
+unlabeled	cached	avocado oil
+unlabeled	cached	canola oil
+unlabeled	cached	vegetable oil
+unlabeled	cached	coconut oil
+unlabeled	cached	sesame oil
+condiments	new	cooking spray
+condiments	new	pam cooking spray
+unlabeled	cached	balsamic vinegar
+unlabeled	cached	apple cider vinegar
+unlabeled	cached	rice vinegar
+unlabeled	cached	red wine vinegar
+unlabeled	cached	peanut butter
+unlabeled	cached	jif peanut butter
+unlabeled	cached	skippy peanut butter
+condiments	cached	natural peanut butter
+unlabeled	cached	almond butter
+unlabeled	cached	cashew butter
+unlabeled	cached	sunflower seed butter
+unlabeled	cached	nutella
+unlabeled	cached	grape jelly
+unlabeled	cached	strawberry jam
+condiments	cached	raspberry jam
+condiments	cached	apricot preserves
+unlabeled	cached	honey
+unlabeled	cached	maple syrup
+condiments	cached	agave nectar
+condiments	new	molasses
+unlabeled	cached	apple butter
+condiments	cached	biscoff cookie butter
+condiments	cached	stevia
+condiments	new	splenda
+condiments	new	monk fruit sweetener
+condiments	new	truvia
+condiments	new	erythritol
+condiments	new	allulose
+condiments	cached	brown gravy
+condiments	cached	turkey gravy
+condiments	cached	chicken gravy
+condiments	new	marinade
+condiments	new	steak marinade
+condiments	cached	teriyaki marinade
+condiments	new	everything but the bagel seasoning
+condiments	new	old bay seasoning
+unlabeled	cached	taco seasoning
+condiments	new	ranch seasoning packet
+condiments	cached	garlic powder
+condiments	new	onion powder
+condiments	new	chili powder
+unlabeled	cached	cinnamon
+unlabeled	cached	salt
+unlabeled	cached	black pepper
+unlabeled	cached	paprika
+unlabeled	cached	cumin
+unlabeled	cached	italian seasoning
+condiments	cached	red pepper flakes
+unlabeled	cached	worcestershire sauce
+condiments	cached	a1 steak sauce
+unlabeled	cached	duck sauce
+condiments	new	frenchs mustard
+unlabeled	cached	kraft mayo
+condiments	cached	sir kensingtons ketchup
+condiments	new	lawrys seasoned salt
+condiments	new	mrs dash seasoning
+condiments	cached	better than bouillon
+desserts	new	ben and jerrys half baked
+desserts	new	ben and jerrys cherry garcia
+unlabeled	cached	ben and jerrys chocolate chip cookie dough
+desserts	new	haagen dazs vanilla
+unlabeled	cached	haagen dazs chocolate
+desserts	new	haagen dazs strawberry
+unlabeled	cached	halo top vanilla bean
+unlabeled	cached	halo top chocolate
+desserts	new	breyers natural vanilla
+desserts	new	blue bell homemade vanilla
+unlabeled	cached	talenti sea salt caramel gelato
+unlabeled	cached	talenti vanilla bean gelato
+desserts	cached	tillamook mudslide
+desserts	new	turkey hill vanilla
+desserts	cached	enlightened chocolate peanut butter
+desserts	new	yasso chocolate fudge bar
+unlabeled	cached	yasso mint chocolate chip bar
+desserts	new	nicks swedish chocolate ice cream
+desserts	cached	jenis brambleberry crisp
+desserts	new	store brand vanilla ice cream
+unlabeled	cached	vanilla ice cream
+unlabeled	cached	chocolate ice cream
+unlabeled	cached	strawberry ice cream
+unlabeled	cached	ice cream sandwich
+unlabeled	cached	klondike bar
+desserts	new	drumstick ice cream cone
+unlabeled	cached	popsicle
+desserts	cached	outshine strawberry bar
+desserts	cached	outshine mango bar
+unlabeled	cached	magnum ice cream bar
+desserts	new	fudgsicle
+desserts	new	creamsicle
+desserts	new	choco taco
+desserts	cached	dippin dots
+desserts	new	frozen yogurt
+desserts	cached	soft serve
+unlabeled	cached	vanilla milkshake
+unlabeled	cached	chocolate milkshake
+desserts	cached	root beer float
+unlabeled	cached	oreo
+unlabeled	cached	oreo double stuf
+unlabeled	cached	chips ahoy
+unlabeled	cached	nutter butter
+desserts	new	thin mints
+unlabeled	cached	samoas
+unlabeled	cached	tagalongs
+desserts	new	milano cookie
+desserts	cached	lotus biscoff cookie
+desserts	new	tates bake shop chocolate chip cookie
+desserts	new	famous amos chocolate chip cookie
+unlabeled	cached	chocolate chip cookie
+unlabeled	cached	sugar cookie
+desserts	new	snickerdoodle
+unlabeled	cached	oatmeal raisin cookie
+desserts	new	crumbl cookie
+desserts	cached	insomnia cookies deluxe
+desserts	new	gingerbread cookie
+unlabeled	cached	peanut butter cookie
+unlabeled	cached	macaron
+unlabeled	cached	chocolate cake
+unlabeled	cached	birthday cake
+unlabeled	cached	cheesecake
+desserts	new	strawberry cheesecake
+unlabeled	cached	carrot cake
+unlabeled	cached	red velvet cake
+desserts	new	pound cake
+unlabeled	cached	angel food cake
+unlabeled	cached	tiramisu
+unlabeled	cached	apple pie
+unlabeled	cached	pumpkin pie
+desserts	new	pecan pie
+unlabeled	cached	key lime pie
+unlabeled	cached	banana bread
+unlabeled	cached	brownie
+unlabeled	cached	blondie
+desserts	new	lava cake
+desserts	new	funnel cake
+desserts	new	cupcake
+unlabeled	cached	little debbie swiss rolls
+unlabeled	cached	little debbie oatmeal creme pies
+unlabeled	cached	little debbie zebra cakes
+unlabeled	cached	hostess twinkies
+unlabeled	cached	hostess ding dongs
+unlabeled	cached	hostess cupcakes
+desserts	cached	hostess fruit pie
+desserts	cached	entenmanns chocolate chip cookies
+desserts	cached	jello chocolate pudding
+desserts	new	jello vanilla pudding
+unlabeled	cached	chocolate pudding
+unlabeled	cached	rice pudding
+desserts	new	flan
+unlabeled	cached	creme brulee
+desserts	cached	chocolate mousse
+unlabeled	cached	churro
+desserts	new	cannoli
+unlabeled	cached	baklava
+desserts	new	mochi
+desserts	cached	mochi ice cream
+unlabeled	cached	gelato
+unlabeled	cached	sorbet
+desserts	cached	lemon sorbet
+unlabeled	cached	banana pudding
+desserts	new	smores
+desserts	cached	rice krispie treat
+desserts	new	cotton candy
+desserts	new	caramel apple
+desserts	new	strawberry shortcake
+desserts	cached	chocolate eclair
+desserts	new	napoleon pastry
+unlabeled	cached	tres leches cake
+desserts	cached	black forest cake
+desserts	cached	german chocolate cake
+desserts	cached	lemon bars
+desserts	cached	peach cobbler
+desserts	cached	apple crisp
+desserts	cached	bread pudding
+desserts	cached	ice cream cake
+desserts	cached	soft serve vanilla cone
+desserts	cached	vanilla wafers
+unlabeled	cached	graham crackers
+desserts	cached	fruit tart
+desserts	new	italian ice
+desserts	cached	snow cone
+desserts	new	custard
+unlabeled	cached	tacos al pastor
+mexican	new	carne asada taco
+unlabeled	cached	carnitas taco
+unlabeled	new	fish taco
+mexican	new	shrimp taco
+unlabeled	cached	birria taco
+unlabeled	cached	breakfast taco
+mexican	new	ground beef taco
+mexican	new	chicken taco
+mexican	new	street tacos
+unlabeled	cached	bean and cheese burrito
+mexican	new	california burrito
+mexican	new	wet burrito
+mexican	new	chimichanga
+mexican	new	chicken enchiladas
+mexican	new	cheese enchiladas
+mexican	new	beef enchiladas
+mexican	new	enchiladas verdes
+mexican	new	enchiladas suizas
+unlabeled	cached	quesadilla
+unlabeled	cached	chicken quesadilla
+mexican	new	steak quesadilla
+mexican	new	cheese quesadilla
+unlabeled	cached	tostada
+mexican	new	bean tostada
+unlabeled	cached	sopes
+unlabeled	cached	gorditas
+unlabeled	cached	tamale
+mexican	new	pork tamale
+mexican	new	chicken tamale
+mexican	new	cheese tamale
+mexican	new	sweet tamale
+unlabeled	cached	pozole
+mexican	new	pozole rojo
+unlabeled	cached	menudo
+mexican	new	birria
+mexican	new	birria de res
+unlabeled	cached	barbacoa
+unlabeled	cached	carnitas
+mexican	new	al pastor
+unlabeled	cached	chile relleno
+mexican	new	mole
+mexican	new	chicken mole
+unlabeled	cached	chilaquiles
+mexican	new	chilaquiles verdes
+mexican	new	chilaquiles rojos
+unlabeled	cached	huevos rancheros
+mexican	new	migas
+unlabeled	cached	elote
+mexican	new	esquites
+mexican	cached	nachos
+mexican	new	loaded nachos
+unlabeled	cached	chicken fajitas
+mexican	new	steak fajitas
+mexican	new	shrimp fajitas
+unlabeled	cached	taco salad
+mexican	new	arroz con pollo
+mexican	cached	rice and beans
+mexican	new	mexican rice
+mexican	new	queso fundido
+unlabeled	cached	ceviche
+mexican	new	shrimp ceviche
+mexican	new	aguachile
+mexican	new	tortilla soup
+unlabeled	cached	horchata
+mexican	new	agua fresca
+mexican	new	jarritos
+mexican	new	salsa roja
+mexican	new	salsa macha
+mexican	new	salsa taquera
+unlabeled	cached	empanadas
+mexican	new	beef empanadas
+mexican	new	chicken empanadas
+unlabeled	cached	pupusas
+mexican	new	pupusas de queso
+mexican	new	pupusas revueltas
+mexican	new	fried plantains
+mexican	new	maduros
+mexican	new	mangonada
+mexican	new	paletas
+mexican	new	huarache
+mexican	new	taco de lengua
+mexican	new	taco de tripa
+mexican	new	taco de cabeza
+mexican	new	suadero taco
+mexican	new	carne en su jugo
+mexican	new	caldo de res
+mexican	new	caldo de pollo
+mexican	new	sopa de fideo
+mexican	new	frijoles charros
+mexican	new	picadillo
+mexican	new	tinga de pollo
+mexican	new	cochinita pibil
+mexican	new	huitlacoche quesadilla
+mexican	new	esquites con queso
+mexican	new	michelada
+mexican	new	jamaica agua fresca
+mexican	new	tamarindo agua fresca
+mexican	new	conchas
+mexican	new	pan dulce
+mexican	new	cemita
+asian	new	chicken pad thai
+unlabeled	cached	pad see ew
+asian	new	drunken noodles
+asian	new	green curry chicken
+asian	new	red curry chicken
+unlabeled	cached	massaman curry
+asian	new	panang curry
+unlabeled	cached	tom yum soup
+unlabeled	cached	tom kha gai
+asian	new	larb
+unlabeled	cached	papaya salad
+asian	new	thai fried rice
+unlabeled	cached	mango sticky rice
+asian	new	chicken satay
+unlabeled	cached	orange chicken
+asian	cached	general tso's chicken
+asian	new	sesame chicken
+unlabeled	cached	kung pao chicken
+asian	new	beef and broccoli
+asian	new	mongolian beef
+unlabeled	cached	lo mein
+unlabeled	cached	chow mein
+asian	cached	egg roll
+unlabeled	cached	spring roll
+asian	new	crab rangoon
+unlabeled	cached	wonton soup
+asian	new	egg drop soup
+unlabeled	cached	hot and sour soup
+asian	new	pork dumplings
+unlabeled	cached	potstickers
+asian	new	steamed pork bun
+unlabeled	cached	char siu
+unlabeled	cached	mapo tofu
+asian	new	dan dan noodles
+asian	new	salt and pepper shrimp
+unlabeled	cached	california roll
+asian	new	spicy tuna roll
+asian	new	rainbow roll
+asian	new	dragon roll
+asian	new	philadelphia roll
+asian	new	salmon nigiri
+asian	new	tuna sashimi
+unlabeled	cached	poke bowl
+unlabeled	cached	tonkotsu ramen
+asian	new	shoyu ramen
+asian	new	miso ramen
+asian	new	udon noodle soup
+asian	new	tempura shrimp
+unlabeled	cached	chicken katsu
+asian	new	tonkatsu
+unlabeled	cached	katsu curry
+unlabeled	cached	teriyaki chicken
+asian	new	hibachi chicken
+asian	new	hibachi steak
+unlabeled	cached	gyoza
+unlabeled	cached	miso soup
+unlabeled	cached	onigiri
+unlabeled	cached	takoyaki
+asian	new	japanese curry
+unlabeled	cached	bibimbap
+unlabeled	cached	bulgogi
+asian	new	korean bbq short ribs
+asian	new	galbi
+unlabeled	cached	japchae
+unlabeled	cached	tteokbokki
+unlabeled	cached	kimchi jjigae
+unlabeled	cached	korean fried chicken
+asian	new	kimbap
+unlabeled	cached	sundubu jjigae
+unlabeled	cached	korean corn dog
+unlabeled	cached	pho
+unlabeled	cached	banh mi
+asian	new	vermicelli bowl
+asian	new	vietnamese summer rolls
+unlabeled	cached	vietnamese iced coffee
+asian	new	bun bo hue
+unlabeled	cached	chicken tikka masala
+unlabeled	cached	butter chicken
+unlabeled	cached	chana masala
+unlabeled	cached	palak paneer
+unlabeled	cached	saag paneer
+unlabeled	cached	dal
+asian	new	dal makhani
+unlabeled	cached	chicken biryani
+unlabeled	cached	tandoori chicken
+unlabeled	cached	samosa
+unlabeled	cached	roti
+asian	new	chapati
+unlabeled	cached	dosa
+asian	new	idli
+unlabeled	cached	aloo gobi
+asian	new	chicken korma
+asian	new	lamb vindaloo
+unlabeled	cached	raita
+asian	new	mango lassi
+asian	new	paneer tikka
+unlabeled	cached	chicken adobo
+unlabeled	cached	lumpia
+unlabeled	cached	pancit
+unlabeled	cached	sinigang
+asian	new	lechon
+asian	new	shrimp lo mein
+asian	new	beef chow fun
+unlabeled	cached	scallion pancake
+asian	new	sweet and sour chicken
+asian	new	black pepper beef
+asian	new	szechuan chicken
+asian	new	orange beef
+asian	new	honey walnut shrimp
+asian	new	unagi roll
+asian	new	shrimp tempura roll
+asian	new	vegetable tempura
+asian	cached	chicken teriyaki bowl
+asian	new	beef bulgogi bowl
+asian	new	spicy pork bulgogi
+unlabeled	cached	kimchi fried rice
+asian	new	japchae noodles
+asian	new	seaweed salad
+asian	new	chicken pho
+asian	new	beef pho
+asian	new	vietnamese spring rolls
+asian	new	lamb biryani
+asian	new	vegetable biryani
+asian	new	paneer butter masala
+asian	new	malai kofta
+asian	new	chettinad chicken
+asian	new	masala dosa
+asian	new	pad kra pao
+unlabeled	cached	thai basil chicken
+asian	new	khao soi
+asian	new	chicken satay skewers
+asian	new	shrimp pad thai
+american-home	cached	spaghetti and meatballs
+unlabeled	cached	chicken parmesan
+american-home	cached	eggplant parmesan
+unlabeled	cached	fettuccine alfredo
+unlabeled	cached	chicken alfredo
+american-home	new	lasagna
+american-home	new	baked ziti
+american-home	cached	penne vodka
+unlabeled	cached	carbonara
+american-home	cached	cacio e pepe
+unlabeled	cached	shrimp scampi
+american-home	cached	chicken piccata
+american-home	cached	chicken marsala
+unlabeled	new	risotto
+unlabeled	cached	meatball sub
+unlabeled	cached	garlic bread
+unlabeled	cached	bruschetta
+unlabeled	cached	caprese salad
+american-home	new	minestrone
+unlabeled	cached	meatloaf
+american-home	cached	pot roast
+american-home	new	beef stew
+american-home	new	chili
+american-home	cached	turkey chili
+unlabeled	cached	shepherd's pie
+american-home	cached	chicken pot pie
+unlabeled	cached	tuna casserole
+unlabeled	cached	green bean casserole
+american-home	cached	mac and cheese
+american-home	new	baked mac and cheese
+american-home	cached	chicken and waffles
+american-home	cached	chicken fried steak
+american-home	new	bbq ribs
+unlabeled	cached	pulled pork sandwich
+american-home	new	brisket plate
+american-home	cached	sloppy joe
+american-home	cached	salisbury steak
+american-home	cached	stuffed peppers
+american-home	new	chicken and rice
+american-home	new	jambalaya
+american-home	new	gumbo
+american-home	cached	crawfish etouffee
+unlabeled	cached	clam chowder
+unlabeled	cached	lobster roll
+american-home	cached	crab cakes
+american-home	cached	fish and chips
+unlabeled	cached	philly cheesesteak
+american-home	new	reuben
+american-home	new	blt
+unlabeled	cached	club sandwich
+american-home	new	grilled cheese
+unlabeled	cached	tuna salad sandwich
+american-home	cached	chicken salad sandwich
+american-home	new	egg salad sandwich
+unlabeled	cached	turkey sandwich
+american-home	cached	chili dog
+unlabeled	cached	corn dog
+unlabeled	cached	chicken noodle soup
+unlabeled	cached	tomato soup
+american-home	cached	broccoli cheddar soup
+unlabeled	cached	potato soup
+american-home	new	split pea soup
+unlabeled	cached	lentil soup
+unlabeled	cached	french onion soup
+unlabeled	cached	chicken tortilla soup
+american-home	cached	beef barley soup
+unlabeled	cached	butternut squash soup
+unlabeled	cached	caesar salad
+unlabeled	cached	chicken caesar salad
+unlabeled	cached	cobb salad
+unlabeled	cached	greek salad
+unlabeled	cached	garden salad
+american-home	new	chef salad
+american-home	new	wedge salad
+unlabeled	cached	spinach salad
+unlabeled	cached	kale salad
+unlabeled	cached	pasta salad
+american-home	new	potato salad
+unlabeled	cached	macaroni salad
+american-home	new	broccoli salad
+american-home	new	three bean salad
+unlabeled	cached	quinoa salad
+unlabeled	cached	chicken salad
+unlabeled	cached	tuna salad
+american-home	new	egg salad
+american-home	new	baked potato
+american-home	new	loaded baked potato
+american-home	cached	french fries
+american-home	cached	sweet potato fries
+unlabeled	cached	tater tots
+unlabeled	cached	stuffing
+unlabeled	cached	deviled eggs
+american-home	new	mac salad
+american-home	cached	cole slaw
+american-home	cached	onion rings
+american-home	cached	hush puppies
+american-home	cached	chicken parmesan sandwich
+american-home	cached	eggplant rollatini
+american-home	cached	stuffed shells
+american-home	new	manicotti
+unlabeled	cached	spaghetti carbonara
+american-home	cached	italian wedding soup
+american-home	cached	sausage and peppers
+american-home	cached	chicken cacciatore
+unlabeled	cached	osso buco
+american-home	cached	veal parmesan
+american-home	cached	tortellini soup
+american-home	cached	zuppa toscana
+american-home	cached	pasta e fagioli
+american-home	new	antipasto salad
+unlabeled	cached	italian sub
+american-home	new	meatball parmesan sandwich
+american-home	new	prosciutto and melon
+american-home	cached	chicken tetrazzini
+american-home	cached	king ranch chicken
+american-home	cached	beef stroganoff
+american-home	cached	swedish meatballs
+american-home	new	chicken divan
+unlabeled	cached	scalloped potatoes
+american-home	new	au gratin potatoes
+american-home	cached	turkey pot pie
+american-home	cached	beef pot pie
+american-home	cached	country fried steak
+american-home	new	smothered chicken
+american-home	new	chicken fried rice
+american-home	new	pepper steak
+american-home	cached	beef fajitas
+american-home	cached	buffalo chicken sandwich
+american-home	cached	buffalo chicken salad
+american-home	cached	crab bisque
+american-home	cached	new england clam chowder
+american-home	cached	manhattan clam chowder
+american-home	cached	seafood gumbo
+american-home	cached	chicken and dumplings
+american-home	cached	turkey club sandwich
+unlabeled	cached	ham and cheese sandwich
+american-home	cached	italian beef sandwich
+american-home	cached	meatball soup
+american-home	new	sausage and peppers sandwich
+american-home	cached	chicken parmesan pasta
+mediterranean-global	new	gyro
+unlabeled	cached	chicken gyro
+mediterranean-global	new	lamb gyro
+unlabeled	cached	souvlaki
+unlabeled	cached	spanakopita
+mediterranean-global	new	moussaka
+unlabeled	cached	pastitsio
+unlabeled	cached	dolma
+unlabeled	cached	feta
+mediterranean-global	new	avgolemono
+mediterranean-global	new	loukoumades
+unlabeled	cached	greek yogurt bowl
+mediterranean-global	new	keftedes
+mediterranean-global	new	saganaki
+mediterranean-global	new	tiropita
+mediterranean-global	new	galaktoboureko
+mediterranean-global	new	greek lemon potatoes
+unlabeled	cached	falafel
+mediterranean-global	cached	chicken shawarma
+mediterranean-global	new	beef shawarma
+unlabeled	cached	baba ganoush
+unlabeled	cached	tabbouleh
+unlabeled	cached	fattoush
+unlabeled	cached	kebab
+mediterranean-global	new	shish kebab
+mediterranean-global	new	kofta
+unlabeled	cached	kibbeh
+mediterranean-global	new	mujadara
+unlabeled	cached	shakshuka
+unlabeled	cached	labneh
+unlabeled	cached	halloumi
+mediterranean-global	new	za'atar manakish
+mediterranean-global	new	chicken kabob plate
+mediterranean-global	cached	harissa chicken
+mediterranean-global	cached	chicken tawook
+mediterranean-global	new	muhammara
+mediterranean-global	cached	foul medames
+mediterranean-global	new	fatteh
+mediterranean-global	cached	lebanese lentil soup
+mediterranean-global	new	couscous tagine
+mediterranean-global	new	harira
+mediterranean-global	new	merguez
+unlabeled	cached	pierogi
+unlabeled	cached	borscht
+unlabeled	cached	stuffed cabbage
+mediterranean-global	new	goulash
+unlabeled	cached	schnitzel
+mediterranean-global	new	bratwurst plate
+unlabeled	cached	spaetzle
+mediterranean-global	new	blintz
+mediterranean-global	new	latke
+mediterranean-global	new	kasha
+mediterranean-global	cached	chicken paprikash
+mediterranean-global	new	pelmeni
+mediterranean-global	new	kolache
+unlabeled	cached	jerk chicken
+mediterranean-global	new	oxtail
+unlabeled	new	curry goat
+unlabeled	cached	rice and peas
+unlabeled	cached	plantains
+unlabeled	cached	tostones
+mediterranean-global	new	mofongo
+mediterranean-global	cached	ropa vieja
+unlabeled	cached	cuban sandwich
+unlabeled	cached	arepa
+unlabeled	cached	feijoada
+mediterranean-global	new	churrasco
+mediterranean-global	cached	chimichurri steak
+mediterranean-global	new	ceviche peruano
+unlabeled	cached	lomo saltado
+mediterranean-global	new	pollo a la brasa
+mediterranean-global	new	tres leches
+unlabeled	cached	pernil
+mediterranean-global	new	mondongo
+mediterranean-global	new	sancocho
+mediterranean-global	cached	arroz con gandules
+mediterranean-global	new	alcapurria
+mediterranean-global	new	mangu
+unlabeled	cached	jollof rice
+mediterranean-global	new	injera
+unlabeled	cached	doro wat
+unlabeled	new	suya
+mediterranean-global	new	bobotie
+unlabeled	cached	egusi soup
+unlabeled	cached	fufu
+mediterranean-global	new	kelewele
+mediterranean-global	cached	fried catfish
+mediterranean-global	cached	smothered pork chops
+mediterranean-global	cached	oxtail stew
+unlabeled	cached	candied yams
+mediterranean-global	new	cornbread dressing
+mediterranean-global	new	chitterlings
+mediterranean-global	new	okra and tomatoes
+mediterranean-global	cached	fried okra
+mediterranean-global	cached	red beans and rice
+mediterranean-global	cached	hoppin john
+mediterranean-global	cached	matzo ball soup
+mediterranean-global	new	pastrami on rye
+mediterranean-global	new	knish
+mediterranean-global	new	bagel and lox
+unlabeled	cached	challah
+store-brands	new	kirkland signature rotisserie chicken
+store-brands	new	kirkland signature organic chicken breast
+store-brands	cached	kirkland signature protein bars
+store-brands	cached	kirkland signature almonds
+store-brands	new	kirkland signature extra virgin olive oil
+store-brands	cached	kirkland signature quinoa
+store-brands	cached	kirkland signature greek yogurt
+store-brands	new	kirkland signature chocolate covered almonds
+store-brands	cached	kirkland signature muffins
+store-brands	cached	kirkland signature croissants
+store-brands	cached	kirkland signature wild salmon
+store-brands	new	kirkland signature ground beef
+store-brands	new	kirkland signature shredded mozzarella cheese
+store-brands	cached	kirkland signature granola
+store-brands	cached	kirkland signature trail mix
+store-brands	cached	kirkland signature bacon
+store-brands	new	kirkland signature creamy peanut butter
+store-brands	new	kirkland signature mixed nuts
+store-brands	new	kirkland signature protein shake
+store-brands	new	kirkland signature organic eggs
+store-brands	new	kirkland signature dried mango
+store-brands	cached	kirkland signature cashews
+store-brands	new	kirkland signature turkey bacon
+store-brands	cached	kirkland signature chicken sausage
+store-brands	cached	trader joes cauliflower gnocchi
+store-brands	new	trader joes everything but the bagel seasoning
+store-brands	cached	trader joes mandarin orange chicken
+store-brands	new	trader joes chili onion crunch
+unlabeled	cached	trader joes dark chocolate peanut butter cups
+store-brands	cached	trader joes unexpected cheddar
+store-brands	new	trader joes joe joes
+store-brands	cached	trader joes soy chorizo
+store-brands	new	trader joes frozen orange chicken
+store-brands	cached	trader joes cold brew
+store-brands	cached	trader joes hold the cone
+store-brands	new	trader joes elote dip
+store-brands	cached	trader joes tzatziki
+store-brands	new	trader joes protein pasta
+store-brands	cached	trader joes cornbread crunch
+store-brands	cached	trader joes vegetable gyoza
+store-brands	cached	trader joes chicken tikka masala
+store-brands	new	trader joes pumpkin spice granola
+store-brands	cached	trader joes speculoos cookie butter
+store-brands	new	trader joes gone bananas
+store-brands	cached	trader joes scandinavian swimmers
+store-brands	new	trader joes kung pao chicken burrito
+store-brands	new	trader joes vanilla almondmilk yogurt
+store-brands	cached	trader joes turkey burgers
+store-brands	new	great value shredded cheddar cheese
+store-brands	new	great value 2 percent milk
+store-brands	new	great value creamy peanut butter
+unlabeled	cached	great value white bread
+store-brands	new	great value greek yogurt
+store-brands	new	great value frozen chicken breast
+unlabeled	cached	great value trail mix
+store-brands	new	great value granola bars
+store-brands	cached	great value orange juice
+store-brands	new	great value large eggs
+store-brands	cached	great value macaroni and cheese
+store-brands	cached	great value almonds
+store-brands	cached	great value string cheese
+store-brands	new	good and gather chicken breast
+store-brands	cached	good and gather greek yogurt
+store-brands	new	good and gather trail mix
+store-brands	cached	good and gather almond butter
+store-brands	new	good and gather sparkling water
+store-brands	cached	good and gather rotisserie chicken
+store-brands	cached	good and gather granola
+store-brands	new	favorite day ice cream sandwiches
+store-brands	cached	favorite day chocolate chip cookies
+store-brands	cached	simply nature organic peanut butter
+store-brands	new	millville honey nut toasted oats
+store-brands	cached	clancys tortilla chips
+store-brands	cached	fit and active protein shake
+store-brands	cached	specially selected croissants
+store-brands	cached	simply nature almond butter
+store-brands	cached	millville granola bars
+store-brands	new	clancys pretzels
+store-brands	new	365 organic peanut butter
+store-brands	new	365 greek yogurt
+store-brands	new	365 organic chicken broth
+store-brands	new	365 trail mix
+store-brands	new	365 organic tortilla chips
+store-brands	new	365 organic quinoa
+store-brands	new	365 organic whole milk
+store-brands	new	simple truth organic chicken breast
+store-brands	cached	simple truth greek yogurt
+store-brands	cached	simple truth almond butter
+store-brands	new	kroger shredded cheddar cheese
+store-brands	new	kroger 2 percent milk
+store-brands	cached	simple truth emerge protein bar
+store-brands	cached	kroger peanut butter
+store-brands	cached	publix deli fried chicken
+store-brands	new	publix pecan pie
+store-brands	cached	publix key lime pie
+store-brands	new	publix greenwise chicken breast
+store-brands	cached	publix sub sandwich
+store-brands	cached	wegmans organic greek yogurt
+store-brands	new	wegmans italian classics chicken parmesan
+store-brands	cached	wegmans trail mix
+store-brands	cached	wegmans salted caramel gelato
+store-brands	new	signature select sparkling water
+store-brands	cached	signature select greek yogurt
+store-brands	cached	signature select trail mix
+store-brands	new	signature select butter
+store-brands	cached	heb rotisserie chicken
+store-brands	new	heb greek yogurt
+store-brands	cached	heb creamy peanut butter
+store-brands	cached	heb tortillas
+store-brands	new	members mark rotisserie chicken
+store-brands	cached	members mark greek yogurt
+store-brands	cached	members mark trail mix
+store-brands	cached	members mark almonds
+store-brands	new	members mark protein bar
+store-brands	new	members mark chicken breast
+store-brands	cached	sprouts organic peanut butter
+store-brands	cached	sprouts trail mix
+store-brands	cached	sprouts almond butter
+store-brands	new	sprouts brand granola
+store-brands	new	amazon fresh greek yogurt
+store-brands	new	amazon fresh chicken breast
+store-brands	new	amazon fresh trail mix
+store-brands	new	amazon fresh almond butter
+sitdown-chains	cached	applebees bourbon street chicken
+sitdown-chains	cached	applebees fiesta lime chicken
+unlabeled	new	applebees riblets
+sitdown-chains	new	applebees three cheese chicken penne
+sitdown-chains	cached	applebees oriental chicken salad
+sitdown-chains	new	applebees classic bacon cheeseburger
+sitdown-chains	new	applebees boneless wings
+sitdown-chains	cached	chilis molten lava cake
+unlabeled	new	chilis baby back ribs
+sitdown-chains	cached	chilis chicken crispers
+sitdown-chains	new	chilis fajitas
+sitdown-chains	new	chilis triple dipper
+unlabeled	new	chilis queso
+sitdown-chains	new	chilis southwestern eggrolls
+unlabeled	new	olive garden breadsticks
+sitdown-chains	new	olive garden fettuccine alfredo
+sitdown-chains	new	olive garden lasagna classico
+sitdown-chains	cached	olive garden zuppa toscana
+sitdown-chains	new	olive garden chicken parmigiana
+sitdown-chains	new	olive garden tour of italy
+sitdown-chains	cached	olive garden five cheese ziti al forno
+sitdown-chains	cached	olive garden shrimp scampi
+unlabeled	cached	texas roadhouse rolls
+unlabeled	new	texas roadhouse cactus blossom
+sitdown-chains	cached	texas roadhouse fried pickles
+sitdown-chains	new	texas roadhouse country fried sirloin
+sitdown-chains	new	texas roadhouse dallas filet
+sitdown-chains	new	texas roadhouse cinnamon butter
+sitdown-chains	cached	texas roadhouse grilled bbq chicken
+sitdown-chains	new	outback bloomin onion
+sitdown-chains	new	outback alice springs chicken
+sitdown-chains	cached	outback bushman bread
+sitdown-chains	new	outback aussie cheese fries
+sitdown-chains	cached	outback baby back ribs
+sitdown-chains	new	outback toowoomba chicken
+sitdown-chains	cached	longhorn parmesan crusted chicken
+sitdown-chains	new	longhorn renegade sirloin
+sitdown-chains	new	longhorn wild west shrimp
+sitdown-chains	new	longhorn firecracker chicken wraps
+sitdown-chains	new	cheesecake factory original cheesecake
+sitdown-chains	cached	cheesecake factory chicken madeira
+sitdown-chains	new	cheesecake factory avocado eggrolls
+sitdown-chains	new	cheesecake factory bang bang chicken and shrimp
+sitdown-chains	cached	cheesecake factory louisiana chicken pasta
+sitdown-chains	new	cheesecake factory oreo dream extreme cheesecake
+unlabeled	cached	red lobster cheddar bay biscuits
+sitdown-chains	new	red lobster ultimate feast
+sitdown-chains	new	red lobster walts favorite shrimp
+sitdown-chains	cached	red lobster garlic shrimp scampi
+sitdown-chains	new	red lobster admirals feast
+sitdown-chains	cached	tgi fridays loaded potato skins
+sitdown-chains	cached	tgi fridays jack daniels glazed ribs
+sitdown-chains	new	tgi fridays sesame jack chicken strips
+sitdown-chains	new	buffalo wild wings ultimate nachos
+unlabeled	new	cracker barrel chicken and dumplings
+sitdown-chains	new	cracker barrel country fried steak
+sitdown-chains	cached	cracker barrel meatloaf
+unlabeled	new	cracker barrel hashbrown casserole
+sitdown-chains	cached	cracker barrel sunday homestyle chicken
+sitdown-chains	new	cracker barrel pancakes
+sitdown-chains	new	ihop 2 x 2 x 2
+sitdown-chains	new	ihop rooty tooty fresh n fruity
+sitdown-chains	cached	ihop original buttermilk pancakes
+sitdown-chains	cached	ihop colorado omelette
+sitdown-chains	new	ihop cinn a stack pancakes
+sitdown-chains	new	ihop philly cheese steak stacker
+unlabeled	cached	dennys grand slam
+sitdown-chains	new	dennys moons over my hammy
+sitdown-chains	new	dennys lumberjack slam
+sitdown-chains	new	dennys country fried steak and eggs
+sitdown-chains	new	waffle house waffle
+sitdown-chains	cached	waffle house hashbrowns
+sitdown-chains	new	waffle house all star special
+sitdown-chains	new	waffle house bacon cheese steak melt
+sitdown-chains	new	first watch avocado toast
+sitdown-chains	new	first watch quinoa power bowl
+sitdown-chains	new	first watch million dollar bacon
+sitdown-chains	new	first watch chickichanga
+sitdown-chains	cached	red robin whiskey river bbq burger
+sitdown-chains	new	red robin bonzai burger
+sitdown-chains	cached	red robin bottomless steak fries
+sitdown-chains	new	red robin tavern double burger
+sitdown-chains	new	bjs pizookie
+sitdown-chains	cached	bjs deep dish pizza
+sitdown-chains	new	bjs avocado eggrolls
+sitdown-chains	new	bjs brewhouse burger
+sitdown-chains	new	yard house nashville hot chicken sandwich
+sitdown-chains	new	yard house poke nachos
+sitdown-chains	new	yard house garlic noodles
+sitdown-chains	cached	pf changs orange chicken
+sitdown-chains	cached	pf changs dynamite shrimp
+sitdown-chains	cached	pf changs mongolian beef
+sitdown-chains	cached	pf changs chicken lettuce wraps
+sitdown-chains	new	cheddars scratch made croissants
+sitdown-chains	new	cheddars monte cristo sandwich
+sitdown-chains	new	cheddars painted hills sirloin
+sitdown-chains	new	carrabbas chicken bryan
+sitdown-chains	new	carrabbas lasagne verde
+sitdown-chains	new	carrabbas tagliarini picchi pacchiu
+sitdown-chains	new	maggianos rigatoni d
+sitdown-chains	new	maggianos chicken parmesan
+sitdown-chains	new	maggianos moms lasagna
+sitdown-chains	new	bonefish grill bang bang shrimp
+sitdown-chains	cached	bonefish grill chilean sea bass
+sitdown-chains	new	bonefish grill saucy shrimp
+sitdown-chains	cached	ruths chris filet mignon
+sitdown-chains	new	ruths chris sweet potato casserole
+sitdown-chains	new	ruths chris bone in ribeye
+sitdown-chains	new	dave and busters bourbon bacon burger
+sitdown-chains	new	chuys chicken flauta
+sitdown-chains	new	chuys creamy jalapeno dip
+sitdown-chains	cached	on the border stacked enchiladas
+sitdown-chains	cached	on the border queso
+sitdown-chains	cached	ruby tuesday garden bar
+sitdown-chains	new	ruby tuesday triple prime burger
+sitdown-chains	cached	golden corral pot roast
+sitdown-chains	cached	golden corral yeast rolls
+sitdown-chains	new	golden corral fried chicken
+sitdown-chains	cached	golden corral bourbon street chicken
+kids-misc	cached	lunchables ham and cheese
+kids-misc	new	uncrustables peanut butter and jelly
+kids-misc	cached	gogo squeez applesauce pouch
+kids-misc	new	welch's fruit snacks
+kids-misc	new	mott's fruit snacks
+kids-misc	cached	fruit roll ups
+kids-misc	new	gushers
+unlabeled	cached	animal crackers
+kids-misc	cached	teddy grahams
+unlabeled	cached	nilla wafers
+kids-misc	new	danimals smoothie
+kids-misc	cached	yoplait go-gurt
+kids-misc	cached	pb and j sandwich
+kids-misc	new	ants on a log
+kids-misc	new	apple slices with peanut butter
+unlabeled	cached	kraft mac and cheese
+kids-misc	cached	easy mac
+kids-misc	new	spaghettios
+unlabeled	cached	chef boyardee ravioli
+kids-misc	new	ramen packet
+kids-misc	new	cup noodles
+unlabeled	cached	hot pockets
+unlabeled	cached	bagel bites
+kids-misc	new	pop-tarts
+kids-misc	cached	rice krispies treats
+kids-misc	cached	nutri-grain bars
+unlabeled	cached	belvita breakfast biscuits
+kids-misc	new	taquito
+kids-misc	cached	beef stick
+kids-misc	new	slurpee
+kids-misc	new	big gulp
+unlabeled	cached	sunflower seeds
+kids-misc	cached	gum
+unlabeled	cached	rice cakes
+kids-misc	cached	corn thins
+kids-misc	cached	cauliflower crust pizza
+kids-misc	new	egg bites
+kids-misc	cached	starbucks egg bites
+unlabeled	cached	chia pudding
+unlabeled	cached	smoothie
+unlabeled	cached	protein smoothie
+kids-misc	new	green juice
+kids-misc	new	celery juice
+kids-misc	new	meal prep bowl
+kids-misc	new	gerber puree
+kids-misc	new	baby oatmeal
+kids-misc	cached	gerber puffs
+kids-misc	new	plum organics pouch
+kids-misc	cached	fiber gummies
+kids-misc	new	multivitamin gummy
+kids-misc	new	airborne
+kids-misc	new	emergen-c
+kids-misc	new	water
+kids-misc	new	ice
+kids-misc	new	leftover pizza
+kids-misc	new	leftover chinese food
+kids-misc	new	homemade smoothie
+kids-misc	new	protein oatmeal
+kids-misc	new	salad with chicken
+kids-misc	new	lunchables pizza
+kids-misc	new	lunchables turkey and cheddar
+kids-misc	new	uncrustables chocolate hazelnut
+kids-misc	new	danimals smoothie squeeze
+kids-misc	cached	gushers tropical
+kids-misc	cached	fruit by the foot
+kids-misc	new	kraft easy mac cups
+kids-misc	cached	chef boyardee mini ravioli
+kids-misc	new	maruchan ramen
+kids-misc	cached	nissin cup noodles
+unlabeled	cached	hot pockets pepperoni pizza
+kids-misc	new	bagel bites pepperoni
+kids-misc	new	nature valley oats and honey bar
+kids-misc	cached	quaker granola bar
+kids-misc	cached	belvita blueberry
+kids-misc	new	combos
+kids-misc	new	pringles single serve
+unlabeled	cached	jello cup
+kids-misc	cached	pudding cup
+kids-misc	cached	applesauce cup
+kids-misc	new	horizon organic milk box
+kids-misc	new	gerber baby food stage 2
+kids-misc	new	gerber teether biscuits
+kids-misc	new	happy baby puffs
+kids-misc	cached	plum organics baby food
+kids-misc	new	munchkin snack cup
+kids-misc	new	world's finest chocolate bar
+kids-misc	new	takis
+kids-misc	new	rice krispies treats big
+unlabeled	cached	kind bar
+kids-misc	cached	clif bar kids
+kids-misc	new	lara bar
+kids-misc	cached	special k bar
+kids-misc	new	kellogg's pop tarts brown sugar
+kids-misc	cached	oreo cakesters
+kids-misc	new	uncrustables strawberry
+kids-misc	new	gushers berry
+kids-misc	cached	nature's bakery fig bar
+kids-misc	cached	frito lay variety pack
+kids-misc	cached	quaker granola bar chocolate chip
+kids-misc	cached	gogo squeez yogurtz
+kids-misc	cached	stonyfield yokids
+kids-misc	new	chobani kids yogurt tube
+kids-misc	cached	go-gurt strawberry
+kids-misc	cached	horizon organic string cheese
+kids-misc	new	mott's applesauce cup
+kids-misc	cached	nutri-grain strawberry
+kids-misc	new	egg white bites
+kids-misc	cached	cottage cheese bowl
+condiments	cached	heinz tomato ketchup
+condiments	cached	heinz reduced sugar ketchup
+condiments	cached	hunt's tomato ketchup
+condiments	cached	french's tomato ketchup
+condiments	cached	hellmann's real mayonnaise
+condiments	cached	hellmann's light mayonnaise
+condiments	cached	kraft real mayo
+condiments	new	kraft mayo with olive oil
+condiments	cached	best foods real mayonnaise
+condiments	cached	sir kensington's classic mayonnaise
+condiments	cached	primal kitchen avocado oil mayo
+condiments	new	french's classic yellow mustard
+condiments	cached	grey poupon dijon mustard
+condiments	new	gulden's spicy brown mustard
+condiments	cached	heinz yellow mustard
+condiments	new	frank's redhot original
+condiments	new	tabasco original red sauce
+condiments	new	cholula original hot sauce
+condiments	cached	huy fong sriracha hot chili sauce
+condiments	new	texas pete hot sauce
+condiments	cached	sweet baby ray's original barbecue sauce
+condiments	cached	sweet baby ray's honey barbecue sauce
+condiments	cached	kraft original barbecue sauce
+condiments	cached	stubb's original bbq sauce
+condiments	cached	bull's-eye original barbecue sauce
+condiments	cached	hidden valley light ranch dressing
+condiments	cached	kraft ranch dressing
+condiments	cached	newman's own ranch dressing
+condiments	cached	ken's steak house italian dressing
+condiments	new	walden farms zero calorie ranch dressing
+condiments	cached	bolthouse farms yogurt ranch dressing
+condiments	cached	wish-bone italian dressing
+condiments	new	marzetti simply dressed balsamic vinaigrette
+condiments	cached	tostitos chunky salsa
+condiments	cached	pace picante sauce
+condiments	cached	herdez salsa verde
+condiments	cached	old el paso thick n chunky salsa
+condiments	cached	kikkoman soy sauce
+condiments	new	kikkoman low sodium soy sauce
+condiments	cached	kikkoman teriyaki marinade and sauce
+condiments	cached	la choy soy sauce
+condiments	cached	san-j tamari soy sauce
+condiments	cached	jif creamy peanut butter
+condiments	cached	jif natural creamy peanut butter
+condiments	cached	skippy creamy peanut butter
+condiments	cached	peter pan creamy peanut butter
+condiments	cached	justin's classic almond butter
+condiments	cached	smucker's natural peanut butter
+condiments	cached	smucker's strawberry jam
+condiments	cached	welch's grape jelly
+condiments	new	log cabin original syrup
+condiments	cached	mrs. butterworth's original syrup
+condiments	cached	pearl milling company original syrup
+condiments	new	nature nate's 100% pure raw honey
+condiments	cached	sue bee honey
+condiments	cached	nutella hazelnut spread
+condiments	new	pam original cooking spray
+condiments	new	chosen foods avocado oil spray
+condiments	new	crisco pure vegetable oil
+condiments	cached	wesson vegetable oil
+condiments	new	filippo berio extra virgin olive oil
+condiments	new	bertolli extra virgin olive oil
+condiments	cached	spectrum organic coconut oil
+condiments	cached	kerrygold pure irish butter
+condiments	cached	land o'lakes salted butter
+condiments	cached	challenge butter unsalted
+condiments	cached	i can't believe it's not butter spread
+dairy	cached	chobani greek yogurt strawberry
+dairy	new	fage total 0 plain
+dairy	new	oikos triple zero vanilla
+dairy	cached	yoplait original strawberry
+dairy	cached	dannon activia strawberry
+dairy	cached	siggi's icelandic skyr vanilla
+dairy	cached	noosa strawberry rhubarb yogurt
+dairy	new	two good greek yogurt strawberry
+dairy	cached	stonyfield organic whole milk plain yogurt
+dairy	cached	chobani flip strawberry cheesecake
+dairy	cached	lifeway kefir plain
+dairy	cached	wallaby organic greek yogurt
+dairy	new	yoplait light strawberry
+dairy	cached	friendship cottage cheese
+dairy	cached	knudsen cottage cheese
+dairy	cached	sargento string cheese
+dairy	new	kraft singles american cheese
+dairy	cached	president feta cheese
+dairy	new	tillamook sharp cheddar shredded cheese
+dairy	cached	mini babybel original
+dairy	cached	borden cheese singles
+dairy	cached	cabot sharp cheddar cheese
+dairy	cached	land o lakes american cheese
+dairy	cached	horizon organic whole milk
+dairy	new	almond breeze almond milk original
+dairy	cached	organic valley whole milk
+dairy	cached	dairy pure 2% milk
+dairy	new	eggland's best large eggs
+dairy	new	egg beaters original
+dairy	cached	vital farms pasture raised eggs
+dairy	cached	just egg plant-based
+dairy	cached	nellie's free range eggs
+dairy	new	allwhites egg whites
+dairy	cached	kellogg's frosted flakes
+dairy	cached	kellogg's raisin bran
+dairy	cached	cap'n crunch original
+dairy	cached	kellogg's corn flakes
+dairy	cached	quaker life cereal original
+dairy	new	post grape nuts
+dairy	cached	kellogg's frosted mini wheats
+dairy	new	nature valley oats n honey granola
+dairy	cached	kind vanilla blueberry clusters granola
+dairy	cached	bear naked granola original
+dairy	cached	purely elizabeth original granola
+dairy	cached	bob's red mill granola
+dairy	new	quaker simply granola oats honey almonds
+dairy	cached	bob's red mill old fashioned rolled oats
+dairy	new	mccann's steel cut oatmeal
+dairy	new	quaker weight control oatmeal maple brown sugar
+dairy	new	nature's path organic instant oatmeal
+meat-seafood	new	boar's head maple glazed ham
+meat-seafood	new	boar's head black forest ham
+meat-seafood	new	boar's head deluxe oven roasted turkey breast
+meat-seafood	new	boar's head deluxe roast beef
+meat-seafood	new	boar's head salsalito turkey breast
+meat-seafood	new	applegate naturals slow cooked ham
+meat-seafood	cached	applegate naturals oven roasted turkey breast
+meat-seafood	new	hillshire farm deli select honey ham
+meat-seafood	new	hillshire farm ultra thin oven roasted turkey
+meat-seafood	new	oscar mayer deli fresh oven roasted turkey breast
+meat-seafood	new	oscar mayer deli fresh smoked ham
+meat-seafood	new	buddig original turkey
+meat-seafood	new	carl buddig original ham
+meat-seafood	new	land o frost premium honey ham
+meat-seafood	new	land o frost classic turkey breast
+meat-seafood	new	dietz and watson black forest ham
+meat-seafood	new	sara lee oven roasted turkey breast
+meat-seafood	new	columbus craft meats italian dry salame
+meat-seafood	new	citterio genoa salami
+meat-seafood	new	margherita genoa salami
+meat-seafood	new	perdue short cuts grilled chicken breast strips
+meat-seafood	new	tyson grilled and ready chicken breast strips
+meat-seafood	new	foster farms grilled chicken breast strips
+meat-seafood	new	perdue simply smart organic grilled chicken breast
+meat-seafood	new	applegate naturals roasted chicken breast
+meat-seafood	new	tyson fully cooked grilled chicken breast fillets
+meat-seafood	new	oscar mayer fully cooked bacon
+meat-seafood	new	wright brand hickory smoked bacon
+meat-seafood	new	hormel black label bacon
+meat-seafood	new	applegate naturals sunday bacon
+meat-seafood	new	smithfield hometown original bacon
+meat-seafood	new	jones dairy farm dry aged bacon
+meat-seafood	new	louis rich turkey bacon
+meat-seafood	new	johnsonville beddar with cheddar smoked sausage
+meat-seafood	new	johnsonville breakfast sausage links
+meat-seafood	new	jimmy dean pork sausage links
+meat-seafood	new	eckrich smoked sausage
+meat-seafood	new	aidells chicken apple sausage
+meat-seafood	new	johnsonville original bratwurst
+meat-seafood	new	jimmy dean maple pork sausage patties
+meat-seafood	new	oscar mayer classic wieners
+meat-seafood	new	nathan's famous beef franks
+meat-seafood	new	ball park beef franks
+meat-seafood	new	hebrew national beef franks
+meat-seafood	new	applegate the great organic hot dog
+meat-seafood	new	oscar mayer bun length beef franks
+meat-seafood	new	starkist solid white albacore tuna in water
+meat-seafood	new	bumble bee chunk light tuna in water
+meat-seafood	new	chicken of the sea chunk light tuna
+meat-seafood	new	wild planet wild albacore tuna
+meat-seafood	new	bumble bee solid white albacore tuna
+meat-seafood	new	chicken of the sea solid white albacore tuna
+meat-seafood	new	bumble bee pink salmon
+meat-seafood	new	chicken of the sea pink salmon
+meat-seafood	new	wild planet wild pink salmon
+meat-seafood	new	swanson premium chunk chicken breast
+meat-seafood	new	hormel premium chunk chicken breast
+meat-seafood	new	starkist chicken creations chunk chicken
+meat-seafood	new	bumble bee tuna salad kit
+meat-seafood	new	vita nova smoked salmon
+meat-seafood	new	blue hill bay smoked salmon
+meat-seafood	new	kirkland signature smoked salmon
+meat-seafood	new	trader joe's smoked salmon
+meat-seafood	new	ducktrap river smoked salmon
+bread-bakery	new	dave's killer bread 21 whole grains
+bread-bakery	cached	dave's killer bread good seed
+bread-bakery	cached	sara lee honey wheat bread
+bread-bakery	cached	arnold country white bread
+bread-bakery	cached	ezekiel 4 9 sprouted grain bread
+bread-bakery	cached	franz white bread
+bread-bakery	cached	schmidt old tyme bread
+bread-bakery	cached	aunt millie's healthy 7 grain bread
+bread-bakery	cached	rudi's organic multigrain bread
+bread-bakery	cached	martin's potato bread
+bread-bakery	cached	thomas cinnamon raisin bagel
+bread-bakery	cached	thomas bagel thins plain
+bread-bakery	cached	lender's bagels plain
+bread-bakery	new	lender's blueberry bagels
+bread-bakery	cached	lender's cinnamon raisin bagels
+bread-bakery	cached	trader joe's everything bagels
+bread-bakery	cached	einstein bros plain bagel
+bread-bakery	new	dave's killer bread bagels everything
+bread-bakery	cached	mission whole wheat tortillas
+bread-bakery	cached	guerrero flour tortillas
+bread-bakery	cached	guerrero corn tortillas
+bread-bakery	cached	la banderita street taco tortillas
+bread-bakery	cached	old el paso flour tortillas
+bread-bakery	new	tumaro's low carb tortillas
+bread-bakery	new	la tortilla factory low carb tortillas
+bread-bakery	cached	trader joe's flour tortillas
+bread-bakery	cached	mission street tacos corn tortillas
+bread-bakery	cached	thomas original english muffins
+bread-bakery	new	thomas whole wheat english muffins
+bread-bakery	cached	bays english muffins
+bread-bakery	cached	bays whole wheat english muffins
+bread-bakery	cached	rudi's organic english muffins
+bread-bakery	cached	trader joe's english muffins
+bread-bakery	cached	thomas sourdough english muffins
+bread-bakery	cached	king's hawaiian original rolls
+bread-bakery	cached	king's hawaiian hamburger buns
+bread-bakery	new	martin's potato hamburger buns
+bread-bakery	new	martin's potato hot dog buns
+bread-bakery	cached	pepperidge farm hamburger buns
+bread-bakery	cached	nature's own hamburger buns
+bread-bakery	cached	wonder hot dog buns
+bread-bakery	new	toufayan pita bread
+bread-bakery	cached	joseph's pita bread
+bread-bakery	cached	trader joe's pita bread
+bread-bakery	cached	sahara pita bread
+bread-bakery	cached	cedar's pita bread
+bread-bakery	cached	toufayan whole wheat pita bread
+bread-bakery	cached	stonefire original naan
+bread-bakery	cached	stonefire garlic naan
+bread-bakery	cached	trader joe's garlic naan
+bread-bakery	cached	mission garden spinach herb wraps
+bread-bakery	new	flatout flatbread wraps
+bread-bakery	new	la tortilla factory spinach wraps
+bread-bakery	cached	tumaro's spinach wraps
+salty-snacks	cached	rx bar chocolate sea salt
+salty-snacks	cached	pure protein chocolate deluxe
+salty-snacks	new	think high protein chunky peanut butter
+salty-snacks	new	optimum nutrition protein bar double rich chocolate
+salty-snacks	cached	barebells protein bar caramel cashew
+salty-snacks	cached	clif bar crunchy peanut butter
+salty-snacks	new	nature valley oats n honey crunchy granola bar
+salty-snacks	cached	kind bar dark chocolate nuts and sea salt
+salty-snacks	cached	belvita blueberry breakfast biscuits
+salty-snacks	cached	quaker chewy chocolate chip granola bar
+salty-snacks	cached	nutri grain strawberry
+salty-snacks	cached	special k pastry crisps strawberry
+salty-snacks	cached	nature valley protein chewy bar peanut butter dark chocolate
+salty-snacks	cached	lays classic potato chips
+salty-snacks	cached	tostitos scoops original
+salty-snacks	cached	fritos original corn chips
+salty-snacks	new	kettle brand sea salt and vinegar chips
+salty-snacks	cached	ritz original crackers
+salty-snacks	cached	goldfish cheddar crackers
+salty-snacks	cached	townhouse crackers original
+salty-snacks	cached	skinny pop popcorn
+salty-snacks	cached	pop secret movie theater butter
+salty-snacks	new	orville redenbacher butter popcorn
+salty-snacks	new	angies boomchickapop sea salt popcorn
+salty-snacks	cached	skinny pop white cheddar popcorn
+salty-snacks	cached	pop secret kettle corn
+salty-snacks	cached	blue diamond almonds smokehouse
+salty-snacks	cached	planters honey roasted peanuts
+salty-snacks	new	wonderful pistachios roasted and salted
+salty-snacks	cached	kars trail mix
+salty-snacks	cached	emerald cocoa roast almonds
+salty-snacks	new	planters trail mix nut and chocolate
+salty-snacks	cached	blue diamond almonds wasabi and soy sauce
+salty-snacks	cached	nature valley trail mix fruit and nut
+salty-snacks	cached	jack links original beef jerky
+salty-snacks	cached	chomps original beef stick
+salty-snacks	new	country archer classic original beef jerky
+salty-snacks	new	oberto original beef jerky
+salty-snacks	cached	chomps turkey stick
+salty-snacks	cached	epic bison bacon cranberry bar
+salty-snacks	cached	oreo original
+salty-snacks	cached	chips ahoy chewy chocolate chip cookies
+salty-snacks	new	nutter butter peanut butter sandwich cookies
+salty-snacks	cached	famous amos chocolate chip cookies
+salty-snacks	cached	keebler fudge stripes cookies
+salty-snacks	cached	milano cookies double chocolate
+salty-snacks	cached	golden oreo
+salty-snacks	cached	lorna doone shortbread cookies
+salty-snacks	cached	m&ms peanut
+salty-snacks	cached	kit kat original
+salty-snacks	cached	twix caramel
+salty-snacks	cached	sour patch kids original
+sodas-energy	cached	celsius kiwi guava
+sodas-energy	cached	celsius sparkling watermelon
+sodas-energy	cached	monster energy zero ultra
+sodas-energy	new	monster energy ultra sunrise
+sodas-energy	cached	monster energy mango loco
+sodas-energy	cached	monster energy original
+sodas-energy	cached	red bull sugarfree
+sodas-energy	cached	red bull original
+sodas-energy	cached	bang energy blue razz
+sodas-energy	new	reign total body fuel carnival candy
+sodas-energy	cached	rockstar original
+sodas-energy	cached	alani nu hawaiian shaved ice
+sodas-energy	new	prime energy blue raspberry
+sodas-energy	cached	coca cola classic
+sodas-energy	new	coke zero sugar
+sodas-energy	cached	coca cola cherry
+sodas-energy	cached	pepsi wild cherry
+sodas-energy	new	dr pepper original
+sodas-energy	new	sprite zero sugar
+sodas-energy	cached	olipop vintage cola
+sodas-energy	new	poppi raspberry rose
+sodas-energy	new	gatorade zero glacier cherry
+sodas-energy	cached	powerade mountain berry blast
+sodas-energy	new	powerade zero grape
+sodas-energy	cached	bodyarmor strawberry banana
+sodas-energy	new	bodyarmor lyte fruit punch
+sodas-energy	cached	pedialyte grape
+sodas-energy	cached	starbucks doubleshot espresso
+sodas-energy	new	starbucks vanilla latte
+sodas-energy	cached	chameleon cold brew black coffee
+sodas-energy	new	la colombe vanilla draft latte
+sodas-energy	cached	arizona sweet tea
+sodas-energy	new	pure leaf sweet tea
+sodas-energy	new	pure leaf unsweetened black tea
+sodas-energy	cached	lipton iced tea lemon
+sodas-energy	new	peace tea sweet tea
+sodas-energy	cached	spindrift raspberry lime
+sodas-energy	new	waterloo black cherry
+sodas-energy	cached	liquid iv lemon lime
+sodas-energy	new	liquid iv watermelon
+sodas-energy	cached	liquid iv passion fruit
+sodas-energy	cached	crystal light lemonade
+sodas-energy	new	mio berry pomegranate
+frozen	new	healthy choice chicken teriyaki bowl
+frozen	new	lean cuisine chicken fettuccini
+frozen	cached	devour buffalo chicken mac and cheese
+frozen	cached	amy's brown rice and vegetables bowl
+frozen	new	digiorno rising crust pepperoni
+frozen	new	california pizza kitchen bbq chicken pizza
+frozen	cached	tyson crispy chicken strips
+frozen	new	tyson any'tizers chicken nuggets
+frozen	cached	perdue chicken nuggets
+frozen	cached	banquet chicken nuggets
+frozen	cached	foster farms chicken nuggets
+frozen	new	just bare chicken breast tenderloins
+frozen	new	perdue crispy chicken tenders
+frozen	cached	birds eye steamfresh broccoli
+frozen	cached	green giant broccoli florets
+frozen	cached	cascadian farm organic peas
+frozen	cached	green giant riced cauliflower
+frozen	cached	birds eye steamfresh mixed vegetables
+frozen	new	pictsweet frozen corn
+frozen	new	green giant green beans
+frozen	new	ore ida crinkle cut fries
+frozen	new	ore ida golden tater tots
+frozen	cached	mccain crinkle cut fries
+frozen	new	ore ida extra crispy fast food fries
+frozen	cached	amy's organic lentil soup
+frozen	cached	healthy choice chicken and rice soup
+frozen	cached	progresso minestrone soup
+frozen	cached	campbell's chunky chicken noodle soup
+frozen	cached	progresso vegetable soup
+frozen	cached	bush's best black beans
+frozen	cached	goya black beans
+frozen	cached	s&w pinto beans
+frozen	cached	old el paso refried beans
+frozen	cached	rosarita refried beans
+frozen	cached	bush's best baked beans
+frozen	cached	banza chickpea pasta
+frozen	cached	knorr pasta sides alfredo
+frozen	cached	rice a roni chicken flavor
+frozen	cached	near east rice pilaf
+frozen	cached	zatarain's dirty rice
+frozen	new	barilla protein plus pasta
+frozen	cached	nissin top ramen chicken
+frozen	cached	maruchan instant lunch chicken
+frozen	cached	nongshim shin ramyun
+frozen	cached	indomie mi goreng
+frozen	new	samyang buldak hot chicken ramen
+frozen	cached	nissin cup noodles chicken
+frozen	cached	maruchan ramen noodle soup chicken
+frozen	cached	paldo bowl noodle soup
+frozen	cached	kraft macaroni and cheese
+frozen	cached	annie's white cheddar mac and cheese
+frozen	cached	velveeta shells and cheese
+frozen	cached	kraft deluxe macaroni and cheese
+frozen	cached	annie's shells and cheddar
+frozen	new	cracker barrel mac and cheese
+protein-supplements	cached	optimum nutrition gold standard whey double rich chocolate
+protein-supplements	cached	optimum nutrition gold standard whey vanilla ice cream
+protein-supplements	cached	optimum nutrition gold standard whey cookies and cream
+protein-supplements	cached	optimum nutrition gold standard whey extreme milk chocolate
+protein-supplements	new	optimum nutrition gold standard whey banana cream
+protein-supplements	cached	premier protein shake caramel
+protein-supplements	cached	premier protein shake cookies and cream
+protein-supplements	cached	premier protein shake cinnamon roll
+protein-supplements	new	premier protein powder chocolate
+protein-supplements	new	ghost whey cinnamon toast crunch
+protein-supplements	cached	ghost whey oreo
+protein-supplements	cached	ghost whey chips ahoy
+protein-supplements	cached	ghost whey milk chocolate
+protein-supplements	cached	fairlife core power vanilla
+protein-supplements	cached	fairlife core power chocolate
+protein-supplements	cached	fairlife core power strawberry banana
+protein-supplements	cached	quest protein powder cookies and cream
+protein-supplements	cached	quest protein powder chocolate milkshake
+protein-supplements	new	quest protein powder vanilla milkshake
+protein-supplements	cached	quest protein powder salted caramel
+protein-supplements	cached	muscle milk chocolate
+protein-supplements	new	muscle milk vanilla
+protein-supplements	cached	muscle milk protein powder chocolate
+protein-supplements	new	muscle milk protein powder vanilla
+protein-supplements	cached	orgain organic protein shake chocolate fudge
+protein-supplements	new	orgain organic protein shake vanilla bean
+protein-supplements	new	orgain organic protein shake iced coffee
+protein-supplements	new	orgain organic protein powder chocolate
+protein-supplements	cached	orgain organic protein powder vanilla
+protein-supplements	cached	owyn protein shake chocolate
+protein-supplements	new	owyn protein shake vanilla
+protein-supplements	new	ensure max protein chocolate
+protein-supplements	new	ensure max protein vanilla
+protein-supplements	new	boost high protein chocolate
+protein-supplements	new	boost high protein vanilla
+protein-supplements	cached	slimfast original rich chocolate royale
+protein-supplements	new	slimfast original creamy vanilla
+protein-supplements	new	body fortress whey protein chocolate
+protein-supplements	new	body fortress whey protein vanilla
+protein-supplements	new	dymatize iso100 gourmet chocolate
+protein-supplements	new	dymatize iso100 gourmet vanilla
+protein-supplements	new	dymatize iso100 birthday cake
+protein-supplements	new	muscletech nitro tech chocolate
+protein-supplements	new	muscletech nitro tech vanilla
+protein-supplements	cached	muscletech nitro tech cookies and cream
+protein-supplements	new	bsn syntha 6 chocolate milkshake
+protein-supplements	cached	bsn syntha 6 vanilla ice cream
+protein-supplements	new	bsn syntha 6 strawberry milkshake
+protein-supplements	cached	isopure zero carb dutch chocolate
+protein-supplements	new	isopure zero carb creamy vanilla
+protein-supplements	cached	vega protein and greens chocolate
+protein-supplements	new	vega sport premium protein vanilla
+protein-supplements	new	garden of life sport protein chocolate
+protein-supplements	cached	kirkland signature whey protein chocolate
+protein-supplements	new	kachava vanilla
+protein-supplements	cached	pure protein shake chocolate
+protein-supplements	new	pure protein shake vanilla cream
+protein-supplements	new	pure protein shake strawberry
+protein-supplements	new	iconic protein shake chocolate
+protein-supplements	new	iconic protein shake vanilla
+protein-supplements	new	redcon1 mre chocolate
+protein-supplements	new	redcon1 mre vanilla

--- a/scripts/eval/flywheel-sweep.ts
+++ b/scripts/eval/flywheel-sweep.ts
@@ -119,8 +119,14 @@ const COVERAGE_ONLY = args.includes('--coverage-only');
 
 const RESULTS_DIR = path.join(__dirname, 'results');
 const REPO_ROOT = path.join(__dirname, '..', '..');
+// Cut 2026-08-02 by scripts/eval/_cut_coverage_corpus.ts: the 2026-07-24 corpus
+// (3,307 seeds) plus 447 branded-CPG seeds from warm batches 17-24 that were not
+// already in it by cache key. `coverage-corpus.tsv` stays COMMITTED and unchanged
+// so every reading logged before this date stays readable against its own
+// denominator — that is why this is a new file rather than an append.
+// Restated baseline at the cut: 1954/3754 = 52.1% cached, growth 0% by construction.
 const COVERAGE_CORPUS = argValue('--coverage-corpus')
-    ?? path.join(__dirname, 'coverage-corpus.tsv');
+    ?? path.join(__dirname, 'coverage-corpus-2026-08-02.tsv');
 
 // ---------------------------------------------------------------------------
 // 1. Telemetry

--- a/src/lib/ops/__tests__/cache-coverage.test.ts
+++ b/src/lib/ops/__tests__/cache-coverage.test.ts
@@ -126,13 +126,40 @@ describe('trend', () => {
         expect(findPreviousCoverage(dir, 'flywheel-2026-07-25.json')).toBeNull();
     });
 
-    it('computes the delta in points', async () => {
+    it('computes the delta in points when both reads used the SAME corpus', async () => {
         const dir = tmpdir();
         const p = writeCorpus(dir, ['a\tnew\tbanana', 'a\tnew\tegg']);
         const report = await collectCacheCoverage(db(['banana']), p, RAN_AT);
-        const trend = computeCoverageTrend(report, { file: 'prev.json', pct: 28.8 });
+        const trend = computeCoverageTrend(report, { file: 'prev.json', pct: 28.8, corpus: report.corpus });
         expect(report.pct).toBe(50);
         expect(trend?.deltaPct).toBe(21.2);
+    });
+
+    // Cutting a new corpus is the documented way to extend the denominator, so the
+    // very first read of a new file WILL find a previous report on the old one.
+    // Subtracting those two fractions is not a trend.
+    it('refuses to trend across two different corpora', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana', 'a\tnew\tegg']);
+        const report = await collectCacheCoverage(db(['banana']), p, RAN_AT);
+        expect(computeCoverageTrend(report, {
+            file: 'prev.json', pct: 28.8, corpus: 'coverage-corpus-OLD.tsv',
+        })).toBeNull();
+    });
+
+    it('refuses to trend against a report that predates corpus recording', async () => {
+        const dir = tmpdir();
+        const p = writeCorpus(dir, ['a\tnew\tbanana']);
+        const report = await collectCacheCoverage(db([]), p, RAN_AT);
+        // absent is not "same corpus" — an old report simply cannot say.
+        expect(computeCoverageTrend(report, { file: 'prev.json', pct: 10 })).toBeNull();
+    });
+
+    it('carries the previous report\'s corpus through so the trend can check it', () => {
+        const dir = tmpdir();
+        fs.writeFileSync(path.join(dir, 'flywheel-2026-08-01.json'),
+            JSON.stringify({ coverage: { ok: true, pct: 44, corpus: 'coverage-corpus.tsv' } }));
+        expect(findPreviousCoverage(dir)?.corpus).toBe('coverage-corpus.tsv');
     });
 
     it('has no trend on the first run', async () => {

--- a/src/lib/ops/cache-coverage.ts
+++ b/src/lib/ops/cache-coverage.ts
@@ -26,9 +26,16 @@
  * are already cached and so reports near-100% by construction. It answers "did
  * the cache hold?", not "is the cache big enough yet?".
  *
- * The corpus is COMMITTED (scripts/eval/coverage-corpus.tsv) so the denominator
- * is fixed. Changing it breaks comparability with every earlier reading — cut a
- * new file under a new name instead, and restate the baseline.
+ * The corpus is COMMITTED so the denominator is fixed. Changing it breaks
+ * comparability with every earlier reading — cut a new file under a new name
+ * instead, and restate the baseline. `scripts/eval/_cut_coverage_corpus.ts` does
+ * exactly that and refuses to overwrite an existing cut.
+ *
+ * Cuts so far: `coverage-corpus.tsv` (2026-07-24, 3,307 seeds, baseline 28.8%)
+ * and `coverage-corpus-2026-08-02.tsv` (3,754 seeds, restated baseline 52.1%),
+ * which is what the sweep reads by default now. Both stay committed. Note that
+ * `computeCoverageTrend()` returns null across different corpora — subtracting
+ * two fractions with different denominators is not a trend.
  */
 
 import * as fs from 'fs';
@@ -166,7 +173,7 @@ export async function collectCacheCoverage(
 export function findPreviousCoverage(
     resultsDir: string,
     excludeFile?: string,
-): { file: string; pct: number } | null {
+): { file: string; pct: number; corpus?: string } | null {
     let names: string[];
     try {
         names = fs.readdirSync(resultsDir);
@@ -183,7 +190,7 @@ export function findPreviousCoverage(
             const parsed = JSON.parse(fs.readFileSync(path.join(resultsDir, name), 'utf8'));
             const prev = parsed?.coverage;
             if (prev && prev.ok === true && typeof prev.pct === 'number') {
-                return { file: name, pct: prev.pct };
+                return { file: name, pct: prev.pct, corpus: prev.corpus };
             }
         } catch {
             // Unreadable or partial report — keep looking further back.
@@ -194,9 +201,17 @@ export function findPreviousCoverage(
 
 export function computeCoverageTrend(
     report: CacheCoverageReport,
-    previous: { file: string; pct: number } | null,
+    previous: { file: string; pct: number; corpus?: string } | null,
 ): CoverageTrend | null {
     if (!report.ok || !previous) return null;
+    // A delta across two DIFFERENT corpora is not a trend, it is two unrelated
+    // fractions subtracted. Cutting coverage-corpus-2026-08-02.tsv made the very
+    // first read of the new file print "+2.8pt vs <a report on the old one>",
+    // which is exactly the comparability break this module's header tells you to
+    // avoid by cutting a new file — and then reintroduced it in the trend line.
+    // A previous report from before `corpus` was recorded is also not comparable:
+    // absent is not "same".
+    if (!previous.corpus || previous.corpus !== report.corpus) return null;
     return {
         previousFile: previous.file,
         previousPct: previous.pct,


### PR DESCRIPTION
## Why

The 2026-07-24 corpus contains no branded-CPG seeds, so warm batches 17–24 (544 seeds, **265 rows kept**) moved measured coverage by roughly **0**. The work was real; the denominator could not see it.

## Why a new file rather than an append

`cache-coverage.ts` already says it: *"Changing it breaks comparability with every earlier reading — cut a new file under a new name instead, and restate the baseline."* So `coverage-corpus.tsv` stays committed and byte-identical, and every coverage number in the logs before today stays readable against its own denominator.

| | seeds | baseline |
|---|---:|---|
| `coverage-corpus.tsv` (2026-07-24) | 3,307 | 28.8% cached — unchanged, kept for history |
| `coverage-corpus-2026-08-02.tsv` | **3,754** | **52.1%** cached (1954/3754), growth 0% by construction |

`flywheel-sweep` reads the new file by default.

## Dedupe by cache key, not by string

544 offered, **447 kept** — 97 were already in the base *by cache key*. A raw-string comparison found only 84. The other 13 differ purely in spelling and collapse to the same key; admitting them would have inflated the denominator with rows that can never be independently cached.

## A comparability bug this cut exposed

The very first read of the new corpus printed:

```
📈 52.1% of coverage-corpus-2026-08-02.tsv is cached (1954/3754) (+2.8pt vs flywheel-...json)
```

That `+2.8pt` compares against a report on the **old** corpus — two fractions with different denominators, subtracted. The module header tells you to cut a new file to avoid exactly this, and then the trend line reintroduced it.

`computeCoverageTrend()` now returns `null` unless both reads name the same corpus, and treats a previous report from before `corpus` was recorded as not comparable (absent is not "same"). Three new tests cover it, including the cross-corpus case that would have caught the original.

## Test

- `npx jest src/lib/ops/__tests__/cache-coverage.test.ts` → **15 passed**
- `npm run lint:ci` 0 errors · `npx tsc --noEmit` clean
- `flywheel-sweep --coverage-only` re-run after the fix: reports 52.1% with **no trend line**, which is correct for the first read of a new corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu