### PR TITLE
fix(instruments): one owner for the AI-serving-tier predicate, and it is not the billing one

### DIFF
--- a/scripts/eval/__tests__/correctness-screen.test.ts
+++ b/scripts/eval/__tests__/correctness-screen.test.ts
@@ -986,12 +986,26 @@ describe('realServing() — the anchor D5/D6 judge', () => {
         // corpus cannot anchor. That number is not a property of the cached row; it can
         // differ on the next request. Same rule as the serving gate's
         // AI-NONDETERMINISTIC verdict (PR #174): report it, never gate on it.
-        for (const tier of ['ai_estimated_serving', 'fdc_size_estimated', 'count_ai_default']) {
+        //
+        // ALL FIVE NAMES BELOW ARE REAL. This loop used to read
+        // `ai_estimated_serving`, `fdc_size_estimated`, `count_ai_default` — not one
+        // of which appears anywhere in src/ or has a single row in MappingEventLog.
+        // They passed because the retired regex matched any invented string with an
+        // `ai` token or `estimat` in it, so the test proved the REGEX worked on names
+        // its author made up, never that the PREDICATE worked on names the mapper
+        // stamps. That is why `discrete_unit_backfill` (1,269 live events) and
+        // `fdc_size_qualifier` (345) went unnoticed: no fixture ever contained them.
+        // Re-derive the real set:
+        //   SELECT "servingTier", count(*) FROM "MappingEventLog" GROUP BY 1;
+        for (const tier of [
+            'ai_generated_serving', 'fdc_size_estimate', 'count_unit_ai',
+            'discrete_unit_backfill', 'fdc_size_qualifier',
+        ]) {
             const r = realServing(baseRow({ real: { grams: 28, tier, kcal: 90 } }));
             expect(r.judged).toBe(false);
             expect(r.from).toContain('ai-estimated');
         }
-        const h = tierD(baseRow({ real: { grams: 1.0, tier: 'ai_estimated_serving', kcal: 5 } }), 'balanced')
+        const h = tierD(baseRow({ real: { grams: 1.0, tier: 'ai_generated_serving', kcal: 5 } }), 'balanced')
             .find(x => x.rule === 'D6');
         expect(h?.severity).toBe('INFO');
     });

--- a/scripts/eval/__tests__/prod-shape-coverage.test.ts
+++ b/scripts/eval/__tests__/prod-shape-coverage.test.ts
@@ -21,7 +21,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { AI_SERVING_TIER_RE, realServing, tierD, type ScreenRow } from '../correctness-screen';
+import { realServing, tierD, type ScreenRow } from '../correctness-screen';
+import { isReplayNondeterministicTier } from '../../../src/lib/mapping/serving-ai-tiers';
 
 const FIXTURES = path.join(__dirname, 'fixtures');
 
@@ -127,12 +128,13 @@ describe('the shapes batch 01 was missing are actually SCREENED, not merely pres
 
     it('every fdc row resolves on an AI-ESTIMATED tier, so D5/D6 may never gate on it', () => {
         // Measured over the whole cache: all 78 fdc rows come back on
-        // `fdc_size_estimate`, which AI_SERVING_TIER_RE matches on 'estimat'. The one
-        // source the fixture had no coverage of is also the one whose serving anchor
-        // is a fresh model guess — a number that can differ on the next request and
-        // therefore cannot ground a decision to throw a cache row away.
+        // `fdc_size_estimate`, an explicit member of
+        // REPLAY_NONDETERMINISTIC_SERVING_TIERS. The one source the fixture had no
+        // coverage of is also the one whose serving anchor is a fresh model guess —
+        // a number that can differ on the next request and therefore cannot ground a
+        // decision to throw a cache row away.
         for (const r of fdcRows) {
-            expect(AI_SERVING_TIER_RE.test(r.real?.tier ?? '')).toBe(true);
+            expect(isReplayNondeterministicTier(r.real?.tier)).toBe(true);
             expect(realServing(r).judged).toBe(false);
             const serving = tierD(r, 'strict').filter(h => h.rule === 'D5' || h.rule === 'D6');
             expect(serving.map(h => h.severity)).not.toContain('EVICT');

--- a/scripts/eval/__tests__/serving-divergence.test.ts
+++ b/scripts/eval/__tests__/serving-divergence.test.ts
@@ -148,8 +148,21 @@ describe('a row whose real anchor did not run can NEVER produce an EVICT-severit
         ['the --with-serving pass never ran', { real: undefined }],
         ['hydrateAndSelectServing returned nothing', { real: null }],
         ['hydration threw', { real: { grams: null, tier: null, kcal: null, error: 'FDC API 503' } }],
-        ['the anchor is a fresh AI guess', { real: { grams: 1.2, tier: 'ai_estimated_serving', kcal: 7 } }],
+        // EVERY tier below is a real string the mapper stamps and MappingEventLog
+        // holds. The first of these used to read `ai_estimated_serving`, which exists
+        // nowhere in src/ and has zero live rows — it passed only because the retired
+        // regex matched any invented name containing an `ai` token. Fixtures drawn
+        // from imagination could never have surfaced the two tiers that regex missed,
+        // which is exactly how it missed them for as long as it did.
+        ['the anchor is a fresh AI guess', { real: { grams: 1.2, tier: 'ai_generated_serving', kcal: 7 } }],
         ['the anchor is an fdc size ESTIMATE', { real: { grams: 900, tier: 'fdc_size_estimate', kcal: 1400 } }],
+        // The two the retired regexes missed — pinned here so a future "simplify this
+        // back to a pattern" reintroduces a red test rather than a silent blind spot.
+        // Absurd anchors on purpose, like the two above: D5/D6 only FIRE on a wide
+        // divergence, so a plausible 60 g would make these vacuously green by never
+        // reaching the assertion at all.
+        ['the anchor is a discrete-unit backfill', { real: { grams: 1.4, tier: 'discrete_unit_backfill', kcal: 8 } }],
+        ['the anchor is an fdc size QUALIFIER', { real: { grams: 950, tier: 'fdc_size_qualifier', kcal: 1500 } }],
     ];
 
     /** Rows engineered so the ONLY rule that can fire is a serving rule. */

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -138,6 +138,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { detectBrandInQuery } from '../../src/lib/mapping/brand-detector';
 import { servingMacros } from '../../src/lib/mapping/fs-serving-macros';
+import { isReplayNondeterministicTier } from '../../src/lib/mapping/serving-ai-tiers';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -415,18 +416,20 @@ export function realServing(r: ScreenRow): { grams: number | null; from: string;
     // guess that can differ on the next request, so it cannot ground a decision to
     // throw the row away. Same rule the serving gate uses (PR #174's
     // AI-NONDETERMINISTIC verdict): name it, never silently read it as agreement.
-    if (AI_SERVING_TIER_RE.test(r.real.tier ?? '')) {
+    if (isReplayNondeterministicTier(r.real.tier)) {
         return { grams: r.real.grams, from: `ai-estimated:${r.real.tier}`, judged: false };
     }
     return { grams: r.real.grams, from: `hydrateAndSelectServing:${r.real.tier ?? 'no-tier'}`, judged: true };
 }
 
 /**
- * Tiers produced by a model call rather than by corpus data. Matching one means the
- * screen spent an LLM call resolving that row — see the cost note on
- * `resolveRealServings`.
+ * Tiers produced by a model call rather than by corpus data — see the cost note on
+ * `resolveRealServings`. The predicate now lives in
+ * src/lib/mapping/serving-ai-tiers.ts as `isReplayNondeterministicTier()`, shared
+ * with winner-diff.ts, which is the point: this file and that one each carried a
+ * private regex, and the two disagreed (`estimat` here, `estimate` there). The
+ * divergence was inert on the live tier set; the DEFECT was what both missed.
  */
-export const AI_SERVING_TIER_RE = /(^|_)ai(_|$)|estimat/i;
 
 /**
  * Serving tiers that are a FALLBACK, not a measured portion. A row on one of these
@@ -1034,7 +1037,7 @@ function candidateId(r: ScreenRow): string | null {
  * (one gpt-4o-mini call per ambiguous row). Over the full 3,248-row cache that is
  * minutes of wall clock and a few hundred model calls, NOT the offline pure-function
  * cost of Tier D. Rows it resolves through the estimator come back on an
- * `AI_SERVING_TIER_RE` tier and D5/D6 abstain on them, so the model spend buys
+ * replay-nondeterministic tier and D5/D6 abstain on them, so the model spend buys
  * information about the row but never a verdict. Budget for it, or pass
  * `--no-serving` and accept that D5/D6 report instead of gate.
  */
@@ -1348,7 +1351,7 @@ async function main(): Promise<number> {
         await resolveRealServings(rows);
         const ok = rows.filter(r => r.real && !r.real.error).length;
         const failed = rows.filter(r => r.real?.error).length;
-        const ai = rows.filter(r => r.real && !r.real.error && AI_SERVING_TIER_RE.test(r.real.tier ?? '')).length;
+        const ai = rows.filter(r => r.real && !r.real.error && isReplayNondeterministicTier(r.real.tier)).length;
         console.log(`serving: real anchor resolved for ${ok}/${rows.length} row(s)`
             + (failed ? `, ${failed} errored (D5/D6 abstain on those)` : '')
             + (ai ? `, ${ai} via an AI estimator (D5/D6 abstain on those too)` : ''));

--- a/scripts/eval/winner-diff.ts
+++ b/scripts/eval/winner-diff.ts
@@ -638,6 +638,7 @@ function announceVariantFit(drift: DriftResult, variant: SelectionVariant) {
 // ============================================================
 
 import type { ParsedIngredient } from '../../src/lib/parse/ingredient-line';
+import { isReplayNondeterministicTier } from '../../src/lib/mapping/serving-ai-tiers';
 import type { UnifiedCandidate, GatherOptions } from '../../src/lib/mapping/gather-candidates';
 import type { MappingTelemetry } from '../../src/lib/mapping/map-ingredient-with-fallback';
 
@@ -1779,8 +1780,13 @@ async function preEnrichAiGenerated(entries: SnapshotEntry[]): Promise<number> {
  * Tiers whose grams came from a model rather than from data. They do not replay
  * deterministically, so they are flagged and reported in their own bucket rather
  * than counted as movement the change under test caused.
+ *
+ * The predicate is `isReplayNondeterministicTier()` in
+ * src/lib/mapping/serving-ai-tiers.ts — the one owner, shared with
+ * correctness-screen.ts. It replaced a private `/(^|_)ai(_|$)|estimate/i` here
+ * that missed `discrete_unit_backfill` and `fdc_size_qualifier` (1,614 of 69,529
+ * events), charging their movement to the change under test.
  */
-const AI_SERVING_TIER_RE = /(^|_)ai(_|$)|estimate/i;
 
 /**
  * Run the REAL serving layer for every row that has a winner, and record what the
@@ -1829,7 +1835,7 @@ async function resolveServings(snap: SnapshotFile, rows: ReplayRow[]): Promise<v
                 // grams, not a per-100g figure — it is verbatim what route.ts:296
                 // records as MappingEventLog.totalKcal, i.e. the number on screen.
                 totalKcal: typeof r.kcal === 'number' ? r.kcal : null,
-                aiTouched: tier != null && AI_SERVING_TIER_RE.test(tier),
+                aiTouched: isReplayNondeterministicTier(tier),
             };
         } catch (err: any) {
             row.serving = {

--- a/src/lib/mapping/__tests__/serving-ai-tiers.test.ts
+++ b/src/lib/mapping/__tests__/serving-ai-tiers.test.ts
@@ -1,4 +1,11 @@
-import { servingAiCallForTier, SERVING_AI_TIERS } from '../serving-ai-tiers';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+    servingAiCallForTier,
+    SERVING_AI_TIERS,
+    isReplayNondeterministicTier,
+    REPLAY_NONDETERMINISTIC_SERVING_TIERS,
+} from '../serving-ai-tiers';
 
 /**
  * Each block names the mutation that must kill it. The mutations below were
@@ -78,4 +85,170 @@ describe('SERVING_AI_TIERS — the table itself', () => {
         expect(new Set(Object.values(SERVING_AI_TIERS)))
             .toEqual(new Set(['ambiguous', 'produce', 'weight']));
     });
+});
+
+/**
+ * THE REPLAY-NONDETERMINISM PREDICATE — the offline instruments' half.
+ *
+ * winner-diff.ts and correctness-screen.ts each carried a PRIVATE regex for this
+ * (`/(^|_)ai(_|$)|estimate/i` and `/(^|_)ai(_|$)|estimat/i`). The visible symptom
+ * was that they disagreed; the actual defect was the half they agreed on, because
+ * a name pattern silently returns false for a tier it has never seen.
+ */
+describe('isReplayNondeterministicTier — the two tiers both regexes missed', () => {
+    // MUTATION: delete 'discrete_unit_backfill' from the set. This goes red.
+    // Producer: getOrCreateAmbiguousServing(), the SAME call as `count_unit_ai`,
+    // but this branch stamps one name for both `success` and `cached`, so no
+    // name-based rule can ever separate them. 1,269 of 69,529 events.
+    it('flags `discrete_unit_backfill`, which neither retired regex matched', () => {
+        expect(isReplayNondeterministicTier('discrete_unit_backfill')).toBe(true);
+        expect(/(^|_)ai(_|$)|estimate/i.test('discrete_unit_backfill')).toBe(false);
+        expect(/(^|_)ai(_|$)|estimat/i.test('discrete_unit_backfill')).toBe(false);
+    });
+
+    // MUTATION: delete 'fdc_size_qualifier'. Producer: getOrCreateFdcSizeServings(),
+    // uncached by construction — the same function behind `fdc_size_estimate` and
+    // `fdc_medium_estimate`, both of which the old regexes DID match on 'estimat'.
+    // 345 events. Missing it was a pure naming accident.
+    it('flags `fdc_size_qualifier`, off the same uncached producer as two members', () => {
+        expect(isReplayNondeterministicTier('fdc_size_qualifier')).toBe(true);
+        expect(/(^|_)ai(_|$)|estimate/i.test('fdc_size_qualifier')).toBe(false);
+        expect(/(^|_)ai(_|$)|estimat/i.test('fdc_size_qualifier')).toBe(false);
+    });
+});
+
+describe('isReplayNondeterministicTier — tiers an ADJACENCY scan wrongly nominates', () => {
+    /**
+     * These four were nominated by scanning for tier literals within 55 lines of an
+     * AI producer call, and all four are REFUTED by reading the branch that stamps
+     * them — each sits in a sibling `else` that never reads the AI result:
+     *
+     *   volume_unit         5,379  the `!volumeResolved` hardcoded-density fallback
+     *   bare_plural_serving 2,268  the `!unit && integer qty` branch
+     *   bare_sibling_serving 2,230 the (C2) same-brand sibling MEDIAN — a DB read
+     *   bare_query_default    463  the bare-query inflation guard, a separate block
+     *
+     * Together they are 10,340 events. Marking them nondeterministic would silence
+     * D5/D6 and winner-diff on 15% of the corpus — the instrument going quiet is the
+     * expensive failure here, not the loud one.
+     *
+     * MUTATION: add any one of them to the set. This goes red.
+     */
+    it('does not flag the four sibling-branch tiers', () => {
+        for (const tier of ['volume_unit', 'bare_plural_serving', 'bare_sibling_serving', 'bare_query_default']) {
+            expect(isReplayNondeterministicTier(tier)).toBe(false);
+        }
+    });
+
+    it('does not flag the cached siblings, which are pure row reads', () => {
+        expect(isReplayNondeterministicTier('count_unit_cached')).toBe(false);
+        expect(isReplayNondeterministicTier('fdc_volume_cached')).toBe(false);
+    });
+
+    it('treats an absent tier as deterministic, matching both retired regexes', () => {
+        // The legacy cascade stamps no tier at all (535 live rows). Both instruments
+        // read that as "judge it", and this edit deliberately does not change that —
+        // flipping it is a separate decision with its own blast radius.
+        expect(isReplayNondeterministicTier(null)).toBe(false);
+        expect(isReplayNondeterministicTier(undefined)).toBe(false);
+        expect(isReplayNondeterministicTier('')).toBe(false);
+    });
+});
+
+describe('the two predicates are related but NOT equal', () => {
+    // MUTATION: replace isReplayNondeterministicTier's body with
+    // `servingAiCallForTier(tier).called`. This goes red on both directions below.
+    it('every BILLED tier is also replay-nondeterministic (billing ⊆ nondeterminism)', () => {
+        // The durable invariant: a future addition to SERVING_AI_TIERS that is not
+        // also added here would leave an instrument charging model noise to a change.
+        for (const tier of Object.keys(SERVING_AI_TIERS)) {
+            expect(isReplayNondeterministicTier(tier)).toBe(true);
+        }
+    });
+
+    it('but not the reverse — three members bill nothing through SERVING_AI_TIERS', () => {
+        // ai_generated_serving: runs no model, reads a model-WRITTEN row.
+        // discrete_unit_backfill / fdc_size_qualifier: deliberately not added to the
+        // billing allowlist (see the module header) — it has its own owner doc.
+        for (const tier of ['ai_generated_serving', 'discrete_unit_backfill', 'fdc_size_qualifier']) {
+            expect(isReplayNondeterministicTier(tier)).toBe(true);
+            expect(servingAiCallForTier(tier).called).toBe(false);
+        }
+    });
+
+    /**
+     * The first cut of this exported it as `Object.freeze(new Set([...]))` and
+     * asserted `Object.isFrozen()`. That assertion was GREEN and the guard did not
+     * hold: freezing a Set stops nothing, because its contents are internal slots,
+     * not own properties — `isFrozen` returns true and `.add()` still works. Asserted
+     * here as BEHAVIOUR (does a mutation actually fail?) rather than as a property,
+     * which is the only form that could have caught it.
+     *
+     * MUTATION: drop the Object.freeze wrapper in serving-ai-tiers.ts. Red.
+     */
+    it('rejects mutation for real, not just to Object.isFrozen', () => {
+        expect(Object.isFrozen(REPLAY_NONDETERMINISTIC_SERVING_TIERS)).toBe(true);
+        const before = REPLAY_NONDETERMINISTIC_SERVING_TIERS.length;
+        expect(() => (REPLAY_NONDETERMINISTIC_SERVING_TIERS as string[]).push('x')).toThrow(TypeError);
+        expect(REPLAY_NONDETERMINISTIC_SERVING_TIERS.length).toBe(before);
+    });
+
+    it('has no duplicate members', () => {
+        expect(new Set(REPLAY_NONDETERMINISTIC_SERVING_TIERS).size)
+            .toBe(REPLAY_NONDETERMINISTIC_SERVING_TIERS.length);
+    });
+});
+
+/**
+ * THE DURABLE HALF. Correcting two tiers is a one-off; this is the guard that makes
+ * the NEXT missed tier impossible to add silently.
+ *
+ * An allowlist has the same failure mode as a regex — it returns false for a tier
+ * nobody classified. What it cannot do on its own is notice that a new AI PRODUCER
+ * appeared. So pin the call-site counts: adding a call to any of these four
+ * functions trips this test, and whoever adds it must decide which tier it stamps
+ * and whether that tier belongs in the set above.
+ *
+ * These counts are the reason this fix is not just "two more strings".
+ */
+describe('producer call-site census — the guard against the next silent miss', () => {
+    const SRC = join(__dirname, '..', '..', '..', '..', 'src');
+
+    // Counts measured 2026-08-05 on master @ 93a6219. Re-derive:
+    //   grep -rn "await <fn>(" src/ | grep -v __tests__ | wc -l
+    const EXPECTED: Record<string, number> = {
+        getOrCreateAmbiguousServing: 7,
+        getOrCreateFdcSizeServings: 3,
+        insertFdcAiServing: 1,
+        estimateAmbiguousServing: 4,
+    };
+
+    function countCallSites(fn: string): number {
+        const out: string[] = [];
+        const walk = (dir: string) => {
+            for (const e of require('fs').readdirSync(dir, { withFileTypes: true })) {
+                const p = join(dir, e.name);
+                if (e.isDirectory()) {
+                    if (e.name !== '__tests__' && e.name !== 'node_modules') walk(p);
+                } else if (e.name.endsWith('.ts')) {
+                    out.push(p);
+                }
+            }
+        };
+        walk(SRC);
+        let n = 0;
+        for (const f of out) {
+            for (const line of readFileSync(f, 'utf8').split('\n')) {
+                if (line.includes(`await ${fn}(`)) n++;
+            }
+        }
+        return n;
+    }
+
+    for (const [fn, expected] of Object.entries(EXPECTED)) {
+        // MUTATION: add or remove any call to one of these functions in src/.
+        it(`${fn} still has exactly ${expected} call site(s) outside tests`, () => {
+            expect(countCallSites(fn)).toBe(expected);
+        });
+    }
 });

--- a/src/lib/mapping/serving-ai-tiers.ts
+++ b/src/lib/mapping/serving-ai-tiers.ts
@@ -70,3 +70,111 @@ export function servingAiCallForTier(
     const type = tier ? SERVING_AI_TIERS[tier] : undefined;
     return type ? { called: true, type } : { called: false };
 }
+
+/**
+ * REPLAY NONDETERMINISM — a DIFFERENT predicate from `SERVING_AI_TIERS`, and the
+ * reason this is a second export rather than a reuse of the first.
+ *
+ * `SERVING_AI_TIERS` answers "was a model BILLED for this line" (spend). The two
+ * offline instruments need a different question: **"can this tier's grams differ
+ * between two replays of the same frozen pool"** (attribution). Their own comments
+ * already say so — winner-diff's `aiTouched` exists because such rows "do not
+ * replay deterministically, so they are flagged... rather than counted as movement
+ * the change under test caused", and correctness-screen abstains because the anchor
+ * "is a fresh model guess that can differ on the next request".
+ *
+ * The two predicates are close but NOT equal, in both directions:
+ *   - `ai_generated_serving` bills NOTHING (`getAiServingGrams()` is a findUnique
+ *     plus density maths) so it is absent from `SERVING_AI_TIERS` — but the row it
+ *     reads is written by the model-backed nutrition backfill, so replay 1 can
+ *     create what replay 2 then reads. It is nondeterministic and belongs here.
+ *   - `discrete_unit_backfill` is the mirror image: it is nondeterministic, but it
+ *     is deliberately NOT added to `SERVING_AI_TIERS`, because that allowlist forks
+ *     hit-from-miss by tier NAME (`count_unit_cached` vs `count_unit_ai`) and this
+ *     tier collapses both — see the note on its entry below.
+ *
+ * WHY AN ALLOWLIST AND NOT A REGEX. Until 2026-08-05 each instrument carried its
+ * own private pattern — `/(^|_)ai(_|$)|estimate/i` in winner-diff.ts and
+ * `/(^|_)ai(_|$)|estimat/i` in correctness-screen.ts. The `estimate`/`estimat`
+ * divergence was inert on the live tier set (only `fdc_size_estimate` contains
+ * either), so the visible symptom was harmless. **The real defect was the half they
+ * AGREED on**: a name pattern silently returns false for a tier it has never heard
+ * of, and two tiers stamped directly on an AI producer's result matched neither —
+ * `discrete_unit_backfill` (1,269 events) and `fdc_size_qualifier` (345), 1,614 of
+ * 69,529 (2.3%), measured on the box 2026-08-05. Both instruments were therefore
+ * charging that movement to the change under test.
+ *
+ * Every entry was settled by reading the branch that CONSUMES the producer's
+ * result, not by proximity. An adjacency scan over the same call sites also
+ * nominated `volume_unit` (5,379), `bare_plural_serving` (2,268),
+ * `bare_sibling_serving` (2,230) and `bare_query_default` (463); all four sit in
+ * sibling `else` branches that never read the AI result and are REFUTED — they are
+ * pinned as non-members in the test so the adjacency mistake cannot be re-made.
+ *
+ * Re-derive the population:
+ * `ssh owner@192.168.1.133 'docker exec mealspire-db psql -U postgres -d mealspire
+ *  -c "SELECT \"servingTier\", count(*) FROM \"MappingEventLog\" GROUP BY 1 ORDER BY 2 DESC;"'`
+ *
+ * EXPORTED AS A FROZEN ARRAY, NOT A FROZEN SET, AND THAT IS DELIBERATE.
+ * `Object.freeze(new Set([...]))` is a no-op protection: `Object.isFrozen()` returns
+ * true while `.add()` still mutates, because a Set's contents are internal slots and
+ * not own properties. The first cut of this module did exactly that, and its test
+ * asserted `isFrozen` — a green assertion for a guard that does not hold. A frozen
+ * ARRAY throws on push in strict mode, so the freeze here is real and the sibling
+ * `SERVING_AI_TIERS` (a plain object, where freeze does work) keeps its own pattern.
+ */
+export const REPLAY_NONDETERMINISTIC_SERVING_TIERS: readonly string[] = Object.freeze(
+    ([
+        // --- getOrCreateAmbiguousServing() ---
+        // Cache MISS. Its cached sibling `count_unit_cached` is deterministic and absent.
+        'count_unit_ai',
+        // Same producer, but this call site stamps ONE name for `success` AND `cached`
+        // (map-ingredient-with-fallback.ts, the discrete-unit backfill branch), so no
+        // name-based rule can ever separate them. That is why it is here and not in
+        // SERVING_AI_TIERS: as a nondeterminism flag it is correct on both statuses,
+        // whereas as a BILLING flag it would count every cache hit as a model call.
+        // The durable fix is a provenance field at the producer, not a longer list —
+        // owner: sync-docs/reports/2026-08-05_ai-serving-spend-audit.md.
+        'discrete_unit_backfill',
+
+        // --- getOrCreateFdcSizeServings() -> estimateAmbiguousServing() ---
+        // Uncached by construction (its own docstring says caching is "a future
+        // enhancement"), so every one of these is a live round trip.
+        'fdc_size_estimate',
+        'fdc_medium_estimate',
+        // Third tier off that same producer, stamped on the size-qualifier branch.
+        // Already recorded as a known omission from SERVING_AI_TIERS; it is not
+        // silently added there here, because that allowlist has its own owner doc
+        // and doc-check claims that quote its totals.
+        'fdc_size_qualifier',
+
+        // --- estimateAmbiguousServing(), unitless piece estimation for produce ---
+        'fdc_piece_ai',
+
+        // --- insertFdcAiServing('volume') --- sibling `fdc_volume_cached` is a hit.
+        'fdc_volume_ai',
+
+        // --- ai-nutrition backfill --- bills nothing itself (see header), but the
+        // AiGeneratedServing row it reads is model-written, so it is replay-unstable.
+        // Both retired regexes matched this, so keeping it is the status quo.
+        'ai_generated_serving',
+    ] as const),
+);
+
+/** Lookup index. Module-private so the exported constant stays genuinely frozen. */
+const REPLAY_NONDETERMINISTIC_INDEX = new Set<string>(REPLAY_NONDETERMINISTIC_SERVING_TIERS);
+
+/**
+ * True when `tier`'s grams may differ between two replays of the same frozen pool.
+ *
+ * Returns false for an unclassified tier — the same reading both retired regexes
+ * gave, and deliberately not changed here: flipping the default would mark all ~35
+ * tiers nondeterministic and silence both instruments on the whole corpus, which is
+ * the expensive direction. The guard against a silent miss is instead the producer
+ * call-site census in `serving-ai-tiers.test.ts`: a NEW AI producer cannot be added
+ * without a test failure forcing a decision here. That census is the durable half of
+ * this fix; the two-tier correction is the one-off half.
+ */
+export function isReplayNondeterministicTier(tier: string | null | undefined): boolean {
+    return tier != null && REPLAY_NONDETERMINISTIC_INDEX.has(tier);
+}


### PR DESCRIPTION
## What

`winner-diff.ts` and `correctness-screen.ts` each carried a **private regex** for "did a model produce these grams": `/(^|_)ai(_|$)|estimate/i` and `/(^|_)ai(_|$)|estimat/i`. Both now call one owner, `isReplayNondeterministicTier()` in `src/lib/mapping/serving-ai-tiers.ts`.

## The defect is not the divergence

The two spellings differ, but that is **inert on the live tier set** — only `fdc_size_estimate` contains either. The real defect is the half they **agreed** on: a name pattern silently returns `false` for a tier it has never seen, and two tiers stamped directly on an AI producer's result matched neither.

| tier | live events | producer |
|---|---|---|
| `discrete_unit_backfill` | 1,269 | `getOrCreateAmbiguousServing()` |
| `fdc_size_qualifier` | 345 | `getOrCreateFdcSizeServings()`, uncached |

1,614 of 69,529 (**2.3%**), measured on the box 2026-08-05. winner-diff counted their movement as caused by the change under test; correctness-screen **judged** rows it should abstain on.

## Why a new predicate instead of reusing `SERVING_AI_TIERS`

That allowlist answers *"was a model billed"* (spend). The instruments need *"can this replay differently"* (attribution) — their own comments say so. They are not equal in either direction, so the test pins **billing ⊂ nondeterminism** as the invariant rather than collapsing them.

## Every member was settled by reading the consuming branch

An adjacency scan over the same call sites also nominated `volume_unit` (5,379), `bare_plural_serving` (2,268), `bare_sibling_serving` (2,230), `bare_query_default` (463) — 10,340 events. All four sit in sibling `else` branches that never read the AI result. **Refuted and pinned as non-members**; marking them would have silenced D5/D6 on 15% of the corpus.

## Root cause: three fixture tier names were fictional

`correctness-screen.test.ts` asserted the predicate over `ai_estimated_serving`, `fdc_size_estimated`, `count_ai_default`. **None appears anywhere in `src/`; all three have zero rows in `MappingEventLog`.** They passed because a regex matches any invented string with an `ai` token. Fixtures drawn from imagination could never have contained the two real tiers the regex missed — which is how the gap survived. All fixtures now use names the mapper actually stamps.

Two newly-added divergence cases were also caught being vacuous: D5/D6 only fire on a wide divergence, so a plausible 60 g anchor never reached the assertion.

## A real bug in this change's own first cut

`Object.freeze()` **does not protect a `Set`** — `isFrozen()` returns `true` while `.add()` still mutates, because a Set's contents are internal slots, not own properties. The export is now a frozen **array** (which throws on push) with a module-private Set for lookup, and the test asserts the mutation *fails* rather than asserting `isFrozen`.

## The durable half

The producer **call-site census**. An allowlist has the same blind spot as a regex — it returns false for anything unclassified. The census makes adding a call to any of the four AI producers trip a test, forcing a classification decision.

## Gates

- 164 suites / 3,351 tests · lint 0 errors · `tsc --noEmit` clean
- **Six mutations applied and confirmed red**: drop either missed tier, add `volume_unit`, alias to the billing predicate, remove the freeze, duplicate a member

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu