### PR TITLE
test(eval): give n-cook-03 a total band -- it was green while billing 30% over

### DIFF
--- a/scripts/eval/__tests__/winner-diff.test.ts
+++ b/scripts/eval/__tests__/winner-diff.test.ts
@@ -477,7 +477,11 @@ describe('parseGoldenSet', () => {
         expect(n(c => !!c.grams)).toBe(148);              // the majority assertion
         expect(n(c => !!c.macros)).toBe(65);
         expect(n(c => typeof c.expectItems === 'number')).toBe(47);
-        expect(n(c => !!c.total)).toBe(35);
+        // 36 since 2026-08-04: n-cook-03 gained a total band, because its scale-free
+        // kcal100/carbs100 were passing on a 240 g / 295 kcal bill against USDA's
+        // 172 g / 227 kcal. Adding one here also adds one to the `total` blind count
+        // below — this screen cannot judge totals at all.
+        expect(n(c => !!c.total)).toBe(36);
         // documented in _readme, no live case uses them — parsed anyway so the screen
         // does not go blind the moment one is added back
         expect(n(c => !!c.forbidName)).toBe(0);
@@ -716,7 +720,7 @@ describe('structurallyBlindBands / goldenCoverage over the REAL corpus', () => {
         const kind = (k: string) => cov.byKind.find(b => b.kind === k)!;
         expect(cov.cases).toBe(243);
         expect(kind('grams')).toEqual({ kind: 'grams', asserted: 148, blind: 148 });
-        expect(kind('total')).toEqual({ kind: 'total', asserted: 35, blind: 35 });
+        expect(kind('total')).toEqual({ kind: 'total', asserted: 36, blind: 36 });
         expect(kind('expectItems')).toEqual({ kind: 'expectItems', asserted: 47, blind: 47 });
         // expectName is judgeable except on the segmenter-bound text lines
         const en = kind('expectName');

--- a/scripts/eval/golden-set.json
+++ b/scripts/eval/golden-set.json
@@ -6026,7 +6026,13 @@
           29
         ]
       },
-      "notes": "Lock-in. Cooked black beans -> FDC 'black turtle...cooked' (kcal100=130, carbs100=24.4), stable. Legumes already resolve cooked (unlike grains). Hard."
+      "total": {
+        "calories": [
+          180,
+          280
+        ]
+      },
+      "notes": "Lock-in. Cooked black beans -> FDC 'black turtle...cooked' (kcal100=130, carbs100=24.4), stable. Legumes already resolve cooked (unlike grains). Hard. TOTAL BAND ADDED 2026-08-04, and it is EXPECTED RED until the source-score asymmetry is fixed: the case was green while billing a ~30% over-bill, because scale-free kcal100/carbs100 cannot see grams. Measured on box TqkY7MBZjJjmnKuqDjeoF, 3/3 stable: off_0039400019442 (Bush's) at 240 g / 295 kcal, vs USDA 1 cup cooked black beans = 172 g / 227 kcal. Band is reference +/-23%, matching n-tot-02's style. A case that cannot see a doubled bill is not a test."
     },
     {
       "id": "n-cook-04",


### PR DESCRIPTION
## What

`n-cook-03` (`1 cup cooked black beans`) asserted only `kcal100` and `carbs100`. Both are **scale-free**, so the case could not see grams or the billed total — and it was passing while billing ~30% over.

Measured on box `TqkY7MBZjJjmnKuqDjeoF`, 3/3 stable:

| | value |
|---|---|
| mapped record | `off_0039400019442` "Jamaican Black Beans Slow Cooked In A Spicy Island-Inspired Sauce" |
| billed | **240 g / 295.2 kcal** |
| `kcal100` / `carbs100` | 123 / 25 — both **inside** their bands |
| USDA, 1 cup cooked black beans | **172 g / 227 kcal** |

A prepared dish in sauce is winning a query for plain cooked beans, and the assertion was structurally unable to notice.

Band is `[180, 280]` — reference ±23%, matching `n-tot-02`'s style.

## Expected RED on merge

This does not fix the defect, it makes it visible. The cold gate goes **12 → 13** until the source-score asymmetry is fixed, and that red is the test for it. Deliberately **not** flagged `knownIssue`: a pin here would restore exactly the blindness this removes.

## On the fix that should follow it

The queue documents this as *"FDC candidates score a flat 1 while OFF rows score 2.75–6.9"*, implying a head-to-head 1-vs-5.5 comparison. **Reading the code, that framing is wrong** and the next person should not plan off it:

- `computeOffScore()` (`src/lib/openfoodfacts/search.ts`) is unbounded additive — +4 brand, +3 prefix, +2 per matched query word — so OFF lands 2.75–6.9.
- `computePositionScore()` (`src/lib/mapping/gather-candidates.ts`) returns ~0.5–1.43 for FDC.
- But `simpleRerank()` **clamps both**: `Math.min(candidate.score, 1) * WEIGHTS.ORIGINAL_SCORE` with `ORIGINAL_SCORE = 0.45`.

So the raw scores are never compared head-to-head. The real mechanism is **saturation**: OFF is almost always ≥1 and therefore always contributes the full 0.45, while a low-scoring FDC row contributes proportionally less. Maximum gap **0.225**, not 4.5.

There is a **second, separate** consumer that uses the raw score unclamped — `assessConfidence()` in `gather-candidates.ts` awards a position bonus on `candidate.score >= 0.95 ? 0.1 : >= 0.90 ? 0.05 : 0`. OFF always clears that threshold; FDC often does not. That inflates OFF confidence, which feeds the AI-rerank skip gate.

So the fix is **normalizing `candidate.score` per source at the point it is produced**, so the field means the same thing across lanes — not "boost FDC" — and it has at least two consumers with different blast radii. That makes it a cross-cutting change needing its own gate run, **not** the cheap item the queue currently calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu