### PR TITLE
fix(mapping): put back a decisive brand the normalizer dropped

### DIFF
--- a/src/lib/mapping/__tests__/llm-brand-preservation.test.ts
+++ b/src/lib/mapping/__tests__/llm-brand-preservation.test.ts
@@ -1,0 +1,41 @@
+import { detectBrandInQuery } from '../brand-detector';
+import { hasDecisiveBrandContext, candidateMatchesTargetBrand } from '../simple-rerank';
+
+/**
+ * The decisiveness gate is the whole design. Without it, re-injecting a
+ * detected brand into the AI-rewritten name rebuilds a REFUTED regression:
+ * `bell pepper` matches the lexicon brand `bell` (Bell & Evans), the normalizer
+ * rewrites the food to `capsicum`, and an unconditional prefix produced read/
+ * write key `bell capsicum` — orphaning the live human-triage `capsicum` row
+ * (golden n-mq-30). `deriveMappingCacheKey()`'s own header records this and
+ * `cache-key-symmetry.test.ts` pins it.
+ *
+ * So this file asserts the gate separates the two symptoms BEFORE any fix
+ * leans on it. If these ever converge, the brand-preservation repair must be
+ * disabled, not re-tuned.
+ */
+describe('the decisiveness gate separates the two brand symptoms', () => {
+    it('is DECISIVE for "one bar birthday cake" — a real brand in product context', () => {
+        const det = detectBrandInQuery('one bar birthday cake');
+        expect(det.matchedBrand).toBe('one');
+        expect(hasDecisiveBrandContext('one bar birthday cake', det.matchedBrand!)).toBe(true);
+    });
+
+    it('is NOT decisive for "bell pepper" — a false-positive lexicon hit', () => {
+        const det = detectBrandInQuery('bell pepper');
+        expect(det.matchedBrand).toBe('bell');
+        // The refuted case. A repair gated on this must never fire here.
+        expect(hasDecisiveBrandContext('bell pepper', det.matchedBrand!)).toBe(false);
+    });
+
+    it('recognises a brand still present in the rewritten name', () => {
+        expect(candidateMatchesTargetBrand(undefined, 'one bar birthday cake', 'one')).toBe(true);
+        expect(candidateMatchesTargetBrand(undefined, 'birthday cake', 'one')).toBe(false);
+    });
+
+    it('folds apostrophes, so a possessive brand is not seen as dropped', () => {
+        // The possessive fork has bitten this project repeatedly; a repair that
+        // thought `jerrys` != `jerry's` would prepend a duplicate brand.
+        expect(candidateMatchesTargetBrand(undefined, "ben and jerry's vanilla", "jerry's")).toBe(true);
+    });
+});

--- a/src/lib/mapping/__tests__/llm-output-guard-wiring.test.ts
+++ b/src/lib/mapping/__tests__/llm-output-guard-wiring.test.ts
@@ -170,3 +170,53 @@ describe('the introduced-food-token guard is wired into the mapper', () => {
         expect(names[names.length - 1]).toBe('rolled oats');
     });
 });
+
+describe('the decisive-brand preservation repair is wired into the mapper', () => {
+    it('puts back a decisive brand the model dropped', async () => {
+        // Measured shape: the ONE bar, whose brand the normalizer classifies as
+        // the numeral and strips as a size phrase.
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'birthday cake',
+            canonicalBase: 'birthday cake',
+        });
+
+        await mapIngredientWithFallback('one bar birthday cake');
+
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe('one birthday cake');
+    });
+
+    it('does NOT prefix a non-decisive brand — the "bell capsicum" regression stays dead', async () => {
+        // `bell` is a real lexicon brand (Bell & Evans) and a false positive
+        // here. An unconditional prefix produced key `bell capsicum` and
+        // orphaned the live human-triage `capsicum` row (golden n-mq-30).
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'capsicum',
+            canonicalBase: 'capsicum',
+        });
+
+        await mapIngredientWithFallback('bell pepper');
+
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe('capsicum');
+        // NB: an earlier gather legitimately contains `bell` — that is the
+        // user's own text (`bell pepper`) before the rewrite, not a prefix.
+        // The regression to exclude is specifically the fused brand+rewrite.
+        expect(names).not.toContain('bell capsicum');
+    });
+
+    it('leaves the name alone when the model kept the brand', async () => {
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: 'one birthday cake bar',
+            canonicalBase: 'one birthday cake bar',
+        });
+
+        await mapIngredientWithFallback('one bar birthday cake');
+
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe('one birthday cake bar');
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -22,7 +22,7 @@ import {
     hasNullOrInvalidMacros,
     detectGrainCookingContext,
 } from './filter-candidates';
-import { simpleRerank, toRerankCandidate, extractLeanPercentage, isGenericGroundMeatQuery, stripPrepModifiers } from './simple-rerank';
+import { simpleRerank, toRerankCandidate, extractLeanPercentage, isGenericGroundMeatQuery, stripPrepModifiers, hasDecisiveBrandContext, candidateMatchesTargetBrand } from './simple-rerank';
 import { buildRerankPool, rerankPoolRemainder, RERANK_POOL_LIMIT } from './rerank-pool';
 import {
     singularizeUnit, extractLabelServingUnit,
@@ -98,12 +98,29 @@ async function lookupValidatedMappingWithLegacyFallback(
     brandDetection: BrandKeyInput,
     rawLine: string,
     rejection?: CacheLookupRejection,
+    /**
+     * Name to derive the LEGACY key from, when it differs from the name used
+     * for the symmetric key.
+     *
+     * The brand-preservation repair re-injects a decisive brand into
+     * `normalizedName`. Deriving the brandless legacy key from that repaired
+     * value would make `legacyKey === symmetricKey`, short-circuit this
+     * fallback, and orphan every pre-Track-1c row that only exists under a
+     * brandless key. MEASURED 2026-08-03 over the whole observed corpus (5,585
+     * distinct lines / 64,046 events): 0 rows are actually lost, because
+     * `legacyHitReflectsBrand()` below already refuses all 15 legacy hits that
+     * occur. But the corpus is not a complete record of queries, and the
+     * corpus-independent bound is 142 always-decisive rows — 5 of them at 100+
+     * uses, one `human-triage`. Passing the pre-injection name removes the
+     * exposure by construction rather than relying on that measurement.
+     */
+    legacyName?: string,
 ): Promise<CachedMappedIngredient | null> {
     const symmetricKey = deriveMappingCacheKey(normalizedName, parsed, brandDetection, rawLine);
     const hit = await getValidatedMappingByNormalizedName(symmetricKey, 'fatsecret', rawLine, rejection);
     if (hit) return hit;
 
-    const legacyKey = deriveCacheKeyName(normalizedName, parsed);
+    const legacyKey = deriveCacheKeyName(legacyName ?? normalizedName, parsed);
     if (legacyKey === symmetricKey || isMalformedCacheKey(legacyKey)) return null;
 
     const legacyHit = await getValidatedMappingByNormalizedName(legacyKey, 'fatsecret', rawLine, rejection);
@@ -930,6 +947,11 @@ export async function mapIngredientWithFallback(
         }
 
         let normalizedName = normalizeIngredientName(baseName).cleaned || baseName;
+        // Set only when the brand-preservation repair below rewrites
+        // normalizedName. The legacy (brandless) cache key must keep being
+        // derived from the PRE-injection value or the legacy fallback
+        // short-circuits — see lookupValidatedMappingWithLegacyFallback().
+        let preBrandNormalizedName: string | undefined;
 
         // ── Brand detection (static list + AI passed brand) ─────────────
         // Must run before the early cache check so the brand guard is available
@@ -1383,6 +1405,48 @@ export async function mapIngredientWithFallback(
                     aiCanonicalBase = aiHint.canonicalBase
                         ? stripIntroducedFoodTokens(guardInput, aiHint.canonicalBase).cleaned
                         : aiHint.canonicalBase;
+
+                    // Brand preservation over the model's OWN output. The guard
+                    // near the top of this function cannot cover this: it is
+                    // gated on a caller-supplied options.normalizedForm AND it
+                    // runs before these assignments overwrite normalizedName.
+                    // The prompt does carry the rule ("INCLUDE the brand name in
+                    // canonical_base when is_branded") and nothing enforces it —
+                    // measured 2026-08-03, the brand is dropped on ~58 of 1,776
+                    // brand-bearing lines in AiNormalizeCache.
+                    //
+                    // GATED ON DECISIVENESS, and that gate is the design. An
+                    // UNCONDITIONAL prefix is already refuted: `bell pepper`
+                    // matches the lexicon brand `bell` (Bell & Evans), the model
+                    // rewrites the food to `capsicum`, and prefixing produced key
+                    // `bell capsicum` — orphaning the live human-triage
+                    // `capsicum` row (golden n-mq-30). See deriveMappingCacheKey()
+                    // and cache-key-symmetry.test.ts, which pins it.
+                    // llm-brand-preservation.test.ts asserts the two symptoms
+                    // stay separated; if they ever converge, disable this repair
+                    // rather than re-tuning it.
+                    //
+                    // REPAIRS, never rejects: dropping the model's name would
+                    // also discard its typo repair and cooked-state retention.
+                    const targetBrand = brandDetection.matchedBrand?.trim();
+                    if (targetBrand && hasDecisiveBrandContext(trimmed, targetBrand)) {
+                        const keepBrand = (s: string | undefined) =>
+                            s && !candidateMatchesTargetBrand(undefined, s, targetBrand)
+                                ? `${targetBrand} ${s}`.trim()
+                                : s;
+                        const rebranded = keepBrand(normalizedName);
+                        if (rebranded !== normalizedName) {
+                            logger.info('mapping.llm_dropped_decisive_brand', {
+                                rawLine: trimmed,
+                                llmOutput: normalizedName,
+                                repaired: rebranded,
+                                brand: targetBrand,
+                            });
+                            preBrandNormalizedName = normalizedName;
+                        }
+                        normalizedName = rebranded ?? normalizedName;
+                        aiCanonicalBase = keepBrand(aiCanonicalBase);
+                    }
                     aiCookingModifier = aiHint.cookingModifier;
                     aiSynonyms = aiHint.synonyms || [];
                     if (aiSynonyms.length > 0) {
@@ -1489,7 +1553,7 @@ export async function mapIngredientWithFallback(
             // request-stable, so this key matches the save key exactly. A
             // miss falls back to the legacy (pre-Track-1c) key.
             const normalizedLookupRejection: CacheLookupRejection = { reason: null };
-            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, normalizedLookupRejection);
+            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, normalizedLookupRejection, preBrandNormalizedName);
             if (!normalizedCache && normalizedLookupRejection.reason) {
                 if (telemetry) telemetry.cacheEscape = 'lookup_normalized:' + normalizedLookupRejection.reason;
                 noteReadEscape(normalizedLookupRejection.targetKey, 'lookup_normalized:' + normalizedLookupRejection.reason);


### PR DESCRIPTION
**Stacked on #228** — base is `fix/flavour-word-promotion` so the diff stays clean. GitHub will retarget this to `master` automatically once #228 merges. Merge #228 first.

## The defect

`ai-normalize`'s prompt already carries the rule — *"INCLUDE the brand name (lowercase) in canonical_base when is_branded=true"* — and **nothing enforces it**. The output is assigned unconditionally.

Measured 2026-08-03 over `AiNormalizeCache` (3,130 distinct lines): the detected brand is absent from the model's output on **~58 of 1,776 brand-bearing lines (3.3%)**.

```
trader joes chicken breast            -> "skinless chicken breast"    (61 reads)
burger king impossible whopper        -> "impossible whopper"
kirkland signature rotisserie chicken -> "rotisserie chicken"
optimum nutrition creatine monohydrate-> "creatine monohydrate"
```

The existing brand-preservation guard cannot cover it: that guard is gated on a **caller-supplied** `options.normalizedForm`, and it runs *before* the assignments that overwrite `normalizedName` with the model's output.

## The decisiveness gate is the design, not a detail

An unconditional prefix is **already refuted in writing by the module it would change**. `bell pepper` matches the lexicon brand `bell` (Bell & Evans); the model rewrites the food to `capsicum`; prefixing produced read/write key `bell capsicum`, orphaning the live `human-triage` `capsicum` row (golden `n-mq-30`). `deriveMappingCacheKey()`'s header records it and `cache-key-symmetry.test.ts` pins it.

`hasDecisiveBrandContext()` separates the two symptoms cleanly — verified in `llm-brand-preservation.test.ts`:

| query | matched brand | decisive? | repair fires? |
|---|---|---|---|
| `one bar birthday cake` | `one` | **true** | yes |
| `bell pepper` | `bell` | **false** | no |

If those ever converge, **disable the repair rather than re-tuning it**.

## Legacy keys — exposure removed by construction

Re-injecting the brand makes `legacyKey === symmetricKey`, which would short-circuit the brandless fallback and orphan pre-Track-1c rows.

Measured over the entire observed corpus (**5,585 distinct lines / 64,046 events**): **0 rows lost**, because `legacyHitReflectsBrand()` already refuses all 15 legacy hits that occur. But that corpus is not a complete record of queries, and the corpus-independent bound is **142 always-decisive rows** — 5 at 100+ uses, one `human-triage`.

So the legacy key is now derived from the **pre-injection** name. The exposure is gone by construction rather than by measurement. `legacy-key-fallback.test.ts` — which this change was predicted to break — still passes.

## Deliberately NOT included

Making `isBranded` **upgrade-only**. It looks adjacent but it is a different fix with a wider blast radius: **56 of the 79 measured downgrades keep the brand string**, so token preservation does not address them at all, and the change re-arms the `brand_guard` cache escape at the normalized-cache site. It deserves its own PR and its own measurement.

## Verified

- `npm run typecheck` → clean
- `npm run lint:ci` → 0 errors
- `npx jest src/lib/mapping src/lib/parse` → 75 suites, 1277 passed, 0 failed
- **Tripwire**: with the decisiveness gate removed, exactly the bell-capsicum regression test dies (1 failed / 121 total); restored, 121 pass

Not run: the cold golden eval. Per `winner-diff.ts`'s own blind-spot list this change is invisible to `winner-gate` — it replays a frozen gather snapshot and reads `normalizedName` straight from it, so both variants would report SAME. That green would be meaningless; it was not used as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu