### PR TITLE
feat(eval): a cold run can no longer rewrite the cache it measures

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -993,11 +993,23 @@
       "verified": "2026-08-02"
     },
     {
-      "id": "eval-nocache-refuses-write-baseline",
-      "claim": "--nocache with --write-baseline exits 2 rather than overwrite the WARM knownIssue baseline the batch gate compares against with cold values",
-      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_batch-rollback-is-partial.md",
+      "id": "eval-cold-baseline-is-separate",
+      "claim": "A --nocache run scores against its OWN known-issue-baseline-cold.json, never the warm baseline the batch gate uses. Supersedes the earlier exit-2 refusal of --nocache --write-baseline: with separate files the combination is the intended way to record cold pins, and the invariant that matters is the separation.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
       "where": "backend",
-      "command": "grep -c 'NO_CACHE && WRITE_BASELINE' scripts/eval/run-eval.ts",
+      "command": "grep -c \"NO_CACHE ? 'known-issue-baseline-cold.json'\" scripts/eval/run-eval.ts",
+      "expect": {
+        "kind": "matches",
+        "value": "^1$"
+      },
+      "verified": "2026-08-02"
+    },
+    {
+      "id": "eval-cold-run-cannot-write-cache",
+      "claim": "A --nocache run sends nosave=1, so measuring the pipeline cold cannot rewrite the FoodMapping cache it is measuring. Before this, one cold golden run changed 20 rows and added 3 over freshly agent-screened rows.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
+      "where": "backend",
+      "command": "grep -c 'nocache=1&nosave=1' scripts/eval/run-eval.ts",
       "expect": {
         "kind": "matches",
         "value": "^1$"

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -60,17 +60,17 @@ const WRITE_BASELINE = args.includes('--write-baseline');
  *
  * `/api/nlp/parse` honours this only for dev-bypass callers, which is what
  * API_KEY above makes this harness.
+ *
+ * A cold run also sends `nosave=1`, so it cannot rewrite the cache it measures,
+ * and it scores against its own `known-issue-baseline-cold.json`.
  */
 const NO_CACHE = args.includes('--nocache');
 
-// Recording a cold baseline would silently replace the warm values every batch gate
-// compares against, and the next batch would be blamed for the difference. Exit 2 —
-// the campaign's contract for "this run is not a result", never a pass.
-if (NO_CACHE && WRITE_BASELINE) {
-    console.error('!! --nocache with --write-baseline would overwrite the WARM knownIssue baseline');
-    console.error('!! with COLD values. The batch gate compares against it; refusing.');
-    process.exit(2);
-}
+// NOTE: `--nocache --write-baseline` used to exit 2, because both modes shared one
+// baseline file and a cold run would have overwritten the WARM values every batch
+// gate compares against. The files are separate now (see `baselinePath` below), so
+// the combination is not only safe but the intended way to record cold pins. The
+// invariant that actually matters is the SEPARATION, not the refusal.
 
 const goldenPath = path.join(__dirname, 'golden-set.json');
 const golden = JSON.parse(fs.readFileSync(goldenPath, 'utf8'));
@@ -125,7 +125,23 @@ function percentile(sorted: number[], p: number): number {
 // ---------------------------------------------------------------------------
 
 
-const baselinePath = path.join(__dirname, 'known-issue-baseline.json');
+/**
+ * Cold and warm runs get SEPARATE baselines, because a pin records what a case
+ * currently does and those are different questions: warm is "what does the cache
+ * hold for this key", cold is "what does the pipeline produce for it". Measured
+ * 2026-08-02 on the same build, minutes apart: 0 real failures warm, 19 cold.
+ * Scoring cold results against warm pins reclassifies cases wholesale, which is
+ * why the first cold run's 19 is an upper bound on new information rather than a
+ * count of new defects.
+ *
+ * The cold file is absent until someone records it. That is deliberate and it is
+ * SAFE: an empty baseline means no case is pinned, so nothing is silently
+ * absolved — a cold failure reads as a real failure until a human pins it.
+ */
+const baselinePath = path.join(
+    __dirname,
+    NO_CACHE ? 'known-issue-baseline-cold.json' : 'known-issue-baseline.json',
+);
 
 function loadKnownIssueBaseline(): Record<string, BaselineEntry> {
     try {
@@ -225,7 +241,11 @@ async function runNlpCase(c: any): Promise<CaseResult> {
     const query = c.item?.name ?? c.text;
     try {
         const body = c.item ? { items: [c.item] } : { text: c.text };
-        const res = await fetch(`${BASE}/api/nlp/parse${NO_CACHE ? '?nocache=1' : ''}`, {
+        // nosave rides along with nocache, always. A cold run exists to measure
+        // the pipeline; without this it rewrites the cache as it goes and the
+        // "measurement" is also a mutation. Measured 2026-08-02: 20 rows changed,
+        // 3 added, over rows that had just been agent-screened.
+        const res = await fetch(`${BASE}/api/nlp/parse${NO_CACHE ? '?nocache=1&nosave=1' : ''}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'x-api-key': API_KEY },
             body: JSON.stringify(body),

--- a/src/app/api/nlp/parse/route.ts
+++ b/src/app/api/nlp/parse/route.ts
@@ -178,6 +178,14 @@ export async function POST(req: NextRequest) {
     const noCache = isDevBypass &&
       (req.nextUrl.searchParams.get('nocache') === '1' || body.nocache === true);
 
+    // Companion to nocache: do not WRITE the FoodMapping cache either. Admin-only.
+    // nocache alone still saved every line, so a cold audit rewrote the cache it
+    // was auditing — one cold golden run on 2026-08-02 changed 20 rows and added
+    // 3 over freshly agent-screened rows. Deliberately a SEPARATE flag rather
+    // than implied by nocache: some cold runs (a warm-from-cold) do want the write.
+    const noSave = isDevBypass &&
+      (req.nextUrl.searchParams.get('nosave') === '1' || body.nosave === true);
+
     let items: Array<{ rawText: string; mealType: 'breakfast' | 'lunch' | 'dinner' | 'snacks'; brand?: string; normalizedForm?: string }> = [];
 
     // Segmentation-cache outcome for telemetry: true = split served from
@@ -294,6 +302,7 @@ export async function POST(req: NextRequest) {
         brand: brand || undefined,
         normalizedForm: normalizedForm || undefined,
         skipCache: noCache,
+        skipSave: noSave,
         telemetry,
         aiNutritionBudget: nutritionBudget,
         aiHydrationBudget: hydrationBudget,

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -353,6 +353,24 @@ export interface MapIngredientOptions {
     debug?: boolean;
     skipAiValidation?: boolean;
     skipCache?: boolean;
+    /**
+     * Do not WRITE the FoodMapping cache. Sibling of `skipCache`, which only
+     * gates the two read layers.
+     *
+     * Why it exists: a cold audit run (`skipCache`) still called
+     * `saveValidatedMapping()` for every line, so measuring the pipeline
+     * rewrote the thing being measured. On 2026-08-02 a single cold golden run
+     * changed 20 rows and added 3 in a cache that had just been agent-screened,
+     * replacing screened rows with unscreened ones.
+     *
+     * Scope, precisely: this gates the FoodMapping write — the curated identity
+     * map. It does NOT make the request read-only. Hydration still persists
+     * upstream records (FatSecretFood, OffFood, AiGenerated*, FdcServing,
+     * OffServing) and telemetry still writes MappingEventLog. Those are caches
+     * of other people's data, not curated rows; the identity map is the asset a
+     * measurement must not disturb.
+     */
+    skipSave?: boolean;
     skipFdc?: boolean;
     /** Internal flag - skip in-flight lock for recursive fallback calls */
     _skipInFlightLock?: boolean;
@@ -551,6 +569,7 @@ export async function mapIngredientWithFallback(
         minConfidence = 0,
         debug = false,
         skipCache = false,
+        skipSave = false,
         skipFdc = false,
         allowLiveFallback = true,
         _skipInFlightLock = false,
@@ -3149,7 +3168,13 @@ export async function mapIngredientWithFallback(
                 });
             }
 
-            await saveValidatedMapping(rawLine, result, {
+            // skipSave: a measurement must not rewrite what it measures. Placed
+            // around the call rather than inside saveValidatedMapping() so the
+            // save-gate telemetry classes keep meaning "a gate rejected this
+            // write" — a suppressed write is not a rejected one, and folding the
+            // two together would corrupt the save_rejected counters the funnel
+            // reads.
+            if (!skipSave) await saveValidatedMapping(rawLine, result, {
                 approved: true,
                 confidence,
                 reason: selectionReason,


### PR DESCRIPTION
Two halves of one defect, both measured on the first cold golden run (2026-08-02).

## 1. The measurement was also a mutation

`skipCache` gates the two `FoodMapping` **read** layers. Nothing gated the **write**. So `--nocache` mapped every case from scratch and then saved the result: **20 rows changed, 3 added**, over rows that had just been agent-screened — including `Cinnabon Protein Powder` → `Oreo Protein Powder` and an OFF→FatSecret source flip.

New `skipSave` option (sibling of `skipCache`) plus a `nosave=1` admin-only flag on `/api/nlp/parse`. `run-eval` sends it whenever `--nocache` is set.

**Scoped honestly.** This gates the `FoodMapping` write — the curated identity map. It does **not** make the request read-only: hydration still persists upstream records (`FatSecretFood`, `OffFood`, `AiGenerated*`, `FdcServing`, `OffServing`) and telemetry still writes `MappingEventLog`. Those are caches of other people's data; the identity map is the asset a measurement must not disturb. It's called `nosave` rather than `readonly` so the name doesn't overclaim.

Two placement decisions worth flagging for review:
- The guard sits **around** the call, not inside `saveValidatedMapping()`, so save-gate telemetry keeps meaning *"a gate rejected this write"*. A suppressed write is not a rejected one, and folding them together would corrupt the `save_rejected` counters the funnel reads.
- `nosave` is **separate** from `nocache`, not implied by it — a warm-from-cold run legitimately wants the write.

## 2. Cold results were scored against warm pins

Same build, same 348 cases, minutes apart: **0** real failures warm, **19** cold. A pin records what a case currently does, and warm ("what does the cache hold") and cold ("what does the pipeline produce") are different questions.

Cold now reads its own `known-issue-baseline-cold.json`. **That file is absent until someone records it**, which is deliberate and safe: an empty baseline pins nothing, so a cold failure reads as a real failure until a human pins it — it fails closed, not open.

This supersedes the exit-2 refusal of `--nocache --write-baseline` from #217, which existed only because both modes shared one file. With separate files that combination is the intended way to record cold pins. Registry updated in the same commit per doc rule 7: `eval-nocache-refuses-write-baseline` → `eval-cold-baseline-is-separate` + `eval-cold-run-cannot-write-cache`.

## Test

- `npx tsc --noEmit` clean · `npm run lint:ci` 0 errors
- both new claim commands run and return their expected values (the first draft of one returned `2`, not `1`, because the string also appears in a comment — retargeted at the code)
- default path unchanged: `skipSave` defaults to `false`, so a normal parse saves exactly as before
- **not yet verified against the live box** — the flag needs a deploy before it can be exercised end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu