### PR TITLE
fix(mapping): IDENTITY_QUALIFIERS must reach retrieval, not only the cache key

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1005,6 +1005,18 @@
       "verified": "2026-08-02"
     },
     {
+      "id": "identity-qualifiers-reach-retrieval",
+      "claim": "mapIngredientWithFallback restores IDENTITY_QUALIFIERS into the retrieval query, not just IDENTITY_UNIT_HINTS. deriveCacheKeyName() restores both into the cache KEY; until 2026-08-03 only the hints reached the search term, so '1 cup cooked quinoa' was retrieved as bare 'quinoa' and filterCandidatesByTokens dropped FDC 168917 'Quinoa, cooked' as bloated. That is an ADMISSION defect -- the record was ingested and gathered the whole time, and the golden-set notes calling it CORPUS-BLOCKED were false.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",
+      "where": "backend",
+      "command": "grep -c 'IDENTITY_QUALIFIERS' src/lib/mapping/map-ingredient-with-fallback.ts",
+      "expect": {
+        "kind": "matches",
+        "value": "^[2-9][0-9]*$"
+      },
+      "verified": "2026-08-03"
+    },
+    {
       "id": "eval-results-record-the-build",
       "claim": "A golden-eval results file records the buildId it ran against, fetched from /api/ok. Without it, base and noCache are the only provenance a results file carries, and two runs spanning a deploy are indistinguishable from two runs of one build -- which is how PR #226's effect read as a 10-case noise floor on 2026-08-03.",
       "ownerDoc": "mobile:sync-docs/reports/2026-08-02_the-golden-gate-cold.md",

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -5755,7 +5755,7 @@
           140
         ]
       },
-      "notes": "PR D pt3 class (c) KNOWN ISSUE — INGEST GAP. 'cooked' becomes a key discriminator (stops sibling-poisoning the bare 'quinoa' key immediately) but no cooked-quinoa record exists in the corpus (FDC 168917 ~120 kcal/100g not ingested), so dry ~368 kcal keeps winning and the case churns until the ingest lands. Promote after cooked-record ingest + 2 stable runs. PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals."
+      "notes": "FIXED 2026-08-03. The 'INGEST GAP — FDC 168917 not ingested' claim here was FALSE: that record was present and in-band throughout. The bare 'quinoa' search term caused filterCandidatesByTokens to drop it as bloated, so dry 'uncooked quinoa' (368 kcal/100g) kept winning. Fixed by restoring IDENTITY_QUALIFIERS into the retrieval query, mirroring what deriveCacheKeyName() already did for the cache key. PROMOTED HARD 2026-07-21."
     },
     {
       "id": "n-mq-36",
@@ -6060,7 +6060,7 @@
           28
         ]
       },
-      "notes": "DEFECT + CORPUS-BLOCKED. Explicit 'cooked quinoa' still returns FDC 'uncooked quinoa' (kcal100=368, carbs100=64.2) because NO cooked-quinoa record is retrievable. Band is a TARGET (cooked quinoa ~21g carb/100g), NOT observed-correct. Same root as n-serv-06's nutrition. Needs ingest, not ranking. knownIssue, non-gating. PROMOTED HARD 2026-07-21: passed x3 post-PR-D-pt3-deploy evals."
+      "notes": "FIXED 2026-08-03. The 'CORPUS-BLOCKED / needs ingest' reading here was FALSE and cost two rankings: FDC 168917 'Quinoa, cooked' (120 kcal/100g, 21.3g carbs) was ingested the whole time. It was gathered and then DROPPED by filterCandidatesByTokens, because the search term was bare 'quinoa' and its extra 'cooked' token read as bloat. Cause was ADMISSION, not ingest and not ranking. Restoring IDENTITY_QUALIFIERS into the retrieval query fixed it. PROMOTED HARD 2026-07-21."
     },
     {
       "id": "n-cook-06",
@@ -6078,7 +6078,7 @@
         ]
       },
       "knownIssue": true,
-      "notes": "DEFECT + CORPUS-BLOCKED. 'cooked oats'/'oatmeal' returns DRY 'Rolled Oats' (kcal100=361) — no cooked-oatmeal record in corpus, explicit-cooked token ignored. Band is a TARGET (cooked oatmeal ~70 kcal/100g), NOT observed. Needs ingest. knownIssue, non-gating."
+      "notes": "NOW PASSING 2026-08-03, still flagged knownIssue — promote after 2 more stable cold runs. The 'CORPUS-BLOCKED / needs ingest' reading was FALSE here too: restoring IDENTITY_QUALIFIERS into the retrieval query moved this from dry 'Rolled Oats' (361 kcal/100g) to FatSecret 'Steel Cut Oats (Cooked)' with no ingest. Note the sibling n-mq-36 'oatmeal' is a DIFFERENT case — it carries no 'cooked' token, so no qualifier can be restored and it still returns dry oats."
     },
     {
       "id": "n-brand-02",

--- a/src/lib/mapping/__tests__/identity-qualifier-reaches-retrieval.test.ts
+++ b/src/lib/mapping/__tests__/identity-qualifier-reaches-retrieval.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The identity QUALIFIER must reach RETRIEVAL, not only the cache key.
+ *
+ * Sibling of identity-hint-reaches-retrieval.test.ts, one set over. That file
+ * covers IDENTITY_UNIT_HINTS ({white, yolk}); this one covers IDENTITY_QUALIFIERS
+ * ({cooked, whole, raw, dried, canned}). The defect is identical in shape:
+ * `deriveCacheKeyName()` restores BOTH into the cache key, and until now only the
+ * unit hints were restored into the search term.
+ *
+ * Measured 2026-08-03 with scripts/filter-trace-probe.ts: on the query `quinoa`,
+ * the FDC record "cooked quinoa" IS gathered and is then DROPPED by
+ * `filterCandidatesByTokens` — its extra `cooked` token reads as bloat against a
+ * bare query — leaving "uncooked quinoa" (368 kcal/100g) to answer `cooked quinoa`
+ * (120 kcal/100g). On the query `cooked quinoa` it is kept. So the defect was
+ * ADMISSION, not ranking: the pool never contained the right answer.
+ *
+ * These tests assert the SEARCH TERM, not the final pick. The pick depends on
+ * corpus state; the search term is what this change controls. Each names the
+ * mutation it kills.
+ */
+
+const mockGatherCandidates = jest.fn();
+
+// Generic prisma stub: every model answers "nothing found" for any query verb.
+// Same rationale as the sibling file — enumerating models by hand once made that
+// file assert nothing, because the mapper hit an unmocked model and threw before
+// retrieval, leaving an empty search-term list that passed vacuously.
+jest.mock('../../db', () => {
+    const emptyFor = (verb: string) =>
+        jest.fn().mockResolvedValue(
+            verb.startsWith('findMany') || verb === 'findMany' ? [] : null);
+    const model = new Proxy({}, {
+        get: (_t, verb: string) => emptyFor(verb),
+    });
+    return { prisma: new Proxy({}, { get: () => model }) };
+});
+
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: (...a: unknown[]) => mockGatherCandidates(...a) };
+});
+
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
+import { mapIngredientWithFallback } from '../map-ingredient-with-fallback';
+import { parseIngredientLine } from '../../parse/ingredient-line';
+
+/** Every search term handed to retrieval during one mapper call. */
+async function searchTermsFor(line: string, options: Record<string, unknown> = {}): Promise<string[]> {
+    mockGatherCandidates.mockResolvedValue([]);
+    await mapIngredientWithFallback(line, { skipCache: true, skipSave: true, ...options } as never)
+        .catch(() => undefined);
+    return mockGatherCandidates.mock.calls.map(c => String(c[2] ?? ''));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('the parse layer really does strip the qualifier', () => {
+    it('"1 cup cooked quinoa" parses with `cooked` moved into qualifiers', () => {
+        // Not a test of the change — it pins the PREMISE. If the parser stops
+        // stripping `cooked`, the restoration below is solving a problem that moved.
+        const p = parseIngredientLine('1 cup cooked quinoa');
+        expect(p?.qualifiers?.map(q => q.toLowerCase())).toContain('cooked');
+        expect(p?.name?.toLowerCase()).not.toContain('cooked');
+    });
+});
+
+describe('the qualifier reaches the search query', () => {
+    it('"1 cup cooked quinoa" searches for COOKED quinoa, not bare quinoa', async () => {
+        // MUTATION: delete the restoration block. Kills it — every search term is
+        // bare "quinoa", which is exactly what let "uncooked quinoa" win n-mq-35
+        // and n-cook-05 at 368 kcal/100g against a [100,140] band.
+        const terms = await searchTermsFor('1 cup cooked quinoa');
+        expect(terms.length).toBeGreaterThan(0);
+        expect(terms.every(t => t.toLowerCase().includes('cooked'))).toBe(true);
+    });
+
+    it('a cooked line and its bare form no longer search for the same thing', async () => {
+        // MUTATION: restore the qualifier but drop it from baseName. This is the
+        // defect stated directly — one search term for two different foods.
+        const cooked = await searchTermsFor('1 cup cooked quinoa');
+        jest.clearAllMocks();
+        const bare = await searchTermsFor('1 cup quinoa');
+        expect(cooked[0]).not.toBe(bare[0]);
+    });
+
+    it('restores `dried` too, not just `cooked`', async () => {
+        // MUTATION: hardcode the restored qualifier to 'cooked'. The set has five
+        // members and the fix must not special-case the one case that motivated it.
+        const terms = await searchTermsFor('50g dried apricots');
+        expect(terms.length).toBeGreaterThan(0);
+        expect(terms.some(t => t.toLowerCase().includes('dried'))).toBe(true);
+    });
+});
+
+describe('the restoration is bounded', () => {
+    it('a NON-identity qualifier stays out of the query', async () => {
+        // MUTATION: restore every parsed qualifier instead of only IDENTITY_QUALIFIERS.
+        // `chopped` is a prep concern — it does not name a different food, and
+        // widening the query with it would narrow the pool for no identity gain.
+        const terms = await searchTermsFor('1 cup chopped onion');
+        expect(terms.length).toBeGreaterThan(0);
+        expect(terms.some(t => t.toLowerCase().includes('chopped'))).toBe(false);
+    });
+
+    it('a caller-supplied normalizedForm is left alone', async () => {
+        // MUTATION: drop the `!options.normalizedForm` guard. A caller that has
+        // already decided the search term owns it — golden n-serv-06 passes today
+        // precisely because it supplies "cooked quinoa" itself.
+        const terms = await searchTermsFor('1 cup cooked quinoa', { normalizedForm: 'quinoa' });
+        expect(terms.length).toBeGreaterThan(0);
+        expect(terms.every(t => t.toLowerCase().split(/\s+/).includes('cooked'))).toBe(false);
+    });
+
+    it('a line with no qualifier gains nothing', async () => {
+        // MUTATION: append unconditionally (undefined → "quinoa undefined").
+        const terms = await searchTermsFor('chicken breast');
+        expect(terms.length).toBeGreaterThan(0);
+        for (const t of terms) {
+            expect(t.toLowerCase()).not.toContain('undefined');
+            expect(t.toLowerCase().split(/\s+/)).not.toContain('cooked');
+        }
+    });
+
+    it('does not duplicate a qualifier the name already carries', async () => {
+        // MUTATION: drop the `!present.has(q)` check → "cooked cooked quinoa".
+        const terms = await searchTermsFor('1 cup cooked quinoa');
+        for (const t of terms) {
+            const cookedCount = t.toLowerCase().split(/\s+/).filter(w => w === 'cooked').length;
+            expect(cookedCount).toBeLessThanOrEqual(1);
+        }
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -9,6 +9,7 @@
  */
 
 import { parseIngredientLine, type ParsedIngredient } from '../parse/ingredient-line';
+import { IDENTITY_QUALIFIERS } from '../parse/qualifiers';
 import { normalizeIngredientName } from './normalization-rules';
 import { gatherCandidates, confidenceGate, type UnifiedCandidate, type GatherOptions } from './gather-candidates';
 import { funnelReason, type FunnelStage, type FunnelSink } from './funnel';
@@ -664,6 +665,43 @@ export async function mapIngredientWithFallback(
             rawLine: trimmed, baseName, unitHint: parsed.unitHint, restored: withHint,
         });
         baseName = withHint;
+    }
+
+    // The SAME gap, one set over: IDENTITY_QUALIFIERS.
+    //
+    // `deriveCacheKeyName()` restores unit hints AND qualifiers into the key; the
+    // block above restored only the hints into the QUERY. So `extractQualifiers()`
+    // strips `cooked` out of `parsed.name`, the key keeps it, and the search term
+    // does not — `1 cup cooked quinoa` is retrieved as bare `quinoa`.
+    //
+    // Measured 2026-08-03 with filter-trace-probe: on query `quinoa` the FDC record
+    // "cooked quinoa" is gathered and then DROPPED by filterCandidatesByTokens
+    // (the extra `cooked` token reads as bloat against a bare query), leaving
+    // "uncooked quinoa" to win. On `cooked quinoa` it is kept. So this is an
+    // ADMISSION defect, not a ranking one — pool never contained the right answer.
+    //
+    // Note this NARROWS the query, which is the opposite of the usual relaxation,
+    // so it cannot be waved through as admit-only. Blast radius measured before
+    // shipping: 12 of 348 golden cases carry one of these tokens and 57 of 5,586
+    // distinct live lines (1.0%). `whole` is in the set but cannot reach here on a
+    // unit-less line — `unit.ts` consumes it as a count unit first — so in practice
+    // this fires for cooked/raw/dried/canned.
+    //
+    // Reuses IDENTITY_QUALIFIERS rather than re-deriving it, for the same reason
+    // the block above reuses IDENTITY_UNIT_HINTS: the key and the query must not
+    // drift apart again.
+    if (!options.normalizedForm?.trim() && parsed?.qualifiers?.length) {
+        const present = new Set(baseName.toLowerCase().split(/\s+/));
+        const restore = parsed.qualifiers
+            .map(q => q.toLowerCase())
+            .filter(q => IDENTITY_QUALIFIERS.has(q) && !present.has(q));
+        if (restore.length) {
+            const withQualifiers = `${[...new Set(restore)].join(' ')} ${baseName}`.trim();
+            logger.info('mapping.identity_qualifier_restored', {
+                rawLine: trimmed, baseName, qualifiers: restore, restored: withQualifiers,
+            });
+            baseName = withQualifiers;
+        }
     }
 
     // Brand-preservation guard.


### PR DESCRIPTION
Closes cold golden **`n-mq-35`** and **`n-cook-05`** (2 of the 13 stable cold failures) and moves **`n-cook-06`** to passing.

## The gap

`deriveCacheKeyName()` restores `IDENTITY_UNIT_HINTS` **and** `IDENTITY_QUALIFIERS` into the cache key. PR #226 restored only the unit hints into the search term. So `extractQualifiers()` strips `cooked` out of `parsed.name`, the key keeps it, and the query does not — `1 cup cooked quinoa` is retrieved as bare `quinoa`.

Same *"one owner, not every caller"* shape as #221 / #223 / #226. Fourth instance.

## It was ADMISSION, not ranking — and not ingest

Measured with `scripts/filter-trace-probe.ts`:

```
================ quinoa ================
gathered: 19  mustHave= ["quinoa"]
   [fdc] "cooked quinoa"    => DROPPED@filterCandidatesByTokens
   [fdc] "uncooked quinoa"  => KEPT

================ cooked quinoa ================
   [fdc] "cooked quinoa"    => KEPT
```

FDC 168917 "Quinoa, cooked" is gathered and then dropped — its extra `cooked` token reads as bloat against a bare query — leaving `uncooked quinoa` (368 kcal/100g) to answer a `[100,140]` band. Per playbook §5a, a wrong answer from a pool that never contained the right record is not a ranking bug.

**The `golden-set.json` notes on all three cases claimed `CORPUS-BLOCKED` / "FDC 168917 … not ingested".** That was false the entire time and had already misdirected two rankings toward the ingest. Corrected in this PR.

## Blast radius, measured before shipping

This **narrows** the query — the opposite of the usual relaxation — so it is explicitly *not* admit-only and could not be waved through by inspection.

- **12 of 348** golden cases carry one of these tokens
- **57 of 5,586** distinct live `MappingEventLog` lines (**1.0%**)
- `whole` is in the set but cannot reach here on a unit-less line (`unit.ts` consumes it as a count unit first), so in practice this fires for `cooked`/`raw`/`dried`/`canned`

Measured on **one dev server toggling only this code**, cold (`nocache=1&nosave=1`), so there is no host confound:

| case | before | after |
|---|---|---|
| `n-mq-35` | `uncooked quinoa` | **`cooked quinoa`** ✅ |
| `n-cook-05` | `uncooked quinoa` | **`cooked quinoa`** ✅ |
| `n-cook-06` | `Rolled Oats` (dry, 361) | **`Steel Cut Oats (Cooked)`** ✅ |
| `n-cook-01/02/03/04`, `n-mq-34`, `n-mq-37`, `n-serv-01/06`, `n-seg-01` | — | unchanged |

Full cold run against the patched server: **11 of the 13 box-stable failures remain**, both targets pass, and the only extra is `n-serv-31` — the documented AI-tier flake already inside the recorded noise set.

## One thing worth knowing: `n-cook-03`

It changes record (to a Bush's OFF dish) **without changing verdict**. Why it moved: the correct FDC record is admitted at score **1** and loses to that OFF row at **5.5** — the pre-existing flat-FDC-score mismatch, newly exposed. This is the documented "a lane winning more queries converts its latent gaps into live defects" pattern.

Against the USDA reference (1 cup ≈ 172 g / 227 kcal) it billed **138 kcal before** and **295 after** — already wrong, now wrong in the other direction, marginally closer. Not a regression, but it is the next thread to pull.

## Gates

- **8 new tests**, each naming the mutation it kills. Verified by mutation: disabling the restoration kills exactly the three restoration tests and leaves the four boundedness tests green.
- `lint:ci` 0 errors · `typecheck` 0 · `doc-check` **93/93**, with the new claim `identity-qualifiers-reach-retrieval` **watched go red** before being trusted.

`n-cook-06` is left flagged `knownIssue` deliberately — promote after two more stable cold runs rather than in the PR that changed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
