### PR TITLE
test(ci): no jest test may reach a live LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,12 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 SCREEN_AI_MODEL=openai/gpt-4o-mini
 
 # Ollama (local LLM for parse tasks — $0 cost)
+# DEFAULTS TO TRUE when unset (getFlag('OLLAMA_ENABLED', true) in src/lib/mapping/config.ts),
+# and the Ollama provider entry carries its own literal apiKey, so it is the one provider that
+# is armed WITHOUT any credential being configured. Undocumented here until 2026-08-02 because
+# config.ts reads it through a dynamic process.env[name], which the .env.example parity check
+# cannot see — it surfaced only when a test referenced the name literally.
+OLLAMA_ENABLED=true
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen2.5:14b
 OLLAMA_TIMEOUT_MS=15000

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,10 @@ module.exports = {
       moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
       },
+      // Blanks the provider credentials BEFORE any module is imported, so no test can
+      // reach a live LLM. Must stay in `setupFiles`, not `setupFilesAfterEnv` — the
+      // keys are captured into module-scope consts at import time. See the file.
+      setupFiles: ['<rootDir>/jest.setup.no-llm.js'],
     },
     {
       displayName: 'components',
@@ -38,6 +42,9 @@ module.exports = {
       moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
       },
+      // Same gate as the `api` project: a component test can import the mapper chain
+      // transitively, so the jsdom project needs it too.
+      setupFiles: ['<rootDir>/jest.setup.no-llm.js'],
       setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
       extensionsToTreatAsEsm: ['.ts', '.tsx'],
       globals: {

--- a/jest.setup.no-llm.js
+++ b/jest.setup.no-llm.js
@@ -1,0 +1,86 @@
+/**
+ * Jest gate: a test may never reach a live LLM provider.
+ *
+ * WHY THIS FILE EXISTS
+ * Five mapper modules — `ai-parse`, `ai-normalize`, `ai-simplify`, `ai-rerank`,
+ * `ai-search-refine` — do `import 'dotenv/config'` at module scope (re-derive:
+ * `grep -rln "^import 'dotenv/config'" src/lib/` -> 5, measured 2026-08-02). So a
+ * jest process that imports any part of the mapper chain loads the developer's real
+ * `.env` and comes up holding working production credentials.
+ *
+ * MEASURED 2026-08-02 on clean master: ten runs of
+ * `src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts` made 129
+ * successful `openrouter / openai/gpt-4o-mini` round trips, 810-3163 ms each. Two or
+ * three of those landed inside a single `it()` against jest's 5000 ms default, so all
+ * ten runs failed with a different set of tests timing out each time.
+ *
+ * CI IS NOT A CHECK ON THIS. CI has no key, so `getProviderChain()` returns [] there
+ * and CI has always been green. The defect only fires on a developer machine with a
+ * populated `.env`, which is also the only place the calls are billable.
+ *
+ * WHY `setupFiles` AND NOT `setupFilesAfterEnv`
+ * Every provider credential is captured into a module-scope `const` at import time —
+ * `OPENROUTER_API_KEY` / `OLLAMA_*` in `src/lib/mapping/config.ts`, `OPENAI_API_KEY`
+ * in `getProviderChain()`'s own module and in each direct-fetch module. Once those
+ * modules are imported the value is frozen, so the blanking has to happen before the
+ * first import. `setupFiles` runs before the test framework and before the test file
+ * is loaded; `setupFilesAfterEnv` runs after, i.e. too late.
+ *
+ * WHY THIS ASSIGNS '' AND MUST NEVER `delete`
+ * dotenv (17.2.3) writes a key only when
+ * `Object.prototype.hasOwnProperty.call(processEnv, key)` is false and `override` is
+ * unset — see `node_modules/dotenv/lib/main.js`. Assigning '' creates the property,
+ * so the later `import 'dotenv/config'` is a no-op for that key. `delete
+ * process.env.X` would remove the property and hand dotenv permission to put the real
+ * key straight back, which is the same gate that looks identical and does nothing.
+ *
+ * The invariant is asserted by `src/lib/ai/__tests__/no-live-llm-egress.test.ts`,
+ * which loads `dotenv/config` itself and then requires the chain to still be empty.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Credential-gated providers.
+// `getProviderChain()` in src/lib/ai/structured-client.ts pushes an OpenRouter or
+// OpenAI entry only when the corresponding key is truthy, so '' removes both from
+// every chain. OPENAI_API_KEY additionally disarms the four modules that bypass
+// callStructuredLlm() and fetch `${OPENAI_API_BASE_URL}/chat/completions` directly:
+// aiRerankCandidates() in src/lib/mapping/ai-rerank.ts, the refine call in
+// src/lib/mapping/ai-search-refine.ts, src/lib/mapping/ai-synonym-generator.ts, and
+// src/lib/ai/simple-serving-estimator.ts — each returns early on a falsy key.
+// ---------------------------------------------------------------------------
+process.env.OPENROUTER_API_KEY = '';
+process.env.OPENAI_API_KEY = '';
+
+// ---------------------------------------------------------------------------
+// 2. The provider that needs no credential.
+// `OLLAMA_ENABLED = getFlag('OLLAMA_ENABLED', true)` in src/lib/mapping/config.ts
+// DEFAULTS TO TRUE, and the Ollama branch of `getProviderChain()` supplies the
+// literal string 'ollama' as its apiKey. Blanking the keys above therefore does not
+// stop it: `purpose: 'parse'` and `forceProvider: 'ollama'` would still dial
+// http://localhost:11434/v1 on any machine running Ollama, with a 60 s timeout.
+// This machine happens to carry OLLAMA_ENABLED=false in `.env`, which is exactly why
+// the flag has to be set here rather than relied upon.
+// ---------------------------------------------------------------------------
+process.env.OLLAMA_ENABLED = 'false';
+
+// ---------------------------------------------------------------------------
+// 3. Base URLs — defence in depth, not the primary gate.
+// Sections 1 and 2 are enumerations of today's provider list; a provider added later
+// without a key guard would walk straight past them. Every LLM request in this repo
+// is built as `${<one of these>}/chat/completions`, so pointing them at a closed port
+// converts that class of leak from a silent live call into an immediate
+// ECONNREFUSED naming this gate. `??` in config.ts falls back only on null/undefined,
+// so an explicitly assigned value survives. Port 1 is reserved and never listening:
+// no DNS, no hang.
+// ---------------------------------------------------------------------------
+const BLACKHOLE = 'http://127.0.0.1:1/jest-no-llm-gate';
+process.env.OPENROUTER_BASE_URL = BLACKHOLE;
+process.env.OPENAI_API_BASE_URL = BLACKHOLE;
+process.env.OLLAMA_BASE_URL = BLACKHOLE;
+
+// Deliberately NOT provided: an escape hatch such as JEST_ALLOW_LIVE_LLM. No test in
+// this repo asserts real provider behaviour (re-derive: `grep -rln
+// "OPENROUTER_API_KEY\|OPENAI_API_KEY\|OLLAMA" --include="*.test.ts" src scripts` ->
+// no matches, measured 2026-08-02). A test that genuinely needs LLM behaviour should
+// stub `callStructuredLlm` — the single chokepoint — the way
+// src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts does.

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1051,6 +1051,18 @@
         "value": "^1@1$"
       },
       "verified": "2026-08-02"
+    },
+    {
+      "id": "jest-llm-egress-gate-wired",
+      "claim": "Both jest projects load jest.setup.no-llm.js via setupFiles, so no test can reach a live LLM provider. Five mapper modules import 'dotenv/config' at module scope, so before this a test importing the mapper chain held the developer's real keys -- measured 129 billable OpenRouter round trips over 10 runs of one suite. The second half of the command is the load-bearing one: the gate must ASSIGN '' and must never `delete process.env.X`, because dotenv only writes a key it does not already own, so a delete hands the real key straight back and the gate looks identical while doing nothing. CI has no key and was green throughout, so CI is not a check on this.",
+      "ownerDoc": "backend:jest.setup.no-llm.js",
+      "where": "backend",
+      "command": "echo \"$(grep -c 'jest.setup.no-llm.js' jest.config.js)@$(grep -c 'delete process.env' jest.setup.no-llm.js)\"",
+      "expect": {
+        "kind": "matches",
+        "value": "^2@0$"
+      },
+      "verified": "2026-08-02"
     }
   ]
 }

--- a/src/lib/ai/__tests__/no-live-llm-egress.test.ts
+++ b/src/lib/ai/__tests__/no-live-llm-egress.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Guard for the jest LLM-egress gate (`jest.setup.no-llm.js`, wired as `setupFiles`
+ * in both projects of jest.config.js).
+ *
+ * The gate is an enumeration of today's provider list, so its failure mode is silent:
+ * delete a line, or add a provider it does not know about, and nothing goes red — the
+ * suite just starts making live, billable calls again on developer machines, while CI
+ * (which has no key) stays green either way. This file is what makes that loud.
+ *
+ * MEASURED 2026-08-02, before the gate existed, by a temporary probe run under
+ * `npx jest`: `getProviderChain()` returned `['openrouter','openrouter','openai']` for
+ * all seven purposes and one `callStructuredLlm` reached OpenRouter for real
+ * (`provider=openrouter, model=openai/gpt-4o-mini, duration=1114ms`). With
+ * OLLAMA_ENABLED=true — the code default in `getFlag()` — the `parse` chain led with
+ * a keyless `ollama` entry. After the gate every one of those chains is [].
+ */
+
+// FIRST import on purpose. `ai-parse`, `ai-normalize`, `ai-simplify`, `ai-rerank` and
+// `ai-search-refine` each do exactly this at module scope, which is how the real
+// `.env` gets into a jest process at all. Loading it here means the assertions below
+// run against the worst case rather than a convenient one: if the gate ever switches
+// from assigning '' to `delete`, dotenv repopulates the real keys at this line and
+// every expectation in this file fails.
+import 'dotenv/config';
+
+import {
+    getProviderChain,
+    callStructuredLlm,
+    isOpenRouterConfigured,
+    type StructuredLlmPurpose,
+    type StructuredLlmProvider,
+} from '../structured-client';
+
+// Written as exhaustive Records rather than arrays so that adding a purpose or a
+// provider to structured-client.ts is a COMPILE error here (the api project runs
+// ts-jest with type-checking on), not a silently unchecked new egress path.
+const ALL_PURPOSES: Record<StructuredLlmPurpose, true> = {
+    normalize: true,
+    serving: true,
+    ambiguous: true,
+    produce: true,
+    parse: true,
+    simplify: true,
+    nutrition: true,
+};
+
+const ALL_PROVIDERS: Record<StructuredLlmProvider, true> = {
+    ollama: true,
+    openrouter: true,
+    openai: true,
+};
+
+const purposes = Object.keys(ALL_PURPOSES) as StructuredLlmPurpose[];
+const providers = Object.keys(ALL_PROVIDERS) as StructuredLlmProvider[];
+
+describe('no test may reach a live LLM provider', () => {
+    it('leaves the credentials blank even after dotenv/config has run', () => {
+        // '' and not undefined: the empty string is what stops dotenv from writing the
+        // real value, because dotenv only fills keys absent from process.env.
+        expect(process.env.OPENROUTER_API_KEY).toBe('');
+        expect(process.env.OPENAI_API_KEY).toBe('');
+    });
+
+    it('disables the provider that needs no credential', () => {
+        // OLLAMA_ENABLED defaults to TRUE in getFlag() (src/lib/mapping/config.ts) and
+        // the Ollama branch supplies its own literal apiKey, so blanking keys alone
+        // leaves localhost:11434 reachable.
+        expect(process.env.OLLAMA_ENABLED).toBe('false');
+    });
+
+    it('points every provider base URL at a closed port', () => {
+        // Defence in depth for a provider added without a key guard: every request in
+        // this repo is `${baseUrl}/chat/completions`.
+        for (const url of [
+            process.env.OPENROUTER_BASE_URL,
+            process.env.OPENAI_API_BASE_URL,
+            process.env.OLLAMA_BASE_URL,
+        ]) {
+            expect(url).toBe('http://127.0.0.1:1/jest-no-llm-gate');
+        }
+    });
+
+    it.each(purposes)('builds an empty provider chain for purpose %s', (purpose) => {
+        expect(getProviderChain(purpose)).toEqual([]);
+    });
+
+    it.each(providers)('builds an empty provider chain when forced to %s', (provider) => {
+        // forceProvider bypasses purpose routing, so it needs its own coverage — the
+        // ollama case in particular short-circuits before any key is consulted.
+        for (const purpose of purposes) {
+            expect(getProviderChain(purpose, provider)).toEqual([]);
+        }
+    });
+
+    it('reports OpenRouter as unconfigured', () => {
+        expect(isOpenRouterConfigured()).toBe(false);
+    });
+
+    it('degrades callStructuredLlm to the same shape CI sees', async () => {
+        // An empty chain returns before fetch() is ever reached, so this makes no
+        // network call. The error text is the one CI has always produced.
+        const result = await callStructuredLlm({
+            schema: { type: 'object' },
+            systemPrompt: 'unused',
+            userPrompt: 'unused',
+            purpose: 'simplify',
+        });
+        expect(result.status).toBe('error');
+        expect(result.error).toContain('No API keys configured');
+    });
+});


### PR DESCRIPTION
PR #224 stubbed the two suites that were dialling out. **This is the gate that stops the next one.**

Five mapper modules `import 'dotenv/config'` at module scope, so *any* test importing the mapper chain comes up holding the developer's real production credentials. That is how one suite made **129 billable OpenRouter round trips over 10 runs**.

`jest.setup.no-llm.js` blanks the provider credentials, wired via `setupFiles` on **both** projects — not `setupFilesAfterEnv`, because every credential is captured into a module-scope `const` at import time, so blanking afterwards is inert.

## Two things a plausible version would miss

- **`OLLAMA_ENABLED` defaults to `true`** and the Ollama branch supplies its own literal `apiKey: 'ollama'` — so blanking API keys alone leaves a provider that needs no credential fully armed.
- **The gate assigns `''` and must never `delete process.env.X`.** dotenv 17.2.3 writes a key only when the property is absent and `override` is unset (`node_modules/dotenv/lib/main.js`), so assigning `''` makes the later import a no-op while a `delete` hands the real key straight back. A delete-based gate is byte-for-byte as convincing and does nothing. The doc-check claim guards this, not just the wiring.

## Verification

| check | before | after |
|---|---|---|
| `npm test` | 149 suites / 3121 passed | **150 / 3136**, exit 0 |
| `getProviderChain()`, all 7 purposes | `['openrouter','openrouter','openai']` | `[]` |
| forced `ollama` chain | `['ollama']` | `[]` |
| `npm run typecheck` | — | clean |
| `npm run lint:ci` | — | 0 errors |

**The full-run call count was already 0 before this change** — #224 had fixed the only two offenders — so that delta proves nothing and is not offered as proof. Instead: a throwaway probe doing nothing but `import 'dotenv/config'` + `callStructuredLlm` made a real billable call before the gate and returned `No API keys configured` after; and a **tripwire** re-run with the gate swapped for a no-op turns **14 of the 15 guard tests red**, one of them burning 5003 ms attempting a real call. A removed gate is now loud rather than silent.

`no-live-llm-egress.test.ts` imports `dotenv/config` itself first, reproducing the exact leak. Purposes and providers are exhaustive `Record<Union, true>` maps, so adding either to `structured-client.ts` is a **compile error here** rather than a silently uncovered egress path.

## Deliberately no escape hatch

No `JEST_ALLOW_LIVE_LLM`. An unused env-var bypass is precisely how this kind of gate fails open later; the documented route for a test needing LLM behaviour is stubbing `callStructuredLlm`, the single chokepoint. No test currently needs one (`grep -rln "OPENROUTER_API_KEY\|OPENAI_API_KEY\|OLLAMA" --include="*.test.ts" src scripts` → no matches).

## How it can still fail open

It enumerates today's provider list. A new provider with a new key var walks past sections 1–2; the exhaustive `Record<StructuredLlmProvider, true>` converts the likely path into a compile error but not one bolted on outside that union. `dotenv.config({ override: true })` or `dotenv-flow` would defeat it — nothing uses those today.

## Out of scope

`src/lib/usda/__tests__/fdc-api.test.ts` makes live calls to the USDA FDC API (429s in the run log). Same class, not billable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu