### PR TITLE
fix(mapping): the FS volume branch never read a label that names the unit

### DIFF
--- a/src/lib/mapping/__tests__/build-fatsecret-result-declared-volume.test.ts
+++ b/src/lib/mapping/__tests__/build-fatsecret-result-declared-volume.test.ts
@@ -1,0 +1,296 @@
+/**
+ * buildFatSecretResult — what answers a VOLUME request when the record states
+ * the answer in a serving description but carries no `volumeMl`.
+ *
+ * The volume branch resolved grams as `totalMl * (grams / volumeMl)` and so
+ * filtered `usableServings` on `volumeMl != null` BEFORE any description was
+ * consulted. A label reading "1 cup cooked" = 158 g was therefore structurally
+ * unreachable: the filter dropped it, `servingMatchesVolumeUnit()` never saw it,
+ * and the request fell to the category density fallback.
+ *
+ * That is not a rare shape. Measured on the box 2026-08-03: 7,768
+ * FatSecretServing rows carry grams and a volume-named description with NULL
+ * volumeMl, against 2,478 rows the density path can see at all — 3.1x more
+ * unreachable than reachable.
+ *
+ * `fs_4501` "White Rice" is the worked case (golden eval n-tot-02,
+ * "1 cup white rice", band [160, 260] kcal). Live cold on build
+ * cqJKyfD4ps_ZPNPpBDCoA it billed 120 g / 154.8 kcal — 240 ml x the 0.5 g/ml
+ * category density — while the record's own declared default serving says a cup
+ * is 158 g / 204 kcal.
+ *
+ * The fixture is the real fs_4501 row, verbatim from the box, ordered by
+ * `servingId` ascending as the include's `orderBy` returns it.
+ */
+
+const mockFatSecretFoodFindUnique = jest.fn();
+
+jest.mock('../../db', () => ({
+    prisma: {
+        fatSecretFood: {
+            findUnique: (...args: unknown[]) => mockFatSecretFoodFindUnique(...args),
+        },
+    },
+}));
+
+import { buildFatSecretResult } from '../build-fatsecret-result';
+import type { ParsedIngredient } from '../../parse/ingredient-line';
+
+function makeCandidate(over: Record<string, unknown> = {}) {
+    return {
+        id: 'fs_4501', source: 'fatsecret' as const, name: 'White Rice',
+        brandName: null, score: 1, foodType: 'Generic', rawData: {}, ...over,
+    } as any;
+}
+
+function serving(
+    servingId: string, description: string, grams: number,
+    nutrients: Record<string, number> | null = null,
+) {
+    return {
+        servingId, description, measurementDescription: null,
+        grams, volumeMl: null, numberOfUnits: 1, nutrients,
+    };
+}
+
+function makeRow(over: Record<string, unknown> = {}) {
+    return {
+        fsId: '4501', name: 'White Rice', brandName: null, foodType: 'Generic',
+        nutrientsPer100g: { calories: 129, protein: 2.66, carbs: 27.9, fat: 0.28 },
+        // "1 cup cooked" — the row the volumeMl filter was hiding.
+        defaultServingId: '16834',
+        fetchedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        servings: [
+            serving('15284', '1 cup, dry, yields', 570,
+                { calories: 735, protein: 15.16, carbohydrate: 159.03, fat: 1.6 }),
+            serving('16834', '1 cup cooked', 158,
+                { calories: 204, protein: 4.2, carbohydrate: 44.08, fat: 0.44 }),
+            serving('17592', '1 serving (105 g)', 105,
+                { calories: 135, protein: 2.79, carbohydrate: 29.3, fat: 0.29 }),
+            serving('18252', '1 oz, dry, yields', 87,
+                { calories: 112, protein: 2.31, carbohydrate: 24.27, fat: 0.24 }),
+            {
+                ...serving('53181', '100 g', 100,
+                    { calories: 129, protein: 2.66, carbohydrate: 27.9, fat: 0.28 }),
+                numberOfUnits: 100,
+            },
+        ],
+        ...over,
+    };
+}
+
+function parsedLine(over: Partial<ParsedIngredient>): ParsedIngredient {
+    return { qty: 1, multiplier: 1, unit: null, name: '', ...over } as ParsedIngredient;
+}
+
+const CUP_RICE = () => parsedLine({ qty: 1, unit: 'cup', name: 'white rice' });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockFatSecretFoodFindUnique.mockResolvedValue(makeRow());
+});
+
+describe('n-tot-02 — "1 cup white rice" reads the record\'s own cup label', () => {
+    it('bills the declared 158 g cup, not the 120 g category density guess', async () => {
+        // MUTATION: delete the `declaredGramsPerUnit` branch -> falls to
+        // volumeToGrams() and bills 240ml * 0.5 = 120 g / 154.8 kcal, which is
+        // what production did before this change.
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r).not.toBeNull();
+        expect(r!.grams).toBe(158);
+        expect(r!.servingTier).toBe('fs_label_volume_declared');
+    });
+
+    it('lands inside the golden case band the density fallback missed', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        // The serving carries its own panel, so the cup bills the label's 204
+        // kcal directly. Band is [160, 260]; the old path billed 154.8.
+        expect(r!.kcal).toBeCloseTo(204, 0);
+        expect(r!.kcal).toBeGreaterThan(160);
+        expect(r!.kcal).toBeLessThan(260);
+    });
+
+    it('scales with quantity', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 2, unit: 'cups', name: 'white rice' }), 0.98,
+            '2 cups white rice'
+        );
+        expect(r!.grams).toBe(316);
+    });
+});
+
+describe('a YIELD is not a portion', () => {
+    it('refuses "1 cup, dry, yields" even when the record declares it default', async () => {
+        // 570 g is what a cup of DRY rice becomes after cooking, not what a cup
+        // weighs — billing it is ~3.6x wrong. Only 5 of the 3,677 cup-named
+        // default servings on the box say "yield", but they are the worst-wrong
+        // rows in the set.
+        // MUTATION: drop the /yield/i test -> this bills 570 g / 735 kcal.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({ defaultServingId: '15284' }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.grams).not.toBe(570);
+        expect(r!.servingTier).toBe('fs_volume_density');
+    });
+
+    it('does NOT refuse a plain "dry" portion', async () => {
+        // 77 of those defaults read "1/4 cup dry" = 43 g and similar. Those are
+        // ordinary fractional portions and a correct answer to a volume request;
+        // only an explicit yield is a different measurement.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            defaultServingId: '99001',
+            servings: [serving('99001', '1/4 cup dry', 43, null)],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.servingTier).toBe('fs_label_volume_declared');
+        expect(r!.grams).toBeCloseTo(172, 5);   // 43 / 0.25
+    });
+});
+
+describe('the label\'s own leading quantity is divided out', () => {
+    // 1,474 of the 3,677 cup-named default servings (40.1%) lead with a
+    // fraction, and 91 more are mixed numbers. Reading them as one unit
+    // under-bills a full cup by 2-4x. `labelLeadingCount()` in count-label.ts
+    // cannot be reused for this: it is integer-only and returns null below 2,
+    // i.e. null for every shape below.
+    it.each([
+        ['1 cup cooked', 158, 158],
+        ['1/2 cup', 56, 112],
+        ['1/4 cup', 45, 180],
+        ['2/3 cup', 100, 150],
+        // NOT 90g: 90/0.75 = 120, which collides exactly with the density
+        // fallback's 240ml * 0.5 — the case passed with the branch deleted.
+        ['3/4 cup', 120, 160],
+        ['1 1/4 cups', 250, 200],
+        ['2 cups', 300, 150],
+    ])('%s = %ig -> one cup is %ig', async (description, grams, expected) => {
+        // MUTATION: treat the leading quantity as 1 -> every fractional row
+        // bills its raw grams and under-bills the cup.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            defaultServingId: '99002',
+            servings: [serving('99002', description as string, grams as number, null)],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.grams).toBeCloseTo(expected as number, 5);
+    });
+});
+
+describe('the declaration must be UNAMBIGUOUS for the requested unit', () => {
+    // A record can carry several rows naming one unit, and then the default's
+    // choice among them is a claim about product FORM, not about the request.
+    // fs_39558 "Brown Sugar" verbatim from the box: three tsp rows, and the
+    // declared default is the UNPACKED one. Golden n-dens-03 bands [3.5, 5.5]
+    // because a recipe's "1 tsp brown sugar" means packed.
+    const BROWN_SUGAR = (over: Record<string, unknown> = {}) => makeRow({
+        fsId: '39558', name: 'Brown Sugar',
+        nutrientsPer100g: { calories: 380, protein: 0.1, carbs: 98.1, fat: 0 },
+        defaultServingId: '40102',
+        servings: [
+            serving('40102', '1 tsp unpacked', 3),
+            serving('40100', '1 tsp brownulated', 3.2),
+            serving('40101', '1 tsp packed', 4.6),
+            serving('45797', '1 oz', 28.35),
+            serving('40099', '1 cup unpacked', 145),
+            serving('40098', '1 cup packed', 220),
+        ],
+        ...over,
+    });
+
+    it('refuses when the record holds sibling rows for that unit', async () => {
+        // MUTATION: drop the `sameUnitDeclarations === 1` test -> this bills the
+        // unpacked 3 g and reopens n-dens-03.
+        mockFatSecretFoodFindUnique.mockResolvedValue(BROWN_SUGAR());
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_39558', name: 'Brown Sugar' }),
+            parsedLine({ qty: 1, unit: 'tsp', name: 'brown sugar' }), 0.9, '1 tsp brown sugar'
+        );
+        expect(r!.servingTier).toBe('fs_volume_density');
+        expect(r!.grams).not.toBe(3);
+    });
+
+    it('refuses per-unit, not globally — cup is ambiguous on this record too', async () => {
+        // The default must NAME the unit for the guard to be what refuses; with
+        // the tsp default this case falls through for a different reason and
+        // would pass even with the guard deleted. Point the default at the cup
+        // row so the ambiguity is genuinely what is being tested.
+        // MUTATION: drop the guard -> this bills the unpacked 145 g.
+        mockFatSecretFoodFindUnique.mockResolvedValue(
+            BROWN_SUGAR({ defaultServingId: '40099' })
+        );
+        const r = await buildFatSecretResult(
+            makeCandidate({ id: 'fs_39558', name: 'Brown Sugar' }),
+            parsedLine({ qty: 1, unit: 'cup', name: 'brown sugar' }), 0.9, '1 cup brown sugar'
+        );
+        // "1 cup unpacked" 145 and "1 cup packed" 220 — same ambiguity.
+        expect(r!.servingTier).toBe('fs_volume_density');
+        expect(r!.grams).not.toBe(145);
+    });
+
+    it('a YIELD sibling does not make the declaration ambiguous', async () => {
+        // fs_4501 holds TWO cup rows, but "1 cup, dry, yields" is removed by the
+        // yield rule before the count is taken — so white rice still resolves.
+        // MUTATION: count siblings before applying the yield rule -> n-tot-02
+        // reopens.
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.servingTier).toBe('fs_label_volume_declared');
+        expect(r!.grams).toBe(158);
+    });
+});
+
+describe('scope — the rule stays out of paths that already work', () => {
+    it('a volumeMl-bearing serving still wins (density is more precise)', async () => {
+        // MUTATION: put the declared branch BEFORE the volMatch branch -> this
+        // bills 158 g instead of the 240 g the record's own density gives.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({
+            servings: [
+                { ...serving('16834', '1 cup cooked', 158), volumeMl: 240 },
+                serving('17592', '1 serving (105 g)', 105),
+            ],
+        }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.servingTier).toBe('fs_label_volume');
+        expect(r!.grams).toBeCloseTo(158, 5);
+    });
+
+    it('only fires for the unit the description actually names', async () => {
+        // The default says "cup"; a tbsp request must not read it.
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 1, unit: 'tbsp', name: 'white rice' }), 0.98,
+            '1 tbsp white rice'
+        );
+        expect(r!.servingTier).toBe('fs_volume_density');
+    });
+
+    it('does not fire on a non-default serving that happens to name the unit', async () => {
+        // Deliberate scope limit: fs_4501 holds TWO cup rows, and picking among
+        // them without a declaration is a positional pick. With the default
+        // pointing elsewhere, the request falls through rather than guess.
+        mockFatSecretFoodFindUnique.mockResolvedValue(makeRow({ defaultServingId: '17592' }));
+        const r = await buildFatSecretResult(
+            makeCandidate(), CUP_RICE(), 0.98, '1 cup white rice'
+        );
+        expect(r!.servingTier).toBe('fs_volume_density');
+    });
+
+    it('leaves an explicit WEIGHT request alone', async () => {
+        const r = await buildFatSecretResult(
+            makeCandidate(), parsedLine({ qty: 100, unit: 'g', name: 'white rice' }), 0.98,
+            '100g white rice'
+        );
+        expect(r!.servingTier).toBe('fs_weight_direct');
+        expect(r!.grams).toBe(100);
+    });
+});

--- a/src/lib/mapping/build-fatsecret-result.ts
+++ b/src/lib/mapping/build-fatsecret-result.ts
@@ -13,6 +13,8 @@
  * Gram-resolution priority:
  *   (a) explicit weight unit  → direct conversion       ('fs_weight_direct')
  *   (b) volume unit           → serving volumeMl match  ('fs_label_volume'),
+ *       else the record's own declared serving when its
+ *       description names the unit           ('fs_label_volume_declared'),
  *       else category-density fallback                  ('fs_volume_density')
  *   (c) count/serving request → noun-matched serving    ('fs_label_count'),
  *       else default serving                            ('fs_default_serving')
@@ -43,6 +45,12 @@ import { volumeToGrams } from '../units/volume-density';
 // there is no cycle back through map-ingredient-with-fallback.
 import { isAmbiguousUnit, getOrCreateAmbiguousServing } from './ambiguous-unit-backfill';
 import { classifyUnit } from './unit-type';
+// Leading-quantity parsing for serving labels ("1/2 cup" -> 0.5, "1 1/4 cups"
+// -> 1.25). The ONE owner of that grammar; it has no imports of its own, so
+// there is no cycle risk here. Deliberately NOT a local copy: 40.1% of the
+// labels this module now reads lead with a fraction (measured below), and a
+// second parser is exactly how this cascade's rules diverged before.
+import { parseQuantityTokens } from '../parse/quantity';
 import type { ParsedIngredient } from '../parse/ingredient-line';
 import type { UnifiedCandidate } from './gather-candidates';
 import type { FatsecretMappedIngredient } from './map-ingredient-with-fallback';
@@ -200,11 +208,60 @@ function servingMatchesNoun(s: FsServingView, noun: string): boolean {
 }
 
 /** True when the serving's description names the requested volume unit. */
-function servingMatchesVolumeUnit(s: FsServingView, unit: string): boolean {
+function textMatchesVolumeUnit(text: string, unit: string): boolean {
     const stems = VOLUME_UNIT_STEMS[unit];
     if (!stems) return false;
-    const text = `${s.description ?? ''} ${s.measurementDescription ?? ''}`;
     return stems.some(stem => new RegExp(`\\b${stem.replace(' ', '\\s+')}s?\\b`, 'i').test(text));
+}
+
+function servingMatchesVolumeUnit(s: FsServingView, unit: string): boolean {
+    return textMatchesVolumeUnit(`${s.description ?? ''} ${s.measurementDescription ?? ''}`, unit);
+}
+
+/**
+ * Grams for ONE of the requested volume unit, read off a serving that NAMES
+ * that unit in its own description but carries no `volumeMl`.
+ *
+ * Why this exists: the density path above filters on `volumeMl != null` BEFORE
+ * any description is consulted, so a label that states the answer outright is
+ * structurally unreachable. That is not a rare shape — 7,768 FatSecretServing
+ * rows carry grams and a volume-named description with NULL volumeMl, against
+ * 2,478 rows the density path can see at all (measured 2026-08-03, box; see the
+ * call site for the re-derive). `fs_4501` "White Rice" is the worked example:
+ * its servings are `1 cup cooked` = 158 g and `1 cup, dry, yields` = 570 g, both
+ * volumeMl NULL, so `1 cup white rice` fell to the category density fallback and
+ * billed 240 ml x 0.5 = 120 g.
+ *
+ * Three things this rule is careful about, each measured over the 3,677
+ * cup-named default servings on the box (2026-08-03):
+ *
+ *  1. THE LEADING QUANTITY IS USUALLY NOT 1. 1,474 of them (40.1%) lead with a
+ *     fraction ("1/2 cup" x519, "1/4 cup" x382, "2/3 cup" x239) and 91 more are
+ *     mixed numbers ("1 1/4 cups"). Reading those as one unit would under-bill a
+ *     full cup by 2-4x, so the label's own quantity is divided out. Note that
+ *     `labelLeadingCount()` in count-label.ts CANNOT be reused for this: it is
+ *     integer-only and returns null below 2, i.e. null for every shape above.
+ *  2. A YIELD IS NOT A PORTION. "1 cup, dry, yields" states what a cup of the
+ *     dry product becomes after cooking (570 g for rice), not what a cup weighs
+ *     — billing it would be ~3x wrong. Only 5 of the 3,677 defaults say "yield",
+ *     but they are the worst-wrong rows in the set, so they are refused. Plain
+ *     "dry" is NOT refused: those 77 rows are ordinary fractional portions
+ *     ("1/4 cup dry" = 43 g) and are a correct answer to a volume request.
+ *  3. IT READS THE DESCRIPTION ONLY, not `measurementDescription`. The
+ *     population above was measured on `description`, and the quantity is parsed
+ *     from that same string — gating on a field the measurement never covered
+ *     would be a claim about rows nobody counted.
+ */
+function declaredVolumeUnitGrams(s: FsServingView, unit: string): number | null {
+    if (s.grams == null || s.grams <= 0) return null;
+    const description = s.description ?? '';
+    if (!textMatchesVolumeUnit(description, unit)) return null;
+    if (/yield/i.test(description)) return null;
+    const parsedQty = parseQuantityTokens(description.trim().split(/\s+/));
+    // No leading quantity means the label is not self-describing ("cup, chopped"
+    // with no count); 4 of 3,677 are that shape. Refuse rather than assume 1.
+    if (!parsedQty || !(parsedQty.qty > 0)) return null;
+    return s.grams / parsedQty.qty;
 }
 
 // ============================================================
@@ -400,11 +457,62 @@ export async function buildFatSecretResult(
         const totalMl = qty * VOLUME_UNIT_ML[unit];
         const volServings = usableServings.filter(s => s.volumeMl != null && s.volumeMl > 0);
         const volMatch = volServings.find(s => servingMatchesVolumeUnit(s, unit)) ?? volServings[0];
+        // The record's OWN declared default, when it names the requested unit.
+        // Only reached when no volumeMl-bearing serving exists, so this never
+        // displaces the more precise density path above.
+        //
+        // Scoped to `defaultServingId` deliberately, and NOT widened to "any
+        // serving whose description matches". 3,677 of the 4,822 cup-named
+        // NULL-volumeMl rows (76.3%) ARE the record's default, so the declared
+        // row carries most of the population anyway — and a record can hold
+        // several cup rows ("1 cup cooked" 158 g vs "1 cup, dry, yields" 570 g
+        // on fs_4501 itself), where picking among them without a declaration is
+        // the positional pick this module already had to fix once at the hydrate
+        // step. An explicit declaration beats an inference and needs no
+        // threshold; widening this is a separate change with its own gate run.
+        //
+        // Re-derive the population (box, read-only):
+        //   SELECT count(*) FILTER (WHERE s."volumeMl" IS NULL OR s."volumeMl" <= 0),
+        //          count(*) FILTER (WHERE s."volumeMl" > 0)
+        //   FROM "FatSecretServing" s
+        //   WHERE s.grams IS NOT NULL AND s.description ~* '\ycups?\y';
+        const declaredDefault = row?.defaultServingId
+            ? usableServings.find(s => s.servingId === row.defaultServingId)
+            : undefined;
+        // ...and only when that declaration is UNAMBIGUOUS for this unit.
+        //
+        // A record can carry several rows naming the same unit, and then the
+        // default's choice among them is a claim about PRODUCT FORM, not about
+        // what the user asked for. `fs_39558` "Brown Sugar" is the case: it holds
+        // `1 tsp unpacked` = 3 g (its declared default), `1 tsp brownulated` =
+        // 3.2 g and `1 tsp packed` = 4.6 g. Billing a bare "1 tsp brown sugar"
+        // as unpacked is picking a variant the request never named — recipes mean
+        // packed, which is why golden `n-dens-03` bands [3.5, 5.5]. Refusing here
+        // falls through to the category density, which answers the generic
+        // question generically.
+        //
+        // Cheap, measured 2026-08-03 on the box: of the 3,672 records whose
+        // declared default is a non-yield cup row, 3,624 (98.7%) have exactly one
+        // such row, so this gives up 1.3% of the population. Note `fs_4501`
+        // "White Rice" stays in: its second cup row is `1 cup, dry, yields`,
+        // which the yield rule already removed before this count is taken.
+        const sameUnitDeclarations = declaredDefault
+            ? usableServings.filter(s => declaredVolumeUnitGrams(s, unit) != null).length
+            : 0;
+        const declaredGramsPerUnit = declaredDefault && sameUnitDeclarations === 1
+            ? declaredVolumeUnitGrams(declaredDefault, unit)
+            : null;
+
         if (volMatch) {
             grams = totalMl * (volMatch.grams! / volMatch.volumeMl!);
             servingDescription = `${qty} ${unit}`;
             servingTier = 'fs_label_volume';
             pickedServing = volMatch;
+        } else if (declaredGramsPerUnit != null) {
+            grams = qty * declaredGramsPerUnit;
+            servingDescription = `${qty} ${unit}`;
+            servingTier = 'fs_label_volume_declared';
+            pickedServing = declaredDefault!;
         } else {
             // Density fallback, from the ONE owner of this rule
             // (`resolveVolumeGrams()` in `src/lib/units/volume-density.ts`).


### PR DESCRIPTION
## What

`buildFatSecretResult()`'s volume branch filtered `usableServings` on `volumeMl != null` **before** `servingMatchesVolumeUnit()` — which reads the serving *description* — was ever consulted. A label reading `1 cup cooked` = 158 g was therefore structurally unreachable, and the request fell through to the category density fallback: 240 ml × 0.5 = **120 g**.

Same shape as #221 / #223 / #226 / #233 — the predicate already existed; the filter in front of it meant no caller ever reached it.

## Why it matters

Measured on the box, 2026-08-03:

| | rows |
|---|---|
| `FatSecretServing` with grams + volume-named description, **NULL `volumeMl`** | **7,768** |
| rows the density path can see at all (`volumeMl > 0`) | 2,478 |

3.1× more unreachable than reachable. Live, `fs_volume_density` holds **384** `MappingEventLog` events to `fs_label_volume`'s **10** — the fallback was answering 97.5% of FS volume requests. **323 of 369** joinable events point at a record whose declared default would qualify.

## The rule

Reads the record's **own declared default serving** when its description names the requested unit, and only then. Three things the measurements changed about the design:

- **The label's leading quantity is divided out.** 1,474 of the 3,677 cup-named default servings (**40.1%**) lead with a fraction (`1/2 cup` ×519, `1/4 cup` ×382, `2/3 cup` ×239) and 91 more are mixed numbers (`1 1/4 cups`). Reading those as one unit under-bills a cup by 2–4×. `labelLeadingCount()` **cannot** be reused — it is integer-only and returns null below 2, i.e. null for every one of those shapes. `parseQuantityTokens()` already handles all of them and has zero imports, so this adds no second parser.
- **A yield is not a portion.** `1 cup, dry, yields` = 570 g states what a cup of dry rice *becomes*, ~3.6× wrong as a cup weight. Only **5** of 3,677 defaults say "yield", but they are the worst-wrong rows. Plain `dry` is deliberately **not** refused — those 77 rows are ordinary fractional portions (`1/4 cup dry` = 43 g).
- **The declaration must be unambiguous for that unit.** `fs_39558` "Brown Sugar" holds `1 tsp unpacked` = 3 g (its declared default), `1 tsp brownulated` = 3.2 and `1 tsp packed` = 4.6. Billing a bare request as unpacked picks a variant the user never named. Refusing costs **1.3%** — 3,624 of 3,672 records have exactly one non-yield row for the unit.

New tier `fs_label_volume_declared`, so the change is visible to the tier-keyed instruments. The guard-alias map is deliberately untouched: a volume request is never bare, so the bare-query guard cannot apply.

## Cold golden gate

Both arms **built and served on the same host** with `FATSECRET_RETRIEVAL_ENABLED=1`, diffed by case id:

**13 real failures → 12.** Five cases moved:

| case | direction | attribution |
|---|---|---|
| `n-tot-02` | **closed** | this change — same record `fs_4501`, 120 → 158 g |
| `n-dens-05` | **opened** | see below |
| `n-serv-26`, `n-svd-03`, `n-seg-18` | rotating | noise — `1 bowl cereal` returned **40 / 30 / 60 / 45 g on four probes of one build**, since ambiguous units estimate via LLM |

`n-dens-05` is worth reading carefully before treating it as a regression: 86.4 → 96 g against band [78,95], because `fs_4569633` is **Bob's Red Mill Rolled Oats** and `1/2 cup = 48 g` is that product's genuine label. The case goes red because a *generic* query resolves to a *branded* record — a PICK defect the density guess was accidentally masking, not a serving regression.

External references for the same live tier all move toward truth:

| query | before | after | reference |
|---|---|---|---|
| `1 cup spinach` | 360 g | **30 g** | USDA 30 |
| `1 cup cheerios` | 120 g | **26 g** | box label 1½ cups = 39 g |
| `1 cup cooked oats` | 86.4 g | **240 g** | USDA ≈ 234 |
| `1 cup brown rice` | 120 g | **195 g** | USDA 195 |
| `1 cup black beans` | 120 g | **172 g** | USDA 172 |

## Gates

Re-run **after the last edit**: `typecheck` 0 · `lint:ci` 0 errors · `next build` 0 · **68 suites / 1240 tests** green across `src/lib/mapping` + `src/lib/servings`.

Every guard is mutation-checked, not just commented: deleting the branch kills 11 tests, the yield rule 1, the leading-quantity division 7, the unambiguous rule 2. One fixture (`3/4 cup` = 90 g) survived the first mutation because 90/0.75 = 120 collides exactly with the density fallback it replaces — corrected.

## Note for anyone gating locally

`FATSECRET_RETRIEVAL_ENABLED` is `getFlag(..., false)` and was **absent from the dev Mac's `.env`**, so `npm start` there serves a pipeline with no FatSecret lane and `run-eval.ts --base http://localhost:3000` gates code this PR never touches. Caught by probing one case on both hosts first (`1 cup white rice` → `fdc_169759` local vs `fs_4501` box, 5/5 stable each way) — source files hash byte-identical across hosts, so the whole difference was one missing env line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu