### PR TITLE
chore(doc-check): guard the [AI:*] skip rate, 0.5(b)'s blind spot, and the tier allowlist

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1126,6 +1126,42 @@
       },
       "verified": "2026-08-03",
       "timeoutMs": 60000
+    },
+    {
+      "id": "ai-tag-gate-skip-rate",
+      "claim": "The normalize-gate SKIP rate over the box's [AI:*] tag stream is in the 50s percent (56% measured 2026-08-04: 8,667 GATE vs 6,784 NORM). The `-h` on grep is load-bearing — without it `grep -o` over a multi-file glob prefixes each match with its filename and a per-file count reads as the corpus, which is how a 74.9% figure once got documented here. Counting the bare tag body rather than the whole [AI:...] token keeps combined tags like [AI:GATE+SERV] counted once.",
+      "ownerDoc": "mobile:CLAUDE.md",
+      "where": "box",
+      "command": "cd /home/owner/Recipe-App/logs && g=$(grep -oh \"AI:GATE\" mapping-summary-*.txt | wc -l) && n=$(grep -oh \"AI:NORM\" mapping-summary-*.txt | wc -l) && echo $(( g * 100 / (g + n) ))",
+      "expect": {
+        "kind": "matches",
+        "value": "^5[0-9]$"
+      },
+      "verified": "2026-08-04"
+    },
+    {
+      "id": "serving-tier-null-share-small",
+      "claim": "The legacy fatsecret/ai serving cascade stamps no servingTier, so aiCalls.serving (PR #237) reads called:false for those lines whatever they did. That blind spot is only 0.8% of MappingEventLog (measured 2026-08-04), which is what makes [AI:SERV] usable as a FLOOR. If this climbs the tag stops being a floor and becomes misleading.",
+      "ownerDoc": "mobile:sync-docs/pipeline_hardening_plan.md",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -tAc 'SELECT round(100.0*count(*) FILTER (WHERE \"servingTier\" IS NULL)/NULLIF(count(*),0))::int FROM \"MappingEventLog\";'",
+      "expect": {
+        "kind": "max",
+        "value": "2"
+      },
+      "verified": "2026-08-04"
+    },
+    {
+      "id": "serving-ai-tiers-is-an-allowlist",
+      "claim": "SERVING_AI_TIERS excludes ai_generated_serving. The tier names are unreliable in BOTH directions: getAiServingGrams() runs no model despite the name, while fdc_size_estimate (the largest AI-serving tier) has no 'ai' in its name and getOrCreateFdcSizeServings() has no cache. A substring rule on 'ai' gets both wrong, so the table must stay an explicit allowlist.",
+      "ownerDoc": "mobile:sync-docs/pipeline_hardening_plan.md",
+      "where": "backend",
+      "command": "sed -n '/SERVING_AI_TIERS/,/});/p' src/lib/mapping/serving-ai-tiers.ts | grep -cE \"^ *ai_generated_serving:\"",
+      "expect": {
+        "kind": "count",
+        "value": "0"
+      },
+      "verified": "2026-08-04"
     }
   ]
 }


### PR DESCRIPTION
Three claims that were owed as prose with no gate. `doc-check` **96/96**.

| id | where | expect | today |
|---|---|---|---|
| `ai-tag-gate-skip-rate` | box | band `/^5[0-9]$/` | 56 |
| `serving-tier-null-share-small` | box | `max 2` | 1 |
| `serving-ai-tiers-is-an-allowlist` | backend | `count 0` | 0 |

**1.** Guards `CLAUDE.md`'s corrected normalize-gate skip rate. The `-h` on grep is the load-bearing part — without it `grep -o` over a multi-file glob prefixes each match with its filename and a per-file count reads as the whole corpus, which is how a 74.9% figure got documented. The command counts the bare tag body rather than the whole `[AI:...]` token, so combined tags like `[AI:GATE+SERV]` still count once — which matters now that #237 writes them.

**2.** Guards what makes `[AI:SERV]` usable as a **floor** rather than misleading: the legacy serving cascade stamps no `servingTier`, so those lines read `called:false` whatever they did. A `max` bound rather than an equality, because the raw count grows with traffic.

**3.** Pins the #237 finding that the tier names are unreliable in *both* directions (`fdc_size_estimate` is the largest AI tier and has no "ai" in its name; `ai_generated_serving` runs no model), so the table must stay an explicit allowlist.

## Trap found while writing these — and `CLAUDE.md` was wrong about it

**A `box` claim has no reliable cwd.** Off-box the runner shells out as `ssh <host> <command>` with **no `cd`** (`runClaim()` in `scripts/doc-check/run-doc-check.ts`), so a relative path resolves against `/home/owner`, not the backend repo. Running the same claim *on* the box gives cwd = the repo — so the bug is invisible on the nightly.

A `cd logs && …` claim was therefore **empty from the Mac and would have been green on the box**. Every pre-existing `box` claim already uses `/home/owner/Recipe-App/…` or a cwd-independent `docker exec`; the doc rule said otherwise and is corrected in the mobile repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu