### PR TITLE
telemetry(0.5b): write aiCalls.serving/nutrition — [AI:SERV] was unreachable

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -909,12 +909,12 @@
       "claim": "requestAiNutrition() has exactly three production call sites in src/ (tests and comments excluded): two last-resort arms in mapIngredientWithFallback() and one in buildOffResult(). A fourth call site is a new AI-spend path and must be given a budget explicitly — the hydration arm was uncapped precisely because it was added without one.",
       "ownerDoc": "mobile:sync-docs/log/2026-08-01_1539_prelaunch-mapping-cleanup.md",
       "where": "backend",
-      "command": "grep -rn 'requestAiNutrition(' src --include='*.ts' | grep -v '/__tests__/' | grep -vE ':[0-9]+: *\\*' | grep -v 'export async function' | wc -l",
+      "command": "grep -rn 'requestAiNutrition(' src --include='*.ts' | grep -v '/__tests__/' | grep -vE ':[0-9]+: *(\\*|//)' | grep -v 'export async function' | wc -l",
       "expect": {
         "kind": "count",
         "value": "3"
       },
-      "verified": "2026-08-01"
+      "verified": "2026-08-04"
     },
     {
       "id": "cooking-state-survives-into-key",

--- a/src/lib/mapping/__tests__/serving-ai-tiers.test.ts
+++ b/src/lib/mapping/__tests__/serving-ai-tiers.test.ts
@@ -1,0 +1,81 @@
+import { servingAiCallForTier, SERVING_AI_TIERS } from '../serving-ai-tiers';
+
+/**
+ * Each block names the mutation that must kill it. The mutations below were
+ * actually applied and confirmed red before this file was committed — a test
+ * written against its own author's mental model shares that model's blind spots.
+ *
+ * The defect class this guards is specific: the `servingTier` strings are NOT a
+ * reliable guide to whether a model ran, in EITHER direction. Anyone who
+ * "simplifies" the allowlist into a name pattern reintroduces both halves at once,
+ * so the two traps get a test each.
+ */
+
+describe('servingAiCallForTier — tiers whose producer calls an LLM', () => {
+    // MUTATION: delete `fdc_size_estimate` from SERVING_AI_TIERS, or replace the
+    // allowlist with a /ai/ substring test. Either makes this red.
+    it('reports the largest AI tier, whose name contains no "ai" at all', () => {
+        // getOrCreateFdcSizeServings() has no cache — every event is a live call.
+        expect(servingAiCallForTier('fdc_size_estimate')).toEqual({ called: true, type: 'produce' });
+        expect(servingAiCallForTier('fdc_medium_estimate')).toEqual({ called: true, type: 'produce' });
+    });
+
+    it('reports the explicitly-named AI tiers with their purpose', () => {
+        expect(servingAiCallForTier('count_unit_ai')).toEqual({ called: true, type: 'ambiguous' });
+        expect(servingAiCallForTier('fdc_volume_ai')).toEqual({ called: true, type: 'weight' });
+        expect(servingAiCallForTier('fdc_piece_ai')).toEqual({ called: true, type: 'produce' });
+    });
+});
+
+describe('servingAiCallForTier — tiers that must NOT be reported', () => {
+    // MUTATION: add `ai_generated_serving: 'ambiguous'` to SERVING_AI_TIERS — the
+    // reading a name-based rule would produce. This is the over-reporting half:
+    // getAiServingGrams() only reads AiGeneratedServing rows and does unit maths.
+    it('does not invent a call for `ai_generated_serving`, which runs no model', () => {
+        expect(servingAiCallForTier('ai_generated_serving')).toEqual({ called: false });
+    });
+
+    // MUTATION: map either cached sibling to its AI counterpart's type. These are
+    // cache HITS of `count_unit_ai` / `fdc_volume_ai` and cost nothing.
+    it('does not count the cached siblings of AI tiers', () => {
+        expect(servingAiCallForTier('count_unit_cached')).toEqual({ called: false });
+        expect(servingAiCallForTier('fdc_volume_cached')).toEqual({ called: false });
+    });
+
+    it('does not count deterministic label/weight tiers', () => {
+        for (const tier of ['weight_unit', 'label_unit_match', 'bare_label_serving', 'flat_100g_default']) {
+            expect(servingAiCallForTier(tier)).toEqual({ called: false });
+        }
+    });
+});
+
+describe('servingAiCallForTier — the legacy-cascade blind spot', () => {
+    // MUTATION: return `{}` or `undefined` for an absent tier instead of
+    // `{ called: false }`. The whole point of 0.5(b) is telling "resolved without a
+    // model" apart from "never populated", and an absent field collapses them.
+    it('returns an explicit called:false for an unstamped tier, never undefined', () => {
+        expect(servingAiCallForTier(undefined)).toEqual({ called: false });
+        expect(servingAiCallForTier(null)).toEqual({ called: false });
+        expect(servingAiCallForTier('')).toEqual({ called: false });
+    });
+
+    it('has no `type` when nothing was called, so the log cannot imply a purpose', () => {
+        expect(servingAiCallForTier('weight_unit').type).toBeUndefined();
+    });
+});
+
+describe('SERVING_AI_TIERS — the table itself', () => {
+    // MUTATION: drop Object.freeze. A caller mutating the shared table would
+    // silently change every later line's telemetry in the same process.
+    it('is frozen', () => {
+        expect(Object.isFrozen(SERVING_AI_TIERS)).toBe(true);
+    });
+
+    // MUTATION: widen the union in serving-ai-tiers.ts without updating
+    // mapping-logger.ts's `aiCalls.serving.type`. Types are erased at runtime, so
+    // only an explicit assertion catches the drift.
+    it('emits only the three purposes mapping-logger.ts declares', () => {
+        expect(new Set(Object.values(SERVING_AI_TIERS)))
+            .toEqual(new Set(['ambiguous', 'produce', 'weight']));
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -25,6 +25,7 @@ import {
 } from './filter-candidates';
 import { simpleRerank, toRerankCandidate, extractLeanPercentage, isGenericGroundMeatQuery, stripPrepModifiers, hasDecisiveBrandContext, candidateMatchesTargetBrand } from './simple-rerank';
 import { buildRerankPool, rerankPoolRemainder, RERANK_POOL_LIMIT } from './rerank-pool';
+import { servingAiCallForTier } from './serving-ai-tiers';
 import {
     singularizeUnit, extractLabelServingUnit,
     LABEL_COUNT_PIECE_NOUNS, GENERIC_PIECE_WORDS,
@@ -2735,6 +2736,10 @@ export async function mapIngredientWithFallback(
                                     called: !skippedLlmNormalize && !usedGenericFallback,
                                     skipped: skippedLlmNormalize,
                                 },
+                                // 0.5(b). `ai_generated_serving` is NOT an AI call —
+                                // getAiServingGrams() only reads AiGeneratedServing rows.
+                                serving: servingAiCallForTier(aiMapped.servingTier),
+                                nutrition: { called: true, cached: aiResult.cached, success: true },
                             },
                         });
                     }
@@ -3260,6 +3265,9 @@ export async function mapIngredientWithFallback(
                                     called: !skippedLlmNormalize,
                                     skipped: skippedLlmNormalize,
                                 },
+                                // 0.5(b). See the sibling site above.
+                                serving: servingAiCallForTier(aiMapped.servingTier),
+                                nutrition: { called: true, cached: aiResult.cached, success: true },
                             },
                         });
                     }
@@ -3483,6 +3491,14 @@ export async function mapIngredientWithFallback(
                         skipped: skippedLlmNormalize,
                         reason: skippedLlmNormalize ? 'gate_skipped' : undefined,
                     },
+                    // 0.5(b): derived from the tier that billed the grams — see
+                    // serving-ai-tiers.ts for why the tier NAMES cannot be trusted
+                    // and why this is a lower bound.
+                    serving: servingAiCallForTier(result.servingTier),
+                    // requestAiNutrition() is reached only on the backfill branch,
+                    // which returns at its own log sites above. Every path arriving
+                    // here left the nutrition model untouched.
+                    nutrition: { called: false, cached: false, success: false },
                 },
             });
         }

--- a/src/lib/mapping/serving-ai-tiers.ts
+++ b/src/lib/mapping/serving-ai-tiers.ts
@@ -1,0 +1,72 @@
+/**
+ * serving-ai-tiers.ts — which `servingTier` values mean "an LLM ran for this line".
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `MappingAnalysisLog.aiCalls.serving` was declared in mapping-logger.ts and never
+ * written by anyone, so the `[AI:SERV]` tag in `logs/mapping-summary-*.txt` is
+ * structurally unreachable and reads 0 — which is Phase 0.5(b), not evidence that
+ * no serving AI calls happen. The fix belongs at the WRITE sites; this module is
+ * the shared derivation they call.
+ *
+ * THE TIER NAMES ARE NOT A RELIABLE GUIDE, IN BOTH DIRECTIONS.
+ * Each entry below was settled by reading the producer, not by pattern-matching
+ * the string (2026-08-04):
+ *
+ *   - `fdc_size_estimate` is the LARGEST live AI-serving tier (3,450 of 67,842
+ *     MappingEventLog rows) and has no "ai" in its name at all. It and
+ *     `fdc_medium_estimate` both come from `getOrCreateFdcSizeServings()`
+ *     (src/lib/usda/fdc-ai-backfill.ts), which despite the "getOrCreate" name has
+ *     NO CACHE — its own docstring says results "should be cached in a future
+ *     enhancement" — so every event is an unconditional live LLM round trip.
+ *
+ *   - `ai_generated_serving` does the opposite: it is stamped by the AI-nutrition
+ *     backfill path, but its grams come from `getAiServingGrams()`, which only does
+ *     `aiGeneratedServing.findUnique` reads plus deterministic unit/density maths.
+ *     No model runs. Mapping it to `called: true` would INVENT calls that never
+ *     happened, which is the same class of defect as the missing tag.
+ *
+ * KNOWN BLIND SPOT — the count this produces is a LOWER BOUND.
+ * The legacy fatsecret/ai serving path stamps no `servingTier` at all (the field is
+ * documented `undefined` there), so those lines read as `called: false` whatever
+ * they did. That is 529 of 67,842 rows, 0.78% (re-derive:
+ * `SELECT count(*) FROM "MappingEventLog" WHERE "servingTier" IS NULL;`, measured
+ * 2026-08-04). Quote `[AI:SERV]` as a floor, never as a total.
+ */
+
+/** The logger's `aiCalls.serving.type` union, kept in sync with mapping-logger.ts. */
+export type ServingAiCallType = 'ambiguous' | 'produce' | 'weight';
+
+/**
+ * Tiers whose producer makes a live LLM call, mapped to the call's purpose.
+ *
+ * Deliberately an ALLOWLIST rather than a name pattern: `count_unit_cached` and
+ * `fdc_volume_cached` are the cached siblings of members here, and a substring
+ * rule on "ai" would take `ai_generated_serving` (no model) while missing
+ * `fdc_size_estimate` (always a model).
+ */
+export const SERVING_AI_TIERS: Readonly<Record<string, ServingAiCallType>> = Object.freeze({
+    // getOrCreateAmbiguousServing(), cache miss — the sibling `count_unit_cached` is a hit.
+    count_unit_ai: 'ambiguous',
+    // getOrCreateFdcSizeServings() -> estimateAmbiguousServing(). Uncached by construction.
+    fdc_size_estimate: 'produce',
+    fdc_medium_estimate: 'produce',
+    // Unitless piece estimation for produce.
+    fdc_piece_ai: 'produce',
+    // insertFdcAiServing(volume) — the sibling `fdc_volume_cached` is a hit.
+    fdc_volume_ai: 'weight',
+});
+
+/**
+ * Derive the `aiCalls.serving` record from the tier that billed this line.
+ *
+ * Returns `called: false` for an absent tier rather than `undefined`, so the
+ * analysis log distinguishes "resolved without a model" from "never populated" —
+ * telling those two apart is the whole point of 0.5(b).
+ */
+export function servingAiCallForTier(
+    tier: string | null | undefined,
+): { called: boolean; type?: ServingAiCallType } {
+    const type = tier ? SERVING_AI_TIERS[tier] : undefined;
+    return type ? { called: true, type } : { called: false };
+}


### PR DESCRIPTION
Closes Phase 0.5(b) of `sync-docs/pipeline_hardening_plan.md`.

## The hole

`MappingAnalysisLog.aiCalls.serving` and `.nutrition` are declared in `mapping-logger.ts` and were **written by nobody**. All three write sites in `mapIngredientWithFallback()` populated `normalize` only, so `[AI:SERV]` and `[AI:NUTR]` read 0 in `logs/mapping-summary-*.txt` for structural reasons — not because no serving or nutrition model ever ran. Fixed at the write sites, not the logger.

## Why this is an allowlist and not a name rule

`servingTier` is misleading in **both** directions. Every entry was settled by reading its producer:

| tier | live LLM call? | why |
|---|---|---|
| `fdc_size_estimate` | **yes** — 3,450 of 67,842 rows | `getOrCreateFdcSizeServings()` has **no cache** despite the name; its own docstring says results "should be cached in a future enhancement" |
| `fdc_medium_estimate` | yes | same function |
| `count_unit_ai` | yes | `getOrCreateAmbiguousServing()` miss — `count_unit_cached` is the hit |
| `fdc_volume_ai` | yes | `insertFdcAiServing()` — `fdc_volume_cached` is the hit |
| `fdc_piece_ai` | yes | unitless piece estimator |
| `ai_generated_serving` | **no** | `getAiServingGrams()` only does `aiGeneratedServing.findUnique` reads + density maths |

The largest AI tier has no `ai` in its name; the tier that does have `ai` in its name runs no model. A substring rule gets both wrong, which is why `SERVING_AI_TIERS` is a frozen allowlist and four of the nine tests pin exactly that.

`nutrition` needed no plumbing — `AiNutritionResult` already carries `cached`.

## Known blind spot (documented in the module)

The legacy fatsecret/ai serving path stamps **no** `servingTier`, so those lines read `called:false` whatever they did: **529 of 67,842 rows, 0.78%**. `[AI:SERV]` is a floor, never a total.

Re-derive: `SELECT count(*) FROM "MappingEventLog" WHERE "servingTier" IS NULL;`

## Mutation control — executed, not described

| mutation | tests killed |
|---|---|
| add `ai_generated_serving` to the allowlist | 1 (the over-report case) |
| replace the allowlist with a `/ai/` substring | 3 (both directions) |
| return `{}` instead of `{called:false}` | 4 (the blind-spot case) |

## Gates

`test:ci` 156 suites / 3,214 pass · `typecheck` 0 · `lint:ci` 0 errors.

**No cold-gate case is predicted to move.** This writes telemetry fields only and touches no selection, serving or scoring logic. It does need a deploy to take effect (runtime path under `src/`); `ENABLE_MAPPING_ANALYSIS=true` is already set on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu