### PR TITLE
fix(parse): stop eating `whole` as a count unit on identity phrases

### DIFF
--- a/scripts/eval/__tests__/failure-classes.test.ts
+++ b/scripts/eval/__tests__/failure-classes.test.ts
@@ -312,7 +312,12 @@ describe('finding 2 — the key is the DERIVED key, not canonicalizeCacheKey alo
 
     it('is idempotent under an already-discriminated form', () => {
         expect(makeFunnelRow({ rawLine: 'egg white', normalizedForm: 'egg white' }).cacheKey).toBe('egg white');
-        expect(makeFunnelRow({ rawLine: 'whole milk', normalizedForm: 'milk' }).cacheKey).toBe('milk');
+        // `whole milk` used to derive bare 'milk' here, because the parser ate
+        // `whole` as a count unit before it could reach the qualifiers. It now
+        // carries the discriminator. deriveFunnelCacheKey() parses rawLine, so
+        // this row moves with the parser even though normalizedForm is unchanged
+        // — which is precisely why it has to flip in the same PR as the fix.
+        expect(makeFunnelRow({ rawLine: 'whole milk', normalizedForm: 'milk' }).cacheKey).toBe('milk whole');
     });
 
     it('PINS the one step that is still missing — the brand prefix — instead of implying it is closed', () => {

--- a/src/lib/mapping/__tests__/cache-key.test.ts
+++ b/src/lib/mapping/__tests__/cache-key.test.ts
@@ -53,8 +53,12 @@ describe('deriveCacheKeyName', () => {
     // IDENTITY QUALIFIERS (cooked, whole)
     // ======================================================================
     describe('identity qualifiers', () => {
-        it('"whole milk" → key "milk whole"', () => {
-            const p = parseIngredientLine('1 cup whole milk')!;
+        // This test was titled `"whole milk" → key "milk whole"` while actually
+        // parsing `1 cup whole milk` — the unit-led spelling, which was the only
+        // one that worked. Both spellings now derive the same key, so assert on
+        // both and let the title be true.
+        it.each(['whole milk', '1 cup whole milk'])('"%s" → key "milk whole"', (line) => {
+            const p = parseIngredientLine(line)!;
             expect(p.qualifiers).toContain('whole');
             expect(deriveCacheKeyName(p.name, p)).toBe('milk whole');
         });

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -684,9 +684,11 @@ export async function mapIngredientWithFallback(
     // Note this NARROWS the query, which is the opposite of the usual relaxation,
     // so it cannot be waved through as admit-only. Blast radius measured before
     // shipping: 12 of 348 golden cases carry one of these tokens and 57 of 5,586
-    // distinct live lines (1.0%). `whole` is in the set but cannot reach here on a
-    // unit-less line — `unit.ts` consumes it as a count unit first — so in practice
-    // this fires for cooked/raw/dried/canned.
+    // distinct live lines (1.0%). `whole` reaches here as of 2026-08-04 on the
+    // three PROTECTED_PRODUCT_PHRASES identity lines (`whole milk`, `whole wheat`,
+    // `whole grain`) — previously `unit.ts` consumed it as a count unit first and
+    // it could never fire. Elsewhere `whole` is still a portion word and is still
+    // consumed as a unit, so this fires for those three plus cooked/raw/dried/canned.
     //
     // Reuses IDENTITY_QUALIFIERS rather than re-deriving it, for the same reason
     // the block above reuses IDENTITY_UNIT_HINTS: the key and the query must not

--- a/src/lib/mapping/normalization-rules.ts
+++ b/src/lib/mapping/normalization-rules.ts
@@ -297,6 +297,82 @@ export type NormalizationResult = {
   stripped: string[];
 };
 
+/**
+ * PROTECTED PRODUCT PHRASES: compound phrases that must be preserved as-is.
+ * These are phrases where the combination IS the product type.
+ *
+ * Module-scoped and exported so the parser can consult the same list instead of
+ * re-deriving it. `parseIngredientLine()` needs the `whole` entries specifically
+ * (see `isIdentityWholePhrase`), and a second copy would drift: the whole point
+ * of these three strings is that they draw a product-judgement line, so the
+ * judgement must live in exactly one place.
+ */
+export const PROTECTED_PRODUCT_PHRASES = [
+  // Compound cooking method phrases
+  'fire roasted',
+  'fire-roasted',
+  'oven roasted',
+  'oven-roasted',
+  'slow roasted',
+  'slow-roasted',
+  'sun dried',
+  'sun-dried',
+  'flame grilled',
+  'flame-grilled',
+  'char grilled',
+  'char-grilled',
+  'pan fried',
+  'stir fried',
+  'stir-fried',
+  'deep fried',
+  // Specific product names that contain prep words
+  'smoked salmon',
+  'tomato paste',
+  'tomato sauce',
+  'tomato puree',
+  'cream cheese',
+  'cottage cheese',
+  'peanut butter',
+  'apple sauce',
+  'apple butter',
+  'coconut milk',
+  'coconut cream',
+  // "whole" as identity (not prep): whole milk is a distinct product from
+  // milk; whole wheat/grain are distinct from refined. Deliberately NOT
+  // listed: "whole chicken"/"whole almonds" ("whole" is prep there).
+  'whole milk',
+  'whole wheat',
+  'whole grain',
+];
+
+/**
+ * Does this line use `whole` as IDENTITY rather than as a portion word?
+ *
+ * `whole` is polysemous and the two readings want opposite handling:
+ *   - portion  — "1 whole banana", "whole roasted chicken": `whole` is a count
+ *     unit, and dropping it would lose the serving size (a banana bills 118 g).
+ *   - identity — "whole milk", "whole wheat bread": `whole` names a DIFFERENT
+ *     PRODUCT from the bare noun, and eating it as a unit collapses the two onto
+ *     one cache key. `whole milk` served a2 skim-ish "Milk" to 222 live events.
+ *
+ * The disambiguator is the `whole` half of PROTECTED_PRODUCT_PHRASES, which
+ * already draws exactly this line and is guarded by shipped tests. Only these
+ * three phrases are treated as identity; every other `whole` keeps the portion
+ * reading, which is why the genuine counts above are untouched.
+ *
+ * Substring, not word-boundary, to match how the phrase list is used in
+ * `normalizeIngredientName()`. The known failure mode is a longer product name
+ * that merely CONTAINS one of them — `whole milk chocolate` reads as identity.
+ * Not present in the coverage corpus, the seed corpora, or MappingEventLog as of
+ * 2026-08-04, but that is the shape a regression here would take.
+ */
+export function isIdentityWholePhrase(line: string): boolean {
+  const lower = line.toLowerCase();
+  return PROTECTED_PRODUCT_PHRASES.some(
+    (p) => p.startsWith('whole ') && lower.includes(p)
+  );
+}
+
 export function normalizeIngredientName(raw: string): NormalizationResult {
   const rules = readRulesFile();
   const stripped: string[] = [];
@@ -440,46 +516,6 @@ export function normalizeIngredientName(raw: string): NormalizationResult {
   // e.g., "pineapple, canned" → don't preserve (not at start)
   const firstWord = workingLower.split(/\s+/)[0]?.replace(/[^a-z]/g, '');
   const startsWithProductModifier = PRODUCT_TYPE_MODIFIERS.has(firstWord);
-
-  // PROTECTED PRODUCT PHRASES: Compound phrases that must be preserved as-is
-  // These are phrases where the combination is the product type
-  const PROTECTED_PRODUCT_PHRASES = [
-    // Compound cooking method phrases
-    'fire roasted',
-    'fire-roasted',
-    'oven roasted',
-    'oven-roasted',
-    'slow roasted',
-    'slow-roasted',
-    'sun dried',
-    'sun-dried',
-    'flame grilled',
-    'flame-grilled',
-    'char grilled',
-    'char-grilled',
-    'pan fried',
-    'stir fried',
-    'stir-fried',
-    'deep fried',
-    // Specific product names that contain prep words
-    'smoked salmon',
-    'tomato paste',
-    'tomato sauce',
-    'tomato puree',
-    'cream cheese',
-    'cottage cheese',
-    'peanut butter',
-    'apple sauce',
-    'apple butter',
-    'coconut milk',
-    'coconut cream',
-    // "whole" as identity (not prep): whole milk is a distinct product from
-    // milk; whole wheat/grain are distinct from refined. Deliberately NOT
-    // listed: "whole chicken"/"whole almonds" ("whole" is prep there).
-    'whole milk',
-    'whole wheat',
-    'whole grain',
-  ];
 
   const protectedPhrasesInInput = PROTECTED_PRODUCT_PHRASES.filter(p =>
     workingLower.includes(p)

--- a/src/lib/parse/__tests__/identity-qualifiers.test.ts
+++ b/src/lib/parse/__tests__/identity-qualifiers.test.ts
@@ -59,16 +59,53 @@ describe('IDENTITY_QUALIFIERS keeps state off the bare generic key', () => {
     expect(key('large egg')).toBe(key('egg'));
   });
 
-  it('KNOWN GAP: "whole" is consumed as a unit, so whole milk still collides', () => {
-    // 'whole' is in IDENTITY_QUALIFIERS and the comment there claims it keeps
-    // "whole milk" off "milk". It does not: src/lib/parse/unit.ts maps
-    // 'whole' as a UNIT, so it never reaches parsed.qualifiers. Suspected cause
-    // of golden n-mq-34 ("whole milk" -> "Milk" at fat100 1.3, i.e. skim).
-    // Deliberately NOT fixed with the cooking-state change — it runs through
-    // serving sizes. This test documents the gap; when it is fixed this
-    // assertion flips to .not.toBe and the comment in qualifiers.ts comes out.
-    expect(IDENTITY_QUALIFIERS.has('whole')).toBe(true);
-    expect(parseIngredientLine('whole milk')!.qualifiers ?? []).not.toContain('whole');
-    expect(key('whole milk')).toBe(key('milk'));
+  // This block was `KNOWN GAP: "whole" is consumed as a unit, so whole milk
+  // still collides` — a test that deliberately pinned the broken behaviour.
+  // Fixed by gating the parser's count-unit consumption on the `whole` half of
+  // PROTECTED_PRODUCT_PHRASES; the assertions below are the same three, flipped.
+  describe('"whole" reaches the key on identity phrases, and only those', () => {
+    it('splits whole milk off bare milk', () => {
+      expect(IDENTITY_QUALIFIERS.has('whole')).toBe(true);
+      expect(parseIngredientLine('whole milk')!.qualifiers ?? []).toContain('whole');
+      expect(key('whole milk')).not.toBe(key('milk'));
+    });
+
+    it('agrees with the unit-led spelling of the same food', () => {
+      // The collision this fix closes has a second half nobody had written down:
+      // `whole milk` and `1 cup whole milk` derived DIFFERENT keys, because a
+      // preceding unit token left `whole` in the name. They must now agree.
+      expect(key('whole milk')).toBe(key('1 cup whole milk'));
+    });
+
+    it.each([
+      ['whole wheat bread', 'wheat bread'],
+      ['whole wheat pasta', 'wheat pasta'],
+      ['whole grain oats', 'grain oats'],
+    ])('splits %s off %s', (identity, bare) => {
+      expect(key(identity)).not.toBe(key(bare));
+      expect(parseIngredientLine(identity)!.qualifiers ?? []).toContain('whole');
+    });
+
+    // NEGATIVE CONTROLS — the reason this fix is gated rather than blanket.
+    // `whole` is a portion word here, and dropping it as a unit would lose the
+    // serving size: a banana bills 118 g and a whole egg 50 g through the count
+    // estimator. The blanket fix (removing `whole` from countUnits in unit.ts)
+    // regresses all three of these; measured 2026-08-04.
+    it.each([
+      '1 whole organic banana',
+      'whole egg',
+      '2 whole eggs',
+      'whole pita bread',
+      'whole chicken',
+      'whole almonds',
+    ])('keeps %s on the count-unit route', (line) => {
+      const parsed = parseIngredientLine(line)!;
+      expect(parsed.unit).toBe('whole');
+      expect(parsed.qualifiers ?? []).not.toContain('whole');
+    });
+
+    it('keeps the whole-egg base key, which n-mq-33 depends on', () => {
+      expect(key('whole egg')).toBe(key('egg'));
+    });
   });
 });

--- a/src/lib/parse/ingredient-line.ts
+++ b/src/lib/parse/ingredient-line.ts
@@ -4,6 +4,7 @@ import { extractQualifiers, extractQualifiersFromParentheses } from './qualifier
 import { extractUnitHint } from './unit-hint';
 import { isDigitBrandToken, matchDigitBrandTokens } from '../mapping/digit-brands';
 import { detectBrandInQuery } from '../mapping/brand-detector';
+import { isIdentityWholePhrase } from '../mapping/normalization-rules';
 
 /**
  * Flavor/product words that mark "rocket" as part of a branded product name
@@ -105,6 +106,20 @@ function parseFraction(str: string): number {
   const parsed = parseFloat(trimmed);
   return isNaN(parsed) ? 1 : parsed;
 }
+
+/**
+ * Tokens classified as count units that are really HINTS about the food, not
+ * portions ("3 egg whites" — `white` describes the egg, it is not a measure).
+ *
+ * Hoisted to module scope because `parseIngredientLine()` consumes count units
+ * at THREE separate sites and two of them carried byte-identical private copies
+ * of this list. A hint added to one copy and not the other silently changes
+ * behaviour depending on which site a given line happens to reach.
+ */
+const POSSIBLE_UNIT_HINTS = [
+  'cloves', 'clove', 'leaves', 'leaf', 'yolks', 'yolk',
+  'whites', 'white', 'sheets', 'sheet', 'stalks', 'stalk',
+];
 
 export function parseIngredientLine(line: string): ParsedIngredient | null {
   if (!line || line.trim().length === 0) return null;
@@ -331,8 +346,25 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
 
   // Check if first token is a unit (e.g., "pinch of salt")
   // If so, we'll use default qty of 1
+  // `whole` is classified as a count unit (alongside small/medium/large) so that
+  // "1 whole banana" routes to the AI weight estimator. On a UNIT-LESS identity
+  // line that is wrong: "whole milk" loses the word entirely, so it never reaches
+  // extractQualifiers() and derives the same cache key as bare "milk".
+  //
+  // Decide once, here, and have ALL THREE consumption sites below honour it:
+  // the `startsWithUnit` branch, the `kind === 'count'` branch, and the
+  // after-parentheses check. They consume count units independently, so guarding
+  // any subset leaves the defect intact — and the third is the one that actually
+  // fires here, because it is gated on `!unit` and therefore reached precisely
+  // when the first two decline. Measured while building this: guarding only the
+  // first two left `whole milk` completely unchanged.
+  const wholeIsIdentity =
+    mergedTokens.length > 0 &&
+    mergedTokens[0].toLowerCase() === 'whole' &&
+    isIdentityWholePhrase(mergedTokens.join(' '));
+
   let startsWithUnit = false;
-  if (mergedTokens.length > 0) {
+  if (mergedTokens.length > 0 && !wholeIsIdentity) {
     const firstToken = mergedTokens[0];
     const firstNormalized = normalizeUnitToken(firstToken);
     if (firstNormalized.kind === 'mass' || firstNormalized.kind === 'volume' || firstNormalized.kind === 'count') {
@@ -446,9 +478,11 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
       // But we'll check later if they're actually unit hints (like "leaves", "cloves")
       // First check if it's a unit hint - if so, don't consume as unit
       const lowerToken = firstToken.toLowerCase();
-      const possibleHints = ['cloves', 'clove', 'leaves', 'leaf', 'yolks', 'yolk', 'whites', 'white', 'sheets', 'sheet', 'stalks', 'stalk'];
-      if (possibleHints.includes(lowerToken)) {
-        // Don't consume - it's a unit hint, not a unit
+      if (POSSIBLE_UNIT_HINTS.includes(lowerToken) || (lowerToken === 'whole' && wholeIsIdentity)) {
+        // Don't consume - it's a unit hint, or `whole` acting as identity
+        // ("whole milk"), not a portion. See wholeIsIdentity above: this is the
+        // SECOND branch that consumes count units, and it is the one a unit-less
+        // line actually reaches once startsWithUnit has been suppressed.
       } else {
         unit = firstNormalized.unit;
         rawUnit = firstToken;
@@ -522,8 +556,10 @@ export function parseIngredientLine(line: string): ParsedIngredient | null {
     if (afterParenNormalized.kind === 'mass' || afterParenNormalized.kind === 'volume' || afterParenNormalized.kind === 'count') {
       // Check if it's not a unit hint
       const lowerToken = afterParenToken.toLowerCase();
-      const possibleHints = ['cloves', 'clove', 'leaves', 'leaf', 'yolks', 'yolk', 'whites', 'white', 'sheets', 'sheet', 'stalks', 'stalk'];
-      if (!possibleHints.includes(lowerToken)) {
+      // THIRD count-unit consumption site. It is guarded on `!unit`, so it is
+      // reached precisely when the two branches above declined — which makes it
+      // the one that actually fires for a unit-less identity line.
+      if (!POSSIBLE_UNIT_HINTS.includes(lowerToken) && !(lowerToken === 'whole' && wholeIsIdentity)) {
         unit = afterParenNormalized.unit;
         rawUnit = afterParenToken;
         i++; // Consume the unit

--- a/src/lib/parse/qualifiers.ts
+++ b/src/lib/parse/qualifiers.ts
@@ -30,12 +30,17 @@ const QUALIFIERS = new Set([
 // it. 'raw'/'dried'/'canned' were added 2026-08-01 — they were already being
 // captured as qualifiers and then dropped at the key.
 //
-// 'whole' is the standing counter-example and is NOT fixed by this list:
-// src/lib/parse/unit.ts consumes it as a UNIT, so "whole milk" reaches here
-// with qualifiers=[] and derives key "milk", identical to bare "milk"
-// (measured 2026-08-01; suspected cause of golden n-mq-34, "whole milk" ->
-// "Milk" at fat100 1.3, which is skim). Fixing it means touching unit parsing
-// and therefore serving sizes, so it is deliberately a separate change.
+// 'whole' WAS the standing counter-example — src/lib/parse/unit.ts classifies it
+// as a count unit, so "whole milk" used to reach here with qualifiers=[] and
+// derive key "milk", identical to bare "milk". Closed 2026-08-04: the parser now
+// declines to consume `whole` as a unit when the line matches the `whole` half of
+// PROTECTED_PRODUCT_PHRASES (normalization-rules.ts), which is the list that
+// already draws the identity-vs-portion line. Membership in THIS set is still
+// necessary but not sufficient — the token has to survive the parser first, and
+// that is where the fix lives, not here.
+//
+// The gate is deliberately narrow: "1 whole banana" and "whole egg" keep the
+// count-unit reading, because there `whole` really is the portion.
 export const IDENTITY_QUALIFIERS = new Set([
   'cooked',
   'whole',


### PR DESCRIPTION
## ⛔ DO NOT MERGE WITHOUT DIEGO

This is under `src/`. Per `sync-docs/reports/2026-08-05_autonomous-session-brief.md` §1 that means **open the PR, post the gate output, stop**. Posting the gates below and stopping.

Plan item #10 / W4. Scoped and measured 2026-08-04; owner doc `sync-docs/pipeline_hardening_plan.md` §Phase 2 #10.

## The defect

`whole` is classified as a count unit in `normalizeUnitToken()` alongside `small`/`medium`/`large`, so `1 whole banana` routes to the AI weight estimator. On a **unit-less identity line** that is wrong: `whole milk` loses the word before `extractQualifiers()` sees it, derives the same cache key as bare `milk`, and **222 live events** were served a2 skim-ish "Milk".

Fires on unit-less lines only — a preceding unit or brand token claims the slot first, which is why `1 cup whole milk` was already correct.

## Why this is gated, not blanket

The obvious fix — drop `whole` from `countUnits` — has **three measured live regressions**:

| line | today | under the blanket fix |
|---|---|---|
| `1 whole organic banana` | 118 g, correct | unit lost → bare-query path |
| `whole egg` | 50 g, correct | breaks `n-mq-33`'s base-key invariant |
| `whole pita bread` | 42 events, 30 g | unit lost |

So gate on the `whole` half of **`PROTECTED_PRODUCT_PHRASES`**, which already draws exactly this identity-vs-portion line and carries this comment verbatim:

> `"whole" as identity (not prep): whole milk is a distinct product from milk; whole wheat/grain are distinct from refined. Deliberately NOT listed: "whole chicken"/"whole almonds" ("whole" is prep there).`

**Sixth instance of this repo's signature shape** (#221/#223/#226/#233/#234): that list works, is test-guarded, and was **unreachable** — all three `normalizeIngredientName()` call sites pass `baseName` = `parsed.name`, from which the parser had already eaten the word. Hoisted and exported rather than re-derived, so the two cannot drift apart.

## THREE consumption sites, not two

This is the part that cost the most and is the most reusable. `parseIngredientLine()` consumes count units at three independent sites, and the **after-parentheses** one is gated on `!unit` — so it is reached *precisely when the other two decline*. Guarding only the first two left `whole milk` **completely unchanged**; the probe showed `unit=whole` with every guard I thought I needed already in place.

Two of the three also carried byte-identical private copies of the unit-hint list. Hoisted to one `POSSIBLE_UNIT_HINTS` const — a hint added to one copy and not the other silently changes behaviour depending on which site a line reaches.

## Measured effect

```
--- now split (identity) ---
whole milk          unit=null  qual=[whole]  key="milk whole"
whole wheat bread   unit=null  qual=[whole]  key="bread wheat whole"
whole wheat pasta   unit=null  qual=[whole]  key="pasta wheat whole"
1 cup whole milk    unit=cup   qual=[whole]  key="milk whole"     <-- now AGREES
--- unchanged (genuine counts) ---
1 whole organic banana  unit=whole  key="banana organic"
whole egg               unit=whole  key="egg"
2 whole eggs            unit=whole  key="egg"
whole pita bread        unit=whole  key="bread pita"
whole chicken           unit=whole  key="chicken"
```

`whole milk` → `milk whole` lands on a **hand-validated `human-triage` "Whole milk" row that already exists** in `FoodMapping`; `whole wheat bread` → `bread wheat whole` lands on an existing row with 208 uses. 6 lines / 269 live events move, **zero measured regressions** on the coverage corpus (3,754 seeds), the seed corpora, or `MappingEventLog`.

Also closes a **second collision nobody had written down**: `whole milk` and `1 cup whole milk` derived *different* keys. They now agree.

## Gates

- `npx jest src/lib/parse src/lib/mapping scripts/eval` → **99 suites / 2,469 passed**, 1 skipped
- **Mutation control**: removing each of the three guards independently kills **7 tests** each. All three are load-bearing.
- `npm run typecheck` → clean
- `npm run lint:ci` → **0 errors** (592 pre-existing warnings, unchanged)
- **NOT run**: golden eval (billable), no deploy, no DB writes, no `scp`

## Both pinning tests flipped here

The brief said "a shipped test" — singular. There are **two**, and the second is in `scripts/`:

1. `src/lib/parse/__tests__/identity-qualifiers.test.ts` — `KNOWN GAP: "whole" is consumed as a unit…`
2. `scripts/eval/__tests__/failure-classes.test.ts` — `deriveFunnelCacheKey()` parses `rawLine`, so it moves with the parser even though its `normalizedForm` is unchanged

Plus a third that was mislabelled: `cache-key.test.ts` had a test *titled* `"whole milk" → key "milk whole"` that actually parsed `1 cup whole milk`. Now asserts both spellings.

## Two things left for you

1. **`n-mq-34` is grams-blind on exactly the case this targets** — it asserts only scale-free `fat100`, so the one real risk here (the bare-query default is applied as a **CAP**, so it can only lower) is invisible to it. It needs a `total.calories` band. **I did not add one**: I cannot run the gate to observe the real value, and an unverified band in the golden set is how bad bands later get "fixed" in code. Set it from the gate run.
2. **`winner-diff` CANNOT gate this.** It freezes the pool at `gatherCandidates()` output and this fix changes the retrieval query, so both arms would replay a pool neither would produce. The brief's `--with-serving` instruction rested on that premise. Use the golden eval cold, both arms on the same host, 3 runs per arm diffed by case id (20/348 noise floor). `scripts/filter-trace-probe.ts` is a free intermediate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu