### PR TITLE
fix(serving): let the name-sibling median LOWER inside a tight name group

### DIFF
--- a/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
+++ b/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
@@ -14,7 +14,7 @@
  * count-label divide).
  */
 
-import { buildOffResult } from '../map-ingredient-with-fallback';
+import { buildOffResult, isTightNameGroup } from '../map-ingredient-with-fallback';
 import { hydrateOffCandidate } from '../../openfoodfacts/hydrate';
 import { getOrCreateAmbiguousServing } from '../ambiguous-unit-backfill';
 import { prisma } from '../../db';
@@ -515,14 +515,122 @@ describe('step (E) — name-group sibling median, raise-only', () => {
             nutrientsPer100g: { calories: 20, protein: 2.2, carbs: 3.9, fat: 0.1 },
         }));
         setAllSiblingRows([]);
-        nameSiblingRows = [{ med: 85, n: 25 }];
+        // A genuine MIXTURE, which is the population the clamp was justified on:
+        // fresh spears sit near 85 g and dried/freeze-dried packs near 20-30 g,
+        // so p75/p25 = 200/40 = 5.0 and the group median is not a serving size.
+        nameSiblingRows = [{ med: 85, n: 25, p25: 40, p75: 200 }];
 
         const result = await buildOffResult(
             makeCandidate('Asparagus'), bareParsed('asparagus'), 0.9, 'asparagus'
         );
 
         // MUTATION TEST: deleting `&& nameSib.grams > grams` from the (E) rung
-        // makes this fail with 'bare_name_sibling_serving' / 85.
+        // makes this fail with 'bare_name_sibling_serving' / 85. Deleting the
+        // `isTightNameGroup(...)` conjunct from `lowersIntoTightGroup` fails it
+        // with 'bare_name_sibling_serving_tight' / 85.
+        expect(result?.servingTier).toBe('count_unresolved_floor');
+        expect(result?.grams).toBe(100);
+    });
+
+    it('TIGHT group lowers below the floor (mature cheddar 100 → 30 g, n=17 all 30)', async () => {
+        // Real corpus group, measured 2026-08-05: 17 in-band siblings named
+        // 'Mature cheddar', every one declaring 30 g, so p75/p25 = 1.00. This is
+        // a conventional label serving repeated across near-identical SKUs, not
+        // a mixture — the 100 g floor is a bare literal outranking it.
+        //
+        // SINGULAR on purpose. 'Broccoli florets' is the more vivid uniform
+        // group (n=130, all 85 g) but it is bare-PLURAL, so rung (E) never runs
+        // for it and the fixture would prove nothing about this clamp. The two
+        // blockers partition the residual: 15 raise-blocked, 13 plural-blocked.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Mature cheddar',
+            brandName: null,
+            servingGrams: null,
+            nutrientsPer100g: { calories: 416, protein: 25.4, carbs: 0.1, fat: 34.9 },
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 30, n: 17, p25: 30, p75: 30 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Mature cheddar'), bareParsed('mature cheddar'), 0.9, 'mature cheddar'
+        );
+
+        // MUTATION TEST: restoring the raise-only clamp (dropping the
+        // `|| lowersIntoTightGroup` disjunct) fails this with
+        // 'count_unresolved_floor' / 100.
+        expect(result?.servingTier).toBe('bare_name_sibling_serving_tight');
+        expect(result?.grams).toBe(30);
+    });
+
+    it('the bare-PLURAL gate still pre-empts a tight lowering (broccoli florets stays on the floor)', async () => {
+        // The uniform group above (n=130, all 85 g) is unreachable BY DESIGN:
+        // rung (E) requires !isBarePluralRequest. This pins that the tight-group
+        // relaxation did NOT quietly widen the plural gate — 13 of the 28
+        // residual rows are blocked here, and closing them is a separate change
+        // with its own gate.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Broccoli florets',
+            brandName: null,
+            servingGrams: null,
+            nutrientsPer100g: { calories: 34, protein: 2.8, carbs: 6.6, fat: 0.4 },
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 85, n: 130, p25: 85, p75: 85 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Broccoli florets'), bareParsed('broccoli florets'), 0.9, 'broccoli florets'
+        );
+
+        expect(result?.servingTier).toBe('count_unresolved_floor');
+        expect(result?.grams).toBe(100);
+    });
+
+    it('the SEPARATE tier is keyed on DIRECTION, not on tightness (a tight RAISE stays the original tier)', async () => {
+        // Without this the two axes are confounded and a tier-keyed instrument
+        // reading `_tight` would silently be reading "was measured tight", not
+        // "billed below the floor". 'Big Mac' is tight AND raises.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Big Mac',
+            brandName: null,
+            servingGrams: null,
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 232, n: 3, p25: 220, p75: 240 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Big Mac'), bareParsed('big mac'), 0.9, 'big mac'
+        );
+
+        expect(result?.servingTier).toBe('bare_name_sibling_serving');
+        expect(result?.grams).toBe(232);
+    });
+
+    it('a NULL p25/p75 never reads as tight (fail-closed on absent dispersion)', async () => {
+        // The borrow coalesces NULLs to p25=0 / p75=Infinity precisely so a
+        // missing aggregate cannot be mistaken for a uniform group. A fixture
+        // that simply omits the columns is the shape an older cached/mocked row
+        // has, and it must decline rather than lower.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Asparagus',
+            brandName: null,
+            servingGrams: null,
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 85, n: 25, p25: null, p75: null }];
+
+        const result = await buildOffResult(
+            makeCandidate('Asparagus'), bareParsed('asparagus'), 0.9, 'asparagus'
+        );
+
+        // MUTATION TEST: coalescing a missing percentile to `row.med` — the
+        // "helpful" refactor, which makes every NULL group read as p25 == p75
+        // and therefore perfectly tight — fails this with 30 g.
+        //
+        // Swapping the 0/Infinity sentinels for each other does NOT fail it, and
+        // that was checked rather than assumed: the ratio arithmetic already
+        // fails closed for every NULL combination, so the sentinel choice is
+        // unobservable here. This is a REGRESSION PIN on the outcome, not a
+        // guard test for those two literals.
         expect(result?.servingTier).toBe('count_unresolved_floor');
         expect(result?.grams).toBe(100);
     });
@@ -537,7 +645,7 @@ describe('step (E) — name-group sibling median, raise-only', () => {
             servingGrams: null,
         }));
         setAllSiblingRows([]);
-        nameSiblingRows = [{ med: 232, n: 3 }];
+        nameSiblingRows = [{ med: 232, n: 3, p25: 220, p75: 240 }];
 
         const result = await buildOffResult(
             makeCandidate('Big Mac'), bareParsed('big mac'), 0.9, 'big mac'
@@ -586,5 +694,50 @@ describe('step (E) — name-group sibling median, raise-only', () => {
 
         expect(result?.servingTier).toBe('bare_category_default');
         expect(result?.grams).toBe(355);
+    });
+});
+
+/**
+ * The dispersion predicate on its own. Every ratio below is a real name group
+ * measured over `OffFood` on 2026-08-05 (the 28-row #18 residual), so the
+ * boundary is pinned by the corpus rather than by invented numbers.
+ */
+describe('isTightNameGroup', () => {
+    it.each([
+        ['Broccoli florets — 130 rows all 85 g', 85, 85, true],
+        ['Mature cheddar — 17 rows all 30 g', 30, 30, true],
+        ['Chicken tenderloins — 112/113.4', 112, 113.4, true],
+        ['Rotisserie chicken — 84/113, ratio 1.345', 84, 113, true],
+        ['Albacore tuna — 75.75/113, ratio 1.492 (just inside)', 75.75, 113, true],
+        ['Spaghetti and meatballs — 198.75/336, ratio 1.69', 198.75, 336, false],
+        ['pasta — 56/115.5, ratio 2.06 (dry vs cooked)', 56, 115.5, false],
+        ['hot chocolate — 15.5/33, ratio 2.13 (sachet vs mug)', 15.5, 33, false],
+        ['Roasted red peppers — 30/130, ratio 4.33', 30, 130, false],
+    ])('%s', (_label, p25, p75, expected) => {
+        expect(isTightNameGroup(p25 as number, p75 as number)).toBe(expected);
+    });
+
+    it('the boundary is inclusive at exactly 1.5 and excludes just above it', () => {
+        // MUTATION TEST: flipping `<=` to `<` fails the first of these.
+        expect(isTightNameGroup(100, 150)).toBe(true);
+        expect(isTightNameGroup(100, 150.01)).toBe(false);
+    });
+
+    it('degenerate inputs are never tight', () => {
+        // p25 = 0 would make the ratio Infinity or NaN; Infinity is the borrow's
+        // coalesce for a NULL p75. Each must decline, not divide.
+        expect(isTightNameGroup(0, 0)).toBe(false);
+        expect(isTightNameGroup(0, 85)).toBe(false);
+        expect(isTightNameGroup(85, 0)).toBe(false);
+        expect(isTightNameGroup(0, Number.POSITIVE_INFINITY)).toBe(false);
+        expect(isTightNameGroup(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(false);
+        expect(isTightNameGroup(Number.NaN, 85)).toBe(false);
+        expect(isTightNameGroup(-30, -20)).toBe(false);
+    });
+
+    it('an inverted pair is refused rather than silently reordered', () => {
+        // p75 < p25 can only mean the aggregate was misread. Sorting the pair
+        // here would turn a broken instrument into a plausible answer.
+        expect(isTightNameGroup(113, 84)).toBe(false);
     });
 });

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -5503,7 +5503,18 @@ async function borrowNameSiblingLabelServing(
  */
 const NAME_GROUP_TIGHT_RATIO = 1.5;
 
-/** Exported for tests. A group is tight when its IQR ratio is finite and <= the threshold. */
+/**
+ * Exported for tests. A group is tight when its IQR ratio is <= the threshold.
+ *
+ * The `<= 0` and inverted-pair guards are load-bearing and each has a test that
+ * dies without it (negative percentiles otherwise divide to a plausible ratio;
+ * an inverted pair otherwise gets silently reordered into one). The `isFinite`
+ * guard is deliberately redundant — verified by mutation on 2026-08-05, nothing
+ * observes its removal, because every non-finite input already fails the checks
+ * below or the comparison itself. It is kept because it is what makes the
+ * Infinity sentinel in the borrow legible, and it is recorded as redundant here
+ * so nobody later reads its presence as evidence of a case it handles alone.
+ */
 export function isTightNameGroup(p25: number, p75: number): boolean {
     if (!Number.isFinite(p25) || !Number.isFinite(p75)) return false;
     if (p25 <= 0 || p75 <= 0) return false;

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -5445,14 +5445,18 @@ async function borrowSiblingLabelServing(
 async function borrowNameSiblingLabelServing(
     foodName: string | null | undefined,
     selfBarcode: string,
-): Promise<{ grams: number; samples: number } | null> {
+): Promise<{ grams: number; samples: number; p25: number; p75: number } | null> {
     const nm = foodName?.trim();
     if (!nm || nm.length < 2) return null;
     try {
         const { prisma } = await import('../db');
-        const rows = await prisma.$queryRaw<Array<{ med: number | null; n: number }>>`
+        const rows = await prisma.$queryRaw<
+            Array<{ med: number | null; n: number; p25: number | null; p75: number | null }>
+        >`
             SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY "servingGrams") AS med,
-                   count(*)::int AS n
+                   count(*)::int AS n,
+                   percentile_cont(0.25) WITHIN GROUP (ORDER BY "servingGrams") AS p25,
+                   percentile_cont(0.75) WITHIN GROUP (ORDER BY "servingGrams") AS p75
             FROM "OffFood"
             WHERE lower(name) = lower(${nm})
               AND barcode <> ${selfBarcode}
@@ -5462,10 +5466,49 @@ async function borrowNameSiblingLabelServing(
               AND "servingGrams" <> 100`;
         const row = rows[0];
         if (!row?.med || row.n < 3) return null;
-        return { grams: row.med, samples: row.n };
+        // p25/p75 come from the same aggregate as `med`, so a non-null med over
+        // n >= 3 rows in a [3, 400] band implies both are non-null and >= 3. The
+        // fallbacks exist so a NULL can never silently read as a TIGHT group
+        // (p75 = Infinity, p25 = 0 both force isTightNameGroup false).
+        return {
+            grams: row.med,
+            samples: row.n,
+            p25: row.p25 ?? 0,
+            p75: row.p75 ?? Number.POSITIVE_INFINITY,
+        };
     } catch {
         return null;
     }
+}
+
+/**
+ * Interquartile spread of a name group, as a RATIO so it is scale-free (a
+ * cheese group at 28 g and a chicken group at 112 g are comparable).
+ *
+ * The threshold exists to separate two populations the RAISE-ONLY clamp at
+ * rung (E) treats identically:
+ *  - MIXTURES, which is what the clamp was justified on: `hot chocolate`
+ *    (p75/p25 2.13, powder sachets vs made-up mugs), `pasta` (2.06, dry vs
+ *    cooked). Their median is not a serving size, it is the midpoint of two
+ *    different products, and billing it is worse than the floor.
+ *  - CONVENTIONAL LABEL SERVINGS, which are near-uniform: `Broccoli florets`
+ *    n=130 all 85 g (ratio 1.00), `Wide egg noodles` n=26 all 56 g (1.00),
+ *    `Mature cheddar` n=17 all 30 g (1.00). For these the group median IS the
+ *    label serving, and the 100 g floor is a bare literal outranking it.
+ *
+ * 1.5 measured 2026-08-05 over the 28-row #18 residual: it admits 20 and
+ * excludes 8, and both raise-blocked exclusions (`hot chocolate`, `pasta`) are
+ * the mixtures above. Re-derive with the p25/p75 query in
+ * `sync-docs/reports/2026-08-05_the-raise-only-clamp-is-calibrated-on-the-wrong-population.md`.
+ */
+const NAME_GROUP_TIGHT_RATIO = 1.5;
+
+/** Exported for tests. A group is tight when its IQR ratio is finite and <= the threshold. */
+export function isTightNameGroup(p25: number, p75: number): boolean {
+    if (!Number.isFinite(p25) || !Number.isFinite(p75)) return false;
+    if (p25 <= 0 || p75 <= 0) return false;
+    if (p75 < p25) return false;
+    return p75 / p25 <= NAME_GROUP_TIGHT_RATIO;
 }
 
 // Exported for tests (tier cascade + bare-query guard wire-in).
@@ -5977,9 +6020,18 @@ export async function buildOffResult(
     // bare_category_default, label_serving_default and package_count_*; measured
     // 2026-08-05, that lowers 207 events, 196 of them `coca cola` 355 -> 275.
     //
-    // RAISE-ONLY: a name group is a MIXTURE (asparagus 85 g, blueberries 62.5 g,
-    // strawberries 65.0 g — dried/freeze-dried products dominate), and the
-    // downward half is worse than the floor it would replace.
+    // RAISE-ONLY BY DEFAULT: a name group is usually a MIXTURE (asparagus 85 g,
+    // blueberries 62.5 g, strawberries 65.0 g — dried/freeze-dried products
+    // dominate), and the downward half is worse than the floor it would replace.
+    //
+    // The one exception is a TIGHT group (`isTightNameGroup`, p75/p25 <= 1.5),
+    // which is not a mixture at all but a conventional label serving repeated
+    // across near-identical SKUs. There the clamp is the defect: it pins a
+    // 130-row group of `Broccoli florets` that all declare 85 g to a bare 100 g
+    // literal. Lowering is allowed ONLY for those, and stamps a SEPARATE tier
+    // so the two directions stay independently measurable — merging them would
+    // repeat the serving-cascade-divergence mistake this rung's own borrow
+    // function documents.
     //
     // The tier gate structurally implies five of rung (C2)'s own clauses, which
     // are therefore NOT restated here: grams == null (by construction of the
@@ -6005,15 +6057,23 @@ export async function buildOffResult(
         const nameSib = await borrowNameSiblingLabelServing(
             hydrated.foodName, candidate.id.replace(/^off_/, '')
         );
-        if (nameSib != null && nameSib.grams > grams) {
+        const lowersIntoTightGroup = nameSib != null
+            && nameSib.grams < grams
+            && isTightNameGroup(nameSib.p25, nameSib.p75);
+        if (nameSib != null && (nameSib.grams > grams || lowersIntoTightGroup)) {
+            const tier = lowersIntoTightGroup
+                ? 'bare_name_sibling_serving_tight'
+                : 'bare_name_sibling_serving';
             grams = nameSib.grams;
             servingDescription = `1 serving (~${nameSib.grams.toFixed(0)}g, name median)`;
-            servingTier = 'bare_name_sibling_serving';
-            logger.info('off.build_result.bare_name_sibling_serving', {
+            servingTier = tier;
+            logger.info(`off.build_result.${tier}`, {
                 foodId: candidate.id,
                 name: hydrated.foodName,
                 grams: nameSib.grams,
                 samples: nameSib.samples,
+                p25: nameSib.p25,
+                p75: nameSib.p75,
             });
         }
     }

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -16,12 +16,20 @@
  * This module owns the eligibility predicate, the label-usability band, and
  * the post-cascade override (CAP / REPLACE / floor). Pure functions, no I/O.
  *
- * 'bare_name_sibling_serving' (N1, Aug 2026) is DELIBERATELY absent from every
- * tier set below, and that is not an omission to fix. That rung runs AFTER this
- * guard — it is gated on the guard having already declined (tier still
+ * 'bare_name_sibling_serving' (N1, Aug 2026) and its downward twin
+ * 'bare_name_sibling_serving_tight' are DELIBERATELY absent from every tier set
+ * below, and that is not an omission to fix. That rung runs AFTER this guard —
+ * it is gated on the guard having already declined (tier still
  * 'count_unresolved_floor') — so any membership here would be dead code. Adding
- * it would also re-create the pre-emption bug the rung was placed low to avoid:
- * see the (E) rung comment in buildOffResult (map-ingredient-with-fallback.ts).
+ * either would also re-create the pre-emption bug the rung was placed low to
+ * avoid: see the (E) rung comment in buildOffResult
+ * (map-ingredient-with-fallback.ts).
+ *
+ * The two are ONE rung stamping TWO tiers, split by the DIRECTION the median
+ * moved the bill — up off the floor, or down into a measured-tight name group.
+ * They are not a hit/miss pair and neither implies anything about caching; the
+ * `_cached`-sibling naming convention that misled a previous instrument does
+ * not apply here.
  */
 
 import type { ParsedIngredient } from '../parse/ingredient-line';


### PR DESCRIPTION
Rung (E)'s name-group sibling median is **raise-only**. That clamp was justified on name groups
being MIXTURES — `asparagus` 85 g next to freeze-dried packs — where the median is the midpoint of
two different products and billing it is worse than the 100 g floor.

That is true of dispersed groups. It is false of tight ones, where the group median IS the
conventional label serving repeated across near-identical SKUs and the floor is a bare literal
outranking real label data. `Broccoli florets` has 130 in-band siblings that all declare 85 g;
`Mature cheddar` 17 that all declare 30 g.

**This replaces an assumption about name groups with a measurement of each group.** The borrow now
returns p25/p75 alongside the median, and lowering is permitted only when `p75/p25 <= 1.5`.

## Measured — winner-diff, frozen pool, `--with-serving`, `--variant gate-backstop`

1,136 queries, one snapshot, four arms at four distinct tree hashes.

**Blast radius on the CURRENTLY DEPLOYED build (B -> B'): 24 rows of 1,136 (2.1%).**

- All 24 go `count_unresolved_floor` -> `bare_name_sibling_serving_tight`. Zero rows moved up, and
  the rung cannot reach a row that already holds a real anchor.
- **Zero winner changes.** This is purely serving resolution.
- Hand-adjudicated 24/24 favourable-or-neutral, none harmful: `cool whip` 100 -> 9 g (2 tbsp),
  `provolone` 100 -> 23 g (1 slice), `capellini` 100 -> 56.7 g (2 oz dry), `agave nectar` 100 -> 21 g
  (1 tbsp), `mushroom coffee` 100 -> 6 g (a sachet). Every destination is a plausible single-serving
  label value; every one replaces a bare literal. The least confident is `white coffee` 32.5 g, and
  it is still not worse than 100 g.
- Max IQR ratio actually admitted is **1.49**, so the threshold is binding at the margin rather than
  vacuous.

**On plan item #18 (C -> C'): repairs 13 of the 28 residual rows.** Against the pre-#18 measured
anchor those rows carried one build earlier: **CLOSER 10, further 3**.

The 15 that remain decompose exactly, and neither half is a surprise:
- **13 are bare-PLURAL-blocked**, not clamp-blocked. Rung (E) requires `!isBarePluralRequest`, so
  `broccoli florets` — the most uniform group in the whole population — is unreachable by design.
  Relaxing that gate is a separate change with its own risk (`grapes` pin) and its own gate.
- **2 are the dispersed groups the plan named as this hypothesis's falsifier**: `hot chocolate`
  (2.13, sachet vs made-up mug) and `pasta` (2.06, dry vs cooked). The gate excludes both, which is
  the predicted behaviour. Worth recording honestly: `hot chocolate`'s median is 21 g and the
  pre-#18 anchor was also 21 g, so excluding it costs one exact repair. That is the conservative
  direction and it is the trade the threshold buys.

**Prediction registered before the gate ran: 13 of 28.** It landed on 13.

### Control

The previous session's arm C and this session's rebuilt arm C — same semantics, different base
(`136d0e5`+N1 vs `e1c82c1`) — **agree on all 1,136 rows, winner and tier**. Cross-session,
cross-base reproduction, which is a stronger determinism check than a same-tree double replay.

## Tier split

Lowering stamps `bare_name_sibling_serving_tight`, deliberately NOT reusing
`bare_name_sibling_serving`. One rung, two tiers, split by DIRECTION — merging them would make the
downward half unmeasurable post-deploy, which is the serving-cascade-divergence failure shape this
rung's own borrow function already warns about. It is not a `_cached`-style hit/miss pair.

## Tests

16 new, each naming the mutation that kills it, and each mutation applied and confirmed red:
dropping the tight disjunct, dropping the `isTightNameGroup` conjunct, defaulting a missing
percentile to the median, the exclusive-boundary flip, and silently sorting an inverted pair.

Two honest notes:
- The NULL-dispersion test is a **regression pin, not a guard test**. Swapping the `0`/`Infinity`
  sentinels changes nothing — the ratio arithmetic already fails closed. Checked by mutation rather
  than assumed, and the comment says so.
- The `isFinite` guard in `isTightNameGroup` is **provably redundant** and is labelled as such in
  the source, so its presence is never read as evidence of a case it handles alone.

Fixtures are drawn from the corpus, not invented — `Mature cheddar` is singular on purpose, because
the more vivid `Broccoli florets` is plural-blocked and would have passed for the wrong reason.

Gates: 164 suites / 3,371 tests, `tsc` clean, `lint:ci` 0 errors, doc-check 108/108.
