### PR TITLE
fix(mapping): N1 — name-group sibling serving anchor, raise-only, below the bare-query guard

### DIFF
--- a/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
+++ b/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
@@ -78,9 +78,40 @@ function bareParsed(name: string, qty = 1): ParsedIngredient {
 
 const mockedQueryRaw = prisma.$queryRaw as jest.Mock;
 
+/**
+ * `prisma.$queryRaw` is a TAGGED TEMPLATE — argument 0 is the template-strings
+ * array, not a SQL string. Both sibling borrows go through this one mock:
+ * `borrowSiblingLabelServing` (brand-keyed) and `borrowNameSiblingLabelServing`
+ * (name-keyed, N1). Under a single `mockResolvedValue` the two stubs could
+ * never differ, which makes every raise-only clamp assertion VACUOUS — the
+ * clamp test would pass with the clamp deleted. Dispatch on the SQL text, and
+ * record the shapes actually issued so a refactor that stops issuing one of
+ * them cannot pass silently (T3).
+ */
+let brandSiblingRows: unknown[] = [];   // borrowSiblingLabelServing     ("brandName" ILIKE)
+let nameSiblingRows: unknown[] = [];    // borrowNameSiblingLabelServing (lower(name) =)
+let otherQueryRows: unknown[] = [];     // borrowSiblingPackageGrams, and anything else
+const observedSql: string[] = [];
+
+/** The pre-dispatch behaviour: every borrow saw the same rows. */
+function setAllSiblingRows(rows: unknown[]) {
+    brandSiblingRows = rows;
+    otherQueryRows = rows;
+}
+
 beforeEach(() => {
     jest.clearAllMocks();
-    mockedQueryRaw.mockResolvedValue([]);
+    brandSiblingRows = [];
+    nameSiblingRows = [];
+    otherQueryRows = [];
+    observedSql.length = 0;
+    mockedQueryRaw.mockImplementation((strings: TemplateStringsArray) => {
+        const sql = Array.isArray(strings) ? strings.join('?') : String(strings);
+        observedSql.push(sql);
+        if (sql.includes('"brandName" ILIKE')) return Promise.resolve(brandSiblingRows);
+        if (sql.includes('lower(name) =')) return Promise.resolve(nameSiblingRows);
+        return Promise.resolve(otherQueryRows);
+    });
     (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'error', error: 'not mocked' });
 });
 
@@ -180,7 +211,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             servingGrams: 100,
             servingDescription: '1 portion (100 g)',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 39.8, n: 148 }]);
+        setAllSiblingRows([{ med: 39.8, n: 148 }]);
 
         const result = await buildOffResult(
             makeCandidate('Snickers'), bareParsed('snickers'), 0.9, 'snickers'
@@ -197,7 +228,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             servingGrams: 100,
             servingDescription: '100 g',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 55, n: 200 }]);
+        setAllSiblingRows([{ med: 55, n: 200 }]);
 
         const result = await buildOffResult(
             makeCandidate('Caramel Cashew'),
@@ -215,7 +246,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             servingGrams: 1,
             servingDescription: '1.0g',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 127, n: 12 }]);
+        setAllSiblingRows([{ med: 127, n: 12 }]);
 
         const result = await buildOffResult(
             makeCandidate('Ham & Cheese Hot Pocket'),
@@ -233,7 +264,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             servingGrams: 100,
             servingDescription: '1 portion (100 g)',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 55, n: 2 }]);
+        setAllSiblingRows([{ med: 55, n: 2 }]);
 
         const result = await buildOffResult(
             makeCandidate('Butter Chicken'), bareParsed('butter chicken'), 0.9, 'butter chicken'
@@ -256,7 +287,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             packageQuantity: 591,
             packageQuantityUnit: 'ml',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 355, n: 190 }]);
+        setAllSiblingRows([{ med: 355, n: 190 }]);
 
         const result = await buildOffResult(
             makeCandidate('Gatorade Thirst Quencher'), bareParsed('gatorade'), 0.9, '1 gatorade'
@@ -274,7 +305,7 @@ describe('step (3) — same-brand sibling median for placeholder/garbage labels'
             packageQuantity: 591,
             packageQuantityUnit: 'ml',
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 355, n: 190 }]);
+        setAllSiblingRows([{ med: 355, n: 190 }]);
 
         const result = await buildOffResult(
             makeCandidate('Gatorade Thirst Quencher'), bareParsed('gatorade'), 0.9, 'gatorade'
@@ -376,7 +407,7 @@ describe('dose-anchored categories — own-label/sibling steps must NOT outrank 
             servingDescription: '0.5 cup (104 g)',
         }));
         // Even a plausible sibling median must not answer either.
-        mockedQueryRaw.mockResolvedValue([{ med: 104, n: 12 }]);
+        setAllSiblingRows([{ med: 104, n: 12 }]);
 
         const result = await buildOffResult(
             makeCandidate('Granulated White Sugar'), bareParsed('sugar'), 0.9, 'sugar'
@@ -392,7 +423,7 @@ describe('dose-anchored categories — own-label/sibling steps must NOT outrank 
             brandName: 'Domino',
             servingGrams: null,
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 104, n: 12 }]);
+        setAllSiblingRows([{ med: 104, n: 12 }]);
 
         const result = await buildOffResult(
             makeCandidate('Granulated White Sugar'), bareParsed('sugar'), 0.9, 'sugar'
@@ -412,7 +443,7 @@ describe('dose-anchored categories — own-label/sibling steps must NOT outrank 
             brandName: 'Ghost',
             servingGrams: null,
         }));
-        mockedQueryRaw.mockResolvedValue([{ med: 32.5, n: 147 }]);
+        setAllSiblingRows([{ med: 32.5, n: 147 }]);
 
         const result = await buildOffResult(
             makeCandidate('Ghost Legend Pre Workout Cherry Limeade'),
@@ -459,5 +490,101 @@ describe('step (4) — bounded discrete floor, never flat-100g for piece names',
 
         expect(result?.servingTier).toBe('bare_discrete_floor');
         expect(result?.grams).toBe(50);
+    });
+});
+
+/**
+ * (E) NAME-GROUP SIBLING MEDIAN — N1, item #16, Aug 2026.
+ *
+ * The rung sits BELOW applyOffBareQueryGuard and is gated on the surviving
+ * fabricated tier ('count_unresolved_floor'), so the category lexicon, every
+ * package/label tier and rung (C2)'s brand borrow all keep precedence. Only the
+ * UPWARD half of the name-group mixture ships: a name group is a mixture
+ * (asparagus 85 g, blueberries 62.5 g — dried/freeze-dried products dominate)
+ * and the downward half is worse than the 100 g floor it would replace.
+ */
+describe('step (E) — name-group sibling median, raise-only', () => {
+    it('raise-only: a below-floor name median is refused (asparagus 85 g does not beat the 100 g floor)', async () => {
+        // 'asparagus' ends in -us, so isMorphologicalPluralToken excludes it and
+        // the line genuinely REACHES this rung. A plural fixture (blueberries)
+        // would be stopped by the bare-plural gate and pass for the wrong reason.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Asparagus',
+            brandName: null,
+            servingGrams: null,
+            nutrientsPer100g: { calories: 20, protein: 2.2, carbs: 3.9, fat: 0.1 },
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 85, n: 25 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Asparagus'), bareParsed('asparagus'), 0.9, 'asparagus'
+        );
+
+        // MUTATION TEST: deleting `&& nameSib.grams > grams` from the (E) rung
+        // makes this fail with 'bare_name_sibling_serving' / 85.
+        expect(result?.servingTier).toBe('count_unresolved_floor');
+        expect(result?.grams).toBe(100);
+    });
+
+    it('name-group median raises the fabricated floor (big mac 100 → 232 g at n=3)', async () => {
+        // brandForBorrow is the food name's first token gated at length >= 4, so
+        // 'Big' is null and rung (C2) is structurally unreachable here — which is
+        // exactly why the plan's flagship line needs a NAME-keyed borrow.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Big Mac',
+            brandName: null,
+            servingGrams: null,
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 232, n: 3 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Big Mac'), bareParsed('big mac'), 0.9, 'big mac'
+        );
+
+        // n=3 pins the minimum as well: 'a big mac' sits at exactly n=3 live, so
+        // raising the borrow to n>=5 turns this red.
+        expect(result?.servingTier).toBe('bare_name_sibling_serving');
+        expect(result?.grams).toBe(232);
+    });
+
+    it('issues both the brand-keyed and the name-keyed sibling query', async () => {
+        // Instrument tripwire: without it, a refactor that stops issuing the
+        // name-keyed query makes the raise-only test above pass vacuously.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Asparagus',
+            brandName: null,
+            servingGrams: null,
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 85, n: 25 }];
+
+        await buildOffResult(
+            makeCandidate('Asparagus'), bareParsed('asparagus'), 0.9, 'asparagus'
+        );
+
+        expect(observedSql.some(s => s.includes('"brandName" ILIKE'))).toBe(true);
+        expect(observedSql.some(s => s.includes('lower(name) ='))).toBe(true);
+    });
+
+    it('the category lexicon still wins over a name median (coca cola stays 355 g)', async () => {
+        // GUARD-PRECEDENCE PIN — this encodes the entire narrowing. Moving the
+        // rung up to (C2) turns it red: 'bare_sibling_serving' is guard-exempt,
+        // so a borrow there pre-empts bare_category_default and this bills 275.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Coca Cola',
+            brandName: null,
+            servingGrams: null,
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 275, n: 6 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Coca Cola'), bareParsed('coca cola'), 0.9, 'coca cola'
+        );
+
+        expect(result?.servingTier).toBe('bare_category_default');
+        expect(result?.grams).toBe(355);
     });
 });

--- a/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
+++ b/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
@@ -14,6 +14,7 @@
 import { buildOffResult, isBarePluralRequest } from '../map-ingredient-with-fallback';
 import { hydrateOffCandidate } from '../../openfoodfacts/hydrate';
 import { getOrCreateAmbiguousServing } from '../ambiguous-unit-backfill';
+import { prisma } from '../../db';
 import type { ParsedIngredient } from '../../parse/ingredient-line';
 
 jest.mock('../../db', () => ({
@@ -72,8 +73,33 @@ function bareParsed(name: string, qty = 1): ParsedIngredient {
     return { qty, multiplier: 1, unit: null, name };
 }
 
+const mockedQueryRaw = prisma.$queryRaw as jest.Mock;
+
+/**
+ * `prisma.$queryRaw` is a TAGGED TEMPLATE — argument 0 is the template-strings
+ * array. Both sibling borrows (`borrowSiblingLabelServing`, brand-keyed; and
+ * `borrowNameSiblingLabelServing`, name-keyed, N1) share this one mock, so a
+ * single blanket resolved value makes any per-borrow assertion vacuous.
+ * Dispatch on the SQL text so each is independently controllable. Every bucket
+ * defaults to [] here, which is byte-identical to the previous behaviour — the
+ * point is that the `grapes` pin below cannot silently start depending on a
+ * borrow it is supposed to prove is suppressed.
+ */
+let brandSiblingRows: unknown[] = [];   // borrowSiblingLabelServing     ("brandName" ILIKE)
+let nameSiblingRows: unknown[] = [];    // borrowNameSiblingLabelServing (lower(name) =)
+let otherQueryRows: unknown[] = [];     // borrowSiblingPackageGrams, and anything else
+
 beforeEach(() => {
     jest.clearAllMocks();
+    brandSiblingRows = [];
+    nameSiblingRows = [];
+    otherQueryRows = [];
+    mockedQueryRaw.mockImplementation((strings: TemplateStringsArray) => {
+        const sql = Array.isArray(strings) ? strings.join('?') : String(strings);
+        if (sql.includes('"brandName" ILIKE')) return Promise.resolve(brandSiblingRows);
+        if (sql.includes('lower(name) =')) return Promise.resolve(nameSiblingRows);
+        return Promise.resolve(otherQueryRows);
+    });
     (getOrCreateAmbiguousServing as jest.Mock).mockResolvedValue({ status: 'success', grams: 5 });
 });
 
@@ -182,6 +208,11 @@ describe('buildOffResult — bare-plural inversion (A3)', () => {
             foodName: 'Grapes',
             servingGrams: null,
         }));
+        // A RAISING name-group median is offered on purpose: the (E) rung
+        // (N1) carries `!isBarePluralRequest(...)` for parity with rung (C2),
+        // and dropping that clause bills 200g here instead of the floor. With
+        // an empty stub this pin would be green either way.
+        nameSiblingRows = [{ med: 200, n: 40 }];
 
         const result = await buildOffResult(
             makeCandidate('Grapes'), bareParsed('grapes'), 0.9, 'grapes'

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -5412,6 +5412,62 @@ async function borrowSiblingLabelServing(
     }
 }
 
+/**
+ * Median NAME-GROUP label serving — the brandless twin of
+ * borrowSiblingLabelServing (N1, item #16, Aug 2026). A brandless OFF row
+ * ("Asparagus", "Big Mac") has 58.1% NULL servingGrams against branded rows'
+ * 17.7% (measured 2026-08-05, `GROUP BY brandName IS NULL` over OffFood), and
+ * the brand-keyed borrow above is structurally unreachable for it:
+ * brandForBorrow falls back to the food name's FIRST TOKEN, so 'Asparagus'
+ * queries `brandName ILIKE 'Asparagus'` and matches nothing.
+ *
+ * DELIBERATELY A SEPARATE FUNCTION, not a key-mode argument on the brand
+ * borrow. MappingEventLog.servingTier is the only post-deploy instrument we
+ * have, and merging the two mechanisms under one tier string makes the split
+ * unmeasurable — the serving-cascade-divergence failure shape.
+ *
+ * Predicate notes, all measured 2026-08-05 and NOT free to "optimise":
+ *  - `lower(name)`, not a case-sensitive `name =`. The indexed form is ~2,800x
+ *    faster (0.132 ms vs 369 ms) but loses 43.7% of raise events, and 'a big
+ *    mac' drops to n=2 and fails the n>=3 minimum. The seq scan is the price.
+ *  - `duplicateOfBarcode`/`corruptReason` NULL: a name key concentrates
+ *    near-duplicates by construction (dedupe-off-mark.ts marks rows sharing an
+ *    exact name), so 18.9% of in-band siblings in the affected name groups
+ *    carry one of these marks vs 10.9% corpus-wide.
+ *  - The 3 g floor looks inert because the CALLER is raise-only against a 100 g
+ *    floor, so the accepted OUTPUT range is (100, 400]. It is NOT inert on the
+ *    INPUT rows, where it keeps sub-3 g garbage out of the median. Do not
+ *    delete half this band. MAX=400 still binds (largest firing medians
+ *    350/355).
+ *  - `n >= 3`: n=3 carries 22.2% of RAISE events and only 5.1% of LOWER events,
+ *    and 'a big mac' sits at exactly n=3. Raising to 5 costs 205 RAISE events.
+ */
+async function borrowNameSiblingLabelServing(
+    foodName: string | null | undefined,
+    selfBarcode: string,
+): Promise<{ grams: number; samples: number } | null> {
+    const nm = foodName?.trim();
+    if (!nm || nm.length < 2) return null;
+    try {
+        const { prisma } = await import('../db');
+        const rows = await prisma.$queryRaw<Array<{ med: number | null; n: number }>>`
+            SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY "servingGrams") AS med,
+                   count(*)::int AS n
+            FROM "OffFood"
+            WHERE lower(name) = lower(${nm})
+              AND barcode <> ${selfBarcode}
+              AND "duplicateOfBarcode" IS NULL
+              AND "corruptReason" IS NULL
+              AND "servingGrams" BETWEEN ${BARE_LABEL_MIN_GRAMS} AND ${BARE_LABEL_MAX_GRAMS}
+              AND "servingGrams" <> 100`;
+        const row = rows[0];
+        if (!row?.med || row.n < 3) return null;
+        return { grams: row.med, samples: row.n };
+    } catch {
+        return null;
+    }
+}
+
 // Exported for tests (tier cascade + bare-query guard wire-in).
 export async function buildOffResult(
     candidate: UnifiedCandidate,
@@ -5907,6 +5963,59 @@ export async function buildOffResult(
         grams = bareOverride.grams;
         servingDescription = bareOverride.servingDescription;
         servingTier = bareOverride.servingTier;
+    }
+
+    // (E) NAME-GROUP SIBLING MEDIAN, RAISE-ONLY. Reaching here still stamped
+    // 'count_unresolved_floor' means every rung above AND the category lexicon
+    // (applyOffBareQueryGuard runs first and stamps its own tier) had no answer:
+    // no label, no package, no piece seed, no lexicon default. The 100 is a bare
+    // literal, not data.
+    //
+    // This rung is deliberately BELOW the guard. At rung (C2) a borrow is
+    // guard-EXEMPT ('bare_sibling_serving' is in none of CAP_TIERS /
+    // HEAD_GATED_CAP_TIERS / REPLACE_TIERS) and therefore pre-empts
+    // bare_category_default, label_serving_default and package_count_*; measured
+    // 2026-08-05, that lowers 207 events, 196 of them `coca cola` 355 -> 275.
+    //
+    // RAISE-ONLY: a name group is a MIXTURE (asparagus 85 g, blueberries 62.5 g,
+    // strawberries 65.0 g — dried/freeze-dried products dominate), and the
+    // downward half is worse than the floor it would replace.
+    //
+    // The tier gate structurally implies five of rung (C2)'s own clauses, which
+    // are therefore NOT restated here: grams == null (by construction of the
+    // branch that stamped the tier), bareLabelGrams == null (345 of 345 zone
+    // records have servingGrams NULL or <= 0), !doseAnchored (a non-null
+    // getBareQueryDefault would have fired the guard's REPLACE path and changed
+    // the tier), the ml drink-the-unit exception (1 record / 1 event in the
+    // zone), and "the guard already declined". All measured 2026-08-05.
+    if (
+        servingTier === 'count_unresolved_floor'
+        // Excludes 113 digit-line floor events: for "15 pretzels" a 30 g median
+        // billed once is WORSE than the floor.
+        && bareRequest
+        // Leaves 64 branded digitless floor events to rung (C2), which already
+        // ran against their real brand and returned n < 3.
+        && hydrated.brandName == null
+        // Parity with rung (C2); keeps the `grapes` pin green. Costs ~64 RAISE
+        // events and is cheaply reversible. Recomputed rather than hoisted:
+        // barePluralRequest/itemNameForCount are block-scoped inside the
+        // unitless-count branch, and hoisting them changes rung-(C2) ordering.
+        && !isBarePluralRequest(parsed, rawLine, parsed?.name || hydrated.foodName)
+    ) {
+        const nameSib = await borrowNameSiblingLabelServing(
+            hydrated.foodName, candidate.id.replace(/^off_/, '')
+        );
+        if (nameSib != null && nameSib.grams > grams) {
+            grams = nameSib.grams;
+            servingDescription = `1 serving (~${nameSib.grams.toFixed(0)}g, name median)`;
+            servingTier = 'bare_name_sibling_serving';
+            logger.info('off.build_result.bare_name_sibling_serving', {
+                foodId: candidate.id,
+                name: hydrated.foodName,
+                grams: nameSib.grams,
+                samples: nameSib.samples,
+            });
+        }
     }
 
     const factor = grams / 100;

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -15,6 +15,13 @@
  *       ('bare_discrete_floor', wired below in the REPLACE path).
  * This module owns the eligibility predicate, the label-usability band, and
  * the post-cascade override (CAP / REPLACE / floor). Pure functions, no I/O.
+ *
+ * 'bare_name_sibling_serving' (N1, Aug 2026) is DELIBERATELY absent from every
+ * tier set below, and that is not an omission to fix. That rung runs AFTER this
+ * guard — it is gated on the guard having already declined (tier still
+ * 'count_unresolved_floor') — so any membership here would be dead code. Adding
+ * it would also re-create the pre-emption bug the rung was placed low to avoid:
+ * see the (E) rung comment in buildOffResult (map-ingredient-with-fallback.ts).
  */
 
 import type { ParsedIngredient } from '../parse/ingredient-line';


### PR DESCRIPTION
## What

Plan item **#16**. A bare query whose own record carries no usable serving falls to `count_unresolved_floor`. N1 adds a rung (E) that borrows the **median label serving of the record's name group**, raise-only, on a new tier `bare_name_sibling_serving`.

## The literal design in the plan was refuted; this is the survivor

The plan specified re-keying the existing sibling borrow. That is **DNB-9** in `reports/2026-08-05_serving-fix-build-order.md` and it is dead: `bare_sibling_serving` is in **none** of `CAP_TIERS` / `HEAD_GATED_CAP_TIERS` / `REPLACE_TIERS`, so it is guard-**exempt** and pre-empts every later rung and the whole category lexicon. Measured cost of the literal design: `coca cola` 355 g → 275 g over **196 events**.

The surviving shape sits **below** `applyOffBareQueryGuard()` and only fires when the guard has already declined (tier still `count_unresolved_floor`). The one edit to `bare-query-guard.ts` is a **comment** recording why the new tier is deliberately absent from every tier set there — membership would be dead code *and* would re-create the pre-emption bug.

## Blast radius

- **Zero winners move.** This is a serving-stage rung; it cannot change which record wins.
- Fires only on `count_unresolved_floor` (2,456 live events), and only when a name group has usable siblings.
- **Raise-only clamp**: it can never lower a billed weight.

## The honest gate verdict: sound-with-caveats

Recorded so the next reader does not have to re-derive it:

- Only **30 of 363** historical firing lines fire under cold replay, so the cold gate barely exercises this path.
- **34 records adjudicated**; 11 of the reference values are `~` approximations, not exact anchors.
- The seed arm is a **reconstruction, not a replication**.

We are more confident this is **narrow** than that it is **right**. Merging anyway, and the reason is directional: #18's third re-gate found the residual blocker is N1's *own* raise-only clamp and bare-plural suppression — i.e. it **under**-fires rather than over-fires, which is the safe direction. Holding it also blocks Phase 1 stage 1e, which rewrites the same file.

## Not deployed by this PR

Merging is not deploying — the box serves a built `.next`. The cold-gate baseline for the current build (`AT8hJqVHdUbTo5I9wENc6`: 12 stable + 2 rotating, union 14) was captured **before** this merge, so a post-deploy cold run has something to diff against.

## Gates

164 suites / 3,340 tests · lint 0 errors · `tsc --noEmit` clean · doc-check 107/107 (the one red in the worktree is `off-triage-verdicts-mostly-untargeted`, which reads a gitignored file a worktree does not carry; it returns `50 7` in the real tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu