### PR TITLE
fix(doc-check): delete a claim that cannot run in any context

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -894,22 +894,10 @@
     },
     {
       "id": "ai-nutrition-hydration-budget-code",
-      "claim": "Hydration-time AI nutrition has its OWN allowance, separate from the parse-time one: AI_NUTRITION_HYDRATION_MAX_PER_REQUEST and AI_NUTRITION_HYDRATION_MAX_PER_BATCH are both exported from src/lib/mapping/config.ts. Sharing the parse-time budget made the exhaustion guard in requestAiNutrition() unreachable.",
+      "claim": "Hydration-time AI nutrition has its OWN allowance, separate from the parse-time one: AI_NUTRITION_HYDRATION_MAX_PER_REQUEST and AI_NUTRITION_HYDRATION_MAX_PER_BATCH are both exported from src/lib/mapping/config.ts. Sharing the parse-time budget made the exhaustion guard in requestAiNutrition() unreachable. The .env.example half of this fact is NOT a doc-check claim and must not be re-added as one: it was tried as `where: backend` (red on the box, which Syncthing cannot deliver .env* to) and then as `where: devmachine` (which runs with cwd = the MOBILE repo, where .env.example does not exist, so it returned empty and was red on the Mac too). It needs no claim -- CI's `check` job runs scripts/check-env-example.js on every PR and fails if any literal process.env.X in src/** is missing from .env.example, and both of these are read literally. That gate is blocking and always runs; this registry cannot beat it.",
       "ownerDoc": "mobile:sync-docs/log/2026-08-01_1539_prelaunch-mapping-cleanup.md",
       "where": "backend",
       "command": "grep -cE '^export const AI_NUTRITION_HYDRATION_MAX_PER_(REQUEST|BATCH) =' src/lib/mapping/config.ts",
-      "expect": {
-        "kind": "equals",
-        "value": "2"
-      },
-      "verified": "2026-08-02"
-    },
-    {
-      "id": "ai-nutrition-hydration-budget-documented",
-      "claim": "Both hydration-time AI nutrition budget vars are documented in .env.example. DEVMACHINE ONLY: Syncthing does not deliver .env* files, so the box's .env.example is a stale copy (dated 2026-07-25) and this claim ran red there nightly from 2026-08-01 while the fact was TRUE on every host that actually has the file.",
-      "ownerDoc": "mobile:sync-docs/log/2026-08-01_1539_prelaunch-mapping-cleanup.md",
-      "where": "devmachine",
-      "command": "grep -cE '^AI_NUTRITION_HYDRATION_MAX_PER_(REQUEST|BATCH)=' .env.example",
       "expect": {
         "kind": "equals",
         "value": "2"


### PR DESCRIPTION
`ai-nutrition-hydration-budget-documented` greps `.env.example`.

- As **`where: backend`** it ran red on the box nightly — Syncthing does not deliver `.env*` files, so the box holds a stale copy.
- The 2026-08-02 split moved it to **`where: devmachine`** to name that. But `devmachine` runs with **cwd = the MOBILE repo**, where `.env.example` does not exist — so it returned empty and went red on the Mac instead.

The fact was true throughout. The claim was unrunnable in both homes it was given.

## It needs no claim at all

CI's `check` job runs `scripts/check-env-example.js` on every PR and fails when any literal `process.env.X` in `src/**` is missing from `.env.example`. Both hydration vars are read literally (`config.ts`), so a **blocking, always-run** gate already owns this fact. The registry cannot beat that.

The surviving sibling claim — the `config.ts` exports, `where: backend`, which passes everywhere — now records why the `.env.example` half is deliberately absent, so it doesn't get re-added a third time.

## Verification

`npm run doc-check` on the Mac, all four contexts: **87/87**.

A related footgun is now written into CLAUDE.md §Doc rules: **a context also picks the working directory**, so a claim reading a *backend* file can never be `devmachine`, however true "only a dev machine has that file" is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu