### PR TITLE
chore(doc-check): guard the deliberately-stopped flywheel timer

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -665,6 +665,18 @@
       "verified": "2026-07-31"
     },
     {
+      "id": "flywheel-sweep-timer-is-deliberately-stopped",
+      "claim": "flywheel-sweep.timer is STOPPED on purpose for the duration of the pipeline-hardening program (decided 2026-08-04, plan section 'Running under all of this'), so no nightly writer moves a warm number underneath a measurement. It is still `is-enabled`=enabled, so the pause is NOT durable across a box reboot — this claim goes red the moment the timer is running again, which is the prompt to update the plan's restart line rather than let a stale 'stopped for the duration' outlive the program.",
+      "ownerDoc": "mobile:sync-docs/pipeline_hardening_plan.md",
+      "where": "box",
+      "command": "systemctl --user is-active flywheel-sweep.timer 2>/dev/null || true",
+      "expect": {
+        "kind": "equals",
+        "value": "inactive"
+      },
+      "verified": "2026-08-04"
+    },
+    {
       "id": "off-corrupt-marks-restored",
       "claim": "OffFood.corruptReason is populated: 6,905 rows marked 2026-07-31 (6,901 from corrupt-panel-scan-2026-07-31T14-49-22-771Z.json + 4 hand-audited panel-inflated-family rows). Replaces the off-corrupt-marks-wiped tripwire, which fired when the restore ran.",
       "ownerDoc": "mobile:sync-docs/backend_integration_guide.md",


### PR DESCRIPTION
The hardening plan asserted *"The restart is guarded by a `box` doc-check claim, not by memory, because nothing else in this repo guards a paused timer."* **No such claim existed.** The sentence naming the defect shipped; the guard did not. A doc that names its own mitigation reads as mitigated.

**What this claim guards.** `is-active` = `inactive`, so it goes RED the moment the timer runs again — forcing the plan paragraph to be rewritten rather than letting "stopped for the duration" quietly outlive the program. Nothing mechanical can nag for the *restart* itself; that needs a date, and Phase 2 has no close date.

**Positive control, run before committing** (a claim never seen to fail is not known to work):

    doc-check.timer          -> active      # discriminates
    flywheel-sweep.timer     -> inactive    # subject

**Second finding, recorded in the claim text:** `is-enabled` is still `enabled`, so a box reboot re-arms the timer silently and the pause is **not durable** across one.

`npm run doc-check` -> 97/97, exit 0.

Owner doc: `mobile:sync-docs/pipeline_hardening_plan.md` §"Running under all of this", corrected in mobile `d5d277f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu