### PR TITLE
chore(doc-check): claim that the LLM egress counter is LIVE, not merely merged

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1297,6 +1297,19 @@
         "value": "4"
       },
       "verified": "2026-08-04"
+    },
+    {
+      "id": "llm-usage-counters-live-on-the-box",
+      "claim": "the DEPLOYED build serves a keyed /api/ok carrying a per-purpose byPurpose block, i.e. the 0.5(c) LLM egress counter is live in production and not merely merged",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-05_ai-serving-spend-audit.md",
+      "where": "box",
+      "command": "key=$(grep '^DEV_API_KEY=' /home/owner/Recipe-App/.env | cut -d= -f2- | tr -d '\"'); curl -s --max-time 10 -H \"x-api-key: $key\" http://localhost:3000/api/ok | grep -c '\"byPurpose\"'",
+      "expect": {
+        "kind": "equals",
+        "value": "1"
+      },
+      "verified": "2026-08-05",
+      "note": "Deliberately a box claim reading the SERVED artifact rather than a backend claim greping src/: per CLAUDE.md a backend claim proves only that someone has the code checked out, which is exactly the merge-is-never-a-deploy gap this counter exists to close. Key read from the box's own .env rather than embedded, matching fatsecret-live-wire. Falsifier steps 1-5 passed before this landed; adding it pre-deploy would have redded the 04:50 nightly."
     }
   ]
 }


### PR DESCRIPTION
Step 6 of the 0.5(c) live falsifier (`reports/2026-08-05_ai-serving-spend-audit.md`), which was gated on step 3.

**Step 3 passed 2026-08-05.** `run-eval.ts` cannot do a warm run (its `nosave` rides with `nocache`), but `/api/nlp/parse` reads the two params independently, so `?nosave=1` alone gives a warm, cache-enabled request that writes nothing. Four lines on a freshly restarted process left **all seven counters at 0**, `since`/`pid` identical either side, and all six components logged `cacheHit='early'` / `funnelStage='cache_hit'`.

**With a control**, because `0 → 0` is also the shape of a dead instrument: cold lines in the *same process* then moved it (`normalize` 1, `ambiguous` 5, `parse` 2).

**Why `box` and not `backend`:** a `backend` claim greping `src/` proves only that someone has the code checked out — the exact merge-is-never-a-deploy gap this counter exists to close. This one reads the **served artifact**. The key comes from the box's own `.env` rather than being embedded, matching `fatsecret-live-wire`.

doc-check: **108/108**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu