### PR TITLE
eval: make a cold noise floor reproducible — record the build, diff by case id

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "parser:bench": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/parser-bench.ts",
         "eval": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register eval/run.ts",
         "eval:golden": "ts-node --project tsconfig.scripts.json --transpile-only scripts/eval/run-eval.ts",
+        "eval:diff": "ts-node --project tsconfig.scripts.json --transpile-only scripts/eval/diff-eval-runs.ts",
         "eval:analyze": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register eval/analyze.ts",
         "flywheel:sweep": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/eval/flywheel-sweep.ts",
         "seg:replay-diff": "ts-node --project tsconfig.scripts.json --transpile-only -r tsconfig-paths/register scripts/seg-replay-diff.ts",

--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1005,6 +1005,30 @@
       "verified": "2026-08-02"
     },
     {
+      "id": "eval-results-record-the-build",
+      "claim": "A golden-eval results file records the buildId it ran against, fetched from /api/ok. Without it, base and noCache are the only provenance a results file carries, and two runs spanning a deploy are indistinguishable from two runs of one build -- which is how PR #226's effect read as a 10-case noise floor on 2026-08-03.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
+      "where": "backend",
+      "command": "grep -c 'buildId' scripts/eval/run-eval.ts src/app/api/ok/route.ts | awk -F: '{s+=$2} END {print s}'",
+      "expect": {
+        "kind": "matches",
+        "value": "^([5-9]|[1-9][0-9]+)$"
+      },
+      "verified": "2026-08-03"
+    },
+    {
+      "id": "eval-diff-requires-a-build-id",
+      "claim": "diff-eval-runs.ts refuses to run without --build, and fails closed on a cold-vs-warm or cross-base pair. A noise floor computed across a deploy is not a noise floor, and nothing in a results file prevents it, so the guard lives in the tool.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
+      "where": "backend",
+      "command": "grep -c 'MODE MISMATCH\\|BASE MISMATCH\\|--build <BUILD_ID> is REQUIRED' scripts/eval/diff-eval-runs.ts",
+      "expect": {
+        "kind": "matches",
+        "value": "^3$"
+      },
+      "verified": "2026-08-03"
+    },
+    {
       "id": "offfood-too-large-to-snapshot-per-batch",
       "claim": "OffFood exceeds 1GB, which is why the warm rollback reverts aux tables with a key-set snapshot instead of widening the per-batch pg_dump",
       "ownerDoc": "mobile:sync-docs/reports/2026-08-02_batch-rollback-is-partial.md",

--- a/scripts/eval/diff-eval-runs.ts
+++ b/scripts/eval/diff-eval-runs.ts
@@ -1,0 +1,202 @@
+/**
+ * diff-eval-runs.ts — diff two golden-eval results files BY CASE ID.
+ *
+ * Why this exists: a cold run total is not stable. On 2026-08-03, three cold runs of the same
+ * build each reported 14 real failures and no two were the same 14 — comparing summaries would
+ * have read "unchanged" three times while the membership moved every time. The differing set
+ * between two same-build runs is the NOISE FLOOR, and a refactor that only moves cases inside it
+ * has not been shown to change behaviour.
+ *
+ * Measured caveat, worth knowing before you trust a number this prints: the floor grows with the
+ * gap between runs. Back-to-back runs differed by 6 cases; runs minutes apart differed by 19-20.
+ * Take at least THREE runs and union the pairwise diffs — a single pair understates the floor by
+ * better than 3x. In-process caches (servingCache, 24h TTL) survive --nocache; only restarting
+ * recipe-api clears them.
+ *
+ * Run (from repo root):
+ *   npx ts-node --project tsconfig.scripts.json --transpile-only \
+ *     scripts/eval/diff-eval-runs.ts <a.json> <b.json> --build <BUILD_ID>
+ *
+ * Exit codes match the house contract: 0 = diffed, 2 = the run is not a result.
+ */
+
+import * as fs from 'fs';
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+}
+
+const BUILD = argValue('--build');
+const flagValues = new Set(['--build'].map(argValue).filter(Boolean) as string[]);
+const positionals = args.filter(a => !a.startsWith('--') && !flagValues.has(a));
+const [pathA, pathB] = positionals;
+
+function die(msg: string): never {
+    console.error(msg);
+    process.exit(2);
+}
+
+if (!pathA || !pathB) {
+    die('usage: diff-eval-runs.ts <a.json> <b.json> --build <BUILD_ID>');
+}
+
+// The build id is REQUIRED and cannot be defaulted. A results file records `base` and `noCache`
+// but not the build it ran against, so nothing in the data stops you diffing across a deploy and
+// calling the difference noise. That is not hypothetical: the 08-02 23:50 / 08-03 00:48 cold pair
+// looks like a clean 10-case floor, and two of those ten are PR #226 landing between the runs.
+// Until a results file carries `summary.buildId`, the operator asserts it from outside.
+if (!BUILD) {
+    console.error('❗ --build <BUILD_ID> is REQUIRED.');
+    console.error('   A results file does not record the build it ran against, so a "noise floor"');
+    console.error('   spanning a deploy is indistinguishable from one that does not.');
+    console.error("   Re-read it around every run:  ssh owner@192.168.1.133 'cat …/.next/BUILD_ID'");
+    process.exit(2);
+}
+
+interface Observed {
+    foodId?: string;
+    grams?: number;
+    kcal100?: number;
+    source?: string;
+    abstained?: boolean;
+}
+interface CaseResult {
+    id: string;
+    kind: string;
+    category: string;
+    query: string;
+    pass: boolean;
+    knownIssue?: boolean;
+    observed?: Observed;
+}
+interface RunFile {
+    summary: { base: string; noCache: boolean; ranAt: string; buildId?: string };
+    results: CaseResult[];
+}
+
+function load(p: string): RunFile {
+    let j: RunFile;
+    try {
+        j = JSON.parse(fs.readFileSync(p, 'utf8')) as RunFile;
+    } catch (e) {
+        die(`${p}: unreadable or not JSON — ${(e as Error).message}`);
+    }
+    if (!Array.isArray(j.results)) die(`${p}: no results[] — this is not an eval results file`);
+    if (j.results.length === 0) die(`${p}: zero cases. A run that executed nothing is not a result.`);
+    return j;
+}
+
+const A = load(pathA);
+const B = load(pathB);
+
+const banner = (j: RunFile, p: string) =>
+    `${p.split('/').pop()}  noCache=${j.summary.noCache}  base=${j.summary.base}  ` +
+    `ranAt=${j.summary.ranAt}  n=${j.results.length}`;
+console.log('A: ' + banner(A, pathA));
+console.log('B: ' + banner(B, pathB));
+
+// Fail closed on a comparison that is not one. Cold measures the pipeline, warm measures the
+// cache; their difference is a statement about the cache, not about nondeterminism.
+if (A.summary.noCache !== B.summary.noCache) {
+    die('\n❗ MODE MISMATCH: one run is cold and the other warm. Their diff is not a noise floor.');
+}
+if (A.summary.base !== B.summary.base) {
+    die('\n❗ BASE MISMATCH: the runs hit different APIs.');
+}
+// If the harness has started recording the build, hold it to the asserted one rather than
+// trusting the flag: an operator-supplied value is exactly as reliable as the operator.
+for (const [j, p] of [[A, pathA], [B, pathB]] as const) {
+    if (j.summary.buildId && j.summary.buildId !== BUILD) {
+        die(`\n❗ BUILD MISMATCH: ${p} records buildId=${j.summary.buildId}, --build says ${BUILD}.`);
+    }
+}
+console.log(
+    A.summary.buildId
+        ? `build: ${BUILD} (recorded in both files)`
+        : `build: ${BUILD} (asserted by caller — the files do not record it)`,
+);
+
+const byId = (j: RunFile) => new Map(j.results.map(r => [r.id, r]));
+const a = byId(A);
+const b = byId(B);
+
+const onlyA = [...a.keys()].filter(k => !b.has(k));
+const onlyB = [...b.keys()].filter(k => !a.has(k));
+if (onlyA.length || onlyB.length) {
+    console.log(`\n⚠️  case-set mismatch — only in A: ${onlyA.join(',') || '(none)'} | ` +
+        `only in B: ${onlyB.join(',') || '(none)'}`);
+}
+
+/**
+ * Fields worth diffing, and why:
+ *   pass    — the only one that gates. A flip here turns a gate red on noise alone.
+ *   foodId  — the PICK. Movement here is retrieval/rerank nondeterminism, not serving.
+ *   grams   — the SERVING. The AI serving tiers land here.
+ *   kcal100 — the chosen row's panel; moves iff foodId moves.
+ *   source  — which lane won. A block of these moving together is a lane shift, not per-case noise.
+ */
+const FIELDS = ['pass', 'foodId', 'grams', 'kcal100', 'source', 'abstained'] as const;
+type Field = typeof FIELDS[number];
+const get = (r: CaseResult, f: Field): unknown =>
+    f === 'pass' ? r.pass : (r.observed ?? {})[f as keyof Observed];
+
+interface Delta { f: Field; a: unknown; b: unknown }
+interface Moved { id: string; kind: string; category: string; query: string; knownIssue: boolean; deltas: Delta[] }
+
+const moved: Moved[] = [];
+const sharedIds = [...a.keys()].filter(k => b.has(k));
+for (const id of sharedIds) {
+    const ra = a.get(id)!;
+    const rb = b.get(id)!;
+    const deltas = FIELDS
+        .filter(f => JSON.stringify(get(ra, f)) !== JSON.stringify(get(rb, f)))
+        .map(f => ({ f, a: get(ra, f), b: get(rb, f) }));
+    if (deltas.length) {
+        moved.push({ id, kind: ra.kind, category: ra.category, query: ra.query, knownIssue: !!ra.knownIssue, deltas });
+    }
+}
+
+const pct = (n: number, d: number) => (d ? `${((100 * n) / d).toFixed(1)}%` : 'n/a');
+console.log(`\n=== ${moved.length} of ${sharedIds.length} cases moved (${pct(moved.length, sharedIds.length)}) ===\n`);
+
+for (const f of FIELDS) {
+    const n = moved.filter(m => m.deltas.some(d => d.f === f)).length;
+    if (n) console.log(`  ${f.padEnd(10)} moved on ${String(n).padStart(3)} case(s)  ${pct(n, sharedIds.length)}`);
+}
+
+const flips = moved.filter(m => m.deltas.some(d => d.f === 'pass'));
+console.log(`\n--- PASS FLIPS (${flips.length}) — these turn a gate red on noise alone ---`);
+for (const m of flips) {
+    const d = m.deltas.find(x => x.f === 'pass')!;
+    console.log(`  ${m.id.padEnd(12)} ${d.a ? 'PASS→FAIL' : 'FAIL→PASS'}  ${m.knownIssue ? '[known]' : '[REAL] '}  ${m.query}`);
+}
+
+console.log('\n--- ALL MOVED CASES ---');
+for (const m of moved) {
+    console.log(`  ${m.id.padEnd(12)} ${m.kind}/${m.category}  "${m.query}"${m.knownIssue ? ' [known]' : ''}`);
+    for (const d of m.deltas) console.log(`      ${d.f}: ${JSON.stringify(d.a)}  →  ${JSON.stringify(d.b)}`);
+}
+
+console.log('\n--- MOVED SET (case ids) ---');
+console.log(moved.map(m => m.id).sort().join(' '));
+
+// The gating population, side by side. A case failing in one run and not the other is a flake and
+// must not be quoted as a failure count — report the stable intersection.
+const realFails = (j: RunFile) => j.results.filter(r => !r.pass && !r.knownIssue).map(r => r.id).sort();
+const fa = realFails(A);
+const fb = realFails(B);
+const stable = fa.filter(x => fb.includes(x));
+const flaky = [...fa.filter(x => !fb.includes(x)), ...fb.filter(x => !fa.includes(x))].sort();
+console.log('\n--- REAL FAILURES ---');
+console.log(`  A (${fa.length}): ${fa.join(' ')}`);
+console.log(`  B (${fb.length}): ${fb.join(' ')}`);
+console.log(`  STABLE in both (${stable.length}): ${stable.join(' ')}`);
+console.log(`  flaky (in one only): ${flaky.join(' ') || '(none)'}`);
+if (flaky.length) {
+    console.log(`\n  ⚠️  Quote ${stable.length}, not ${fa.length} or ${fb.length}. The totals agree by coincidence`);
+    console.log('     more often than the membership does.');
+}
+
+console.log('\nNOTE: one pair is not a noise floor. Union at least three pairwise diffs.');

--- a/scripts/eval/known-issue-baseline-cold.json
+++ b/scripts/eval/known-issue-baseline-cold.json
@@ -1,0 +1,141 @@
+{
+  "_readme": "Recorded state of each knownIssue case. run-eval compares against this and reports 🟠 DRIFT when a pinned case keeps failing but fails DIFFERENTLY — the signal a pass/fail boolean cannot carry. Refresh with --write-baseline once the new values are understood to be the intended state. Writes MERGE: a filtered (--only/--grep) run refreshes only the pins it ran and leaves the rest intact.",
+  "writtenAt": "2026-08-03T15:58:48.279Z",
+  "cases": {
+    "s-typo-08": {
+      "foodId": "off_9310653104835",
+      "foodName": "banna yoghurt",
+      "grams": null,
+      "kcal100": 73.69999694824219,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 21
+    },
+    "s-typo-14": {
+      "foodId": "off_5060929632145",
+      "foodName": "Banan",
+      "grams": null,
+      "kcal100": 80,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 21
+    },
+    "n-supp-12": {
+      "foodId": "off_0810169607039",
+      "foodName": "Ghost Clear Whey Blue Raspberry",
+      "grams": 21.5,
+      "kcal100": 312.5,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-serv-24": {
+      "foodId": "off_5449000008299",
+      "foodName": "Capri sun",
+      "grams": 330,
+      "kcal100": 7,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-serv-51": {
+      "foodId": "off_0259645028140",
+      "foodName": "Ribeye",
+      "grams": 100,
+      "kcal100": 250,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-27": {
+      "foodId": "fs_5268",
+      "foodName": "Lemon",
+      "grams": 58,
+      "kcal100": 29,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-34": {
+      "foodId": "fs_793",
+      "foodName": "Milk",
+      "grams": 240,
+      "kcal100": 50,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-36": {
+      "foodId": "off_9415077369829",
+      "foodName": "Rolled Oats",
+      "grams": 40,
+      "kcal100": 378,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-cook-06": {
+      "foodId": "off_9415077369829",
+      "foodName": "Rolled Oats",
+      "grams": 86.39999999999999,
+      "kcal100": 378,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-brand-05": {
+      "foodId": "off_0810076291826",
+      "foodName": "Fruit Punch Pre Workout",
+      "grams": 19.8,
+      "kcal100": 50.5,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-brand-06": {
+      "foodId": "fs_2528458",
+      "foodName": "Cotton Candy",
+      "grams": 28,
+      "kcal100": 394,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-38": {
+      "foodId": "off_3393977744423733154062300",
+      "foodName": "Chipotle, Chicken",
+      "grams": 118.294,
+      "kcal100": 140,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-39": {
+      "foodId": "off_45994633744286743131",
+      "foodName": "Qdoba, Tequila Lime Chicken",
+      "grams": 50,
+      "kcal100": 448,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-40": {
+      "foodId": "off_0898328002222",
+      "foodName": "Harissa",
+      "grams": 28,
+      "kcal100": 250,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    },
+    "n-mq-47": {
+      "foodId": "off_0296763206050",
+      "foodName": "Boneless Skinless Chicken Breast",
+      "grams": 112,
+      "kcal100": 116,
+      "abstained": false,
+      "errored": false,
+      "itemCount": 1
+    }
+  }
+}

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -300,7 +300,16 @@ async function main() {
     const searchCases = (ONLY && ONLY !== 'search') ? [] : golden.search.filter((c: any) => !GREP || c.id.includes(GREP));
     const nlpCases = (ONLY && ONLY !== 'nlp') ? [] : golden.nlp.filter((c: any) => !GREP || c.id.includes(GREP));
 
-    console.log(`Eval against ${BASE} — ${searchCases.length} search + ${nlpCases.length} nlp cases\n`);
+    // Which build answered? Recorded in the results file so a later diff can tell "two runs of
+    // one build" (noise) from "two runs spanning a deploy" (an effect). Older API versions do not
+    // return it and Vercel cannot read it, so a null is expected and never fatal.
+    const buildId = await fetch(`${BASE}/api/ok`)
+        .then(r => r.json())
+        .then((j: any) => (typeof j?.buildId === 'string' ? j.buildId : null))
+        .catch(() => null);
+
+    console.log(`Eval against ${BASE} — ${searchCases.length} search + ${nlpCases.length} nlp cases`);
+    console.log(`build: ${buildId ?? 'UNKNOWN (API does not report one — record it by hand)'}\n`);
 
     // Warm the API (dev-mode compile, embedding model) so case 1 isn't penalized.
     await fetch(`${BASE}/api/foods/search?s=warmup&local=true`, { headers: { 'x-api-key': API_KEY } }).catch(() => {});
@@ -328,7 +337,7 @@ async function main() {
     // noCache is recorded because a cold run and a warm run are not comparable and
     // the file is the only thing a later reader has. The batch gate's baseline was
     // recorded warm; a cold report scored against it would read as mass regression.
-    const summary: any = { base: BASE, noCache: NO_CACHE, ranAt: new Date().toISOString(), kinds: {}, categories: {} };
+    const summary: any = { base: BASE, noCache: NO_CACHE, buildId, ranAt: new Date().toISOString(), kinds: {}, categories: {} };
 
     for (const kind of ['search', 'nlp']) {
         const rs = byKind(kind);

--- a/src/app/api/ok/route.ts
+++ b/src/app/api/ok/route.ts
@@ -1,10 +1,34 @@
 import { NextResponse } from 'next/server';
+import * as fs from 'fs';
+import * as path from 'path';
+
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET() {
-  return NextResponse.json({ ok: true, ts: Date.now() });
+/**
+ * The deployed build's id, so a measurement taken against this API can record WHICH code
+ * produced it. Without it an eval results file carries `base` and `noCache` but nothing
+ * identifying the build, and two runs spanning a deploy are indistinguishable from two runs of
+ * one build — which is how a deploy's effect gets recorded as "noise". Measured 2026-08-03: the
+ * 08-02 23:50 / 08-03 00:48 cold pair reads as a clean 10-case noise floor, and two of those ten
+ * are PR #226 landing between the runs.
+ *
+ * Read once per process and memoised — BUILD_ID cannot change without a restart. Fails soft to
+ * null (Vercel serves from a different layout with no readable .next/BUILD_ID). A null is honest;
+ * a confidently wrong id would be worse than none.
+ */
+let buildIdCache: string | null | undefined;
+function readBuildId(): string | null {
+  if (buildIdCache !== undefined) return buildIdCache;
+  try {
+    buildIdCache = fs.readFileSync(path.join(process.cwd(), '.next', 'BUILD_ID'), 'utf8').trim() || null;
+  } catch {
+    buildIdCache = null;
+  }
+  return buildIdCache;
 }
 
-
+export async function GET() {
+  return NextResponse.json({ ok: true, ts: Date.now(), buildId: readBuildId() });
+}


### PR DESCRIPTION
## Why

Three cold golden runs of the **same build** on 2026-08-03 each reported **14 real failures, and no two were the same 14**. Comparing run summaries would have read "unchanged" three times while the membership moved every time. The stable population is **13**; the 14th seat rotates between `n-svd-03`, `n-svd-04`, `s-supp-17`.

Phase 1's refactor rule ("a stage that moves a cold case id is not a refactor") is unsatisfiable without knowing which case ids move on their own. Measuring that needed three things that did not exist.

## What

**1. A results file did not record its build.** `summary` carried `base` and `noCache` and nothing identifying the deployed code, so a diff spanning a deploy was indistinguishable from a noise measurement. This is not hypothetical — the 08-02 23:50 / 08-03 00:48 cold pair reads as a clean 10-case floor, and two of those ten are PR #226 landing between the runs.

`/api/ok` now returns `buildId` (read once from `.next/BUILD_ID`, memoised, **fails soft to `null`** — Vercel serves from a layout where it is unreadable, and a null is honest where a wrong id would be worse than none). `run-eval.ts` fetches it and records it in `summary`.

**2. Nothing diffed two runs by case id.** `scripts/eval/diff-eval-runs.ts` (`npm run eval:diff`) does, reporting per-field movement (`pass`/`foodId`/`grams`/`kcal100`/`source`), the pass flips that can turn a gate red on noise alone, and the stable-vs-flaky split of real failures.

It **fails closed**, per the house contract (exit 2 = not a result):
- `--build` is **required** — an operator assertion until every results file carries one, cross-checked against `summary.buildId` when present.
- A cold-vs-warm pair exits 2. Warm measures the cache, cold measures the pipeline; their difference is a statement about the cache, not about nondeterminism.
- A cross-base pair, an empty run, or an unreadable file exits 2.

**3. `known-issue-baseline-cold.json` did not exist.** Written cold: **15 pins** — the golden set's `knownIssue` count, not the 34 previously estimated. Shape-only, for 🟠 DRIFT detection; it absolves nothing, since `realFails` filters on the golden-set flag rather than this file.

## The measured caveat, which is the easy part to get wrong

The noise floor **grows with the gap between runs**:

| pair | idle gap | cases moved |
|---|---|---:|
| 1 → 2 | none | **6** |
| 2 → 3 | ~3 min | **19** |
| 1 → 3 | ~5 min | **20** |

So the cheapest way to measure a floor — two runs back to back — understates it by better than 3×. **Take three runs and union the pairwise diffs** (20 of 348, 5.7%). That is in the tool's header comment, not just here.

`--nocache` does not clear in-process state either: `servingCache` in `fdc-servings.ts` is a module-level `Map` with a 24 h TTL. Only restarting `recipe-api` clears it.

Separately confirmed while measuring: `nosave=1` is **broader** than its documented `FoodMapping` scope — zero rows were created in `FoodMapping`, `AiNormalizeCache`, `SegmentationCache`, `AiGeneratedFood` or `FatSecretFood` across the runs.

## Gates

- `lint:ci` — 0 errors
- `typecheck` — 0
- `doc-check` — **92/92** (two new claims: `eval-results-record-the-build`, `eval-diff-requires-a-build-id`). Each was **watched go red before being trusted** — a claim that has never been seen to fail is not known to work.
- Tool exercised end to end on the three real results files; the missing-`--build` and cold-vs-warm guards both verified to exit 2.

No env vars added. No schema change. `/api/ok` gains one field and keeps `ok`/`ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
