### PR TITLE
fix(mapping): a flavour word must not become a distinct ingredient

### DIFF
--- a/data/fatsecret/normalization-rules.json
+++ b/data/fatsecret/normalization-rules.json
@@ -450,10 +450,6 @@
       "to": "garlic powder spice"
     },
     {
-      "from": "vanilla",
-      "to": "vanilla extract"
-    },
-    {
       "from": "red and plain quinoa mix",
       "to": "quinoa"
     },

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1051,6 +1051,32 @@
         "value": "^2@0$"
       },
       "verified": "2026-08-02"
+    },
+    {
+      "id": "vanilla-rewrite-is-context-gated",
+      "claim": "A flavour word must not become a distinct ingredient. data/fatsecret/normalization-rules.json carried an unguarded synonym_rewrites entry vanilla -> vanilla extract which fired before any LLM ran, so `vanilla yogurt` was searched as `vanilla extract yogurt` and resolved to a 288 kcal/100g, 4.2 g ingredient (MEASURED cold on the live box 2026-08-03; `vanilla protein shake` billed 150 g = 429 kcal of extract). DEFAULT_RULES never held that entry and the in-code rule implementing the same recipe default IS context-gated on a following food noun, but readRulesFile() prefers the on-disk JSON so the naive entry won. Asserts BOTH halves: the flavour-plus-food form is left alone AND bare vanilla still gets the intended recipe default. Output is normalize(vanilla yogurt)|normalize(vanilla).",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-03_flavour-word-promotion.md",
+      "where": "backend",
+      "command": "npx ts-node --project tsconfig.scripts.json --transpile-only -e \"const {normalizeIngredientName:n}=require('./src/lib/mapping/normalization-rules');process.stdout.write(n('vanilla yogurt').cleaned+'|'+n('vanilla').cleaned)\"",
+      "expect": {
+        "kind": "equals",
+        "value": "vanilla yogurt|vanilla extract"
+      },
+      "verified": "2026-08-03",
+      "timeoutMs": 180000
+    },
+    {
+      "id": "box-rules-file-has-no-bare-vanilla-rewrite",
+      "claim": "THE DELIVERED HALF of the flavour-promotion fix, and the only check that can see it. data/ is in the box's .stignore so Syncthing NEVER carries data/fatsecret/normalization-rules.json to /home/owner/Recipe-App, and readRulesFile() prefers that on-disk JSON over DEFAULT_RULES. A stale copy therefore reinstates vanilla -> vanilla extract on the LIVE service while every Mac-side gate stays green, including the backend-context twin vanilla-rewrite-is-context-gated, which reads the Mac file. Same failure shape as PR #211, which sat inert on the box until an scp on 2026-08-01. Output is bareVanillaRewriteCount@synonymRewriteCount: a missing, unreadable or unparseable file emits nothing and FAILS, never passes.",
+      "ownerDoc": "mobile:CLAUDE.md#deploying-the-backend",
+      "where": "box",
+      "command": "node -e \"const p='/home/owner/Recipe-App/data/fatsecret/normalization-rules.json';const r=JSON.parse(require('fs').readFileSync(p,'utf8'));const h=(r.synonym_rewrites||[]).filter(a=>String(a.from||'').trim().toLowerCase()==='vanilla');process.stdout.write(h.length+'@'+(r.synonym_rewrites||[]).length)\"",
+      "expect": {
+        "kind": "matches",
+        "value": "^0@[1-9][0-9]*$"
+      },
+      "verified": "2026-08-03",
+      "timeoutMs": 60000
     }
   ]
 }

--- a/src/lib/mapping/__tests__/llm-output-guard-wiring.test.ts
+++ b/src/lib/mapping/__tests__/llm-output-guard-wiring.test.ts
@@ -1,0 +1,172 @@
+/**
+ * WIRING test for the introduced-food-token guard.
+ *
+ * `llm-output-guards.test.ts` proves the predicate. It does NOT prove the
+ * mapper calls it — and on this codebase that is the failure that keeps
+ * recurring: a correct rule with a caller that never uses it (#221, #223 and
+ * #226 were all that shape, and #226's caller was dead code a gate believed was
+ * live). So this file asserts the repaired string actually reaches
+ * `gatherCandidates()`, which is the value retrieval searches on.
+ *
+ * Mock preamble mirrors `legacy-key-fallback.test.ts`, including the
+ * `callStructuredLlm` stub — that is the single chokepoint every LLM caller in
+ * the mapper goes through, and without it this suite makes billable OpenRouter
+ * round trips on any dev machine with a populated .env (CI has no key, so CI
+ * would stay green while the dev machine paid).
+ */
+
+import { mapIngredientWithFallback } from '../map-ingredient-with-fallback';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import {
+    getValidatedMapping,
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates } from '../gather-candidates';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        ingredient: { findMany: jest.fn().mockResolvedValue([]) },
+    },
+}));
+
+jest.mock('../ai-normalize');
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return { ...actual, getCachedFoodWithRelations: jest.fn() };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: jest.fn() };
+});
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: jest.fn().mockResolvedValue({ status: 'error', reason: 'skip' }),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: jest.fn().mockResolvedValue(null),
+    createAiNutritionBudget: (max: number) => ({ remaining: max, spent: 0 }),
+}));
+
+/** Every normalizedName handed to retrieval, in call order. */
+function gatherNames(): string[] {
+    return (gatherCandidates as jest.Mock).mock.calls.map((c) => c[2]);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMapping as jest.Mock).mockResolvedValue(null);
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (gatherCandidates as jest.Mock).mockResolvedValue([]);
+});
+
+describe('the introduced-food-token guard is wired into the mapper', () => {
+    it('does not send an LLM-introduced "extract" to retrieval', async () => {
+        // The measured live failure: `vanilla yogurt` searched as vanilla
+        // extract and resolved to a 288 kcal/100g, 4.2 g ingredient.
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'vanilla yogurt extract',
+            canonicalBase: 'vanilla extract',
+        });
+
+        await mapIngredientWithFallback('vanilla yogurt');
+
+        const names = gatherNames();
+        expect(names.length).toBeGreaterThan(0);
+        // The post-LLM gather is what retrieval actually runs on.
+        expect(names[names.length - 1]).toBe('vanilla yogurt');
+        expect(names.some((n) => /\bextract\b/i.test(n ?? ''))).toBe(false);
+    });
+
+    it('leaves the LLM output alone when the user really said extract', async () => {
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'vanilla extract',
+            canonicalBase: 'vanilla extract',
+        });
+
+        await mapIngredientWithFallback('1 tsp vanilla extract');
+
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe('vanilla extract');
+    });
+
+    it('still applies the qualifiers the normalizer is supposed to add', async () => {
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'rolled oats',
+            canonicalBase: 'rolled oats',
+        });
+
+        await mapIngredientWithFallback('oatmeal');
+
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe('rolled oats');
+    });
+});

--- a/src/lib/mapping/__tests__/llm-output-guards.test.ts
+++ b/src/lib/mapping/__tests__/llm-output-guards.test.ts
@@ -1,0 +1,99 @@
+import { stripIntroducedFoodTokens } from '../llm-output-guards';
+
+/**
+ * Guards the flavour-word promotion measured 2026-08-03: ai-normalize appends
+ * `extract` to a trailing flavour word, turning a yogurt or a protein shake
+ * into a 288 kcal/100g, 34%-alcohol ingredient.
+ *
+ * The live evidence, cold and repeated:
+ *   vanilla yogurt        -> "Vanilla Extract"  288 kcal/100g, 4.2 g
+ *   vanilla protein shake -> "Vanilla extract"  286 kcal/100g, 150 g = 429 kcal
+ *
+ * The golden gate cannot see any of this: `n-supp-15` is the only vanilla case
+ * and it carries a brand (`orgain`), which recovers the pick on its own.
+ */
+describe('stripIntroducedFoodTokens', () => {
+    describe('fires when the model introduced the token', () => {
+        it.each([
+            // [raw input, LLM output, expected repair]
+            ['vanilla yogurt', 'vanilla yogurt extract', 'vanilla yogurt'],
+            ['vanilla protein shake', 'vanilla protein shake extract', 'vanilla protein shake'],
+            // the real rows, highest-traffic first (AiNormalizeCache, 2026-08-03)
+            [
+                'orgain organic protein powder vanilla',
+                'orgain organic protein powder vanilla extract',
+                'orgain organic protein powder vanilla',
+            ],
+            ['haagen dazs vanilla', 'haagen dazs vanilla extract', 'haagen dazs vanilla'],
+            ['chobani zero sugar vanilla', 'chobani zero sugar vanilla extract', 'chobani zero sugar vanilla'],
+            // inserted mid-string, not appended
+            [
+                'orgain organic protein vanilla bean',
+                'orgain organic protein vanilla extract bean',
+                'orgain organic protein vanilla bean',
+            ],
+            // the two REPLACE-shaped rows: stripping cannot restore the lost
+            // noun, but removing the head noun is still strictly better
+            ['latte vanilla', 'vanilla extract', 'vanilla'],
+        ])('%s -> %s', (raw, llm, expected) => {
+            const r = stripIntroducedFoodTokens(raw, llm);
+            expect(r.cleaned).toBe(expected);
+            expect(r.removed).toEqual(['extract']);
+        });
+    });
+
+    describe('does NOT fire', () => {
+        it('when the user actually typed the token', () => {
+            const r = stripIntroducedFoodTokens('vanilla extract', 'vanilla extract');
+            expect(r.cleaned).toBe('vanilla extract');
+            expect(r.removed).toEqual([]);
+        });
+
+        it('when the user typed it with different casing or punctuation', () => {
+            const r = stripIntroducedFoodTokens('1 tsp Vanilla Extract', 'vanilla extract');
+            expect(r.cleaned).toBe('vanilla extract');
+            expect(r.removed).toEqual([]);
+        });
+
+        it('on a substring — "extracted" is not "extract"', () => {
+            const r = stripIntroducedFoodTokens('cold extracted olive oil', 'cold extracted olive oil');
+            expect(r.cleaned).toBe('cold extracted olive oil');
+            expect(r.removed).toEqual([]);
+        });
+
+        it('on the qualifiers the normalizer is SUPPOSED to introduce', () => {
+            // `rolled` (18 rows) and `skinless` (16 rows) refine the same food.
+            // A blanket "token absent from input" rule would revert both; this
+            // guard is an allowlist precisely so it does not.
+            expect(stripIntroducedFoodTokens('oatmeal', 'rolled oats').cleaned).toBe('rolled oats');
+            expect(stripIntroducedFoodTokens('chicken breast', 'skinless chicken breast').cleaned).toBe(
+                'skinless chicken breast',
+            );
+        });
+    });
+
+    describe('safety properties', () => {
+        it('never empties the query', () => {
+            const r = stripIntroducedFoodTokens('vanilla', 'extract');
+            expect(r.cleaned).toBe('extract');
+            expect(r.removed).toEqual([]);
+        });
+
+        it('leaves apostrophes alone — the possessive cache-key fork must not return', () => {
+            const r = stripIntroducedFoodTokens("ben and jerry's vanilla", "ben and jerry's vanilla extract");
+            expect(r.cleaned).toBe("ben and jerry's vanilla");
+        });
+
+        it('tolerates null and empty output', () => {
+            expect(stripIntroducedFoodTokens('vanilla', null).cleaned).toBe('');
+            expect(stripIntroducedFoodTokens('vanilla', undefined).removed).toEqual([]);
+            expect(stripIntroducedFoodTokens('vanilla', '').cleaned).toBe('');
+        });
+
+        it('is idempotent', () => {
+            const once = stripIntroducedFoodTokens('vanilla yogurt', 'vanilla yogurt extract').cleaned;
+            const twice = stripIntroducedFoodTokens('vanilla yogurt', once).cleaned;
+            expect(twice).toBe(once);
+        });
+    });
+});

--- a/src/lib/mapping/llm-output-guards.ts
+++ b/src/lib/mapping/llm-output-guards.ts
@@ -1,0 +1,122 @@
+/**
+ * Deterministic guards over the AI normalizer's OUTPUT.
+ *
+ * `aiNormalizeIngredient()` is trusted unconditionally at its call site in
+ * `mapIngredientWithFallback()` — six plain assignments, no validation. The
+ * brand-preservation guard in that same function does not cover it: that guard
+ * is gated on a CALLER-SUPPLIED `options.normalizedForm` and runs before the
+ * LLM result overwrites `normalizedName`. This module is the missing check.
+ *
+ * Read the token list below before extending this: the defect that motivated it
+ * turned out to originate in a data file, not in the model, and the guard is
+ * deliberately scoped to the residue that fix cannot reach.
+ *
+ * Kept free of imports on purpose. `simple-rerank.ts` — the natural home for a
+ * predicate like this — transitively pulls `db.ts`, which makes it unloadable
+ * outside a configured runtime and therefore untestable in isolation. Same
+ * reason `serving-options.ts` exists separately in the mobile app.
+ */
+
+/**
+ * Tokens that name a DISTINCT FOOD rather than a property of one.
+ *
+ * When something introduces one the user never typed, it does not refine the
+ * query — it replaces the food. MEASURED 2026-08-03 against the live box, cold
+ * and deterministic over repeated probes:
+ *
+ *     vanilla yogurt        -> "Vanilla Extract"  fs_33911      288 kcal/100g, 4.2 g
+ *     vanilla protein shake -> "Vanilla extract"  off_15283979  286 kcal/100g, 150 g = 429 kcal
+ *
+ * THE ROOT CAUSE WAS NOT THE MODEL, and this guard is not the primary fix.
+ * `data/fatsecret/normalization-rules.json` carried an unguarded
+ * `synonym_rewrites` entry, `vanilla -> vanilla extract`, which fired before
+ * any LLM ran and rewrote `vanilla yogurt` to `vanilla extract yogurt`. The
+ * in-code `DEFAULT_RULES` never had it and the code path that implements the
+ * same recipe default is properly context-gated — but `readRulesFile()` prefers
+ * the on-disk file, so the naive entry won. Deleting it is the fix; bare
+ * `vanilla` still becomes `vanilla extract` from the code rule, as intended.
+ *
+ * What remains, and why this module still exists: `AiNormalizeCache` holds 45
+ * rows / 283 reads whose stored output carries an `extract` the raw line never
+ * had (`orgain organic protein powder vanilla` at 232 reads is the single
+ * highest-traffic rewrite in that table). Those rows were written while the
+ * alias was live and are REPLAYED from cache after it is gone, so the data fix
+ * alone does not clear them. This guard covers that replay and any future echo.
+ *
+ * The failure is bounded, which is why the list is narrow: a query with a brand
+ * (`orgain ... vanilla`) or a strong food noun (`vanilla ice cream`) still
+ * retrieves correctly, because the rest of the string carries enough signal to
+ * recover the pick. It is the thin queries — a flavour word plus a weak noun —
+ * that are destroyed.
+ *
+ * DELIBERATELY AN ALLOWLIST OF MEASURED OFFENDERS, not a general
+ * "token absent from the input" rule. The normalizer legitimately introduces
+ * qualifiers — `rolled` for oatmeal (18 rows), `skinless` for chicken breast
+ * (16 rows) — and those refine the SAME food. The distinction that matters is
+ * head-noun versus qualifier, and only the head-noun class belongs here. A
+ * blanket rule would revert both of those and is not what this is.
+ */
+const FOOD_REPLACING_TOKENS: readonly string[] = ['extract'];
+
+const WORD_SPLIT = /[^a-z0-9]+/;
+
+/** Whole-token, case- and punctuation-insensitive membership. */
+function hasToken(text: string, token: string): boolean {
+    return text
+        .toLowerCase()
+        .split(WORD_SPLIT)
+        .some((t) => t === token);
+}
+
+export interface IntroducedTokenRepair {
+    /** The repaired string. Never empty — see `stripIntroducedFoodTokens`. */
+    cleaned: string;
+    /** Tokens removed, lowercased. Empty when nothing fired. */
+    removed: string[];
+}
+
+/**
+ * Remove food-replacing tokens the normalizer introduced that are absent from
+ * the user's own text.
+ *
+ * REPAIRS, never rejects. Rejecting the whole normalized string would also
+ * discard the typo repair, form-word retention and cooking-state preservation
+ * that live in the same value — and on the cache-fallback rerank path the
+ * fallback is the post-AI string anyway, so a reject there is inert. Stripping
+ * the offending token restores the user's own words: the rewrite is an APPEND
+ * in 12 of the 14 highest-traffic cases (`X vanilla` -> `X vanilla extract`),
+ * so removal is exactly the identity the user typed.
+ *
+ * If stripping would empty the string, the original is returned unchanged. A
+ * guard must never hand an empty query downstream — several builders here are
+ * terminal, and an empty retrieval lands on a worse tier than a wrong one.
+ */
+export function stripIntroducedFoodTokens(
+    rawInput: string,
+    normalized: string | null | undefined,
+): IntroducedTokenRepair {
+    if (!normalized) return { cleaned: normalized ?? '', removed: [] };
+
+    const removed: string[] = [];
+    let out = normalized;
+
+    for (const token of FOOD_REPLACING_TOKENS) {
+        // Only intervene when the model added it and the user did not.
+        if (!hasToken(normalized, token) || hasToken(rawInput, token)) continue;
+
+        // Targeted removal, NOT split/rejoin: rebuilding the string from
+        // `WORD_SPLIT` pieces would rewrite `ben and jerry's` to
+        // `ben and jerry s`. Apostrophe handling has forked the cache key on
+        // this project more than once; leave every other character alone.
+        const stripped = out
+            .replace(new RegExp(`\\b${token}\\b`, 'gi'), ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+
+        if (!stripped) continue; // never empty the query
+        out = stripped;
+        removed.push(token);
+    }
+
+    return { cleaned: out, removed };
+}

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -64,6 +64,7 @@ import { assessMacroPlausibility, assessRankTimePlausibility } from './macro-pla
 import { isDenylistedOffRecord } from './corrupt-denylist';
 import { isCorruptExclusionEnabled } from './corrupt-mark';
 import { deriveMappingCacheKey, deriveCacheKeyName, isMalformedCacheKey, IDENTITY_UNIT_HINTS, type BrandKeyInput } from './cache-key';
+import { stripIntroducedFoodTokens } from './llm-output-guards';
 import {
     applyOffBareQueryGuard, isBareUnitlessQty1, usableBareLabelServing,
     isBarePluralRequest,
@@ -1357,10 +1358,31 @@ export async function mapIngredientWithFallback(
                 // FIX: Pass baseName instead of rawLine so the LLM output is cached by the normalized quantity-free string
                 const aiHint = await aiNormalizeIngredient(baseName, normalizedName);
                 if (aiHint.status === 'success') {
+                    // The model's output is otherwise taken on trust here. Strip
+                    // any food-REPLACING token it introduced that the user never
+                    // typed: `vanilla yogurt` -> `vanilla yogurt extract` sends a
+                    // 288 kcal/100g ingredient to retrieval and wins with it.
+                    // Compared against the raw line AND baseName, so a user who
+                    // really did say "extract" (or GENERIC_FALLBACKS expanding the
+                    // bare word into one) is never second-guessed.
+                    const guardInput = `${trimmed} ${baseName}`;
                     if (aiHint.normalizedName) {
-                        normalizedName = aiHint.normalizedName;
+                        const repaired = stripIntroducedFoodTokens(guardInput, aiHint.normalizedName);
+                        if (repaired.removed.length > 0) {
+                            logger.info('mapping.llm_introduced_food_token', {
+                                rawLine: trimmed,
+                                llmOutput: aiHint.normalizedName,
+                                repaired: repaired.cleaned,
+                                removed: repaired.removed,
+                            });
+                        }
+                        normalizedName = repaired.cleaned;
                     }
-                    aiCanonicalBase = aiHint.canonicalBase;
+                    // canonicalBase carries the same pollution and becomes the
+                    // rerank query verbatim, so it needs the same repair.
+                    aiCanonicalBase = aiHint.canonicalBase
+                        ? stripIntroducedFoodTokens(guardInput, aiHint.canonicalBase).cleaned
+                        : aiHint.canonicalBase;
                     aiCookingModifier = aiHint.cookingModifier;
                     aiSynonyms = aiHint.synonyms || [];
                     if (aiSynonyms.length > 0) {
@@ -1387,7 +1409,15 @@ export async function mapIngredientWithFallback(
                 const cachedNormalize = await getAiNormalizeCache(baseName);
                 if (cachedNormalize?.nutritionEstimate) {
                     aiNutritionEstimate = cachedNormalize.nutritionEstimate;
-                    aiCanonicalBase = cachedNormalize.canonicalBase;
+                    // Same repair as the live path: AiNormalizeCache is 86.5%
+                    // v1 rows written before this guard existed, so the polluted
+                    // canonicalBase is replayed from here too.
+                    aiCanonicalBase = cachedNormalize.canonicalBase
+                        ? stripIntroducedFoodTokens(
+                              `${trimmed} ${baseName}`,
+                              cachedNormalize.canonicalBase,
+                          ).cleaned
+                        : cachedNormalize.canonicalBase;
                     logger.debug('normalize_gate.cached_nutrition_estimate', {
                         baseName,
                         estimate: aiNutritionEstimate.caloriesPer100g,


### PR DESCRIPTION
## The defect

`vanilla yogurt` resolved to **Vanilla Extract** (`fs_33911`, 288 kcal/100g, 4.2 g). `vanilla protein shake` billed **150 g of extract — 429 kcal**. Measured cold against the live box 2026-08-03, deterministic over repeated probes:

| query | resolves to | |
|---|---|---|
| `vanilla yogurt` | Vanilla Extract, 288 kcal/100g, 4.2 g | **wrong** |
| `vanilla protein shake` | Vanilla extract, 150 g → 429 kcal | **wrong** |
| `vanilla ice cream` | Vanilla Ice Creams | recovered — strong food noun |
| `orgain … vanilla` | Orgain Organic Protein Powder | recovered — brand |

The failure is bounded: a brand or a strong food noun carries enough signal to recover the pick. It is the thin queries — a flavour word plus a weak noun — that get destroyed.

## Root cause — not the model

`data/fatsecret/normalization-rules.json` carried an unguarded `synonym_rewrites` entry `vanilla -> vanilla extract`, firing **before any LLM ran**.

`DEFAULT_RULES` never held it, and the in-code rule implementing the same recipe default *is* context-gated on a following food noun. But `readRulesFile()` prefers the on-disk JSON, so the naive entry won. Deleting it restores the gated behaviour — bare `vanilla` still becomes `vanilla extract`, which is the intended recipe default:

```
"vanilla yogurt"        -> "vanilla yogurt"        (was: vanilla extract yogurt)
"vanilla protein shake" -> "vanilla protein shake"
"vanilla ice cream"     -> "vanilla ice cream"
"vanilla"               -> "vanilla extract"       (unchanged, intended)
"1 tsp vanilla"         -> "1 tsp vanilla extract" (unchanged, intended)
```

## How it was found, because the method matters here

The predicate unit test for the new guard **passed**. The *wiring* test failed — the last `gatherCandidates()` call was clean while the first was still polluted. That gap is what exposed the real producer. A predicate test alone would have shipped a fix for the wrong layer, which is the shape of #221, #223 and #226.

## `llm-output-guards.ts` is secondary, deliberately

Not the primary fix. `AiNormalizeCache` holds **45 rows / 283 reads** written while the alias was live (`orgain organic protein powder vanilla` at 232 reads is the highest-traffic rewrite in that table); those replay from cache after the alias is gone, and the data fix alone does not clear them.

- **Repairs, never rejects.** Rejecting would also discard the typo repair and cooked-state preservation carried in the same string — and on the cache-fallback rerank path the fallback *is* the post-AI value, so a reject there is inert.
- **Never empties the query** (several builders downstream are terminal).
- **Never touches apostrophes** — targeted removal, not split/rejoin; the possessive cache-key fork must not return.
- **An allowlist of measured offenders, not a general rule.** The normalizer legitimately introduces qualifiers — `rolled` for oatmeal (18 rows), `skinless` for chicken breast (16) — and those refine the same food. A blanket "token absent from input" rule would revert both.

## ⚠️ Delivery — this is inert until the data file is scp'd

`data/` is in the box's `.stignore` and **never syncs**. Until delivered, every Mac-side gate is green and the live service is unchanged — exactly how the #211 cooking-state fix sat dead for a day.

`box-rules-file-has-no-bare-vanilla-rewrite` is **RED right now (`1@129`)** and is the only check that can see it. It should stay red until the file lands on the box.

## Verified

- `npm run typecheck` → clean
- `npm run lint:ci` → 0 errors
- `npx jest src/lib/mapping src/lib/parse` → 74 suites, 1270 passed, 0 failed
- `npm run doc-check -- --only vanilla` → `vanilla-rewrite-is-context-gated` green; the box twin red pending delivery
- **Tripwire**: the 15 predicate tests re-run with the token list emptied → 8 died, 7 held (the 7 are the must-not-fire and safety cases, correctly insensitive)

Not run: the cold golden eval. `n-supp-15` is the only vanilla case in the golden set and it carries a brand, so the gate cannot see this defect either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu