### PR TITLE
fix(serving): admit the name-group median for bare PLURAL requests when the group is tight

### DIFF
--- a/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
+++ b/src/lib/mapping/__tests__/bare-serving-defaults.test.ts
@@ -562,12 +562,15 @@ describe('step (E) — name-group sibling median, raise-only', () => {
         expect(result?.grams).toBe(30);
     });
 
-    it('the bare-PLURAL gate still pre-empts a tight lowering (broccoli florets stays on the floor)', async () => {
-        // The uniform group above (n=130, all 85 g) is unreachable BY DESIGN:
-        // rung (E) requires !isBarePluralRequest. This pins that the tight-group
-        // relaxation did NOT quietly widen the plural gate — 13 of the 28
-        // residual rows are blocked here, and closing them is a separate change
-        // with its own gate.
+    it('a TIGHT bare-PLURAL group lowers, on its own tier (broccoli florets 100 → 85 g, n=130)', async () => {
+        // Real corpus group, measured 2026-08-05: n=130 in-band siblings named
+        // 'Broccoli florets', every one declaring 85 g (1 cup), ratio 1.00 — the
+        // most uniform group in the whole residual population.
+        //
+        // This test previously asserted the OPPOSITE, as a deliberate pin that
+        // #252's tight relaxation had not widened the plural gate. Widening it is
+        // this change, and the pin is inverted rather than deleted so the flip is
+        // visible in history.
         (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
             foodName: 'Broccoli florets',
             brandName: null,
@@ -581,8 +584,60 @@ describe('step (E) — name-group sibling median, raise-only', () => {
             makeCandidate('Broccoli florets'), bareParsed('broccoli florets'), 0.9, 'broccoli florets'
         );
 
+        // MUTATION TEST: restoring `&& !isBarePluralRequest(...)` to the (E)
+        // condition fails this with 'count_unresolved_floor' / 100. Stamping the
+        // singular '_tight' tier instead of '_plural' fails it too — the arms
+        // must stay separately countable.
+        expect(result?.servingTier).toBe('bare_name_sibling_serving_plural');
+        expect(result?.grams).toBe(85);
+    });
+
+    it('a DISPERSED bare-PLURAL group is still refused (roasted red peppers, ratio 4.33)', async () => {
+        // The other half of the plural population, and the reason the relaxation
+        // is tight-gated rather than a plain gate removal. Real corpus group,
+        // measured 2026-08-05: n=13, median 45 g, p25 30 / p75 130 — jarred
+        // whole peppers against sliced portions, exactly the MIXTURE shape.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Roasted red peppers',
+            brandName: null,
+            servingGrams: null,
+            nutrientsPer100g: { calories: 27, protein: 1.1, carbs: 5.4, fat: 0.2 },
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 45, n: 13, p25: 30, p75: 130 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Roasted red peppers'), bareParsed('roasted red peppers'), 0.9, 'roasted red peppers'
+        );
+
+        // MUTATION TEST: dropping the plural arm's `tightGroup` requirement — the
+        // naive "just delete the plural gate" change — fails this with
+        // 'bare_name_sibling_serving_plural' / 45.
         expect(result?.servingTier).toBe('count_unresolved_floor');
         expect(result?.grams).toBe(100);
+    });
+
+    it('a TIGHT bare-PLURAL group also RAISES (cod fillets 100 → 113 g, ratio 1.01)', async () => {
+        // The plural arm is direction-free: tightness alone admits. Real corpus
+        // group, measured 2026-08-05: n=22, median 113 g (4 oz), p25 112 / p75
+        // 113. Only 2 of the 7 tight plural repairs are raises, which is why
+        // DIRECTION was the wrong axis to gate this on — a raise-only plural rule
+        // would have repaired 2 and admitted 3 mixtures.
+        (hydrateOffCandidate as jest.Mock).mockResolvedValue(makeHydrated({
+            foodName: 'Cod fillets',
+            brandName: null,
+            servingGrams: null,
+            nutrientsPer100g: { calories: 82, protein: 17.8, carbs: 0, fat: 0.7 },
+        }));
+        setAllSiblingRows([]);
+        nameSiblingRows = [{ med: 113, n: 22, p25: 112, p75: 113 }];
+
+        const result = await buildOffResult(
+            makeCandidate('Cod fillets'), bareParsed('cod fillets'), 0.9, 'cod fillets'
+        );
+
+        expect(result?.servingTier).toBe('bare_name_sibling_serving_plural');
+        expect(result?.grams).toBe(113);
     });
 
     it('the SEPARATE tier is keyed on DIRECTION, not on tightness (a tight RAISE stays the original tier)', async () => {

--- a/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
+++ b/src/lib/mapping/__tests__/build-off-result-bare-guard.test.ts
@@ -208,11 +208,18 @@ describe('buildOffResult — bare-plural inversion (A3)', () => {
             foodName: 'Grapes',
             servingGrams: null,
         }));
-        // A RAISING name-group median is offered on purpose: the (E) rung
-        // (N1) carries `!isBarePluralRequest(...)` for parity with rung (C2),
-        // and dropping that clause bills 200g here instead of the floor. With
-        // an empty stub this pin would be green either way.
-        nameSiblingRows = [{ med: 200, n: 40 }];
+        // The REAL 'Grapes' name group, measured 2026-08-05: n=8 in-band
+        // siblings, median 142 g, p25 108.05 / p75 184.46 — ratio 1.71, a
+        // genuine mixture of bunch-scale and portion-scale packs. Rung (E)
+        // admits a bare plural only from a TIGHT group (<= 1.5), so this is
+        // refused for the reason the clamp names, not by luck.
+        //
+        // The previous fixture here was a synthetic `{ med: 200, n: 40 }` with
+        // NO percentiles, which declines through the degenerate-sentinel path
+        // (p25=0 / p75=Infinity) instead — i.e. it would have stayed green
+        // whatever the plural rule did. Real values are what make it a pin.
+        // A plain gate removal bills 142 g here.
+        nameSiblingRows = [{ med: 142, n: 8, p25: 108.05, p75: 184.46 }];
 
         const result = await buildOffResult(
             makeCandidate('Grapes'), bareParsed('grapes'), 0.9, 'grapes'

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -6044,6 +6044,38 @@ export async function buildOffResult(
     // repeat the serving-cascade-divergence mistake this rung's own borrow
     // function documents.
     //
+    // A BARE PLURAL takes the tight test in BOTH directions, and that is the
+    // whole of its admission rule. `isBarePluralRequest` exists to suppress
+    // PER-PIECE resolution — label count, seed table, discrete-unit backfill,
+    // the grapes-5g / m&ms-0.9g class — and its own contract says such a
+    // request "must fall through to serving-scale tiers". This rung IS a
+    // serving-scale tier: it borrows the median DECLARED SERVING of same-named
+    // records. Applying a per-piece suppressor to it was over-broad.
+    //
+    // Tightness, not direction, is what makes a plural median safe, and that
+    // was measured rather than argued (2026-08-05, over the 13 plural-blocked
+    // rows of #18's residual): 7 are tight and every one of them is a
+    // conventional serving — `Wide egg noodles` 56 g (2 oz dry, ratio 1.00),
+    // `Broccoli florets` 85 g (1 cup, 1.00), `Cod fillets` 113 g (4 oz, 1.01),
+    // `Chicken tenderloins` 112 g (1.01). The 6 dispersed ones are exactly the
+    // mixtures the clamp was built for (`roasted red peppers` 4.33, `frozen
+    // mozzarella sticks` 4.33). DIRECTION does not separate them — only 2 of
+    // the 7 repairs are RAISES — so a direction rule admits mixtures and
+    // rejects real servings in both directions at once.
+    //
+    // This is also what keeps the `grapes` pin green, and on the real corpus
+    // rather than by accident: `Grapes` measures n=8, median 142 g, ratio 1.71
+    // — genuinely a mixture of bunches and portions, so it is rejected for the
+    // reason the clamp names. A bare relaxation bills it 142 g. Highest
+    // admitted ratio is 1.29 and lowest rejected 1.69, so 1.5 sits in open
+    // space here (it binds at 1.49 for the singular arm — a tighter margin).
+    //
+    // The plural arm stamps its own tier so the new population is countable
+    // and revertible on its own. It needs no direction suffix: this rung only
+    // runs on `count_unresolved_floor` + `bareRequest`, where `grams` is always
+    // the flat 100 literal, so the tier's own grams read the direction (>100
+    // raise, <100 lower) — which is how the singular pair reads live today.
+    //
     // The tier gate structurally implies five of rung (C2)'s own clauses, which
     // are therefore NOT restated here: grams == null (by construction of the
     // branch that stamped the tier), bareLabelGrams == null (345 of 345 zone
@@ -6059,22 +6091,32 @@ export async function buildOffResult(
         // Leaves 64 branded digitless floor events to rung (C2), which already
         // ran against their real brand and returned n < 3.
         && hydrated.brandName == null
-        // Parity with rung (C2); keeps the `grapes` pin green. Costs ~64 RAISE
-        // events and is cheaply reversible. Recomputed rather than hoisted:
-        // barePluralRequest/itemNameForCount are block-scoped inside the
-        // unitless-count branch, and hoisting them changes rung-(C2) ordering.
-        && !isBarePluralRequest(parsed, rawLine, parsed?.name || hydrated.foodName)
     ) {
+        // Recomputed rather than hoisted: barePluralRequest/itemNameForCount are
+        // block-scoped inside the unitless-count branch, and hoisting them
+        // changes rung-(C2) ordering. Computed inside the block, not in the
+        // condition, because it is no longer a gate — only a policy selector.
+        const barePlural = isBarePluralRequest(
+            parsed, rawLine, parsed?.name || hydrated.foodName
+        );
         const nameSib = await borrowNameSiblingLabelServing(
             hydrated.foodName, candidate.id.replace(/^off_/, '')
         );
-        const lowersIntoTightGroup = nameSib != null
-            && nameSib.grams < grams
-            && isTightNameGroup(nameSib.p25, nameSib.p75);
-        if (nameSib != null && (nameSib.grams > grams || lowersIntoTightGroup)) {
-            const tier = lowersIntoTightGroup
-                ? 'bare_name_sibling_serving_tight'
-                : 'bare_name_sibling_serving';
+        const tightGroup = nameSib != null && isTightNameGroup(nameSib.p25, nameSib.p75);
+        // SINGULAR: raise unconditionally, lower only into a tight group (#252).
+        // PLURAL:   tight group only, either direction.
+        // `grams !== grams` is impossible to reach for the singular arm (both of
+        // its disjuncts already imply a move) and is stated once here so the
+        // plural arm cannot stamp a tier on a median that equals the floor.
+        const admitted = nameSib != null
+            && nameSib.grams !== grams
+            && (barePlural ? tightGroup : (nameSib.grams > grams || tightGroup));
+        if (nameSib != null && admitted) {
+            const tier = barePlural
+                ? 'bare_name_sibling_serving_plural'
+                : nameSib.grams < grams
+                    ? 'bare_name_sibling_serving_tight'
+                    : 'bare_name_sibling_serving';
             grams = nameSib.grams;
             servingDescription = `1 serving (~${nameSib.grams.toFixed(0)}g, name median)`;
             servingTier = tier;

--- a/src/lib/servings/bare-query-guard.ts
+++ b/src/lib/servings/bare-query-guard.ts
@@ -16,20 +16,29 @@
  * This module owns the eligibility predicate, the label-usability band, and
  * the post-cascade override (CAP / REPLACE / floor). Pure functions, no I/O.
  *
- * 'bare_name_sibling_serving' (N1, Aug 2026) and its downward twin
- * 'bare_name_sibling_serving_tight' are DELIBERATELY absent from every tier set
+ * 'bare_name_sibling_serving' (N1, Aug 2026), its downward twin
+ * 'bare_name_sibling_serving_tight' and the bare-plural arm
+ * 'bare_name_sibling_serving_plural' are DELIBERATELY absent from every tier set
  * below, and that is not an omission to fix. That rung runs AFTER this guard —
  * it is gated on the guard having already declined (tier still
  * 'count_unresolved_floor') — so any membership here would be dead code. Adding
- * either would also re-create the pre-emption bug the rung was placed low to
- * avoid: see the (E) rung comment in buildOffResult
+ * any of them would also re-create the pre-emption bug the rung was placed low
+ * to avoid: see the (E) rung comment in buildOffResult
  * (map-ingredient-with-fallback.ts).
  *
- * The two are ONE rung stamping TWO tiers, split by the DIRECTION the median
- * moved the bill — up off the floor, or down into a measured-tight name group.
- * They are not a hit/miss pair and neither implies anything about caching; the
- * `_cached`-sibling naming convention that misled a previous instrument does
- * not apply here.
+ * The three are ONE rung stamping THREE tiers. The first two split by the
+ * DIRECTION the median moved the bill — up off the floor, or down into a
+ * measured-tight name group. The third splits on the REQUEST SHAPE instead: a
+ * bare plural takes the tight test in both directions, so it needs no direction
+ * suffix (the rung only runs where grams is the flat 100 literal, so its own
+ * grams read the direction). They are not a hit/miss family and none implies
+ * anything about caching; the `_cached`-sibling naming convention that misled a
+ * previous instrument does not apply here.
+ *
+ * Note the plural arm is a DELIBERATE narrowing of isBarePluralRequest's reach,
+ * not a bypass. That predicate suppresses PER-PIECE resolution (see its own
+ * docstring); the name-median rung is serving-scale, which is precisely what it
+ * says such requests should fall through to.
  */
 
 import type { ParsedIngredient } from '../parse/ingredient-line';


### PR DESCRIPTION
Rung (E) of `buildOffResult()` carried `!isBarePluralRequest(...)`, blocking the name-group sibling median for every bare plural. That predicate exists to suppress **per-piece** resolution (label count, seed table, discrete-unit backfill — the grapes-5g / m&ms-0.9g class) and its own docstring says such a request "must fall through to serving-scale tiers". Rung (E) **is** a serving-scale tier: it borrows the median *declared serving* of same-named records. Applying a per-piece suppressor to it was over-broad.

A bare plural now takes the same tight-group test #252 added (`p75/p25 <= 1.5`), in **both** directions, and stamps its own tier so the new population is countable and revertible alone.

## Why tightness, not direction

Measured over the 13 plural-blocked rows of #18's residual (2026-08-05). Seven are tight and every one is a conventional serving; the six dispersed ones are the mixtures the clamp was built for.

| | ratio | med | dir |
|---|---|---|---|
| extra wide egg noodles | 1.00 | 56 g (2 oz dry) | down |
| broccoli florets | 1.00 | 85 g (1 cup) | down |
| chicken tenderloins | 1.01 | 112 g (4 oz) | up |
| cod fillets | 1.01 | 113 g (4 oz) | up |
| dates | 1.22 | 40 g | down |
| frozen fish sticks | 1.25 | 91 g | down |
| butternut squash cubes | 1.29 | 85 g | down |
| *rejected:* spaghetti and meatballs / cinnamon buns / beef fajitas / falafels / frozen mozzarella sticks / roasted red peppers | 1.69–4.33 | | |

**Only 2 of the 7 repairs are raises**, so a raise-only plural rule would have repaired 2 and admitted 3 mixtures. Highest admitted ratio 1.29, lowest rejected 1.69 — 1.5 sits in open space (it binds at 1.49 for the singular arm).

## The `grapes` pin holds on real data

`Grapes` measures n=8, median 142 g, ratio **1.71** — genuinely a mixture of bunch- and portion-scale packs, so it is refused for the reason the clamp names. Its fixture previously carried a synthetic `{med: 200, n: 40}` with **no percentiles**, so it declined via the degenerate-sentinel path and would have stayed green whatever the plural rule did. It now carries measured values and **dies under the naive gate removal** (mutation-verified).

## Gate — frozen-pool replay, `--variant gate-backstop`, `--with-serving`, 1,136 rows

| arms | moved | winner changes | tiers |
|---|---|---|---|
| master → master+plural | **24 (2.1%)** | **0** | all `count_unresolved_floor` → `bare_name_sibling_serving_plural` |
| master+#18 → master+#18+plural | **28 (2.5%)** | **0** | same |

All 24/28 hand-adjudicated favourable or neutral (`nuts` 28 g, `kidney beans` 130 g, `raisins` 39.5 g, `stuffed peppers` 159 g). The least obvious was checked against the corpus: `au gratin potatoes` 28 g is the **dry boxed mix** ("0.5 cup (28 g)"), not a plated portion.

On #18's own residual: **7 of 13 repaired — exactly the 7 predicted from the tightness table before the gate ran.** CLOSER 6 / further 1 (`cod fillets` 100 → 113 g, moving off a pre-#18 anchor of 80 g toward a conventional 4 oz). **#18's residual goes 15 → 8, and all 8 remaining are dispersed groups** — a residual bounded by measured policy, not by an accidental gate.

## Mutation-verified

Each killed exactly the named tests: restoring the old plural gate → the two tight-plural tests; dropping the plural arm's tightness requirement → the dispersed test **and the `grapes` pin**; stamping `_tight` instead of `_plural` → the two tier tests.

Local gates: 164 suites / 3,373 tests, `tsc --noEmit` 0, `lint:ci` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu