### PR TITLE
test(mapping): stop the FS-cache suite dialling OpenRouter; register the #223 claim

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1039,6 +1039,18 @@
         "value": "^1@1$"
       },
       "verified": "2026-08-02"
+    },
+    {
+      "id": "fs-piece-scan-uses-label-piece-matches-item",
+      "claim": "buildFatSecretResult's counted-request fallback scans for a serving whose label word is a word of the REQUEST, via count-label.ts's labelPieceMatchesItem, not only the request's last token. FatSecret labels the piece with a modifier of the name (fs_519595 'Cherry Tomatoes' carries '1 cherry' at 17 g), so a head-noun-only scan missed it and '5 cherry tomatoes' billed 5 x the declared 123 g serving = 615 g cold. That predicate is also the guard -- '1 cup' and '1 oz' on the same record are rejected because neither word is in the request -- so this checks the call site AND that no measure-word allowlist crept in beside it.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
+      "where": "backend",
+      "command": "echo \"$(grep -c 'labelPieceMatchesItem(labelWord, requestName)' src/lib/mapping/build-fatsecret-result.ts)@$(grep -c '^export function labelPieceMatchesItem' src/lib/mapping/count-label.ts)\"",
+      "expect": {
+        "kind": "matches",
+        "value": "^1@1$"
+      },
+      "verified": "2026-08-02"
     }
   ]
 }

--- a/src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts
+++ b/src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts
@@ -51,6 +51,7 @@ import { queueForDeferredHydration } from '../deferred-hydration';
 import { backfillOnDemand } from '../serving-backfill';
 import { insertAiServing } from '../ai-backfill';
 import { gatherCandidates } from '../gather-candidates';
+import { callStructuredLlm } from '../../ai/structured-client';
 import { prisma } from '../../db';
 
 jest.mock('../../db', () => ({
@@ -101,6 +102,46 @@ jest.mock('../gather-candidates', () => {
     return { ...actual, gatherCandidates: jest.fn() };
 });
 
+// ── Why these last two mocks exist: this file used to reach the network ──────
+//
+// Every assertion below is about `telemetry.cacheEscape`, which is set in the
+// Step 1a / Step 1c cache-validation blocks. But an ESCAPED hit does not end
+// the call — the mapper falls through to full resolution, finds no candidates
+// (gatherCandidates is stubbed to []), and runs its AI fallback chain
+// (ai-simplify, then ai-nutrition-backfill). Both of those go through
+// callStructuredLlm(), the single chokepoint for LLM traffic in the mapper,
+// and ai-simplify.ts does `import 'dotenv/config'` at module scope — so the
+// suite loaded the developer's real .env and billed live OpenRouter calls.
+//
+// MEASURED 2026-08-02 on clean master (`for i in $(seq 10); do npx jest
+// src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts; done`):
+// 129 successful `openrouter / openai/gpt-4o-mini` round trips over 10 runs
+// (~13 per run), each 810–3163 ms. Two or three of those land inside one
+// `it()` against jest's 5000 ms default, so 10 of 10 runs failed, with a
+// DIFFERENT set of 2–5 tests timing out each time. It was network latency,
+// not slow code — the assertions themselves resolve in single-digit ms.
+//
+// So the fix is to remove the network, not to raise the timeout. Stubbing
+// callStructuredLlm to return an error is exactly the shape CI already sees,
+// where no API key is configured and getProviderChain() returns []: the
+// fallback chain still runs, it just degrades instead of dialling out.
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return { ...actual, callStructuredLlm: jest.fn() };
+});
+
+// gather-candidates calls warmupEmbedder() at MODULE scope, and the
+// requireActual above executes that module for real — starting an ONNX
+// feature-extraction model load that outlives the run and produced the
+// "Cannot log after tests are done" warnings. Same stub as
+// src/lib/ai/__tests__/structured-schema-invariant.test.ts.
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
 const fsCacheRow = {
     foodId: 'fs_69219858',
     foodName: 'Ten Vegetable Soup - Bowl',
@@ -111,6 +152,27 @@ const fsCacheRow = {
 
 beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks() is mockClear(), which resets recorded CALLS but leaves
+    // mocked implementations in place — including an unconsumed
+    // mockResolvedValueOnce() queue. Every test below arms
+    // getValidatedMappingByNormalizedName with a `Once`, and a test that
+    // returns down a shorter path than expected leaves its `Once` sitting in
+    // the queue for the NEXT test to consume. (Verified on jest 29.7.0: a
+    // queued-but-uncalled Once survives jest.clearAllMocks() and is returned by
+    // the following test's first call.) That is a second, order-dependent
+    // source of nondeterminism on top of the network one, and it is why the
+    // failures used to cascade — a timed-out test poisoned its successor.
+    // mockReset() is the one that drains the queue; only this mock needs it,
+    // because the prisma stubs get their implementations from the module
+    // factory and a blanket resetAllMocks() would wipe those.
+    (getValidatedMappingByNormalizedName as jest.Mock).mockReset();
+    (callStructuredLlm as jest.Mock).mockResolvedValue({
+        status: 'error',
+        error: 'llm disabled in unit tests',
+        provider: 'openrouter',
+        model: 'none',
+        durationMs: 0,
+    });
     (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
     (getValidatedMapping as jest.Mock).mockResolvedValue(null);
     (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);

--- a/src/lib/mapping/__tests__/legacy-key-fallback.test.ts
+++ b/src/lib/mapping/__tests__/legacy-key-fallback.test.ts
@@ -88,6 +88,30 @@ jest.mock('../gather-candidates', () => {
         gatherCandidates: jest.fn(),
     };
 });
+// ...and ai-nutrition-backfill is not the only LLM caller on that tail: the
+// fallback chain runs ai-simplify FIRST. Stubbing only the nutrition half left
+// one live `openrouter / openai/gpt-4o-mini` simplify round trip per run of
+// this file (MEASURED 2026-08-02: 1 call, 1635 ms —
+// `npx jest src/lib/mapping/__tests__/legacy-key-fallback.test.ts 2>&1 | grep -c
+// 'structured-llm].*call successful'` -> 1 before this mock, 0 after).
+// callStructuredLlm() is the chokepoint every LLM caller in the mapper goes
+// through, so stub it there rather than per-caller; that also matches CI, where
+// no API key is configured and getProviderChain() returns []. Same reason this
+// mock exists in fs-cache-nutrition-validation.test.ts, where the latency of
+// those calls against jest's 5000 ms default was making the suite flaky.
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
 // The zombie-guard test runs the pipeline to a full miss; the AI nutrition
 // backfill tail must not fire a real LLM call from inside jest.
 jest.mock('../ai-nutrition-backfill', () => ({


### PR DESCRIPTION
Two commits, no production code.

## 1. `test(mapping)` — the flaky suite was making live, billable API calls

`fs-cache-nutrition-validation.test.ts` failed **10 of 10 runs** on clean `master` — 2–5 of its 9 tests each time, a *different set* every run, almost all 5000 ms timeouts.

It was not a slow test. Every assertion is about `telemetry.cacheEscape`, but an escaped hit **does not end the call**: the mapper falls through to full resolution, finds no candidates, and runs its AI fallback chain (`ai-simplify`, then `ai-nutrition-backfill`). Both go through `callStructuredLlm()`, and `ai-simplify.ts` does `import 'dotenv/config'` at **module scope** — so the test process loaded the developer's real `.env` and got a working key.

**Measured over 10 runs: 129 successful `openrouter/gpt-4o-mini` round trips**, ~13/run, 810–3163 ms each. Two or three inside one `it()` blow the default timeout.

The split names the cause on its own: the **five tests whose hit ESCAPES are the flaky ones; the four where it is SERVED are 0/10.**

### Removing the network, not raising the timeout

With the stub in place the same assertions resolve in single-digit ms — a higher timeout would have preserved a 21 s suite that still costs money and still flakes on a bad network day. Stubbing `callStructuredLlm` reproduces the shape **CI already runs under**, where no key is configured and `getProviderChain()` returns `[]`.

Two amplifiers also fixed:
- `jest.clearAllMocks()` does **not** drain a `mockResolvedValueOnce()` queue, so a test killed before consuming its `Once` left it for the next test. `mockReset()` on that one mock drains it; a blanket `resetAllMocks()` would wipe the prisma stubs set in the module factory.
- `gather-candidates` calls `warmupEmbedder()` at module scope and the `requireActual` ran it for real, starting an ONNX load that outlived the run.

`legacy-key-fallback.test.ts` gets the same stub — its author had spotted the class and mocked `ai-nutrition-backfill` but missed `ai-simplify`, which runs **first**.

### Verification

| check | result |
|---|---|
| consecutive clean runs | **30/30** |
| suite time | 21.5 s → **0.30 s** |
| live LLM calls | **0** |
| mutations applied to `map-ingredient-with-fallback` | **7 applied, 7 killed** |

Independently re-verified before merge: 10/10 pass, 0 network calls, 0.37 s.

### Not fixed — the bigger class

**Five** mapper modules (`ai-parse`, `ai-normalize`, `ai-simplify`, `ai-rerank`, `ai-search-refine`) import `dotenv/config` at module scope, so **any** jest test importing the mapper chain inherits production credentials and can dial out (re-derive: `grep -rln "^import 'dotenv/config'" src/lib/`). The structural fix is a `setupFiles` entry blanking the keys for the `api` project — one line, but a repo-wide gate change.

**CI has no key, so CI was green throughout.** This only ever bit developers with a populated `.env`.

## 2. `chore(doc-check)` — register `fs-piece-scan-uses-label-piece-matches-item`

Guards both the call site in `buildFatSecretResult` and the `count-label.ts` export it reuses, so removing either turns the nightly red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu