### PR TITLE
chore(doc-check): the AI-tag skip rate tracks the log corpus, not the pipeline

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1141,15 +1141,15 @@
     },
     {
       "id": "ai-tag-gate-skip-rate",
-      "claim": "The normalize-gate SKIP rate over the box's [AI:*] tag stream is in the 50s percent (56% measured 2026-08-04: 8,667 GATE vs 6,784 NORM). The `-h` on grep is load-bearing — without it `grep -o` over a multi-file glob prefixes each match with its filename and a per-file count reads as the corpus, which is how a 74.9% figure once got documented here. Counting the bare tag body rather than the whole [AI:...] token keeps combined tags like [AI:GATE+SERV] counted once.",
+      "claim": "The normalize-gate SKIP rate over the box's [AI:*] tag stream is in the 50s-60s percent (60% measured 2026-08-05: 11,932 GATE vs 7,928 NORM over 122 files; it read 56% on 2026-08-04). This is a property of the accumulated LOG CORPUS, not of the system, and it drifts upward with eval activity - seven cold golden runs moved it 56 -> 60 with no code change, so the band is deliberately wide and a move inside it is not a signal. The `-h` on grep is load-bearing - without it `grep -o` over a multi-file glob prefixes each match with its filename and a per-file count reads as the corpus, which is how a 74.9% figure once got documented here. Counting the bare tag body rather than the whole [AI:...] token keeps combined tags like [AI:GATE+SERV] counted once.",
       "ownerDoc": "mobile:CLAUDE.md",
       "where": "box",
       "command": "cd /home/owner/Recipe-App/logs && g=$(grep -oh \"AI:GATE\" mapping-summary-*.txt | wc -l) && n=$(grep -oh \"AI:NORM\" mapping-summary-*.txt | wc -l) && echo $(( g * 100 / (g + n) ))",
       "expect": {
         "kind": "matches",
-        "value": "^5[0-9]$"
+        "value": "^[56][0-9]$"
       },
-      "verified": "2026-08-04"
+      "verified": "2026-08-05"
     },
     {
       "id": "serving-tier-null-share-small",


### PR DESCRIPTION
`ai-tag-gate-skip-rate` went red today: expected `^5[0-9]$`, measured `60`.

**No code caused it.** The claim counts `[AI:GATE]` vs `[AI:NORM]` across every
`mapping-summary-*.txt` on the box, and that corpus grows with every eval run. Seven cold
golden runs on 2026-08-05 (deploy verification for #250 and #252) moved it 56 → 60.

So the claim was pinning a number that legitimately drifts. Fixed both halves together, as the
doc rules require:

- **Owner doc** (`CLAUDE.md` §Deploying, mobile repo, pushed separately): figures refreshed to
  `[AI:CACHE]` 42,023 · `[AI:GATE]` 11,411 (+521 `GATE+SERV`) · `[AI:NORM]` 7,844 over 122
  files = 60%, dated, **plus a new sentence that this is a property of the accumulated log
  corpus rather than of the system**, so a move between two dates is not read as a pipeline change.
- **Registry**: band widened to `^[56][0-9]$`, claim text states why it is wide, re-dated.

Widening a band is normally the wrong fix, so the reasoning is stated explicitly rather than
left implicit: the underlying quantity is not stable by construction, and the useful assertion
is "the gate skips a large minority of lines", not a specific percent.

doc-check: 108/108.