### PR TITLE
fix(servings): a label that enumerates pieces divides by ITS count, not numberOfUnits

### DIFF
--- a/src/lib/mapping/__tests__/build-fatsecret-result-label-count.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-label-count.test.ts
@@ -1,0 +1,190 @@
+/**
+ * buildFatSecretResult — a serving label that enumerates its own pieces.
+ *
+ * `numberOfUnits` counts SERVINGS, not pieces. fs_63588 ("Tortilla Chips")
+ * carries one usable serving reading `13 chips` at 28.35 g with
+ * numberOfUnits 1, so dividing by numberOfUnits declared the whole 13-chip
+ * serving to be ONE chip and `13 tortilla chips` billed 13 x 28.35 = 368.55 g
+ * / 1950 kcal against a [28, 70] band (golden n-serv-35 and n-tot-05, measured
+ * cold 2026-08-02).
+ *
+ * count-label.ts has owned this predicate since the OFF lane adopted it — its
+ * module header names "13 tortilla chips" as the motivating query — and lists
+ * its callers: buildOffResult, simpleRerank, the cache escape, retrieval.
+ * buildFatSecretResult was never one of them, which is why the identical line
+ * is right through OFF and wrong here.
+ *
+ * Each test names the mutation it kills: the point of this file is that the
+ * divisor choice is load-bearing, not that the happy path works.
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(over: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_63588', source: 'fatsecret' as const, name: 'Tortilla Chips',
+        brandName: null, score: 1, foodType: 'Generic', rawData: {}, ...over,
+    } as any;
+}
+
+/** fs_63588's real shape: the only piece serving enumerates 13 chips at 28.35 g. */
+function makeRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '63588', name: 'Tortilla Chips', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { kcal: 529, protein: 7, carbs: 65, fat: 26 },
+        defaultServingId: 'svChips',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            {
+                servingId: 'svChips', description: '13 chips', measurementDescription: 'serving',
+                grams: 28.35, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 150, protein: 2, carbohydrate: 18, fat: 7 },
+            },
+            {
+                servingId: 'sv100', description: '100 g', measurementDescription: 'g',
+                grams: 100, volumeMl: null, numberOfUnits: 100,
+                nutrients: { calories: 529, protein: 7, carbohydrate: 65, fat: 26 },
+            },
+        ],
+        ...over,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '', ...over } as ParsedIngredient;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+});
+
+describe('the label’s own count is the divisor when it enumerates the noun', () => {
+    it('"13 tortilla chips" bills the 13-chip serving ONCE, not 13 times', async () => {
+        // MUTATION: restore `unitsPerServing = match.numberOfUnits || 1`.
+        // Kills it at 368.55 g — the exact cold-eval failure.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 13, name: 'tortilla chips' }), 0.9,
+            '13 tortilla chips',
+        );
+        expect(r!.grams).toBeCloseTo(28.35, 2);
+        // The band the golden case asserts; 368.55 is 5x its ceiling.
+        expect(r!.grams!).toBeGreaterThanOrEqual(28);
+        expect(r!.grams!).toBeLessThanOrEqual(70);
+    });
+
+    it('scales linearly in PIECES — 26 chips is two servings', async () => {
+        // MUTATION: hardcode grams to the serving weight instead of qty * perUnit.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 26, name: 'tortilla chips' }), 0.9,
+            '26 tortilla chips',
+        );
+        expect(r!.grams).toBeCloseTo(56.7, 2);
+    });
+
+    it('one chip is one chip, not one serving', async () => {
+        // MUTATION: floor the divisor at 1. Kills it at 28.35.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 1, name: 'tortilla chip' }), 0.9,
+            '1 tortilla chip',
+        );
+        expect(r!.grams).toBeCloseTo(2.18, 2);
+    });
+});
+
+describe('the guard — numberOfUnits still wins where the label is not enumerating', () => {
+    it('a count of 1 ("1 thin slice") is NOT a piece enumeration', async () => {
+        // MUTATION: drop the `count >= 2` requirement in labelLeadingCount.
+        // Without it "1 thin slice" divides by 1 anyway, so this test pins the
+        // BEHAVIOUR rather than the branch: 4 slices of a 5 g slice = 20 g.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            fsId: '1517', name: 'Bacon',
+            nutrientsPer100g: { kcal: 541, protein: 37, carbs: 1.4, fat: 42 },
+            defaultServingId: 'svThin',
+            servings: [{
+                servingId: 'svThin', description: '1 thin slice',
+                measurementDescription: 'thin slice',
+                grams: 5, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 27, protein: 1.8, carbohydrate: 0.1, fat: 2.1 },
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_1517', name: 'Bacon' }),
+            parsedLine({ qty: 4, unit: 'slice', name: 'bacon' }), 0.9, '4 slices bacon',
+        );
+        expect(r!.grams).toBeCloseTo(20, 2);
+    });
+
+    it('a fractional numberOfUnits is still honoured ("1/2 breast" → a whole breast)', async () => {
+        // MUTATION: replace the `??` fallback with the labelPieceCount alone.
+        // This is the n-mq-47 shape the bare-fallback comment documents.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            fsId: '4881229', name: 'Chicken Breast',
+            nutrientsPer100g: { kcal: 165, protein: 31, carbs: 0, fat: 3.6 },
+            defaultServingId: 'svHalf',
+            servings: [{
+                servingId: 'svHalf', description: '1/2 breast, bone and skin removed',
+                measurementDescription: 'breast',
+                grams: 118, volumeMl: null, numberOfUnits: 0.5,
+                nutrients: { calories: 195, protein: 37, carbohydrate: 0, fat: 4.2 },
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_4881229', name: 'Chicken Breast' }),
+            parsedLine({ qty: 1, unit: 'breast', name: 'chicken breast' }), 0.9,
+            '1 breast chicken',
+        );
+        expect(r!.grams).toBeCloseTo(236, 1);
+    });
+
+    it('a WEIGHT-labeled serving is not a piece enumeration, even when it names the noun', async () => {
+        // MUTATION: drop the labelWord === pieceNoun check inside
+        // servingLabelCountsPiece. This is the shape that makes the check
+        // load-bearing rather than decorative: the serving reaches this branch
+        // because `servingMatchesNoun` also reads measurementDescription, so
+        // `3 oz` / meas `chip` MATCHES the noun "chip" — but its leading 3
+        // counts OUNCES, not chips. Dividing by it would bill 3 chips at 85 g.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: [{
+                servingId: 'svOz', description: '3 oz', measurementDescription: 'chip',
+                grams: 85, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 450, protein: 6, carbohydrate: 55, fat: 22 },
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 3, unit: 'chip', name: 'tortilla chips' }), 0.9,
+            '3 chips',
+        );
+        // divisor stays numberOfUnits=1 → 3 x 85 g, NOT 3 x 28.3 g.
+        expect(r!.grams).toBeCloseTo(255, 1);
+    });
+
+    it('generalises past the one record: "2 tortillas" divides to a per-tortilla weight', async () => {
+        // Not a guard — the positive case the first block asserts, on a second
+        // record shape, so the fix is not read as a fs_63588 special case.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: [{
+                servingId: 'svTort', description: '2 tortillas',
+                measurementDescription: 'tortilla',
+                grams: 50, volumeMl: null, numberOfUnits: 1,
+                nutrients: { calories: 150, protein: 4, carbohydrate: 26, fat: 3 },
+            }],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 3, unit: 'tortilla', name: 'tortillas' }), 0.9,
+            '3 tortillas',
+        );
+        expect(r!.grams).toBeCloseTo(75, 1);
+    });
+});

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -28,7 +28,10 @@
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { FATSECRET_REFRESH_DAYS } from './config';
-import { singularizeUnit, inferDiscreteUnit, extractLabelServingUnit } from './count-label';
+import {
+    singularizeUnit, inferDiscreteUnit, extractLabelServingUnit,
+    servingLabelCountsPiece, labelLeadingCount,
+} from './count-label';
 import { num, servingMacros, type Macros } from './fs-serving-macros';
 import {
     applyOffBareQueryGuard, isBarePluralRequest, isBareUnitlessQty1,
@@ -523,8 +526,28 @@ export async function buildFatSecretResult(
         }
         if (noun) {
             if (match) {
-                const unitsPerServing = match.numberOfUnits && match.numberOfUnits > 0
-                    ? match.numberOfUnits : 1;
+                // `numberOfUnits` counts SERVINGS, not pieces, so it is 1 on a
+                // serving whose label already enumerates the pieces. fs_63588
+                // reads `13 chips` at 28.35 g with numberOfUnits 1: dividing by
+                // numberOfUnits calls the whole 13-chip serving one chip, and
+                // `13 tortilla chips` bills 13 x 28.35 = 368.55 g / 1950 kcal
+                // (golden n-serv-35, n-tot-05; band [28, 70]).
+                //
+                // When the label enumerates the matched noun, ITS count is the
+                // authority. count-label.ts has owned that predicate since the
+                // OFF lane adopted it — its header names this exact query — and
+                // this branch simply never called it, which is why the same line
+                // is right through buildOffResult and wrong here.
+                //
+                // Guarded, not substituted: `servingLabelCountsPiece` requires a
+                // count >= 2 naming this noun (or a generic piece word) and a
+                // sane per-piece weight, so `1 thin slice` and `1 serving (123 g)`
+                // still fall through to numberOfUnits untouched.
+                const labelPieceCount = servingLabelCountsPiece(match.description, match.grams, noun)
+                    ? labelLeadingCount(match.description)
+                    : null;
+                const unitsPerServing = labelPieceCount
+                    ?? (match.numberOfUnits && match.numberOfUnits > 0 ? match.numberOfUnits : 1);
                 const perUnitGrams = match.grams! / unitsPerServing;
                 if (bareSingular && perUnitGrams < BARE_MIN_PIECE_SERVING_GRAMS) {
                     // Rule (2): leave `grams` null so resolution falls through
@@ -546,6 +569,10 @@ export async function buildFatSecretResult(
                         noun,
                         serving: match.description,
                         perUnitGrams,
+                        // Which divisor won. Without it the tier alone cannot
+                        // distinguish a label-enumerated serving from a
+                        // numberOfUnits one, and that is the whole defect.
+                        labelPieceCount,
                     });
                 }
             }

--- a/src/lib/mapping/count-label.ts
+++ b/src/lib/mapping/count-label.ts
@@ -81,7 +81,7 @@ export function countedPieceNoun(parsed: ParsedIngredient | null): string | null
 }
 
 /** Leading integer count of a label serving string, or null ("15 pieces (28 g)" → 15). */
-function labelLeadingCount(servingSize: string): number | null {
+export function labelLeadingCount(servingSize: string): number | null {
     const count = Number((servingSize.match(/^\s*(\d+(?:\.\d+)?)/) || [])[1]);
     return Number.isInteger(count) && count >= 2 ? count : null;
 }


### PR DESCRIPTION
## The defect

`numberOfUnits` counts **servings**, not pieces, so it is `1` on a serving whose label already enumerates them. `fs_63588` ("Tortilla Chips") carries one usable piece serving:

| description | grams | numberOfUnits |
|---|---|---|
| `13 chips` | 28.35 | 1 |

Dividing by `numberOfUnits` therefore declares the whole 13-chip serving to be **one chip**, and `13 tortilla chips` bills `13 x 28.35 = 368.55 g / 1950 kcal` against a `[28, 70]` band.

## Measured, not inferred

Probed cold on the box (build `uBFD8NQ1882Oy_g3XnYjA`, `?nocache=1&nosave=1`), 2026-08-02:

| query | grams |
|---|---|
| `tortilla chips` | 28.35 |
| `1 tortilla chips` | 28.35 |
| `2 tortilla chips` | 56.7 |
| `13 tortilla chips` | 368.55 |
| `20 tortilla chips` | 567 |

Linear in the stated count. **The bare form is not affected** — telemetry shows it resolves through `fs_default_serving` and already returns 28.35 g, which is why only the counted form fails and why this change cannot regress it.

## Why it was wrong here and right in OFF

`count-label.ts` has owned this predicate since the OFF lane adopted it. Its module header names *"13 tortilla chips"* as the motivating query and lists its callers: `buildOffResult`, `simpleRerank`, the counted-piece cache escape, retrieval. **`buildFatSecretResult` was never one of them.** This is the "owners were extracted, callers were not" shape — not a new rule, an unadopted one.

## Guarded, not substituted

`servingLabelCountsPiece` requires a count `>= 2` naming the matched noun (or a generic piece word) plus a sane per-piece weight, so the `numberOfUnits` divisor still wins where the label is not enumerating:

- `1 thin slice` (bacon) — count 1, not an enumeration
- `1/2 breast, bone and skin removed` — `numberOfUnits` 0.5, the `n-mq-47` shape the bare-fallback comment documents
- `3 oz` with `measurementDescription: chip` — reaches the branch (the matcher reads `measurementDescription` too) but its leading 3 counts **ounces**

`labelPieceCount` is now logged, so the tier alone no longer hides which divisor won.

## Blast radius (measured on the box)

| | |
|---|---|
| `fs_label_count` events all-time | 974 |
| FatSecret records carrying a label-enumerated serving | 3,923 |
| cached `FoodMapping` rows backed by one | 109 |

The 109 is an **upper bound** — only a request carrying a count bills wrong.

## Tests

7 new tests in `build-fatsecret-result-label-count.test.ts`, each naming the mutation it kills. Typecheck clean; `lint:ci` 0 errors.

Note: `src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts` is **flaky independently of this change** — two runs on clean `master` failed 3 tests each with *different* sets, all 5000 ms timeouts. Filed separately, not introduced here.

## Scope

Closes golden `n-serv-35` and `n-tot-05` cold. The other 17 cold failures are separate defects and are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu