### PR TITLE
fix(serving): stop the stale-cache delete from destroying genuine USDA rows

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1198,6 +1198,19 @@
         "value": "3@10"
       },
       "verified": "2026-08-04"
+    },
+    {
+      "id": "stale-cache-delete-is-provenance-filtered",
+      "claim": "hydrateAndSelectServing()'s stale-cache branch deletes a cached size serving when the resolved weight exceeds maxAIGrams. Its fdc_/off_ deleteMany calls MUST filter on isAiEstimated:true. targetSizeUnit is exactly 'small'|'medium'|'large', which is the same key space USDA's own size servings occupy: 94 of the 109 exact-name size rows in FdcServing are genuine source='usda_fdc'/isAiEstimated=false against 15 ai/true (measured 2026-08-04). Unfiltered, the branch destroys curated USDA data, and it fires precisely on foods that are legitimately heavy -- a genuine 'medium' cabbage head at 588g trips the 500g ceiling and is deleted for being correct. Nothing regenerates FdcServing rows. The branch's own comment names a stale FatSecret-derived value as the motivating case, so deleting genuine rows was never the intent. The aiGeneratedServing branch deliberately takes NO filter: that table has no source/isAiEstimated column because every row is AI by construction, so adding one is a typecheck failure. The firing rate is NOT measurable read-only -- the surrounding logs are logger.info and the box runs at warn -- but the guard is unconditionally correct and does not need the count.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-05_ai-serving-spend-audit.md",
+      "where": "backend",
+      "command": "node -e \"const s=require('fs').readFileSync('src/lib/mapping/map-ingredient-with-fallback.ts','utf8');const m=s.match(/(fdcServing|offServing)\\.deleteMany\\(\\{[^}]*\\}/g)||[];const guarded=m.filter(x=>/isAiEstimated:\\s*true/.test(x)).length;process.stdout.write(guarded+'@'+m.length)\"",
+      "expect": {
+        "kind": "equals",
+        "value": "2@2"
+      },
+      "verified": "2026-08-04",
+      "timeoutMs": 60000
     }
   ]
 }

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -3996,19 +3996,37 @@ export async function hydrateAndSelectServing(
                         reason: 'Cached/estimated weight implausibly large, deleting stale cache and skipping',
                     });
 
-                    // Delete the stale cached AI entry so next run gets a fresh estimate
+                    // Delete the stale cached AI entry so next run gets a fresh estimate.
+                    //
+                    // `isAiEstimated: true` is LOAD-BEARING on the fdc_/off_ branches. Without it
+                    // these deleteMany calls match on (id, description) alone, and `targetSizeUnit`
+                    // is exactly 'small' | 'medium' | 'large' — the same key space USDA's own size
+                    // servings occupy. 94 of the 109 exact-name size rows in FdcServing are genuine
+                    // `source='usda_fdc'` / isAiEstimated=false (re-derive:
+                    //   SELECT source,"isAiEstimated",count(*) FROM "FdcServing"
+                    //   WHERE lower(description) IN ('small','medium','large') GROUP BY 1,2;
+                    // -> usda_fdc|f|94, ai|t|15, measured 2026-08-04), so an unfiltered delete
+                    // removes curated USDA data. It fires precisely on legitimately heavy foods: a
+                    // genuine 'medium' cabbage head at 588 g trips `> maxAIGrams` (500) and the row
+                    // is destroyed for being correct. Nothing regenerates it.
+                    //
+                    // The branch's own comment above names a STALE FATSECRET-derived value as the
+                    // motivating case, not a USDA row — deleting genuine rows was never the intent.
+                    //
+                    // AiGeneratedServing deliberately takes no filter: it has no `source` or
+                    // `isAiEstimated` column because every row there is AI by construction.
                     try {
                         const { prisma: prismaDb } = await import('../db');
                         const staleId = `ai_${candidate.id}_${targetSizeUnit}`;
                         if (candidate.id.startsWith('fdc_')) {
                             const fdcId = parseInt(candidate.id.replace('fdc_', ''), 10);
                             await prismaDb.fdcServing.deleteMany({
-                                where: { fdcId, description: targetSizeUnit },
+                                where: { fdcId, description: targetSizeUnit, isAiEstimated: true },
                             });
                         } else if (candidate.id.startsWith('off_')) {
                             const barcode = candidate.id.replace('off_', '');
                             await prismaDb.offServing.deleteMany({
-                                where: { barcode, description: targetSizeUnit },
+                                where: { barcode, description: targetSizeUnit, isAiEstimated: true },
                             });
                         } else {
                             await prismaDb.aiGeneratedServing.deleteMany({


### PR DESCRIPTION
Base: `master` @ `bafc636`. Independent of #245 (which is unmerged; both touch `map-ingredient-with-fallback.ts` but in different regions).

## The defect

`hydrateAndSelectServing()` has a stale-cache branch: when the resolved size weight exceeds `maxAIGrams` (100 g for small produce, 500 g otherwise) it deletes the cached row so the next run re-estimates. Its `fdc_`/`off_` `deleteMany` calls matched on `(id, description)` alone — **no provenance filter**.

`targetSizeUnit` is exactly `small` | `medium` | `large`, which is the same key space USDA's own size servings occupy:

```
SELECT source,"isAiEstimated",count(*) FROM "FdcServing"
WHERE lower(description) IN ('small','medium','large') GROUP BY 1,2;
-> usda_fdc | f | 94
   ai       | t | 15        (measured 2026-08-04)
```

**86% of the rows in that key space are genuine USDA data.** And the branch fires precisely on foods that are legitimately heavy — a genuine `medium` cabbage head at 588 g trips the 500 g ceiling and is deleted for being correct. Nothing regenerates `FdcServing` rows.

## Why this is a bug and not a behaviour change

The branch's own comment names a **stale FatSecret-derived** value as the motivating case (the jalapeño at 164 g vs USDA's ~14 g), not a USDA row. Deleting genuine rows was never the intent; the filter is simply missing.

## The fix

`isAiEstimated: true` on the `fdc_` and `off_` branches.

The `aiGeneratedServing` branch deliberately takes **no** filter — that table has no `source` or `isAiEstimated` column because every row is AI by construction, so adding one is a `typecheck` failure. (`source: { notIn: ['usda_fdc'] }` would also protect nothing on the OFF branch: `OffServing.source` defaults to `'openfoodfacts'`.)

## What is NOT claimed

**The firing rate is not measurable read-only.** The surrounding logs are `logger.info` and the box runs at `warn` (`LOG_LEVEL` is absent from its `.env`), so `hydrate.stale_ai_cache_deleted` produces no lines today. The guard is unconditionally correct and does not need the count — no number is asserted here.

## Guard

Doc-check claim `stale-cache-delete-is-provenance-filtered`, **tripwire-tested**: removing one filter takes the command `2@2` → `1@2`, red.

## Gates

```
npx tsc --noEmit   0 source errors (all output is gitignored .next/ — see note)
npm run lint:ci    0 errors, 592 warnings (pre-existing)
npm run test       158 suites / 3,277 passed, 1 skipped
npm run build      OK
npm run doc-check  100/100
```

Note on `tsc`: this checkout's `.next/` contains Syncthing conflict-copies (`routes.d 2.ts`, `package 2.json`, `validator 2.ts`) that produce duplicate-identifier errors. `.next/` is gitignored and CI builds fresh, so this is local-only — filter on `^\.next/` when reading a local typecheck.

## Deploy

Needed for this to take effect. No `prisma/**` change → no migration. **No file under `data/`** → no hand-`scp` (checked explicitly, per the #211/#228 precedent).

## Falsifier

This is wrong if `hydrate.stale_ai_cache_deleted` was load-bearing on genuine rows — i.e. if some genuine USDA size rows are themselves wrong and the branch existed to remove them. The block's own comment describes a *cached* FatSecret value, not a USDA row, which is the reading this PR relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu