### PR TITLE
Phase 1 stage 1c: cascade-producer characterization suite + recovery-path audit instrument

### DIFF
--- a/src/lib/mapping/__tests__/producer-backfill-after-winner.test.ts
+++ b/src/lib/mapping/__tests__/producer-backfill-after-winner.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Phase 1 stage 1c — CHARACTERIZATION, cluster 1: winner-then-backfill
+ * (census V1, the SECOND requestAiNutrition site).
+ *
+ * Pins the dual-producer path a naive 1d "four mutually-exclusive producers"
+ * orchestrator would delete:
+ *
+ *   Step 1c produces a WINNER (selectionReason 'normalized_cache_hit') whose
+ *   every hydration attempt fails; `filtered` stays [] on the cache path, so
+ *   the Step-5b guard (`!result && filtered.length === 0 &&
+ *   selectionReason === 'normalized_cache_hit'`) matches and re-runs the FULL
+ *   search machinery; when that re-search finds nothing, the `if (!result)`
+ *   tail fires the second `requestAiNutrition` site — AFTER a winner existed —
+ *   and on success `return aiMapped` exits DIRECTLY, bypassing
+ *   `finalizeAndSaveResult()`: no save, no sanity caps, and the telemetry
+ *   funnel facts stamped by the cache hit are never revised.
+ *
+ * These are characterization tests: they assert what the code DOES today.
+ * A failure here after stage 1d is a behavior change, not a test bug.
+ *
+ * Mock seams are the house set (see map-ingredient-with-fallback.test.ts /
+ * legacy-key-fallback.test.ts) plus the stage-1a seam: the mapper imports
+ * hydrateAndSelectServing from './serving/hydration-lane', so mocking that
+ * module intercepts ALL of the mapper's hydration call sites at once.
+ */
+
+import { mapIngredientWithFallback, type MappingTelemetry } from '../map-ingredient-with-fallback';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import {
+    getValidatedMapping,
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates } from '../gather-candidates';
+import { hydrateAndSelectServing } from '../serving/hydration-lane';
+import { simpleRerank } from '../simple-rerank';
+import { aiSimplifyIngredient } from '../ai-simplify';
+import { requestAiNutrition, getAiServingGrams } from '../ai-nutrition-backfill';
+import { AI_NUTRITION_BACKFILL_ENABLED } from '../config';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        fatSecretFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        ingredient: { findMany: jest.fn().mockResolvedValue([]) },
+        // Every serving-store model ambiguous-unit-backfill touches must be
+        // present — omission fails deep in the cascade mimicking a production
+        // bug (the canonical suite's own header warning).
+        aiGeneratedServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        fdcServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        offServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        userPortionOverride: { findUnique: jest.fn().mockResolvedValue(null) },
+    },
+}));
+
+jest.mock('../ai-normalize');
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: jest.fn() };
+});
+// Stage-1a seam: one mock intercepts every mapper hydration call site.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: jest.fn() };
+});
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: jest.fn() };
+});
+jest.mock('../ai-simplify');
+// The Mac .env sets ENABLE_MAPPING_ANALYSIS=true; unmocked, every run writes a
+// logs/mapping-analysis-*.json session file from inside jest. Bare automock —
+// the analysis branches still execute, every sink becomes a jest.fn().
+jest.mock('../mapping-logger');
+// The gather-candidates requireActual pulls in the semantic-search stack;
+// unstubbed, a run can load the real ONNX embedder. Same stub as the sibling
+// suites.
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+// LLM chokepoint: no test in this file may dial out (CI has no key; a dev
+// machine does).
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
+// AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — this mock is mandatory or the
+// backfill tail hits the jest LLM blackhole as a confusing ECONNREFUSED.
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: jest.fn().mockResolvedValue({ status: 'error', reason: 'skip' }),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: jest.fn().mockResolvedValue(null),
+    createAiNutritionBudget: (max: number) => ({ remaining: max, spent: 0 }),
+}));
+
+/** The Step-1c cache row. fdc_ prefix on purpose: the Step-1c validation arms
+ * for fdc_ have no missing-nutrition safety net (deliberate, documented in the
+ * mapper), so a null prisma.fdcFood.findUnique leaves the row servable and the
+ * winner assignment fires. The numeric part is deliberately synthetic —
+ * 168917 would collide with the real FDC 168917 "Quinoa, cooked" documented
+ * elsewhere. */
+const CACHE_ROW = {
+    foodId: 'fdc_999999901',
+    foodName: 'table salt',
+    brandName: null,
+    source: 'fdc',
+    confidence: 0.9,
+    validatedBy: 'ai',
+};
+
+/** Success shape copied from AiNutritionResult (ai-nutrition-backfill.ts). */
+const AI_SUCCESS = {
+    status: 'success' as const,
+    foodId: 'ai-table-salt',
+    displayName: 'Table Salt',
+    caloriesPer100g: 200,
+    proteinPer100g: 10,
+    carbsPer100g: 20,
+    fatPer100g: 5,
+    fiberPer100g: 0,
+    sugarPer100g: 0,
+    sodiumMgPer100g: 38000,
+    saturatedFatPer100g: 0,
+    cholesterolMgPer100g: 0,
+    confidence: 0.85,
+    notes: '',
+    model: 'openai/gpt-4o-mini',
+    cached: false,
+};
+
+const LINE = '1 serving table salt';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMapping as jest.Mock).mockResolvedValue(null);
+    // The row is returned for EVERY lookup key. Current behavior with that
+    // setup: the EARLY cache check also hits, its hydration fails and falls
+    // through (labelled 'early:hydration_failed', deliberately NOT a
+    // readEscapes forfeit), and Step 1c then hits again and assigns `winner`.
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(CACHE_ROW);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    // Every hydration attempt fails — this is the cluster's driving condition.
+    (hydrateAndSelectServing as jest.Mock).mockResolvedValue(null);
+    // Quick-gate gather AND the Step-5b re-search both find nothing.
+    (gatherCandidates as jest.Mock).mockResolvedValue([]);
+});
+
+describe('cluster 1 — cache winner, hydration failure, AI-nutrition backfill (site 2)', () => {
+    it('serves the AI-generated result via direct return, exactly as built at the aiMapped site', async () => {
+        // Loud precondition: the whole cluster rides on the config default.
+        // A silent env flip (AI_NUTRITION_BACKFILL_ENABLED=false) would
+        // otherwise fail these tests confusingly deep in the pipeline.
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+        (requestAiNutrition as jest.Mock).mockResolvedValue(AI_SUCCESS);
+        (getAiServingGrams as jest.Mock).mockResolvedValue(null);
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback(LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+            telemetry,
+        });
+
+        // (a) The returned result is the AI-generated one, field-for-field as
+        // the second backfill site constructs it (getAiServingGrams null ⇒
+        // 100 g flat default, scale 1).
+        expect(result).toEqual({
+            source: 'ai_generated',
+            foodId: 'ai-table-salt',
+            foodName: 'Table Salt',
+            brandName: null,
+            servingId: null,
+            servingDescription: '1 serving',   // `${parsedQty} ${parsedUnit}`
+            grams: 100,
+            kcal: 200,
+            protein: 10,
+            carbs: 20,
+            fat: 5,
+            confidence: 0.85 * 0.8,            // aiResult.confidence * 0.8
+            quality: 'medium',                 // aiResult.confidence >= 0.7
+            rawLine: LINE,
+            servingTier: 'flat_100g_default',  // servingResult?.grams == null
+        });
+
+        // (b) The direct return bypasses finalizeAndSaveResult: no save, ever.
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        // Direct finalize-bypass witness: getKnownSynonyms's ONLY mapper call
+        // site is inside finalizeAndSaveResult, so "never called" proves the
+        // whole post-selection block was skipped — not merely the save.
+        expect(getKnownSynonyms).not.toHaveBeenCalled();
+
+        // (c) requestAiNutrition fired even though a WINNER existed. The winner's
+        // existence is witnessed by the hydration attempts on the cache row:
+        // one at the early-cache hit (falls through on failure) and one at
+        // Step 5 on the Step-1c winner. Site 1 (the `if (!winner)` copy) is
+        // unreachable with a winner present, so this call is site 2.
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect((requestAiNutrition as jest.Mock).mock.calls[0][0]).toContain('salt');
+        expect(hydrateAndSelectServing).toHaveBeenCalledTimes(2);
+        for (const call of (hydrateAndSelectServing as jest.Mock).mock.calls) {
+            expect(call[0].id).toBe('fdc_999999901');
+        }
+
+        // Step 5b DID re-run the full search machinery before the backfill:
+        // gather call #1 is the normalize-gate quick pass (skipOff: true),
+        // call #2 is the 5b re-search (no skipOff).
+        expect(gatherCandidates).toHaveBeenCalledTimes(2);
+        expect((gatherCandidates as jest.Mock).mock.calls[0][3].skipOff).toBe(true);
+        expect((gatherCandidates as jest.Mock).mock.calls[1][3].skipOff).toBeUndefined();
+        // ...and an empty re-search never reaches the reranker.
+        expect(simpleRerank).not.toHaveBeenCalled();
+
+        // Negative independence: a present winner keeps Step 2b closed.
+        expect(aiSimplifyIngredient).not.toHaveBeenCalled();
+
+        // The direct return never revises the telemetry stamped by the cache
+        // hit: the line reads as a normalized cache hit in the funnel even
+        // though the AI backfill actually served it (current behavior).
+        expect(telemetry.cacheHit).toBe('normalized');
+        expect(telemetry.funnelStage).toBe('cache_hit');
+        expect(telemetry.cacheEscape).toBe('early:hydration_failed');
+    });
+
+    it('scales by the AI serving grams and stamps ai_generated_serving when getAiServingGrams resolves', async () => {
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+        (requestAiNutrition as jest.Mock).mockResolvedValue(AI_SUCCESS);
+        (getAiServingGrams as jest.Mock).mockResolvedValue({ grams: 30, servingLabel: '1 scoop' });
+
+        const result = await mapIngredientWithFallback(LINE, { minConfidence: 0, skipFdc: true });
+
+        expect(getAiServingGrams).toHaveBeenCalledWith('ai-table-salt', 'serving', 1);
+        expect(result).toMatchObject({
+            source: 'ai_generated',
+            foodId: 'ai-table-salt',
+            servingDescription: '1 scoop',     // servingResult.servingLabel wins
+            grams: 30,
+            kcal: 60,                          // 200 * (30/100)
+            protein: 3,
+            carbs: 6,
+            fat: 1.5,
+            servingTier: 'ai_generated_serving',
+        });
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+
+    it('serves an absurd AI serving grams UNCAPPED — the direct return has no sanity caps', async () => {
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+        (requestAiNutrition as jest.Mock).mockResolvedValue(AI_SUCCESS);
+        // 50000 g exceeds BOTH finalize caps (MAX_REASONABLE_GRAMS = 10000;
+        // the scaled kcal, 200 * 500 = 100000, exceeds MAX_REASONABLE_KCAL =
+        // 50000). Those caps live inside finalizeAndSaveResult, which this
+        // exit bypasses — so the result is served as-is (current behavior).
+        (getAiServingGrams as jest.Mock).mockResolvedValue({ grams: 50000, servingLabel: '1 vat' });
+
+        const result = await mapIngredientWithFallback(LINE, { minConfidence: 0, skipFdc: true });
+
+        expect(result).not.toBeNull();
+        expect(result).toMatchObject({
+            source: 'ai_generated',
+            foodId: 'ai-table-salt',
+            grams: 50000,
+            kcal: 100000,                      // 200 * (50000/100) — no cap
+            protein: 5000,
+            servingTier: 'ai_generated_serving',
+        });
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        expect(getKnownSynonyms).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the backfill fails — the post-hydration-failure null return', async () => {
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+        (requestAiNutrition as jest.Mock).mockResolvedValue({
+            // Real failure shape/reason from requestAiNutrition itself.
+            status: 'error',
+            reason: 'nutrition_budget_exhausted',
+        });
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback(LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+            telemetry,
+        });
+
+        expect(result).toBeNull();
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(getAiServingGrams).not.toHaveBeenCalled();
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        // Same telemetry shape as the success arm: the null return does not
+        // revise the cache-hit funnel facts either (current behavior).
+        expect(telemetry.cacheHit).toBe('normalized');
+        expect(telemetry.funnelStage).toBe('cache_hit');
+    });
+});

--- a/src/lib/mapping/__tests__/producer-billed-vs-winner.test.ts
+++ b/src/lib/mapping/__tests__/producer-billed-vs-winner.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Phase 1 stage 1c — CLUSTER 4: billed foodId ≠ winner.id via the
+ * serving-failure fallback loop (`fallback_after_serving_failure`).
+ *
+ * CHARACTERIZATION ONLY. These tests pin what the mapper cascade in
+ * `map-ingredient-with-fallback.ts` does TODAY, so the stage-1d extraction can
+ * be proven behavior-preserving. A failure here after 1d means 1d changed
+ * behavior; a failure here before 1d is a transcription error in this file.
+ *
+ * The path under pin (post-selection result-swapper #1, the census's V4):
+ *   Step 2–4 search selects `winner` (candidate A) via simpleRerank;
+ *   Step 5 `hydrateAndSelectServing(winner, …)` fails;
+ *   the fallback loop walks `filtered` (NOT the rerank order), skipping the
+ *   winner, capped at 3 candidates, and rebinds `result` — while `winner`
+ *   stays stale. `finalizeAndSaveResult()` reads `result`, so the SAVE and the
+ *   RETURN both carry the fallback candidate's identity, not the winner's.
+ *   This is the sharpest pin against a 1d Selection-object design keyed on
+ *   `winner`.
+ *
+ * Three different "confidence" values coexist on this path, and the pins keep
+ * them apart:
+ *   - the loop hydrates fallbacks at `confidence * 0.95` (argument only —
+ *     never written back to `confidence`);
+ *   - `finalizeAndSaveResult()`/`saveValidatedMapping()` receive the OUTER
+ *     `confidence` (the rerank winner's, unmultiplied);
+ *   - the RETURNED object is the hydration lane's result verbatim, so the
+ *     caller-visible `confidence` field is whatever the lane wrote into it.
+ *
+ * Mock seams are the house set (see abstention-confidence.test.ts /
+ * map-ingredient-with-fallback.test.ts) plus the stage-1a seam:
+ * `../serving/hydration-lane` intercepts all mapper hydration call sites.
+ */
+
+const mockGatherCandidates = jest.fn();
+const mockConfidenceGate = jest.fn();
+const mockSimpleRerank = jest.fn();
+const mockHydrate = jest.fn();
+const mockSaveValidatedMapping = jest.fn();
+const mockRequestAiNutrition = jest.fn();
+const mockGetAiServingGrams = jest.fn();
+
+// Generic prisma stub: every model answers "nothing found" for any verb.
+// A Proxy rather than a hand-enumerated model list — omitting a serving-store
+// model (aiGeneratedServing/fdcServing/offServing/userPortionOverride) fails
+// deep in the cascade mimicking a production bug (warned in the canonical
+// map-ingredient-with-fallback.test.ts header).
+jest.mock('../../db', () => {
+    const emptyFor = (verb: string) =>
+        jest.fn().mockResolvedValue(verb.startsWith('findMany') ? [] : null);
+    const model = new Proxy({}, { get: (_t, verb: string) => emptyFor(verb) });
+    return { prisma: new Proxy({}, { get: () => model }) };
+});
+
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return {
+        ...actual,
+        gatherCandidates: (...a: unknown[]) => mockGatherCandidates(...a),
+        // Forced non-skip so `gateSelection` is undefined and the winner +
+        // confidence come solely from the mocked simpleRerank (the real gate
+        // would exit `high_confidence_clear_winner` on an exact-name pool and
+        // lift the confidence via the agreement branch).
+        confidenceGate: (...a: unknown[]) => mockConfidenceGate(...a),
+    };
+});
+
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: (...a: unknown[]) => mockSimpleRerank(...a) };
+});
+
+// Stage-1a seam: the mapper imports hydrateAndSelectServing from the lane, so
+// this single mock intercepts the winner hydration AND every fallback retry.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: (...a: unknown[]) => mockHydrate(...a) };
+});
+
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return { ...actual, saveValidatedMapping: (...a: unknown[]) => mockSaveValidatedMapping(...a) };
+});
+
+// AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — unmocked, an exhausted
+// fallback loop dials the jest LLM blackhole (ECONNREFUSED).
+jest.mock('../ai-nutrition-backfill', () => {
+    const actual = jest.requireActual('../ai-nutrition-backfill');
+    return {
+        ...actual,
+        requestAiNutrition: (...a: unknown[]) => mockRequestAiNutrition(...a),
+        getAiServingGrams: (...a: unknown[]) => mockGetAiServingGrams(...a),
+    };
+});
+
+// The mapper's analysis branches execute only when ENABLE_MAPPING_ANALYSIS is
+// set (read from process.env at module load). The Mac .env sets it =true, and
+// unmocked that writes a logs/mapping-analysis-*.json session file from inside
+// jest — so only the sink is stubbed; the branches run whenever the env says so.
+jest.mock('../mapping-logger', () => ({
+    ...jest.requireActual('../mapping-logger'),
+    logMappingAnalysis: jest.fn(),
+}));
+
+// Parity with the simplify suite: without this, the mapper's fire-and-forget
+// deferred hydration (queueForDeferredHydration / proactiveProduceBackfill)
+// runs for real against the Proxy prisma — an unawaited promise doing
+// DB-shaped work after the test resolves. Bare automock suffices.
+jest.mock('../deferred-hydration');
+
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
+import {
+    mapIngredientWithFallback,
+    type FatsecretMappedIngredient,
+} from '../map-ingredient-with-fallback';
+import type { UnifiedCandidate } from '../gather-candidates';
+import type { MappingTelemetry } from '../map-ingredient-with-fallback';
+import { AI_NUTRITION_BACKFILL_ENABLED } from '../config';
+
+/** FDC candidate with an inline panel; hydration itself is mocked. */
+const cand = (id: string, name: string, score: number): UnifiedCandidate => ({
+    id,
+    source: 'fdc',
+    name,
+    brandName: null,
+    score,
+    nutrition: { kcal: 379, protein: 13, carbs: 68, fat: 6.5, per100g: true },
+    servings: [{ description: '100 g', grams: 100, isDefault: true }],
+    rawData: {
+        fdcId: Number(id.replace('fdc_', '')),
+        description: name,
+        dataType: 'SR Legacy',
+        nutrientsPer100g: { calories: 379, protein: 13, carbs: 68, fat: 6.5 },
+        servings: [],
+    },
+});
+
+// All names carry both must-have tokens ('rolled', 'oats') so the REAL
+// filterCandidatesByTokens keeps every one, and the core token 'oats' so the
+// loop's hasCoreTokenMismatch guard passes them (characterized separately
+// below is only what the loop DOES, not the guards' internals).
+const A = () => cand('fdc_1111111', 'Rolled Oats', 5.9);
+const B = () => cand('fdc_2222222', 'Rolled Oats Organic', 4.5);
+const C = () => cand('fdc_3333333', 'Rolled Oats Old Fashioned', 4.0);
+// NOT 'Instant'/'Quick …' — filter-candidates.ts carries a rolled-oats rule
+// (`excludeIfContains: ['quick', 'instant', …]`) that would drop those from
+// `filtered` before the loop ever saw them (found by running this suite).
+const D = () => cand('fdc_4444444', 'Rolled Oats Traditional', 3.5);
+const E = () => cand('fdc_5555555', 'Rolled Oats Large Flake', 3.0);
+
+const LINE = '100 g rolled oats';
+const RERANK_CONFIDENCE = 0.9; // above the 0.85 save gate, below the 0.98 cap
+
+/** The lane result the successful fallback hydration returns. The confidence
+ *  field is a SENTINEL: nothing in the caller may rewrite it. */
+const laneResult = (c: UnifiedCandidate): FatsecretMappedIngredient => ({
+    source: 'fdc',
+    foodId: c.id,
+    foodName: c.name,
+    brandName: null,
+    servingId: null,
+    servingDescription: '100 g',
+    grams: 100,
+    kcal: 379,
+    protein: 13,
+    carbs: 68,
+    fat: 6.5,
+    confidence: 0.4242, // sentinel — see pins on the returned matchConfidence
+    quality: 'medium',
+    rawLine: LINE,
+    servingTier: 'weight_unit', // real tier string (serving-ai-tiers.ts era)
+});
+
+function armSearch(pool: UnifiedCandidate[], winnerId: string) {
+    mockGatherCandidates.mockResolvedValue(pool);
+    mockConfidenceGate.mockReturnValue({
+        // Real non-skip shape (gather-candidates.ts); reason string is a
+        // genuine ConfidenceGateResult reason. skipAiRerank:false makes
+        // gateSelection undefined, so no agreement lift and no backstop.
+        skipAiRerank: false,
+        confidence: 0,
+        reason: 'soft_cooked_grain_full_rerank',
+    });
+    mockSimpleRerank.mockReturnValue({
+        winner: { id: winnerId },
+        confidence: RERANK_CONFIDENCE,
+        reason: 'simple_rerank', // real winning reason string
+        sortedCandidates: [],
+    });
+}
+
+const hydratedIds = () => mockHydrate.mock.calls.map(call => (call[0] as UnifiedCandidate).id);
+
+async function run(telemetry?: MappingTelemetry) {
+    const r = await mapIngredientWithFallback(LINE, {
+        skipCache: true,       // gates the two cache READ layers only
+        skipSave: false,       // the save is an observable in these pins
+        allowLiveFallback: false,
+        telemetry,
+    });
+    return r as FatsecretMappedIngredient | null;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveValidatedMapping.mockResolvedValue(undefined);
+    mockRequestAiNutrition.mockResolvedValue({ status: 'error', reason: 'llm_call_failed' });
+    mockGetAiServingGrams.mockResolvedValue(null);
+});
+
+describe('V4: the serving-failure fallback loop rebills a candidate that never won', () => {
+    it('bills B while the rerank winner was A, and the save carries B (not winner)', async () => {
+        const a = A(); const b = B();
+        armSearch([a, b], a.id);
+        // A (the winner) fails hydration; B succeeds with the lane result.
+        const laneResultB = laneResult(b);
+        mockHydrate.mockImplementation(async (c: UnifiedCandidate) =>
+            c.id === b.id ? laneResultB : null);
+
+        const telemetry: MappingTelemetry = {};
+        const r = await run(telemetry);
+
+        // (a) billed identity is B's; the winner (first hydration attempt) was A.
+        expect(r).not.toBeNull();
+        expect(r!.foodId).toBe('fdc_2222222');
+        expect(hydratedIds()).toEqual(['fdc_1111111', 'fdc_2222222']);
+
+        // The returned object IS the lane's result, by reference — finalize
+        // never clones or rewrites it (sanity caps only reject, at 10 kg/50k kcal).
+        // If 1d deliberately introduces a copy, relax this reference pin to
+        // field equality (toEqual) — the identity content is the behavior;
+        // the shared reference is today's implementation detail.
+        expect(r).toBe(laneResultB);
+
+        // (b) selectionReason lands as 'fallback_after_serving_failure' — pinned
+        // where it is consumed: the approval record handed to saveValidatedMapping.
+        // (d) the save receives `result` (B), NOT `winner` (A): rawLine, B's
+        // mapped object, and the OUTER confidence unmultiplied.
+        expect(mockSaveValidatedMapping).toHaveBeenCalledTimes(1);
+        const [savedRawLine, savedResult, approval] = mockSaveValidatedMapping.mock.calls[0];
+        expect(savedRawLine).toBe(LINE);
+        expect((savedResult as FatsecretMappedIngredient).foodId).toBe('fdc_2222222');
+        expect(approval).toEqual({
+            approved: true,
+            confidence: RERANK_CONFIDENCE, // 0.9 — the winner's confidence, not * 0.95
+            reason: 'fallback_after_serving_failure',
+        });
+
+        // Optimistic funnel mark: finalize stamps 'saved' before the save call
+        // (the real save gate may downgrade it; that gate is mocked out here).
+        expect(telemetry.funnelStage).toBe('saved');
+
+        // The fallback served, so the last-resort nutrition backfill never ran.
+        expect(mockRequestAiNutrition).not.toHaveBeenCalled();
+        // Gather runs TWICE on every search-path line (the normalize-gate quick
+        // gather, then the main Step-2 gather; the second is seeded from the
+        // first when normalizedName is unchanged). A Step-5b re-search would be
+        // a THIRD call — and Step 5b is unreachable here anyway, being gated on
+        // filtered.length === 0 && selectionReason === 'normalized_cache_hit'.
+        expect(mockGatherCandidates).toHaveBeenCalledTimes(2);
+    });
+
+    it('(c) hydrates fallbacks at confidence * 0.95 without writing it back — three confidences stay distinct', async () => {
+        const a = A(); const b = B();
+        armSearch([a, b], a.id);
+        mockHydrate.mockImplementation(async (c: UnifiedCandidate) =>
+            c.id === b.id ? laneResult(b) : null);
+
+        const r = await run();
+
+        // Winner hydrated at the outer confidence; the fallback at * 0.95.
+        expect(mockHydrate.mock.calls[0][2]).toBe(RERANK_CONFIDENCE);
+        expect(mockHydrate.mock.calls[1][2]).toBeCloseTo(RERANK_CONFIDENCE * 0.95, 10);
+
+        // Both attempts spend the SAME hydration budget object (shared pool).
+        expect(mockHydrate.mock.calls[1][4]).toBe(mockHydrate.mock.calls[0][4]);
+
+        // The returned matchConfidence is the LANE RESULT's confidence field,
+        // verbatim (sentinel 0.4242) — neither the outer 0.9 nor 0.855. The
+        // 0.95 multiplier reaches the caller only if the lane writes it into
+        // its result; the mapper itself never sets result.confidence here.
+        expect(r!.confidence).toBe(0.4242);
+        expect(r!.confidence).not.toBe(RERANK_CONFIDENCE);
+        expect(r!.confidence).not.toBeCloseTo(RERANK_CONFIDENCE * 0.95, 10);
+
+        // …while the save simultaneously carried the outer 0.9 — the same flow
+        // holds two different confidences for the same billed record.
+        expect(mockSaveValidatedMapping.mock.calls[0][2].confidence).toBe(RERANK_CONFIDENCE);
+    });
+
+    it('walks fallbacks in FILTERED order (gather order minus the winner), not rerank/score order', async () => {
+        const a = A(); const b = B(); const c = C();
+        // Gather order deliberately DISAGREES with score-descending order:
+        // B(4.5) precedes A(5.9). Winner is C(4.0) — the LAST of the pool.
+        armSearch([b, a, c], c.id);
+        // C (winner) fails; B succeeds on the first fallback attempt.
+        mockHydrate.mockImplementation(async (cd: UnifiedCandidate) =>
+            cd.id === b.id ? laneResult(b) : null);
+
+        const r = await run();
+
+        // Loop order is filtered-with-winner-removed: [B, A] — winner first
+        // (Step 5), then B, which succeeds so A is never tried. A
+        // score-descending walk would have hydrated A (fdc_1111111, 5.9)
+        // BEFORE B (fdc_2222222, 4.5) — the two-element sequence refutes it.
+        expect(hydratedIds()).toEqual(['fdc_3333333', 'fdc_2222222']);
+        expect(r!.foodId).toBe('fdc_2222222');
+        expect(mockSaveValidatedMapping.mock.calls[0][2].reason)
+            .toBe('fallback_after_serving_failure');
+    });
+
+    it('caps the loop at 3 fallback candidates; when all fail, the site-2 backfill answers and nothing is saved', async () => {
+        // Precondition: the site-2 backfill path this test pins is gated on
+        // AI_NUTRITION_BACKFILL_ENABLED (getFlag default TRUE); an env
+        // override flipping it off would skip the path and fail confusingly.
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        const pool = [A(), B(), C(), D(), E()];
+        armSearch(pool, pool[0].id);
+        mockHydrate.mockResolvedValue(null); // every hydration fails
+
+        const r = await run();
+
+        // Winner + fallbacks slice(0, 3): A, then B, C, D. E is never tried.
+        expect(hydratedIds()).toEqual([
+            'fdc_1111111', 'fdc_2222222', 'fdc_3333333', 'fdc_4444444',
+        ]);
+
+        // Exhausted loop falls into the `if (!result)` backfill (census site 2,
+        // the near-duplicate under a winner-exists frame). Our stub declines,
+        // so the line returns null — with NO save attempted.
+        expect(mockRequestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(String(mockRequestAiNutrition.mock.calls[0][0])).toMatch(/oat/);
+        // The backfill spends the NUTRITION budget, a different pool from the
+        // hydration budget the loop spent.
+        expect(mockRequestAiNutrition.mock.calls[0][1].budget)
+            .not.toBe(mockHydrate.mock.calls[0][4]);
+        expect(mockGetAiServingGrams).not.toHaveBeenCalled(); // error status short-circuits
+        expect(r).toBeNull();
+        expect(mockSaveValidatedMapping).not.toHaveBeenCalled();
+    });
+
+    it('negative control: when the winner hydrates, the loop never runs and the save carries the rerank reason', async () => {
+        const a = A(); const b = B();
+        armSearch([a, b], a.id);
+        mockHydrate.mockImplementation(async (c: UnifiedCandidate) =>
+            c.id === a.id ? laneResult(a) : null);
+
+        const r = await run();
+
+        expect(hydratedIds()).toEqual(['fdc_1111111']); // one attempt, no loop
+        expect(r!.foodId).toBe('fdc_1111111');
+        expect(mockSaveValidatedMapping).toHaveBeenCalledTimes(1);
+        expect(mockSaveValidatedMapping.mock.calls[0][2]).toEqual({
+            approved: true,
+            confidence: RERANK_CONFIDENCE,
+            reason: 'simple_rerank', // untouched by the swapper
+        });
+    });
+});

--- a/src/lib/mapping/__tests__/producer-cache-failure-research.test.ts
+++ b/src/lib/mapping/__tests__/producer-cache-failure-research.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Phase 1 stage 1c — characterization, CLUSTER 2 (census V2):
+ * cache-winner → Step-5b search rebill.
+ *
+ * Pins CURRENT behavior of the flow where a normalized-cache hit sets `winner`
+ * (selectionReason 'normalized_cache_hit'), its hydration fails, and — because
+ * `filtered` is empty for a cache-served line — the Step 5b guard
+ * (`!result && filtered.length === 0 && selectionReason === 'normalized_cache_hit'`)
+ * re-runs the FULL search machinery and rebills a search-pool record.
+ *
+ * The pins that matter for the 1d extraction:
+ *   (a) the billed foodId is the SEARCH record, not the failed cache winner;
+ *   (b) selectionReason is overwritten to 'fallback_search_after_cache_failure'
+ *       and that string reaches saveValidatedMapping as `reason`;
+ *   (c) the save PROCEEDS — the overwrite is what defeats the
+ *       'normalized_cache_hit' resave-skip in finalizeAndSaveResult;
+ *   (d) confidence handling: the retry hydration is offered `confidence * 0.9`,
+ *       but the SAVE records the undiscounted cache-row confidence, and the
+ *       returned result carries whatever confidence hydration stamped on it
+ *       (pass-through, never reconciled with the saved value).
+ *
+ * These are characterization tests: they assert what the code DOES today.
+ * A failure here after 1d is a behavior change, which is 1d's abort condition.
+ */
+
+import type { UnifiedCandidate } from '../gather-candidates';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        fatSecretFood: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        ingredient: { findMany: jest.fn().mockResolvedValue([]) },
+        // Serving stores: every model the deep cascade touches must exist or an
+        // omission fails deep in the cascade mimicking a production bug (see the
+        // header warning in map-ingredient-with-fallback.test.ts). Kept even
+        // though hydrateAndSelectServing is mocked here — cheap insurance.
+        aiGeneratedServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        fdcServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        offServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        userPortionOverride: { findUnique: jest.fn().mockResolvedValue(null) },
+    },
+}));
+
+jest.mock('../ai-normalize');
+// Partial mock: db-backed cache reads/writes stubbed; pure predicates stay real.
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return { ...actual, getCachedFoodWithRelations: jest.fn() };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: jest.fn() };
+});
+// ENABLE_MAPPING_ANALYSIS is 'true' in this dev env's .env, which jest loads —
+// without this stub the mapper writes REAL mapping-analysis session files into
+// logs/ from a unit test.
+jest.mock('../mapping-logger');
+// gather-candidates is requireActual'd above, which imports the query-embedding
+// module at load; stub it so no real embedder ever initializes under jest
+// (same stub as producer-billed-vs-winner.test.ts).
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: jest.fn() };
+});
+// Stage-1a seam: the mapper imports hydrateAndSelectServing from the hydration
+// lane; mocking it here intercepts ALL mapper call sites, so hydration
+// success/failure is controlled per candidate id.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: jest.fn() };
+});
+// AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — without this mock the second
+// backfill site dials the jest LLM blackhole (ECONNREFUSED).
+jest.mock('../ai-nutrition-backfill', () => {
+    const actual = jest.requireActual('../ai-nutrition-backfill');
+    return { ...actual, requestAiNutrition: jest.fn(), getAiServingGrams: jest.fn() };
+});
+
+import {
+    mapIngredientWithFallback,
+    type FatsecretMappedIngredient,
+    type MappingTelemetry,
+} from '../map-ingredient-with-fallback';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import {
+    getValidatedMapping,
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates } from '../gather-candidates';
+import { simpleRerank } from '../simple-rerank';
+import { hydrateAndSelectServing } from '../serving/hydration-lane';
+import { requestAiNutrition, getAiServingGrams } from '../ai-nutrition-backfill';
+import { deriveMappingCacheKey } from '../cache-key';
+import { detectBrandInQuery } from '../brand-detector';
+import { AI_NUTRITION_BACKFILL_ENABLED } from '../config';
+
+const RAW_LINE = '1 tbsp light cream cheese';
+const CACHE_WINNER_ID = 'cc-1';
+
+/** The step-1c FoodMapping row that becomes `winner` (selectionReason 'normalized_cache_hit'). */
+const cacheRow = {
+    foodId: CACHE_WINNER_ID,
+    foodName: 'Light Cream Cheese',
+    brandName: null,
+    source: 'ai_generated',
+    confidence: 0.9,
+};
+
+const searchCandidate = (id: string): UnifiedCandidate => ({
+    id,
+    source: 'ai_generated',
+    name: 'Light Cream Cheese',
+    brandName: null,
+    score: 0.9,
+    foodType: 'Generic',
+    rawData: {},
+} as UnifiedCandidate);
+
+/** What the mocked hydration lane returns for the winning SEARCH candidate.
+ *  servingTier is a REAL tier string copied from the mapper (never invented). */
+const searchBill = (foodId: string): FatsecretMappedIngredient => ({
+    source: 'ai_generated',
+    foodId,
+    foodName: 'Light Cream Cheese',
+    brandName: null,
+    servingId: null,
+    servingDescription: '1 tbsp',
+    grams: 14,
+    kcal: 30,
+    protein: 1.1,
+    carbs: 0.8,
+    fat: 2.5,
+    // Distinctive on purpose: pins that the returned result's confidence is the
+    // hydration lane's stamp, passed through untouched (see pin (d)).
+    confidence: 0.7654,
+    quality: 'high',
+    rawLine: RAW_LINE,
+    servingTier: 'flat_100g_default',
+});
+
+function mockStep1cCacheHit() {
+    // Early (pre-AI-normalize) lookup misses once; the Step-1c lookup hits.
+    (getValidatedMappingByNormalizedName as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(cacheRow);
+}
+
+/** The brand input the mapper derives for a line (no options.brand passed) —
+ *  same helper as producer-normalized-name-frozen.test.ts. */
+const brandInputFor = (line: string) => {
+    const det = detectBrandInQuery(line);
+    return { isBranded: det.isBranded, matchedBrand: det.matchedBrand };
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMapping as jest.Mock).mockResolvedValue(null);
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (gatherCandidates as jest.Mock).mockResolvedValue([]);
+    // Step 5b only reads `sortedCandidates`; echo the pool in given order.
+    // confidence is DELIBERATELY distinctive (0.42 != cacheRow's 0.9): if the
+    // save or the retry-hydration offer ever derived from the 5b rerank's
+    // confidence instead of the cache row's, the 0.9 / 0.81 assertions below
+    // would read 0.42 / 0.378 — the two sources are no longer confounded.
+    (simpleRerank as jest.Mock).mockImplementation(
+        (_q: string, cands: Array<{ id: string }>) => ({
+            winner: cands[0] ?? null,
+            confidence: 0.42,
+            reason: 'stub_echo',
+            sortedCandidates: cands,
+        }),
+    );
+    (hydrateAndSelectServing as jest.Mock).mockResolvedValue(null);
+    // Real error-shape string copied from ai-nutrition-backfill.ts.
+    (requestAiNutrition as jest.Mock).mockResolvedValue({ status: 'error', reason: 'llm_call_failed' });
+    (getAiServingGrams as jest.Mock).mockResolvedValue(null);
+});
+
+describe('Step 5b: cache winner fails hydration → full search rebill (census V2)', () => {
+    it('bills the SEARCH record, overwrites selectionReason, and the save PROCEEDS past the resave-skip', async () => {
+        mockStep1cCacheHit();
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            searchCandidate('search-1'),
+            searchCandidate('search-2'),
+        ]);
+        // Hydration keyed on candidate id: the cache winner is unhydratable,
+        // the first search candidate serves.
+        (hydrateAndSelectServing as jest.Mock).mockImplementation(
+            async (candidate: { id: string }) =>
+                candidate.id === 'search-1' ? searchBill('search-1') : null,
+        );
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback(RAW_LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+            telemetry,
+        });
+
+        // (a) billed foodId is the search record, not the failed cache winner.
+        expect(result).not.toBeNull();
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('search-1');
+
+        // TWO gathers, not one: the mapper's pre-cascade QUICK gather (the
+        // normalize-gate feeder, a stale-value reader per the 1c census) always
+        // runs before Step 1c; the SECOND call is Step 5b's re-search. The
+        // cache hit still skipped Step 2 — a third gather would be Step 2.
+        expect(gatherCandidates).toHaveBeenCalledTimes(2);
+        expect((gatherCandidates as jest.Mock).mock.calls[1][2]).toBe('light cream cheese');
+        // Step 5b's rerank is the only rerank call (the quick gather feeds the
+        // normalize gate, which never reranks).
+        expect(simpleRerank).toHaveBeenCalledTimes(1);
+
+        // TWO cache lookups, not four: the early (pre-AI-normalize) lookup and
+        // the Step-1c lookup each make ONE getValidatedMappingByNormalizedName
+        // call, because for this brandless fixture the symmetric key equals the
+        // legacy key and lookupValidatedMappingWithLegacyFallback short-circuits
+        // its legacy point-read (`legacyKey === symmetricKey` → return null).
+        expect(getValidatedMappingByNormalizedName).toHaveBeenCalledTimes(2);
+
+        // Step 5a-VOLUME fires BETWEEN the winner's hydration failure and the
+        // 5b re-search: `1 tbsp` is a volume unit and the cache winner's source
+        // is 'ai_generated', so insertAiServing is offered the FAILED CACHE
+        // WINNER (it declines here via the default mock). A 1d that deleted
+        // this step would otherwise pass the whole suite unnoticed.
+        expect(insertAiServing).toHaveBeenCalledTimes(1);
+        expect((insertAiServing as jest.Mock).mock.calls[0][0]).toBe(CACHE_WINNER_ID);
+        expect((insertAiServing as jest.Mock).mock.calls[0][1]).toBe('volume');
+
+        // Hydration sequence: winner first at the undiscounted cache confidence,
+        // then the search candidate at confidence * 0.9 (pin (d), retry side).
+        const hydrateCalls = (hydrateAndSelectServing as jest.Mock).mock.calls;
+        expect(hydrateCalls).toHaveLength(2);
+        expect(hydrateCalls[0][0].id).toBe(CACHE_WINNER_ID);
+        expect(hydrateCalls[0][2]).toBe(0.9);
+        expect(hydrateCalls[1][0].id).toBe('search-1');
+        expect(hydrateCalls[1][2]).toBeCloseTo(0.81, 10);
+
+        // (b)+(c) the save PROCEEDS (overwritten selectionReason defeats the
+        // 'normalized_cache_hit' resave-skip) and records the overwritten reason
+        // with the UNDISCOUNTED cache-row confidence — not the 0.81 offered to
+        // hydration, not the 0.7654 the result carries, and not the 0.42 the
+        // 5b rerank stub returns (which is what makes 0.9 uniquely cache-row).
+        expect(saveValidatedMapping).toHaveBeenCalledTimes(1);
+        expect((saveValidatedMapping as jest.Mock).mock.calls[0][2]).toEqual({
+            approved: true,
+            confidence: 0.9,
+            reason: 'fallback_search_after_cache_failure',
+        });
+
+        // Save identity: the save proceeds under the ORIGINAL line and key —
+        // arg 0 is the raw line, and canonicalBase is deriveMappingCacheKey
+        // (THE shared read/write key function, used real here) over the FINAL
+        // normalizedName, which is what Step 5b's gather received (captured
+        // args, same pattern as producer-normalized-name-frozen.test.ts).
+        const saveCall = (saveValidatedMapping as jest.Mock).mock.calls[0];
+        expect(saveCall[0]).toBe(RAW_LINE);
+        const finalName = (gatherCandidates as jest.Mock).mock.calls[1][2] as string;
+        const capturedParsed = (gatherCandidates as jest.Mock).mock.calls[0][1];
+        expect(saveCall[3].canonicalBase).toBe(
+            deriveMappingCacheKey(finalName, capturedParsed, brandInputFor(RAW_LINE), RAW_LINE),
+        );
+
+        // (d) the returned result's confidence is the hydration lane's stamp,
+        // passed through untouched.
+        expect(result && 'confidence' in result ? result.confidence : null).toBe(0.7654);
+
+        // The telemetry stamped at cache-hit time is NOT un-stamped by the
+        // rebill: the line still reads as a normalized cache hit.
+        expect(telemetry.cacheHit).toBe('normalized');
+        expect(telemetry.cacheEscape).toBeUndefined();
+    });
+
+    it('CONTRAST: a servable cache winner never re-searches and the resave-skip suppresses the save', async () => {
+        mockStep1cCacheHit();
+        // Same searchable pool as the rebill test — proving the pool's
+        // availability is not what arms Step 5b; the hydration failure is.
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            searchCandidate('search-1'),
+            searchCandidate('search-2'),
+        ]);
+        (hydrateAndSelectServing as jest.Mock).mockImplementation(
+            async (candidate: { id: string }) =>
+                candidate.id === CACHE_WINNER_ID ? searchBill(CACHE_WINNER_ID) : null,
+        );
+
+        const result = await mapIngredientWithFallback(RAW_LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        expect(result && 'foodId' in result ? result.foodId : null).toBe(CACHE_WINNER_ID);
+        // selectionReason stays 'normalized_cache_hit' → the Step-6 resave-skip
+        // holds and the search machinery is never armed: the only gather is the
+        // pre-cascade quick gather, hydration ran once (the winner), and no
+        // rerank ever happened.
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        expect(gatherCandidates).toHaveBeenCalledTimes(1);
+        expect(hydrateAndSelectServing).toHaveBeenCalledTimes(1);
+        expect((hydrateAndSelectServing as jest.Mock).mock.calls[0][0].id).toBe(CACHE_WINNER_ID);
+        expect(simpleRerank).not.toHaveBeenCalled();
+    });
+
+    it('an EMPTY re-search pool falls through to the second backfill site and returns null (no save)', async () => {
+        // Precondition: the second backfill site is inside
+        // `if (AI_NUTRITION_BACKFILL_ENABLED)` — this test is void if a config
+        // change flips the flag off (it defaults true; getFlag reads env).
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        mockStep1cCacheHit();
+        (gatherCandidates as jest.Mock).mockResolvedValue([]);
+        // hydrateAndSelectServing default: null for everything.
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback(RAW_LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+            telemetry,
+        });
+
+        // Witness that the cache WINNER existed and reached hydration — this
+        // is a site-2 run (winner present, hydration failed), not a winner-less
+        // site-1 run: exactly one hydration attempt, offered the cache winner
+        // at the UNDISCOUNTED cache-row confidence, and the telemetry carries
+        // the normalized-cache-hit stamp.
+        expect(hydrateAndSelectServing).toHaveBeenCalledTimes(1);
+        expect((hydrateAndSelectServing as jest.Mock).mock.calls[0][0].id).toBe(CACHE_WINNER_ID);
+        expect((hydrateAndSelectServing as jest.Mock).mock.calls[0][2]).toBe(0.9);
+        expect(telemetry.cacheHit).toBe('normalized');
+
+        // Step 5b DID run its re-search (the guard matched): the first gather
+        // is the pre-cascade quick gather, the second is 5b's.
+        expect(gatherCandidates).toHaveBeenCalledTimes(2);
+        // …found nothing, so the request lands in the second AI-nutrition
+        // backfill site (the one reached after a winner exists), which fails
+        // here, and the mapper returns null without ever saving.
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect((requestAiNutrition as jest.Mock).mock.calls[0][0]).toBe('light cream cheese');
+        expect(result).toBeNull();
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+
+    it('tries at most the FIRST FIVE rerank-sorted candidates — the sixth is never offered', async () => {
+        // Precondition: the fall-through this test lands on (requestAiNutrition
+        // at the second backfill site) is gated on AI_NUTRITION_BACKFILL_ENABLED.
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        mockStep1cCacheHit();
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            searchCandidate('search-1'),
+            searchCandidate('search-2'),
+            searchCandidate('search-3'),
+            searchCandidate('search-4'),
+            searchCandidate('search-5'),
+            searchCandidate('search-6'),
+        ]);
+        // Only the SIXTH sorted candidate could serve — but Step 5b slices the
+        // sorted list to 5, so it is never tried and the request falls through
+        // to the backfill site.
+        (hydrateAndSelectServing as jest.Mock).mockImplementation(
+            async (candidate: { id: string }) =>
+                candidate.id === 'search-6' ? searchBill('search-6') : null,
+        );
+
+        const result = await mapIngredientWithFallback(RAW_LINE, {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        const triedIds = (hydrateAndSelectServing as jest.Mock).mock.calls.map(c => c[0].id);
+        // Winner first, then exactly the first 5 of the sorted search pool.
+        expect(triedIds).toEqual([
+            CACHE_WINNER_ID, 'search-1', 'search-2', 'search-3', 'search-4', 'search-5',
+        ]);
+        expect(triedIds).not.toContain('search-6');
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(result).toBeNull();
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/mapping/__tests__/producer-negative-independence.test.ts
+++ b/src/lib/mapping/__tests__/producer-negative-independence.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Phase 1 stage 1c — cluster 7: producer NEGATIVE-INDEPENDENCE characterization.
+ *
+ * Pins, via mock call COUNTS, that each result producer runs WITHOUT invoking the
+ * machinery of the others (census §2.7 in
+ * sync-docs/reports/2026-08-06_phase-1-stage-1c-handoff.md). These are
+ * characterization tests: they assert what the code DOES today, so the stage-1d
+ * extraction can be proven behavior-preserving. A failure after 1d means a
+ * producer boundary moved — not that this file is wrong.
+ *
+ * Two measured facts pinned here that correct the naive model:
+ *  - "cache hit ⇒ gatherCandidates never called" is FALSE as stated: the
+ *    normalize-gate's quick gather (quickGatherOptions, `skipOff: true`) goes
+ *    through the SAME gatherCandidates import and runs in the preamble BEFORE
+ *    the Step-1c lookup. The true invariant is: exactly ONE call, the quick-gate
+ *    one — the full Step-2 gather (no skipOff flag) never runs.
+ *  - The AI-nutrition backfill (site 1, the `if (!winner)` block) is NOT gated
+ *    by `_skipFallback`. `_skipFallback` gates only Step 2b (dietary-prefix +
+ *    AI-simplify recursions); a recursive frame with an empty pool still spends
+ *    the backfill. Pinned in the last test.
+ *
+ * Mock preamble copied from map-hit-resave-skip.test.ts (partial
+ * validated-mapping-helpers mock keeps the read-time-trust predicates real) with
+ * the full prisma serving-store model list from
+ * map-ingredient-with-fallback.test.ts (omitting aiGeneratedServing/fdcServing/
+ * offServing/userPortionOverride fails deep in the cascade mimicking a
+ * production bug). New stage-1a seam: mocking '../serving/hydration-lane'
+ * intercepts hydrateAndSelectServing at all mapper call sites, so hydration
+ * success/failure is controlled per candidate without touching the DB fixtures.
+ */
+
+import { mapIngredientWithFallback, type MappingTelemetry } from '../map-ingredient-with-fallback';
+import { AI_NUTRITION_BACKFILL_ENABLED } from '../config';
+import { prisma } from '../../db';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import {
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates } from '../gather-candidates';
+import { aiSimplifyIngredient } from '../ai-simplify';
+import { requestAiNutrition, getAiServingGrams } from '../ai-nutrition-backfill';
+import { hydrateAndSelectServing } from '../serving/hydration-lane';
+
+jest.mock('../../db', () => ({
+    prisma: {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        fdcFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        offFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        fatSecretFood: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
+        aiGeneratedFood: {
+            findMany: jest.fn().mockResolvedValue([]),
+            findFirst: jest.fn().mockResolvedValue(null),
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+        foodMapping: { findUnique: jest.fn().mockResolvedValue(null), findMany: jest.fn().mockResolvedValue([]) },
+        ingredient: { findMany: jest.fn().mockResolvedValue([]) },
+        // Serving stores reached via the hydration/backfill machinery — the
+        // canonical test's header warns that omitting these fails deep in the
+        // cascade mimicking a production bug. Kept even though this suite mocks
+        // hydrateAndSelectServing: requireActual loads the real lane module.
+        aiGeneratedServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        fdcServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        offServing: {
+            findUnique: jest.fn().mockResolvedValue(null),
+            findMany: jest.fn().mockResolvedValue([]),
+            upsert: jest.fn().mockResolvedValue(null),
+        },
+        userPortionOverride: {
+            findUnique: jest.fn().mockResolvedValue(null),
+        },
+    },
+}));
+
+jest.mock('../ai-normalize');
+// Partial mock: db-backed cache reads/writes stubbed; the pure read-time-trust
+// predicates (isTrustedHumanRow / isHumanTrustSkippableEscape) and
+// targetKeyOfFoodId stay REAL — the mapper's cache layers depend on them.
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return {
+        ...actual,
+        getCachedFoodWithRelations: jest.fn(),
+    };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return {
+        ...actual,
+        gatherCandidates: jest.fn(),
+    };
+});
+// Step 2b-ii reaches ai-simplify via a dynamic `await import()`; jest.mock
+// still intercepts it. Auto-mock + explicit null resolution below.
+jest.mock('../ai-simplify');
+// AI_NUTRITION_BACKFILL_ENABLED defaults TRUE, so the backfill module MUST be
+// mocked or site-1 calls hit the jest LLM blackhole as ECONNREFUSED.
+// createAiNutritionBudget / extractBaseFoodContext stay real (pure; the budget
+// minting in the options destructure needs the real one).
+jest.mock('../ai-nutrition-backfill', () => {
+    const actual = jest.requireActual('../ai-nutrition-backfill');
+    return {
+        ...actual,
+        requestAiNutrition: jest.fn(),
+        getAiServingGrams: jest.fn(),
+    };
+});
+// Stage-1a seam: intercepts ALL mapper call sites of hydrateAndSelectServing.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return {
+        ...actual,
+        hydrateAndSelectServing: jest.fn(),
+    };
+});
+// The Mac .env sets ENABLE_MAPPING_ANALYSIS=true; unmocked, every run writes a
+// logs/mapping-analysis-*.json session file from inside jest. Automock stubs
+// the whole sink (producer-cache-failure-research.test.ts proves that suffices).
+jest.mock('../mapping-logger');
+// Unmocked, the real module fires an ONNX warmupEmbedder() whose promise
+// dangles past suite end (embedding.model_loaded logged after the summary).
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
+/** A hydrated result as the (mocked) hydration lane would return it.
+ *  servingTier deliberately omitted — it is optional and inventing tier
+ *  strings is forbidden (the #249 lesson). */
+function hydrated(foodId: string, foodName: string, overrides: Record<string, unknown> = {}) {
+    return {
+        source: 'ai_generated' as const,
+        foodId,
+        foodName,
+        brandName: null,
+        servingId: 'srv-1',
+        servingDescription: '1 tbsp',
+        grams: 14,
+        kcal: 30,
+        protein: 1.1,
+        carbs: 0.8,
+        fat: 2.5,
+        confidence: 0.9,
+        quality: 'high' as const,
+        rawLine: '',
+        ...overrides,
+    };
+}
+
+const AI_NUTRITION_SUCCESS = {
+    status: 'success' as const,
+    foodId: 'ai_galaxy_1',
+    displayName: 'Galaxy Spice Mix',
+    caloriesPer100g: 250,
+    proteinPer100g: 10,
+    carbsPer100g: 50,
+    fatPer100g: 2,
+    fiberPer100g: 5,
+    sugarPer100g: 3,
+    sodiumMgPer100g: 100,
+    saturatedFatPer100g: 0.5,
+    cholesterolMgPer100g: 0,
+    confidence: 0.9,
+    notes: '',
+    model: 'test-model',
+    cached: false,
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (gatherCandidates as jest.Mock).mockResolvedValue([]);
+    (aiSimplifyIngredient as jest.Mock).mockResolvedValue(null);
+    (requestAiNutrition as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getAiServingGrams as jest.Mock).mockResolvedValue(null);
+    (hydrateAndSelectServing as jest.Mock).mockResolvedValue(null);
+});
+
+describe('producer negative independence (stage 1c cluster 7)', () => {
+    it('(a) servable Step-1c cache row: only the quick-gate gather runs, no AI, no save', async () => {
+        // Early (pre-AI-normalize) lookup misses; the Step-1c lookup hits.
+        // The fixture id is fs_-PREFIXED so the hit traverses the Step-1c
+        // DB-backed validation arm (the fatSecretFood.findUnique panel read +
+        // hasNullOrInvalidMacros) instead of the unrecognised-prefix
+        // instrument arm, which skips every validation and matches no real
+        // row shape (the lookup helper's no-target-column arm returns null).
+        (getValidatedMappingByNormalizedName as jest.Mock)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValue({
+                foodId: 'fs_9999901',
+                foodName: 'Light Cream Cheese',
+                brandName: null,
+                source: 'fatsecret',
+                confidence: 0.9,
+            });
+        // Healthy panel: non-null macros, Atwater-consistent (4·7.85 + 4·8.13
+        // + 9·15.28 ≈ 201), so hasNullOrInvalidMacros passes and the
+        // missing-nutrition safety net does not trip.
+        (prisma.fatSecretFood.findUnique as jest.Mock).mockResolvedValueOnce({
+            nutrientsPer100g: { calories: 201, protein: 7.85, carbohydrate: 8.13, fat: 15.28 },
+            servings: [],
+        });
+        (hydrateAndSelectServing as jest.Mock).mockResolvedValue(
+            hydrated('fs_9999901', 'Light Cream Cheese', {
+                source: 'fatsecret',
+                rawLine: '1 tbsp light cream cheese',
+            }));
+
+        const telemetry: MappingTelemetry = {};
+        const result = await mapIngredientWithFallback('1 tbsp light cream cheese', {
+            minConfidence: 0,
+            skipFdc: true,
+            telemetry,
+        });
+
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('fs_9999901');
+        expect(telemetry.cacheHit).toBe('normalized');
+
+        // Witness that the DB-backed validation arm actually ran: the fs_ arm's
+        // panel read, keyed on the stripped fsId.
+        expect(prisma.fatSecretFood.findUnique).toHaveBeenCalledTimes(1);
+        expect((prisma.fatSecretFood.findUnique as jest.Mock).mock.calls[0][0].where)
+            .toEqual({ fsId: '9999901' });
+
+        // CURRENT BEHAVIOR (not the naive "0 calls"): the normalize-gate's
+        // quick gather shares the gatherCandidates import and runs in the
+        // preamble BEFORE the Step-1c lookup. Exactly one call, identified as
+        // the quick-gate pass by its skipOff flag; the full Step-2 gather
+        // (whose options carry no skipOff) never runs.
+        expect(gatherCandidates).toHaveBeenCalledTimes(1);
+        expect((gatherCandidates as jest.Mock).mock.calls[0][3]).toMatchObject({ skipOff: true });
+
+        // The cache winner is hydrated exactly once (Step 5), on the cached id.
+        expect(hydrateAndSelectServing).toHaveBeenCalledTimes(1);
+        expect((hydrateAndSelectServing as jest.Mock).mock.calls[0][0].id).toBe('fs_9999901');
+
+        // Negative independence: the other producers' machinery never runs.
+        expect(aiSimplifyIngredient).not.toHaveBeenCalled();
+        expect(requestAiNutrition).not.toHaveBeenCalled();
+        // And the resave-skip: 'normalized_cache_hit' must not re-save itself,
+        // even at confidence 0.9 >= the 0.85 admission gate.
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+
+    it('(b) rerank win: saves exactly once, no simplify, no nutrition backfill', async () => {
+        (gatherCandidates as jest.Mock).mockResolvedValue([
+            { id: 'spin-1', source: 'ai_generated', name: 'Spinach', brandName: null, score: 0.9, foodType: 'Generic', rawData: {} },
+        ]);
+        (hydrateAndSelectServing as jest.Mock).mockResolvedValue(
+            hydrated('spin-1', 'Spinach', {
+                servingId: 'srv-spin',
+                servingDescription: '1 cup',
+                grams: 30,
+                kcal: 6.9,
+                protein: 0.87,
+                carbs: 1.08,
+                fat: 0.12,
+                confidence: 0.98,
+                rawLine: '1 cup spinach',
+            }));
+
+        const result = await mapIngredientWithFallback('1 cup spinach', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('spin-1');
+
+        // Both the quick-gate pass and the full Step-2 gather run on a cache
+        // miss: two calls, quick one first (skipOff true), full one without it.
+        expect(gatherCandidates).toHaveBeenCalledTimes(2);
+        expect((gatherCandidates as jest.Mock).mock.calls[0][3]).toMatchObject({ skipOff: true });
+        expect((gatherCandidates as jest.Mock).mock.calls[1][3].skipOff).toBeUndefined();
+
+        // The rerank winner is hydrated exactly once.
+        expect(hydrateAndSelectServing).toHaveBeenCalledTimes(1);
+        expect((hydrateAndSelectServing as jest.Mock).mock.calls[0][0].id).toBe('spin-1');
+
+        // Negative independence + the ONE save (a search-produced result flows
+        // through finalizeAndSaveResult and Step 6).
+        expect(aiSimplifyIngredient).not.toHaveBeenCalled();
+        expect(requestAiNutrition).not.toHaveBeenCalled();
+        expect(saveValidatedMapping).toHaveBeenCalledTimes(1);
+    });
+
+    it('(c) backfill serve (site 1): empty pool + null simplify -> AI nutrition, direct return, NO save', async () => {
+        // Loud precondition: the site-1 backfill this test pins is gated on
+        // this flag (default TRUE via getFlag). If an env flips it off, fail
+        // HERE, not with an opaque "0 calls" downstream.
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        // Cache misses everywhere, gather returns nothing (both passes), the
+        // AI-simplify fallback declines. _skipFallback is deliberately ABSENT
+        // so Step 2b runs — that is what proves the simplify was CONSULTED
+        // (1 call) before the backfill served.
+        (requestAiNutrition as jest.Mock).mockResolvedValue(AI_NUTRITION_SUCCESS);
+        (getAiServingGrams as jest.Mock).mockResolvedValue({ grams: 30, servingLabel: '2 tbsp' });
+
+        const result = await mapIngredientWithFallback('2 tbsp galaxy spice mix', {
+            minConfidence: 0,
+            skipFdc: true,
+        });
+
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('ai_galaxy_1');
+        expect(result && 'source' in result ? result.source : null).toBe('ai_generated');
+        // Billed off the mocked AI serving: 30 g at 250 kcal/100g, confidence
+        // penalized *0.8, and the REAL tier string the site stamps.
+        expect(result && 'grams' in result ? result.grams : null).toBe(30);
+        expect(result && 'kcal' in result ? result.kcal : null).toBeCloseTo(75);
+        expect(result && 'confidence' in result ? result.confidence : null).toBeCloseTo(0.72);
+        expect(result && 'servingTier' in result ? result.servingTier : null).toBe('ai_generated_serving');
+
+        // The fallback chain was consulted and declined...
+        expect(aiSimplifyIngredient).toHaveBeenCalledTimes(1);
+        // ...then site 1 fired exactly once. Site 2 is unreachable here — it
+        // needs a winner, and the sharp witness that none existed is that the
+        // hydration lane was never entered.
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(hydrateAndSelectServing).not.toHaveBeenCalled();
+        // Direct return at the site: finalizeAndSaveResult/Step 6 never runs.
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+        // Quick-gate + full gather both ran and found nothing.
+        expect(gatherCandidates).toHaveBeenCalledTimes(2);
+    });
+
+    it('(d) _skipFallback gates Step 2b but NOT the site-1 backfill', async () => {
+        // Loud precondition — same rationale as test (c).
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        // Census finding pinned as behavior: `shouldTryFallback && !_skipFallback`
+        // guards only the dietary-prefix and AI-simplify recursions; the
+        // `if (!winner)` backfill block is gated solely on
+        // AI_NUTRITION_BACKFILL_ENABLED. A recursive frame with an empty pool
+        // therefore still spends the nutrition backfill.
+        (requestAiNutrition as jest.Mock).mockResolvedValue(AI_NUTRITION_SUCCESS);
+        (getAiServingGrams as jest.Mock).mockResolvedValue({ grams: 30, servingLabel: '2 tbsp' });
+
+        const result = await mapIngredientWithFallback('2 tbsp galaxy spice mix', {
+            minConfidence: 0,
+            skipFdc: true,
+            _skipFallback: true,
+        });
+
+        expect(result && 'foodId' in result ? result.foodId : null).toBe('ai_galaxy_1');
+        expect(aiSimplifyIngredient).not.toHaveBeenCalled();
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/mapping/__tests__/producer-normalized-name-frozen.test.ts
+++ b/src/lib/mapping/__tests__/producer-normalized-name-frozen.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Phase 1 stage 1c — CHARACTERIZATION, cluster 6: `normalizedName` invariants.
+ *
+ * The stage-1c census (sync-docs/reports/2026-08-06_phase-1-stage-1c-handoff.md
+ * §1, mobile repo) established that every reassignment of `normalizedName`
+ * completes BEFORE `let winner` is declared, so every producer in the cascade
+ * reads one frozen value. The only deliberate stale-value readers are the
+ * EARLY cache lookup (keys off the pre-rewrite value) and `quickGatherName`.
+ * These tests pin that shape through the real `mapIngredientWithFallback()`
+ * so the stage-1d extraction cannot silently move a rewrite past a reader —
+ * or "fix" the early-lookup asymmetry, which is CURRENT DESIGN.
+ *
+ * Trigger: the unconditional bouillon+volume heuristic — `1 cup beef bouillon`
+ * has `normalizedName === 'beef bouillon'` at the early lookup and the quick
+ * gather, then `fatsecret.map.bouillon_broth_rewrite` rewrites it to
+ * `'beef broth'` before `let winner`. Zero LLM involvement: the normalize gate
+ * is stubbed to skip, so the rewrite is the run's ONLY mutation.
+ *
+ * MEASURED DELTA vs the census's suggested trigger (recorded here on purpose):
+ * the pepper spice rewrite (`1 tsp pepper` → 'black pepper') CANNOT exercise
+ * the asymmetry on this tree, because `normalizeIngredientName('pepper')`
+ * already returns 'black pepper' — NOT via the rules JSON (its
+ * `synonym_rewrites` has no bare 'pepper' entry) but via the hardcoded
+ * context-aware bare-word rewrite block (PEPPER_COMPOUNDS / PEPPER_SUFFIXES)
+ * inside `normalizeIngredientName()` in normalization-rules.ts, which runs
+ * AFTER the JSON loop. It fires at the `let normalizedName` initialization,
+ * BEFORE the early lookup, so the in-mapper `/^pepper$/` heuristic is
+ * unreachable for that shape — and because the pre-emption is TS code, no
+ * data-file drift (the box's `data/` never syncs) can re-arm the in-mapper
+ * heuristic. The last describe block pins that pre-emption so 1d inherits it
+ * knowingly.
+ *
+ * These are characterization tests: they assert what the code DOES today.
+ * A failure here after 1d is a behavior change, not a broken test.
+ *
+ * Mock preamble mirrors `llm-output-guard-wiring.test.ts` /
+ * `abstention-confidence.test.ts` (the proven seams). Two seams of note:
+ *  - `../simple-rerank` is stubbed to name a winner so the run traverses the
+ *    search producer into `finalizeAndSaveResult()` and we can read the save
+ *    key. `reason: 'exact_match'` is a real simpleRerank winner reason
+ *    (simple-rerank.ts), not an invented string.
+ *  - `../serving/hydration-lane` (the stage-1a seam) is stubbed so hydration
+ *    succeeds without touching serving stores.
+ */
+
+const mockHydrate = jest.fn();
+const mockSimplify = jest.fn();
+
+// Generic prisma stub: every model answers "nothing found" for any verb.
+// (House pattern from abstention-confidence.test.ts — enumerating models by
+// hand has previously made a sibling file assert nothing.)
+jest.mock('../../db', () => {
+    const emptyFor = (verb: string) =>
+        jest.fn().mockResolvedValue(verb.startsWith('findMany') ? [] : null);
+    const model = new Proxy({}, { get: (_t, verb: string) => emptyFor(verb) });
+    return { prisma: new Proxy({}, { get: () => model }) };
+});
+
+jest.mock('../ai-normalize');
+jest.mock('../normalize-gate', () => {
+    const actual = jest.requireActual('../normalize-gate');
+    return { ...actual, shouldNormalizeLlm: jest.fn() };
+});
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return { ...actual, getCachedFoodWithRelations: jest.fn() };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn(),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: jest.fn() };
+});
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: jest.fn() };
+});
+// Stage-1a seam: ALL 10 mapper call sites route through this import.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: (...a: unknown[]) => mockHydrate(...a) };
+});
+// TRAP (handoff §5): AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — an unmocked
+// backfill dials the jest LLM blackhole and fails as ECONNREFUSED.
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: jest.fn().mockResolvedValue({ status: 'error', reason: 'skip' }),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: jest.fn().mockResolvedValue(null),
+    createAiNutritionBudget: (max: number) => ({ remaining: max, spent: 0 }),
+}));
+// Step 2b-ii seam: the mapper dynamic-imports './ai-simplify'; jest.mock still
+// intercepts it (producer-simplify-exits.test.ts pattern).
+jest.mock('../ai-simplify', () => {
+    const actual = jest.requireActual('../ai-simplify');
+    return { ...actual, aiSimplifyIngredient: (...a: unknown[]) => mockSimplify(...a) };
+});
+// The Mac .env sets ENABLE_MAPPING_ANALYSIS=true; unmocked, every run of this
+// file wrote a real logs/mapping-analysis-*.json session file from inside jest
+// (measured). Automock suffices — producer-cache-failure-research.test.ts
+// proves it against the full mapper.
+jest.mock('../mapping-logger');
+// Unmocked, the first gather loads the real ONNX embedding model
+// (embedding.model_loaded fired after every run of this file — measured).
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
+
+import { mapIngredientWithFallback, type FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import { shouldNormalizeLlm } from '../normalize-gate';
+import {
+    getValidatedMapping,
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+} from '../validated-mapping-helpers';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { insertAiServing } from '../ai-backfill';
+import { gatherCandidates, type UnifiedCandidate } from '../gather-candidates';
+import { simpleRerank } from '../simple-rerank';
+import { requestAiNutrition } from '../ai-nutrition-backfill';
+import { deriveMappingCacheKey, deriveCacheKeyName } from '../cache-key';
+import { detectBrandInQuery } from '../brand-detector';
+import { normalizeIngredientName } from '../normalization-rules';
+import { AI_NUTRITION_BACKFILL_ENABLED } from '../config';
+
+const LINE = '1 cup beef bouillon';
+const PRE_REWRITE = 'beef bouillon';
+const POST_REWRITE = 'beef broth';
+
+/** FDC candidate carrying its own panel (abstention-confidence house shape). */
+const cand = (id: string, name: string, score: number): UnifiedCandidate => ({
+    id,
+    source: 'fdc',
+    name,
+    brandName: null,
+    score,
+    nutrition: { kcal: 7, protein: 1.1, carbs: 0.2, fat: 0.2, per100g: true },
+    servings: [{ description: '100 g', grams: 100, isDefault: true }],
+    rawData: {
+        fdcId: Number(id.replace('fdc_', '')),
+        description: name,
+        dataType: 'SR Legacy',
+        nutrientsPer100g: { calories: 7, protein: 1.1, carbs: 0.2, fat: 0.2 },
+        servings: [],
+    },
+});
+
+// FACTORY, not a shared fixture: the mapper enriches candidate objects in
+// place, so a module-scope array would leak mutations between the quick and
+// full gather and across tests (the documented hazard; A()/B()/C() pattern
+// from producer-billed-vs-winner.test.ts).
+const BROTH_POOL = () => [
+    cand('fdc_1111111', 'Beef Broth', 5.9),
+    cand('fdc_2222222', 'Beef Broth Bouillon and Consomme', 4.0),
+];
+
+/** normalizedName handed to each gatherCandidates call, in call order. */
+const gatherNames = () => (gatherCandidates as jest.Mock).mock.calls.map(c => c[2] as string);
+const gatherOpts = () => (gatherCandidates as jest.Mock).mock.calls.map(c => (c[3] ?? {}) as Record<string, unknown>);
+/** parsed as the mapper computed it — captured off the first gather call. */
+const capturedParsed = () => (gatherCandidates as jest.Mock).mock.calls[0][1];
+/** cache keys handed to the lookup helper, in call order. */
+const lookupKeys = () => (getValidatedMappingByNormalizedName as jest.Mock).mock.calls.map(c => c[0] as string);
+
+/** The brand input the mapper derives for a line (no options.brand passed). */
+const brandInputFor = (line: string) => {
+    const det = detectBrandInQuery(line);
+    return { isBranded: det.isBranded, matchedBrand: det.matchedBrand };
+};
+
+const hydratedResultFor = (winner: UnifiedCandidate, confidence: number): FatsecretMappedIngredient => ({
+    source: 'fdc',
+    foodId: winner.id,
+    foodName: winner.name,
+    brandName: null,
+    servingId: null,
+    servingDescription: '1 cup',
+    grams: 240,
+    kcal: 16.8,
+    protein: 2.6,
+    carbs: 0.5,
+    fat: 0.5,
+    confidence,
+    quality: 'high',
+    rawLine: LINE,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // Normalize gate SKIPS the LLM: the heuristic rewrite is then the run's
+    // only normalizedName mutation, so every delta below is attributable to it.
+    (shouldNormalizeLlm as jest.Mock).mockReturnValue({ shouldCallLlm: false, reason: 'test_gate_skip', confidence: 0.9 });
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    (getValidatedMapping as jest.Mock).mockResolvedValue(null);
+    (getValidatedMappingByNormalizedName as jest.Mock).mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (insertAiServing as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (gatherCandidates as jest.Mock).mockImplementation(async () => BROTH_POOL());
+    mockSimplify.mockResolvedValue(null);
+    // Rerank names the pool head. 'exact_match' is a REAL winner reason and
+    // 0.9 clears the 0.85 save gate, so finalizeAndSaveResult() saves.
+    (simpleRerank as jest.Mock).mockReturnValue({
+        winner: { id: 'fdc_1111111' },
+        confidence: 0.9,
+        reason: 'exact_match',
+        sortedCandidates: [],
+    });
+    mockHydrate.mockImplementation(async (winner: UnifiedCandidate, _p, confidence: number) =>
+        hydratedResultFor(winner, confidence));
+});
+
+describe('FROZEN-BEFORE-CASCADE: every producer reads the final rewritten value', () => {
+    it('the full gather and the save both read "beef broth", never "beef bouillon"', async () => {
+        const result = await mapIngredientWithFallback(LINE);
+
+        expect(result).not.toBeNull();
+        expect((result as FatsecretMappedIngredient).foodId).toBe('fdc_1111111');
+
+        // The FULL gather (the one retrieval actually ranks on) got the final value.
+        const names = gatherNames();
+        expect(names[names.length - 1]).toBe(POST_REWRITE);
+
+        // The save ran, keyed off the SAME final value: canonicalBase is
+        // deriveMappingCacheKey(finalName, …) recomputed inside finalize.
+        expect(saveValidatedMapping).toHaveBeenCalledTimes(1);
+        const saveCall = (saveValidatedMapping as jest.Mock).mock.calls[0];
+        const expectedFinalKey = deriveMappingCacheKey(
+            POST_REWRITE, capturedParsed(), brandInputFor(LINE), LINE);
+        expect(saveCall[3].canonicalBase).toBe(expectedFinalKey);
+        expect(saveCall[2].reason).toBe('exact_match');
+
+        // Zero LLM: the rewrite is heuristic, not model output.
+        expect(aiNormalizeIngredient).not.toHaveBeenCalled();
+        expect(requestAiNutrition).not.toHaveBeenCalled();
+    });
+
+    it('KEY SYMMETRY: the Step-1c lookup key and the save key are byte-identical', async () => {
+        await mapIngredientWithFallback(LINE);
+
+        const keys = lookupKeys();
+        const saveKey = (saveValidatedMapping as jest.Mock).mock.calls[0][3].canonicalBase as string;
+        // The Step-1c symmetric lookup used exactly the key the save writes
+        // under — the cache-key-symmetry.test.ts pin, extended through a full
+        // pipeline run that includes a mid-preamble rewrite.
+        expect(keys).toContain(saveKey);
+        expect(keys[keys.length - 1]).toBe(saveKey);
+    });
+});
+
+describe('EARLY-KEY ASYMMETRY: the early lookup keys off the PRE-rewrite value (current design — 1d must not "fix" it)', () => {
+    it('first lookup call uses the "beef bouillon" key, the Step-1c call uses the "beef broth" key', async () => {
+        await mapIngredientWithFallback(LINE);
+
+        const parsed = capturedParsed();
+        const brand = brandInputFor(LINE);
+        const preRewriteKey = deriveMappingCacheKey(PRE_REWRITE, parsed, brand, LINE);
+        const finalKey = deriveMappingCacheKey(POST_REWRITE, parsed, brand, LINE);
+        expect(preRewriteKey).not.toBe(finalKey); // the asymmetry is real, not vacuous
+
+        const keys = lookupKeys();
+        // CURRENT BEHAVIOR: exactly two lookup-helper calls — early (symmetric
+        // key of the pre-rewrite name) then Step-1c (symmetric key of the final
+        // name). No legacy-key calls fire: with no brand detected the legacy
+        // key equals the symmetric key and the fallback short-circuits inside
+        // lookupValidatedMappingWithLegacyFallback().
+        expect(keys).toEqual([preRewriteKey, finalKey]);
+    });
+
+    it('the quick gather also reads the PRE-rewrite value — the second stale reader the census names', async () => {
+        await mapIngredientWithFallback(LINE);
+
+        const names = gatherNames();
+        expect(names.length).toBe(2);
+        expect(names[0]).toBe(PRE_REWRITE);   // quick-gate gather, pre-rewrite
+        expect(names[1]).toBe(POST_REWRITE);  // full gather, post-rewrite
+    });
+});
+
+describe('BRANDED LEGACY FALLBACK: preBrandNormalizedName feeds the legacy key (handoff §2.6)', () => {
+    it('after the brand-preservation repair, the Step-1c legacy call keys off the PRE-repair model output', async () => {
+        // The LLM path this time: the gate calls the model, the model strips
+        // the decisive brand ('ghost whey' → 'whey protein'), and the
+        // brand-preservation repair re-injects it — setting
+        // preBrandNormalizedName to the model's PRE-repair output and
+        // normalizedName to 'ghost whey protein'. Fixture copied from
+        // legacy-key-fallback.test.ts (proven decisive on this tree).
+        const BRANDED_LINE = '1 cup ghost whey';
+        const MODEL_OUTPUT = 'whey protein';
+        (shouldNormalizeLlm as jest.Mock).mockReturnValue({ shouldCallLlm: true, reason: 'test_gate_call', confidence: 0.5 });
+        (aiNormalizeIngredient as jest.Mock).mockResolvedValue({
+            status: 'success',
+            normalizedName: MODEL_OUTPUT,
+            synonyms: [],
+            isBranded: true,
+        });
+
+        await mapIngredientWithFallback(BRANDED_LINE);
+
+        const parsed = capturedParsed();
+        const brand = brandInputFor(BRANDED_LINE);
+        // Preconditions: the static detector fires and the repair had a brand
+        // to re-inject (keepBrand() prefixes matchedBrand verbatim).
+        expect(brand.isBranded).toBe(true);
+        expect(brand.matchedBrand).toBe('ghost');
+        const repaired = `${brand.matchedBrand} ${MODEL_OUTPUT}`;
+
+        const symmetricKey = deriveMappingCacheKey(repaired, parsed, brand, BRANDED_LINE);
+        const legacyKey = deriveCacheKeyName(MODEL_OUTPUT, parsed);
+        // The witness that the legacy key MUST derive from the pre-repair
+        // value: deriving it from the repaired name yields the symmetric key
+        // itself, and lookupValidatedMappingWithLegacyFallback()
+        // short-circuits on equality — the legacy call would never fire.
+        expect(deriveCacheKeyName(repaired, parsed)).toBe(symmetricKey);
+        expect(legacyKey).not.toBe(symmetricKey);
+
+        // CURRENT BEHAVIOR at the Step-1c site: symmetric (brand-prefixed)
+        // key first, then — on miss — exactly the legacy key derived from
+        // preBrandNormalizedName, adjacent in call order.
+        const keys = lookupKeys();
+        const si = keys.indexOf(symmetricKey);
+        expect(si).toBeGreaterThanOrEqual(0);
+        expect(keys[si + 1]).toBe(legacyKey);
+    });
+});
+
+describe('REUSE INVALIDATION: a rewrite forces a full re-gather', () => {
+    it('rewritten line: full gather runs fresh — no seedCandidates, FDC not skipped', async () => {
+        await mapIngredientWithFallback(LINE);
+
+        const opts = gatherOpts();
+        const fullOpts = opts[opts.length - 1];
+        // canReuseQuickGather requires quickGatherName === normalizedName;
+        // the rewrite broke that, so the quick-gather pool is NOT re-served.
+        expect(fullOpts.seedCandidates).toBeUndefined();
+        expect(fullOpts.skipFdc).toBe(false);
+    });
+
+    it('control — un-rewritten line: the quick-gather pool IS re-served as seedCandidates', async () => {
+        // Minimal-pair control: `1 cup beef broth` is the SAME line shape as
+        // `1 cup beef bouillon` — same qty, same volume unit, differing only
+        // in the token that trips the mid-preamble bouillon heuristic — so
+        // the seedCandidates delta is attributable to the rewrite alone.
+        // NOTE: the rules JSON rewrites 'beef broth' → 'beef stock' at the
+        // `let normalizedName` init (synonym_rewrites), so both gathers read
+        // 'beef stock'. An init-time rewrite is NOT a mid-preamble mutation:
+        // quickGatherName === normalizedName still holds and reuse survives.
+        (gatherCandidates as jest.Mock).mockImplementation(async () => [
+            cand('fdc_3333333', 'Beef Stock', 5.0),
+        ]);
+        (simpleRerank as jest.Mock).mockReturnValue({
+            winner: { id: 'fdc_3333333' },
+            confidence: 0.9,
+            reason: 'exact_match',
+            sortedCandidates: [],
+        });
+
+        await mapIngredientWithFallback('1 cup beef broth');
+
+        const names = gatherNames();
+        expect(names).toEqual(['beef stock', 'beef stock']);
+        const fullOpts = gatherOpts()[1];
+        expect(Array.isArray(fullOpts.seedCandidates)).toBe(true);
+        expect(fullOpts.skipFdc).toBe(true); // reuse: full gather only adds OFF + semantic
+    });
+});
+
+describe('the Step-2b simplify COMPARISON reads the same frozen value', () => {
+    it('a simplify result equal to the POST-rewrite value does not recurse', async () => {
+        // MEASURED DELTA vs the census wording: `aiSimplifyIngredient()`
+        // receives the raw `trimmed` line, NOT normalizedName (read Step
+        // 2b-ii in the mapper). The frozen value is read by the recursion
+        // guard `result.simplified !== normalizedName`. So the pin is on the
+        // COMPARISON: returning exactly the post-rewrite value must NOT
+        // re-enter the mapper. Had the guard read the PRE-rewrite value
+        // ('beef bouillon'), 'beef broth' !== 'beef bouillon' would recurse
+        // with rawLine 'beef broth'.
+        (gatherCandidates as jest.Mock).mockResolvedValue([]); // no winner ⇒ Step 2b runs (no _skipFallback here)
+        mockSimplify.mockResolvedValue({ simplified: POST_REWRITE });
+
+        await mapIngredientWithFallback(LINE);
+
+        expect(mockSimplify).toHaveBeenCalledTimes(1);
+        expect(mockSimplify.mock.calls[0][0]).toBe(LINE);          // trimmed raw line, not normalizedName
+        expect(mockSimplify.mock.calls[0][1]).toBeUndefined();     // no brand detected on this line
+
+        // No recursion happened: both recursion sites re-enter with a NEW
+        // rawLine, so every gather call carrying the original line is the
+        // no-recursion witness.
+        const rawLines = (gatherCandidates as jest.Mock).mock.calls.map(c => c[0] as string);
+        expect(rawLines.length).toBeGreaterThan(0);
+        for (const rl of rawLines) expect(rl).toBe(LINE);
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});
+
+describe('the AI-nutrition backfill producer reads the same frozen value', () => {
+    it('backfill site 1 receives "beef broth" and returns directly with NO save', async () => {
+        // Precondition: site 1 is inside `if (AI_NUTRITION_BACKFILL_ENABLED)`.
+        // A silent env flip would skip the producer and green this test
+        // vacuously (producer-backfill-after-winner.test.ts pattern).
+        expect(AI_NUTRITION_BACKFILL_ENABLED).toBe(true);
+
+        // Empty pool ⇒ no winner. _skipFallback skips both recursions, so the
+        // run lands on backfill site 1 (`if (!winner)`), frame-scoped.
+        (gatherCandidates as jest.Mock).mockResolvedValue([]);
+        (requestAiNutrition as jest.Mock).mockResolvedValue({
+            status: 'success',
+            foodId: 'ai_test_broth',
+            displayName: 'Beef Broth',
+            caloriesPer100g: 7,
+            proteinPer100g: 1.1,
+            carbsPer100g: 0.2,
+            fatPer100g: 0.2,
+            confidence: 0.9,
+            cached: false,
+        });
+
+        // _skipFallback is a typed member of the options interface — no cast.
+        const result = await mapIngredientWithFallback(LINE, { _skipFallback: true });
+
+        // The backfill producer read the FINAL rewritten value.
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect((requestAiNutrition as jest.Mock).mock.calls[0][0]).toBe(POST_REWRITE);
+
+        // Direct-return exit: bypasses finalizeAndSaveResult() entirely.
+        const r = result as FatsecretMappedIngredient;
+        expect(r.source).toBe('ai_generated');
+        expect(r.foodId).toBe('ai_test_broth');
+        // getAiServingGrams (mocked null) ⇒ the flat-100g default tier.
+        // 'flat_100g_default' is copied from the producer, not invented.
+        expect(r.servingTier).toBe('flat_100g_default');
+        expect(r.grams).toBe(100);
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});
+
+describe('MEASURED DELTA: the census\'s pepper trigger is pre-empted inside normalizeIngredientName()', () => {
+    it('normalizeIngredientName already rewrites "pepper" → "black pepper", so the in-mapper spice heuristic never fires', async () => {
+        // The stage-1c handoff (and the plan) name `1 tsp pepper` →
+        // `fatsecret.map.pepper_spice_rewrite` as the cheapest asymmetry
+        // trigger. On this tree that rewrite is DEAD for the bare-'pepper'
+        // shape — and the pre-emptor is NOT the rules JSON (its
+        // synonym_rewrites has no bare 'pepper' entry): it is the hardcoded
+        // context-aware bare-word rewrite block (PEPPER_COMPOUNDS /
+        // PEPPER_SUFFIXES) in normalizeIngredientName() itself
+        // (normalization-rules.ts), which fires at the
+        // `let normalizedName = normalizeIngredientName(baseName)` init,
+        // BEFORE the early lookup — so there is no early/late asymmetry at
+        // all. Pinned so 1d inherits the pre-emption knowingly — and so this
+        // assertion fails loudly if that TS block is ever removed (which
+        // would silently re-arm the in-mapper heuristic). Data-file drift
+        // cannot re-arm it: the pre-emptor is code, not a JSON entry.
+        expect(normalizeIngredientName('pepper').cleaned).toBe('black pepper');
+
+        (gatherCandidates as jest.Mock).mockImplementation(async () => [
+            cand('fdc_4444444', 'Black Pepper', 5.9),
+        ]);
+        (simpleRerank as jest.Mock).mockReturnValue({
+            winner: { id: 'fdc_4444444' },
+            confidence: 0.9,
+            reason: 'exact_match',
+            sortedCandidates: [],
+        });
+
+        await mapIngredientWithFallback('1 tsp pepper');
+
+        // BOTH gathers and BOTH lookups already see the post-rules value:
+        // no mid-preamble mutation, so quick-gather reuse survives.
+        expect(gatherNames()).toEqual(['black pepper', 'black pepper']);
+        const keys = lookupKeys();
+        expect(keys.length).toBe(2);
+        expect(keys[0]).toBe(keys[1]);
+        expect(Array.isArray(gatherOpts()[1].seedCandidates)).toBe(true);
+    });
+});

--- a/src/lib/mapping/__tests__/producer-read-escapes-delivery.test.ts
+++ b/src/lib/mapping/__tests__/producer-read-escapes-delivery.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Phase 1 stage 1c — CHARACTERIZATION, cluster 5: readEscapes delivery.
+ *
+ * `readEscapes` is a frame-local array in `mapIngredientWithFallback()` with
+ * four append sites, all in the two cache-lookup regions (the early check and
+ * Step 1c), and exactly ONE reader: `finalizeAndSaveResult()` hands it to
+ * `saveValidatedMapping()` as `options.readEscapes`, where the save-time
+ * forfeit (`escapeForfeit`) matches on record identity and row-quality class.
+ * The upcoming stage-1d extraction must preserve exactly this delivery, so
+ * this file pins CURRENT behavior:
+ *
+ *  (a) an escaped cache row reaches a SEARCH-produced save as a
+ *      site-prefixed `{ targetKey, reason }` record — prefixes `early:` /
+ *      `normalized:` (row-shape chain), with the record-identity targetKey
+ *      (`off:<barcode>`), never the cache key;
+ *  (b) ACCUMULATION: when both the early and the Step-1c lookups escape on
+ *      one request, BOTH records appear, in site order — an array, not a
+ *      last-write slot;
+ *  (c) the `early:hydration_failed` fall-through is telemetry-labelled but
+ *      deliberately NOT recorded as a readEscape (the documented non-write:
+ *      hydration failure is a property of THIS request's qty/unit, and must
+ *      not strip a healthy incumbent's cross-source margin protection);
+ *  (d) direct-return producers (the `!winner` AI-nutrition backfill) deliver
+ *      no escapes because no outer save runs at all;
+ *  (e) the REJECTION channel: when the lookup HELPER itself refuses a row —
+ *      `noteRejection()` populating the `CacheLookupRejection` out-param and
+ *      returning null — the mapper delivers `lookup_early:` /
+ *      `lookup_normalized:` records built from the out-param's `targetKey`.
+ *      With (a)/(b) covering the row-shape chain, all FOUR append sites in
+ *      the mapper are exercised by this file.
+ *
+ * Escape-reason strings are the code's own: `nutrition_invalid` /
+ * `corrupt_record` (the two ROW_QUALITY_ESCAPES classes) from the mapper's
+ * escape chain, and `core_token_mismatch` from the helper's `noteRejection()`
+ * sites; nothing here is invented. The escape CLASSIFICATION
+ * (`isRowQualityEscape`) lives in `validated-mapping-helpers` and is kept REAL
+ * via the requireActual spread — these pins are about what the MAPPER hands
+ * the save: the raw, unfiltered array.
+ *
+ * Mock preamble follows the house pattern (`llm-output-guard-wiring.test.ts`,
+ * `abstention-confidence.test.ts`), plus the stage-1a seam: the mapper now
+ * imports `hydrateAndSelectServing` from `./serving/hydration-lane`, so
+ * mocking that module intercepts every hydration call site.
+ */
+
+const mockOffFindUnique = jest.fn();
+const mockGatherCandidates = jest.fn();
+const mockSimpleRerank = jest.fn();
+const mockHydrateAndSelectServing = jest.fn();
+
+// Generic prisma stub: every model answers "nothing found" for any verb, with
+// offFood.findUnique controllable per test (it is what the escape-evaluation
+// chains read to decide corrupt_record / nutrition_invalid). The Proxy shape
+// exists because enumerating models by hand has previously made a sibling file
+// die deep in the cascade on an unmocked serving-store model
+// (map-ingredient-with-fallback.test.ts's own header warns about this).
+jest.mock('../../db', () => {
+    const emptyFor = (verb: string) =>
+        jest.fn().mockResolvedValue(verb.startsWith('findMany') ? [] : null);
+    const genericModel = new Proxy({}, { get: (_t, verb) => emptyFor(String(verb)) });
+    return {
+        prisma: new Proxy({}, {
+            get: (_t, prop) => {
+                const name = String(prop);
+                if (name === 'offFood') {
+                    return {
+                        findUnique: (...a: unknown[]) => mockOffFindUnique(...a),
+                        findMany: jest.fn().mockResolvedValue([]),
+                    };
+                }
+                if (name.startsWith('$')) return jest.fn().mockResolvedValue([]);
+                return genericModel;
+            },
+        }),
+    };
+});
+
+jest.mock('../ai-normalize');
+jest.mock('../ai-parse');
+jest.mock('../ai-simplify');
+// Keep the classifiers REAL: the escape chain calls isTrustedHumanRow /
+// isHumanTrustSkippableEscape / targetKeyOfFoodId, and the assertions below
+// use the real isRowQualityEscape as the tie-in to the save-side filter.
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn(),
+        getValidatedMappingByNormalizedName: jest.fn(),
+        saveValidatedMapping: jest.fn(),
+        getAiNormalizeCache: jest.fn(),
+        saveAiNormalizeCache: jest.fn(),
+        trackValidationFailure: jest.fn(),
+    };
+});
+jest.mock('../ai-synonym-generator');
+jest.mock('../learned-synonyms');
+jest.mock('../cache-search', () => {
+    const actual = jest.requireActual('../cache-search');
+    return { ...actual, getCachedFoodWithRelations: jest.fn() };
+});
+jest.mock('../cache');
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../serving-backfill');
+jest.mock('../mapping-logger'); // ENABLE_MAPPING_ANALYSIS=true in the dev .env — keep runs file-free
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'skip' }),
+}));
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: (...a: unknown[]) => mockGatherCandidates(...a) };
+});
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: (...a: unknown[]) => mockSimpleRerank(...a) };
+});
+// Stage-1a seam: ALL mapper hydration call sites go through this import.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: (...a: unknown[]) => mockHydrateAndSelectServing(...a) };
+});
+// TRAP (handoff §5): AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — an unmocked
+// backfill dials the jest LLM blackhole and fails as confusing ECONNREFUSED.
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: jest.fn().mockResolvedValue({ status: 'error', reason: 'skip' }),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: jest.fn().mockResolvedValue(null),
+    createAiNutritionBudget: (max: number) => ({ remaining: max, spent: 0 }),
+}));
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
+import { mapIngredientWithFallback, type MappingTelemetry } from '../map-ingredient-with-fallback';
+import {
+    getValidatedMappingByNormalizedName,
+    saveValidatedMapping,
+    getAiNormalizeCache,
+    isRowQualityEscape,
+} from '../validated-mapping-helpers';
+import { aiNormalizeIngredient } from '../ai-normalize';
+import { findCanonicalName, getKnownSynonyms, saveSynonyms } from '../ai-synonym-generator';
+import { getLearnedSynonyms, extractTermsFromIngredient } from '../learned-synonyms';
+import { getCachedFoodWithRelations } from '../cache-search';
+import { ensureFoodCached } from '../cache';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+import { queueForDeferredHydration } from '../deferred-hydration';
+import { backfillOnDemand } from '../serving-backfill';
+import { requestAiNutrition } from '../ai-nutrition-backfill';
+import { isCorruptExclusionEnabled } from '../corrupt-mark';
+import type { UnifiedCandidate } from '../gather-candidates';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const OFF_BARCODE = '4001234567890';
+const OFF_FOOD_ID = `off_${OFF_BARCODE}`;
+const OFF_TARGET_KEY = `off:${OFF_BARCODE}`; // targetKeyOfFoodId(OFF_FOOD_ID)
+const FDC_ID = 'fdc_555001';
+
+/** The FoodMapping row both cache lookups can return. validatedBy 'ai' so the
+ *  HUMAN_ROW_TRUST skip never fires. */
+const cachedOffRow = () => ({
+    source: 'openfoodfacts',
+    foodId: OFF_FOOD_ID,
+    foodName: 'Onion',
+    brandName: null,
+    servingId: null,
+    servingDescription: '100 g',
+    grams: 100,
+    kcal: 40,
+    protein: 1.1,
+    carbs: 9,
+    fat: 0.1,
+    confidence: 0.9,
+    quality: 'high' as const,
+    rawLine: 'onion',
+    validatedBy: 'ai',
+});
+
+/** An OffFood record that is present, plausible and unmarked — serves cleanly. */
+const healthyOffRecord = () => ({
+    nutrientsPer100g: { calories: 40, protein: 1.1, carbs: 9, fat: 0.1 },
+    servingSize: '100 g',
+    servingGrams: 100,
+    corruptReason: null,
+});
+
+/** Same panel, but triage-marked corrupt ('panel-low' is a real CorruptDirection). */
+const corruptOffRecord = () => ({
+    ...healthyOffRecord(),
+    corruptReason: 'panel-low',
+});
+
+/** FDC search candidate carrying its own panel (no hydration network). */
+const fdcCandidate = (): UnifiedCandidate => ({
+    id: FDC_ID,
+    source: 'fdc',
+    name: 'Onion',
+    brandName: null,
+    score: 0.9,
+    foodType: 'generic',
+    nutrition: { kcal: 40, protein: 1.1, carbs: 9, fat: 0.1, per100g: true },
+    rawData: {
+        fdcId: 555001,
+        description: 'Onion',
+        dataType: 'SR Legacy',
+        nutrientsPer100g: { calories: 40, protein: 1.1, carbs: 9, fat: 0.1 },
+        servings: [],
+    },
+} as unknown as UnifiedCandidate);
+
+/** What the mocked hydration lane bills for a candidate it accepts. */
+const hydrationResultFor = (cand: { id: string; name: string }, conf: number, raw: string) => ({
+    source: 'fdc' as const,
+    foodId: cand.id,
+    foodName: cand.name,
+    brandName: null,
+    servingId: null,
+    servingDescription: '100 g',
+    grams: 100,
+    kcal: 40,
+    protein: 1.1,
+    carbs: 9,
+    fat: 0.1,
+    confidence: conf,
+    quality: 'high' as const,
+    rawLine: raw,
+});
+
+const saveCalls = () => (saveValidatedMapping as jest.Mock).mock.calls;
+const lookupMock = getValidatedMappingByNormalizedName as jest.Mock;
+const hydrationCandidateIds = () =>
+    mockHydrateAndSelectServing.mock.calls.map((c) => (c[0] as { id: string }).id);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+
+    (aiNormalizeIngredient as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    lookupMock.mockResolvedValue(null);
+    (getAiNormalizeCache as jest.Mock).mockResolvedValue(null);
+    (saveValidatedMapping as jest.Mock).mockResolvedValue(undefined);
+    (findCanonicalName as jest.Mock).mockResolvedValue(null);
+    (getKnownSynonyms as jest.Mock).mockReturnValue([]);
+    (saveSynonyms as jest.Mock).mockResolvedValue(undefined);
+    (getLearnedSynonyms as jest.Mock).mockResolvedValue([]);
+    (extractTermsFromIngredient as jest.Mock).mockReturnValue([]);
+    (getCachedFoodWithRelations as jest.Mock).mockResolvedValue(null);
+    (ensureFoodCached as jest.Mock).mockResolvedValue(null);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+    (queueForDeferredHydration as jest.Mock).mockImplementation(() => undefined);
+    (backfillOnDemand as jest.Mock).mockResolvedValue({ success: false, reason: 'skip' });
+    (requestAiNutrition as jest.Mock).mockResolvedValue({ status: 'error', reason: 'skip' });
+    mockOffFindUnique.mockResolvedValue(null);
+
+    // Search wins by default: one FDC candidate, rerank names it.
+    // 'single_candidate' is a real simpleRerank reason string.
+    mockGatherCandidates.mockResolvedValue([fdcCandidate()]);
+    mockSimpleRerank.mockReturnValue({
+        winner: { id: FDC_ID, name: 'Onion' },
+        confidence: 0.9,
+        reason: 'single_candidate',
+        sortedCandidates: [],
+    });
+
+    // Hydration lane: cached OFF candidates fail, everything else succeeds.
+    mockHydrateAndSelectServing.mockImplementation(
+        async (cand: { id: string; name: string }, _parsed: unknown, conf: number, raw: string) =>
+            cand.id.startsWith('off_') ? null : hydrationResultFor(cand, conf, raw),
+    );
+});
+
+describe('cluster 5 — readEscapes delivery to the one reader (the save)', () => {
+    it('(a) an early-lookup row-quality escape reaches the search-produced save, site-prefixed, with the record targetKey', async () => {
+        // Early lookup HITS a row whose off_ record is missing entirely →
+        // the missing-nutrition safety net fires → reason 'nutrition_invalid'
+        // (real string, from the mapper's own escape chain). Step 1c then
+        // misses, search wins, and the save must receive the escape.
+        lookupMock.mockResolvedValueOnce(cachedOffRow()); // early: hit
+        // subsequent lookups (Step 1c): default null → miss
+
+        const result = (await mapIngredientWithFallback('onion')) as { foodId: string } | null;
+
+        expect(result?.foodId).toBe(FDC_ID);
+        expect(saveCalls()).toHaveLength(1);
+
+        const saveOptions = saveCalls()[0][3];
+        expect(saveOptions.readEscapes).toEqual([
+            { targetKey: OFF_TARGET_KEY, reason: 'early:nutrition_invalid' },
+        ]);
+        // Tie-in to the one consumer's filter: this reason IS a row-quality
+        // class, so the forfeit can match it (real classifier, not a copy).
+        expect(isRowQualityEscape('early:nutrition_invalid')).toBe(true);
+
+        // One lookup call per site, legacy fallback short-circuited (the
+        // unbranded symmetric and legacy keys are identical): 2 calls total.
+        expect(lookupMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(a) a Step-1c corrupt_record escape is delivered with the normalized: prefix', async () => {
+        // corrupt_record requires the exclusion flag, which defaults ON.
+        expect(isCorruptExclusionEnabled()).toBe(true);
+
+        // Early lookup misses, Step 1c hits a row whose OFF record is
+        // triage-marked corrupt — corrupt_record outranks a VALID panel in
+        // the escape chain (it is the first arm).
+        let call = 0;
+        lookupMock.mockImplementation(async () => (++call === 1 ? null : cachedOffRow()));
+        mockOffFindUnique.mockResolvedValue(corruptOffRecord());
+
+        const result = (await mapIngredientWithFallback('onion')) as { foodId: string } | null;
+
+        expect(result?.foodId).toBe(FDC_ID);
+        expect(saveCalls()).toHaveLength(1);
+        expect(saveCalls()[0][3].readEscapes).toEqual([
+            { targetKey: OFF_TARGET_KEY, reason: 'normalized:corrupt_record' },
+        ]);
+        expect(isRowQualityEscape('normalized:corrupt_record')).toBe(true);
+    });
+
+    it('(b) ACCUMULATION: both cache layers escaping on one request delivers BOTH records, in site order', async () => {
+        // Both lookups return the same row pointing at a MISSING off_ record →
+        // nutrition_invalid at the early site AND again at Step 1c. The save
+        // must see an array with both, early first — not a last-write slot.
+        lookupMock.mockResolvedValue(cachedOffRow());
+
+        const telemetry: MappingTelemetry = {};
+        const result = (await mapIngredientWithFallback('onion', { telemetry })) as { foodId: string } | null;
+
+        expect(result?.foodId).toBe(FDC_ID);
+        expect(saveCalls()).toHaveLength(1);
+        expect(saveCalls()[0][3].readEscapes).toEqual([
+            { targetKey: OFF_TARGET_KEY, reason: 'early:nutrition_invalid' },
+            { targetKey: OFF_TARGET_KEY, reason: 'normalized:nutrition_invalid' },
+        ]);
+        // The telemetry slot IS last-write (one string), which is exactly why
+        // the save takes the array: the two channels are not interchangeable.
+        expect(telemetry.cacheEscape).toBe('normalized:nutrition_invalid');
+
+        // A row-quality escape never reaches hydration — the cached candidate
+        // is refused before the synthetic-candidate hydration is built.
+        expect(hydrationCandidateIds()).toEqual([FDC_ID]);
+    });
+
+    it('(e) the REJECTION channel: a helper-side refusal written to the out-param reaches the save as lookup_-prefixed records', async () => {
+        // The two remaining append sites read the CacheLookupRejection
+        // out-param (4th argument) that getValidatedMappingByNormalizedName
+        // populates via noteRejection() when a row was FOUND and REFUSED.
+        // The mock plays the helper's part exactly per that contract: write a
+        // REAL noteRejection reason ('core_token_mismatch' — the first arm)
+        // plus the refused row's identity, and return null.
+        lookupMock.mockImplementation(
+            async (
+                key: string,
+                _source: string,
+                _raw: string,
+                rejection?: {
+                    reason: string | null;
+                    normalizedForm?: string;
+                    foodName?: string;
+                    targetKey?: string | null;
+                },
+            ) => {
+                if (rejection) {
+                    rejection.reason = 'core_token_mismatch';
+                    rejection.normalizedForm = key;
+                    rejection.foodName = 'Onion';
+                    // noteRejection stores targetKeyOf(cached) — the RECORD the
+                    // refused row pointed at, never the cache key.
+                    rejection.targetKey = OFF_TARGET_KEY;
+                }
+                return null;
+            },
+        );
+
+        const telemetry: MappingTelemetry = {};
+        const result = (await mapIngredientWithFallback('onion', { telemetry })) as { foodId: string } | null;
+
+        expect(result?.foodId).toBe(FDC_ID);
+        expect(saveCalls()).toHaveLength(1);
+        // Both lookup sites refused → BOTH rejection-channel records, in site
+        // order, each carrying the record targetKey the helper wrote.
+        expect(saveCalls()[0][3].readEscapes).toEqual([
+            { targetKey: OFF_TARGET_KEY, reason: 'lookup_early:core_token_mismatch' },
+            { targetKey: OFF_TARGET_KEY, reason: 'lookup_normalized:core_token_mismatch' },
+        ]);
+        expect(telemetry.cacheEscape).toBe('lookup_normalized:core_token_mismatch');
+
+        // The forfeit tie-in cuts the OTHER way on this channel: an
+        // identity-class rejection is not a row-quality escape, so delivery
+        // does NOT imply the save-time forfeit can match it.
+        expect(isRowQualityEscape('lookup_early:core_token_mismatch')).toBe(false);
+
+        // One helper call per site: for this unbranded line the legacy key
+        // equals the symmetric key, so the fallback short-circuits.
+        expect(lookupMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(c) the early:hydration_failed fall-through is labelled but NOT recorded as a readEscape', async () => {
+        // Early lookup hits a HEALTHY row (no escape reason fires); its
+        // hydration fails for this request. The mapper labels telemetry
+        // 'early:hydration_failed' and falls through — deliberately without
+        // appending to readEscapes, so the incumbent keeps its cross-source
+        // margin protection. Step 1c then misses and search wins.
+        lookupMock.mockResolvedValueOnce(cachedOffRow()); // early: hit, then default null
+        mockOffFindUnique.mockResolvedValue(healthyOffRecord());
+
+        const telemetry: MappingTelemetry = {};
+        const result = (await mapIngredientWithFallback('onion', { telemetry })) as { foodId: string } | null;
+
+        expect(result?.foodId).toBe(FDC_ID);
+        // The fall-through really ran: the cached candidate WAS hydrated (and
+        // failed), then the search winner hydrated successfully.
+        expect(hydrationCandidateIds()).toEqual([OFF_FOOD_ID, FDC_ID]);
+        expect(telemetry.cacheEscape).toBe('early:hydration_failed');
+
+        // ... and the save receives an EMPTY escape list: no forfeit.
+        expect(saveCalls()).toHaveLength(1);
+        expect(saveCalls()[0][3].readEscapes).toEqual([]);
+    });
+
+    it('(d) a direct-return producer (backfill serve) delivers no escapes because no outer save runs', async () => {
+        // Both cache layers escape (missing off_ record), search finds NOTHING,
+        // AI-simplify is inert, so the `!winner` AI-nutrition backfill serves
+        // the line and returns directly — bypassing finalizeAndSaveResult().
+        // The two accumulated escapes are dropped on the floor with it.
+        lookupMock.mockResolvedValue(cachedOffRow());
+        mockGatherCandidates.mockResolvedValue([]);
+        (requestAiNutrition as jest.Mock).mockResolvedValue({
+            status: 'success',
+            foodId: 'clx_ai_generated_test_1',
+            displayName: 'Onion (AI estimate)',
+            caloriesPer100g: 40,
+            proteinPer100g: 1.1,
+            carbsPer100g: 9,
+            fatPer100g: 0.1,
+            confidence: 0.8,
+            cached: false,
+        });
+
+        const telemetry: MappingTelemetry = {};
+        const result = (await mapIngredientWithFallback('onion', { telemetry })) as
+            | { foodId: string; source: string }
+            | null;
+
+        // The backfill really served the line…
+        expect(requestAiNutrition).toHaveBeenCalledTimes(1);
+        expect(result?.source).toBe('ai_generated');
+        expect(result?.foodId).toBe('clx_ai_generated_test_1');
+
+        // …the escapes were genuinely recorded on the way (telemetry shows the
+        // Step-1c one), and yet NO save ever ran to receive them.
+        expect(telemetry.cacheEscape).toBe('normalized:nutrition_invalid');
+        expect(saveValidatedMapping).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/mapping/__tests__/producer-simplify-exits.test.ts
+++ b/src/lib/mapping/__tests__/producer-simplify-exits.test.ts
@@ -1,0 +1,461 @@
+/**
+ * CHARACTERIZATION (Phase 1 stage 1c, cluster 3): the AI-simplify recursion's
+ * TWO exit disciplines in `mapIngredientWithFallback()`.
+ *
+ * These tests pin CURRENT behavior so the stage-1d extraction is provably
+ * behavior-preserving. They assert what the code DOES, not what it should do.
+ *
+ * The producer under test is Step 2b-ii: no winner anywhere -> the mapper calls
+ * `aiSimplifyIngredient()` and RE-ENTERS itself with the simplified name and
+ * `_skipFallback: true`. The inner frame runs the full cascade (so it saves
+ * under the SIMPLIFIED name's key when its own confidence clears the gate).
+ * Back in the outer frame there are two different exits:
+ *
+ *   (i)  REHYDRATION SUCCESS — `hydrateAndSelectServing(fallbackCandidate,
+ *        originalParsed, ...)` returns a result and the outer frame returns it
+ *        DIRECTLY (`return rehydratedResult`). No outer save, no
+ *        `finalizeAndSaveResult()`, and therefore NO sanity caps: a 50 kg
+ *        rehydrated result comes back to the caller unchecked.
+ *
+ *   (ii) REHYDRATION FAILURE — `winner = fallbackCandidate`,
+ *        `selectionReason = 'fallback_simplified: <rationale>'`, and the flow
+ *        continues through the COMMON TAIL: Step 5 hydration retries, then
+ *        `finalizeAndSaveResult()`, which saves under the ORIGINAL line's key
+ *        (and applies the sanity caps AFTER the save).
+ *
+ * Plus the dietary-prefix sibling (Step 2b-i): a `gluten-free X` line whose
+ * recursion succeeds is returned AS-IS (`return dietaryFallbackResult`) — no
+ * rehydration call at all, and `aiSimplifyIngredient()` is never reached.
+ *
+ * HOW THE INNER FRAMES ARE DECIDED (both recursions, verified by the save
+ * pins): the mocked `simpleRerank` names the winner. Each recursion pool is a
+ * token-twin pair ('Roast Beef' / 'Beef Roast'), so `confidenceGate` finds no
+ * clear margin between them and declines to pre-empt; the mock's pick, reason
+ * ('simple_rerank') and confidence (0.9) flow through to the inner save
+ * unaltered — the agreement lift never fires because the gate named nobody.
+ * An earlier revision of this file used SIMPLIFIED = 'chicken breast', which
+ * `normalizeIngredientName()` rewrites to 'skinless chicken breast' (hardcoded
+ * rule in normalization-rules.ts); that evicted the exact-match candidate in
+ * `filterCandidatesByTokens` and routed the inner frame through the
+ * `confidence_gate_backstop` on the surviving sibling — a fixture artifact the
+ * current fixture ('roast beef', probed to pass normalization untouched)
+ * removes. Both the simplify and the dietary inner frames are now
+ * rerank-decided, symmetrically.
+ *
+ * Mock preamble follows the house pattern (abstention-confidence.test.ts /
+ * llm-output-guard-wiring.test.ts): Proxy prisma answering "nothing found" for
+ * every model and verb, `gatherCandidates` keyed on the raw line so the inner
+ * frame gets a pool the outer frame does not, `simpleRerank` returning a winner
+ * only when the pool contains one, the stage-1a seam
+ * `../serving/hydration-lane` intercepting ALL mapper hydration call sites,
+ * and `../mapping-logger` automocked so a run writes no
+ * logs/mapping-analysis-*.json or mapping-summary-*.txt files.
+ *
+ * A failure here after 1d means the extraction changed one of these disciplines
+ * — most likely by routing a direct-return exit through a save/caps path it has
+ * never taken.
+ */
+
+const mockGatherCandidates = jest.fn();
+const mockSimpleRerank = jest.fn();
+const mockHydrate = jest.fn();
+const mockSave = jest.fn();
+const mockLookupByName = jest.fn();
+const mockGetAiNormalizeCache = jest.fn();
+const mockAiSimplify = jest.fn();
+const mockShouldNormalize = jest.fn();
+const mockRequestAiNutrition = jest.fn();
+const mockGetAiServingGrams = jest.fn();
+
+// Generic prisma stub: every model answers "nothing found" for any verb. The
+// Proxy shape (vs an enumerated model list) is deliberate — omitting a
+// serving-store model fails DEEP in the cascade mimicking a production bug
+// (warned in map-ingredient-with-fallback.test.ts's own header).
+jest.mock('../../db', () => {
+    const emptyFor = (verb: string) =>
+        jest.fn().mockResolvedValue(verb.startsWith('findMany') ? [] : null);
+    const model = new Proxy({}, { get: (_t, verb: string) => emptyFor(verb) });
+    return { prisma: new Proxy({}, { get: () => model }) };
+});
+
+jest.mock('../../search/query-embedding', () => ({
+    SEMANTIC_SEARCH_ENABLED: false,
+    CORPUS_POOLING: 'cls',
+    warmupEmbedder: jest.fn(),
+    embedQuery: jest.fn().mockResolvedValue(null),
+}));
+
+// The Mac .env sets ENABLE_MAPPING_ANALYSIS=true; unmocked, every run writes
+// logs/mapping-analysis-*.json + mapping-summary-*.txt session files from
+// inside jest. Bare automock suffices (producer-cache-failure-research.test.ts
+// proves it).
+jest.mock('../mapping-logger');
+
+jest.mock('../gather-candidates', () => {
+    const actual = jest.requireActual('../gather-candidates');
+    return { ...actual, gatherCandidates: (...a: unknown[]) => mockGatherCandidates(...a) };
+});
+
+jest.mock('../simple-rerank', () => {
+    const actual = jest.requireActual('../simple-rerank');
+    return { ...actual, simpleRerank: (...a: unknown[]) => mockSimpleRerank(...a) };
+});
+
+// The stage-1a seam: the mapper imports hydrateAndSelectServing from the lane,
+// so this one mock intercepts every hydration call site in BOTH frames.
+jest.mock('../serving/hydration-lane', () => {
+    const actual = jest.requireActual('../serving/hydration-lane');
+    return { ...actual, hydrateAndSelectServing: (...a: unknown[]) => mockHydrate(...a) };
+});
+
+jest.mock('../validated-mapping-helpers', () => {
+    const actual = jest.requireActual('../validated-mapping-helpers');
+    return {
+        ...actual,
+        getValidatedMapping: jest.fn().mockResolvedValue(null),
+        getValidatedMappingByNormalizedName: (...a: unknown[]) => mockLookupByName(...a),
+        saveValidatedMapping: (...a: unknown[]) => mockSave(...a),
+        getAiNormalizeCache: (...a: unknown[]) => mockGetAiNormalizeCache(...a),
+        saveAiNormalizeCache: jest.fn().mockResolvedValue(undefined),
+        trackValidationFailure: jest.fn().mockResolvedValue(undefined),
+    };
+});
+
+jest.mock('../ai-simplify', () => {
+    const actual = jest.requireActual('../ai-simplify');
+    return { ...actual, aiSimplifyIngredient: (...a: unknown[]) => mockAiSimplify(...a) };
+});
+
+// AI_NUTRITION_BACKFILL_ENABLED defaults TRUE — an unmocked backfill dials the
+// jest LLM blackhole and fails as a confusing ECONNREFUSED.
+jest.mock('../ai-nutrition-backfill', () => ({
+    requestAiNutrition: (...a: unknown[]) => mockRequestAiNutrition(...a),
+    extractBaseFoodContext: jest.fn().mockReturnValue(null),
+    getAiServingGrams: (...a: unknown[]) => mockGetAiServingGrams(...a),
+    createAiNutritionBudget: (max: number) => ({ remaining: max, spent: 0 }),
+}));
+
+jest.mock('../normalize-gate', () => {
+    const actual = jest.requireActual('../normalize-gate');
+    return { ...actual, shouldNormalizeLlm: (...a: unknown[]) => mockShouldNormalize(...a) };
+});
+
+jest.mock('../ai-normalize', () => {
+    const actual = jest.requireActual('../ai-normalize');
+    return {
+        ...actual,
+        aiNormalizeIngredient: jest.fn().mockResolvedValue({ status: 'error', reason: 'llm_disabled_in_test' }),
+    };
+});
+
+jest.mock('../hydrate-cache');
+jest.mock('../deferred-hydration');
+jest.mock('../ai-backfill', () => ({
+    insertAiServing: jest.fn().mockResolvedValue({ success: false, reason: 'disabled_in_test' }),
+    backfillWeightServing: jest.fn().mockResolvedValue({ success: false, reason: 'disabled_in_test' }),
+}));
+
+// The single LLM chokepoint, blackholed deterministically (house rule: there is
+// deliberately no env-var bypass; jest.setup.no-llm.js blanks the credentials).
+jest.mock('../../ai/structured-client', () => {
+    const actual = jest.requireActual('../../ai/structured-client');
+    return {
+        ...actual,
+        callStructuredLlm: jest.fn().mockResolvedValue({
+            status: 'error',
+            error: 'llm disabled in unit tests',
+            provider: 'openrouter',
+            model: 'none',
+            durationMs: 0,
+        }),
+    };
+});
+
+import { mapIngredientWithFallback, type FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
+import type { UnifiedCandidate } from '../gather-candidates';
+import { hydrateSingleCandidate } from '../hydrate-cache';
+
+// ── Fixture lines ───────────────────────────────────────────────────────────
+// ORIGINAL is chosen so the outer frame's own search finds nothing (the gather
+// mock only serves pools for the two recursion lines) and so no dietary prefix
+// fires. SIMPLIFIED / DIETARY_STRIPPED are the lines the two recursions re-enter
+// with, and are the gather mock's keys. SIMPLIFIED must pass
+// normalizeIngredientName() UNCHANGED or the derived search query stops
+// matching the pool names ('chicken breast' -> 'skinless chicken breast' is the
+// probed counterexample; 'roast beef' round-trips identical).
+const ORIGINAL = 'mystery cutlet platter';
+const SIMPLIFIED = 'roast beef';
+const DIETARY_LINE = 'gluten-free mystery platter';
+const DIETARY_STRIPPED = 'mystery platter';
+
+/** An FDC candidate carrying its own plausible panel, so filters keep it. */
+const cand = (
+    id: string,
+    name: string,
+    score: number,
+    macros: { kcal: number; protein: number; carbs: number; fat: number },
+): UnifiedCandidate => ({
+    id,
+    source: 'fdc',
+    name,
+    brandName: null,
+    score,
+    nutrition: { ...macros, per100g: true },
+    servings: [{ description: '100 g', grams: 100, isDefault: true }],
+    rawData: {
+        fdcId: Number(id.replace('fdc_', '')),
+        description: name,
+        dataType: 'SR Legacy',
+        nutrientsPer100g: { calories: macros.kcal, protein: macros.protein, carbs: macros.carbs, fat: macros.fat },
+        servings: [],
+    },
+} as unknown as UnifiedCandidate);
+
+// Fresh arrays per call: the mapper enriches candidate objects in place.
+// Each pool is a TOKEN-TWIN pair (same tokens, swapped order): both survive
+// filterCandidatesByTokens (no missing and no extra tokens), and the gate
+// scores them without a clear margin, so it declines to pre-empt and the
+// mocked simpleRerank decides. A bloat sibling ('... Deluxe') would risk
+// eviction and a single-candidate pool would hand the gate a clear winner.
+const roastBeefPool = () => [
+    cand('fdc_1111111', 'Roast Beef', 5.0, { kcal: 180, protein: 28, carbs: 0, fat: 7 }),
+    cand('fdc_2222222', 'Beef Roast', 4.0, { kcal: 190, protein: 26, carbs: 2, fat: 9 }),
+];
+const mysteryPool = () => [
+    cand('fdc_1111111', 'Mystery Platter', 5.0, { kcal: 200, protein: 10, carbs: 20, fat: 8 }),
+    cand('fdc_2222222', 'Platter Mystery', 4.0, { kcal: 210, protein: 11, carbs: 21, fat: 9 }),
+];
+
+/** A hydrated-result stub. servingTier is a REAL tier string (never invented). */
+const mkResult = (
+    foodName: string,
+    rawLine: string,
+    overrides: Partial<FatsecretMappedIngredient> = {},
+): FatsecretMappedIngredient => ({
+    source: 'fdc',
+    foodId: 'fdc_1111111',
+    foodName,
+    brandName: null,
+    servingId: null,
+    servingDescription: '100 g',
+    grams: 100,
+    kcal: 165,
+    protein: 31,
+    carbs: 0,
+    fat: 3.6,
+    confidence: 1,
+    quality: 'high',
+    rawLine,
+    servingTier: 'flat_100g_default',
+    ...overrides,
+});
+
+const map = (line: string) =>
+    mapIngredientWithFallback(line) as Promise<FatsecretMappedIngredient | null>;
+
+const saveCalls = () => mockSave.mock.calls;
+/** rawLine of every saveValidatedMapping call, in order. */
+const saveLines = () => saveCalls().map((c) => c[0] as string);
+/** The aiHydrationBudget argument (positional arg 5) of every hydrate call. */
+const hydrateBudgets = () => mockHydrate.mock.calls.map((c) => c[4]);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockLookupByName.mockResolvedValue(null);
+    mockGetAiNormalizeCache.mockResolvedValue(null);
+    mockSave.mockResolvedValue(undefined);
+    // Rule-based normalization only; the LLM normalize lane stays cold.
+    mockShouldNormalize.mockReturnValue({ shouldCallLlm: false, reason: 'test_skips_llm_normalize', confidence: 0.9 });
+    mockRequestAiNutrition.mockResolvedValue({ status: 'error', reason: 'backfill_disabled_in_test' });
+    mockGetAiServingGrams.mockResolvedValue(null);
+    mockAiSimplify.mockResolvedValue({ simplified: SIMPLIFIED, rationale: 'test rationale' });
+    // Winner only when the pool has fdc_1111111 — i.e. only in an inner frame.
+    // 'simple_rerank' is a reason string the real reranker produces. This mock
+    // GENUINELY DECIDES both inner frames: the token-twin pools give the gate
+    // no clear margin, so it never pre-empts, and the inner saves carry this
+    // mock's reason and confidence verbatim (pinned below).
+    mockSimpleRerank.mockImplementation((_q: string, cands: Array<{ id: string }>) => {
+        const winner = cands.find((c) => c.id === 'fdc_1111111') ?? null;
+        return winner
+            ? { winner, confidence: 0.9, reason: 'simple_rerank', sortedCandidates: cands }
+            : { winner: null, confidence: 0, reason: 'no_candidates', sortedCandidates: [] };
+    });
+    // Retrieval keyed on the RAW LINE: the outer lines find nothing, the two
+    // recursion lines each find their pool.
+    mockGatherCandidates.mockImplementation(async (raw: string) =>
+        raw === SIMPLIFIED ? roastBeefPool() : raw === DIETARY_STRIPPED ? mysteryPool() : []);
+    (hydrateSingleCandidate as jest.Mock).mockResolvedValue(true);
+});
+
+describe('AI-simplify exit (i): rehydration success returns directly', () => {
+    it('returns the rehydrated result as-is; the only save is the INNER frame\'s, under the SIMPLIFIED key; sanity caps never run', async () => {
+        const innerResult = mkResult('Roast Beef', SIMPLIFIED, { confidence: 1 });
+        // grams 50000 > MAX_REASONABLE_GRAMS(10000): if the outer frame ran
+        // finalizeAndSaveResult() this would come back null. It does not —
+        // the direct-return exit bypasses the caps entirely.
+        const rehydrated = mkResult('Roast Beef', ORIGINAL, { grams: 50000, kcal: 300, confidence: 0.72 });
+        // Keyed on candidate id AND rawLine. The id alone cannot separate the
+        // frames — the outer fallbackCandidate's id IS the inner result's
+        // foodId (fdc_1111111) by construction — but keying on it means a
+        // wrong inner winner gets null back and fails loudly, instead of the
+        // mock laundering it into the expected result.
+        mockHydrate.mockImplementation(async (c: { id: string }, _p: unknown, _conf: unknown, rawLine: string) => {
+            if (c.id !== 'fdc_1111111') return null;
+            return rawLine === SIMPLIFIED ? innerResult : rehydrated;
+        });
+
+        const res = await map(ORIGINAL);
+
+        // Same object reference: `return rehydratedResult;` — no finalize wrap.
+        expect(res).toBe(rehydrated);
+        expect(res!.grams).toBe(50000);
+
+        // The simplify recursion happened, once, on the original trimmed line.
+        expect(mockAiSimplify).toHaveBeenCalledTimes(1);
+        expect(mockAiSimplify.mock.calls[0][0]).toBe(ORIGINAL);
+        // The inner frame searched the SIMPLIFIED name.
+        expect(mockGatherCandidates.mock.calls.some((c) => c[0] === SIMPLIFIED)).toBe(true);
+
+        // Fixture health: the rerank pool STILL CONTAINS the exact-match id —
+        // i.e. filterCandidatesByTokens did not evict it (the failure mode the
+        // old 'chicken breast' fixture had), so the mock's pick is a genuine
+        // decision over both candidates.
+        expect(mockSimpleRerank).toHaveBeenCalled();
+        const rerankPoolIds = (mockSimpleRerank.mock.calls[0][1] as Array<{ id: string }>).map((c) => c.id);
+        expect(rerankPoolIds).toContain('fdc_1111111');
+
+        // Exactly TWO hydrations: inner Step 5 on the rerank winner, then the
+        // outer rehydration of the fallback candidate against the ORIGINAL
+        // parsed input. Both carry the winner's id.
+        expect(mockHydrate).toHaveBeenCalledTimes(2);
+        expect((mockHydrate.mock.calls[0][0] as { id: string }).id).toBe('fdc_1111111');
+        expect(mockHydrate.mock.calls[0][3]).toBe(SIMPLIFIED);
+        expect((mockHydrate.mock.calls[1][0] as { id: string }).id).toBe('fdc_1111111');
+        expect(mockHydrate.mock.calls[1][3]).toBe(ORIGINAL);
+
+        // Cross-frame budget forwarding (census invariant): aiHydrationBudget
+        // is explicitly forwarded past the options spread into the recursion,
+        // so the inner frame's hydration and the outer rehydration receive the
+        // SAME object, not a fresh per-frame allowance.
+        expect(hydrateBudgets()[0]).toBeDefined();
+        expect(hydrateBudgets()[1]).toBe(hydrateBudgets()[0]);
+
+        // ONE save total, and it is the INNER frame's: rawLine and cache key
+        // both belong to the SIMPLIFIED name. The outer frame saves nothing.
+        // Reason and confidence are the rerank MOCK's own values, passed
+        // through unaltered — proof the mocked rerank (not the gate backstop,
+        // and not the agreement lift, which would have raised the number)
+        // decided the inner frame.
+        expect(mockSave).toHaveBeenCalledTimes(1);
+        expect(saveLines()).toEqual([SIMPLIFIED]);
+        expect(saveCalls()[0][2]).toMatchObject({ approved: true, confidence: 0.9, reason: 'simple_rerank' });
+        expect(String(saveCalls()[0][3].canonicalBase)).toContain('beef');
+        expect(saveLines()).not.toContain(ORIGINAL);
+    });
+});
+
+describe('AI-simplify exit (ii): rehydration failure flows through the common tail', () => {
+    /**
+     * Sequencing: call 1 = inner Step 5 (succeeds), call 2 = outer rehydration
+     * (FAILS -> winner = fallbackCandidate), call 3 = outer Step 5 on that
+     * winner (succeeds -> finalize). The outer frame reads the inner RESULT
+     * object's confidence (fbr.confidence — what hydration returned, here 1.0
+     * from mkResult), NOT the inner frame's selection confidence (the rerank
+     * mock's 0.9): fallbackCandidate.score = 1.0 * 0.85 = 0.85, which clears
+     * the >=0.85 save gate, so the outer save is observable.
+     */
+    const wireExitTwo = (tailResult: FatsecretMappedIngredient) => {
+        const innerResult = mkResult('Roast Beef', SIMPLIFIED, { confidence: 1 });
+        let outerCalls = 0;
+        mockHydrate.mockImplementation(async (c: { id: string }, _p: unknown, _conf: unknown, rawLine: string) => {
+            if (c.id !== 'fdc_1111111') return null;
+            if (rawLine === SIMPLIFIED) return innerResult;
+            outerCalls += 1;
+            return outerCalls === 1 ? null : tailResult;
+        });
+    };
+
+    it('saves TWICE — inner frame under the SIMPLIFIED key, outer finalize under the ORIGINAL key with reason fallback_simplified', async () => {
+        const tailResult = mkResult('Roast Beef', ORIGINAL, { confidence: 0.85 });
+        wireExitTwo(tailResult);
+
+        const res = await map(ORIGINAL);
+
+        // The common tail's finalize returns the hydrated result object as-is.
+        expect(res).toBe(tailResult);
+
+        // Three hydrations: inner Step 5, failed outer rehydration, outer Step 5.
+        expect(mockHydrate).toHaveBeenCalledTimes(3);
+        expect((mockHydrate.mock.calls[0][0] as { id: string }).id).toBe('fdc_1111111');
+        expect(mockHydrate.mock.calls[0][3]).toBe(SIMPLIFIED);
+        expect(mockHydrate.mock.calls[1][3]).toBe(ORIGINAL);
+        expect(mockHydrate.mock.calls[2][3]).toBe(ORIGINAL);
+        expect((mockHydrate.mock.calls[2][0] as { id: string }).id).toBe('fdc_1111111');
+        // The outer frame re-bills at fallbackCandidate.score = fbr.confidence * 0.85.
+        expect(mockHydrate.mock.calls[2][2]).toBe(0.85);
+
+        // One budget object threads through ALL THREE hydrations (census
+        // invariant: explicitly forwarded past the options spread).
+        expect(hydrateBudgets()[0]).toBeDefined();
+        expect(hydrateBudgets()[1]).toBe(hydrateBudgets()[0]);
+        expect(hydrateBudgets()[2]).toBe(hydrateBudgets()[0]);
+
+        // TWO saves: the inner frame's (simplified key, at the rerank mock's
+        // confidence and reason), then the outer finalize's (ORIGINAL key,
+        // fallback_simplified reason).
+        expect(mockSave).toHaveBeenCalledTimes(2);
+        expect(saveLines()).toEqual([SIMPLIFIED, ORIGINAL]);
+        expect(saveCalls()[0][2]).toMatchObject({ approved: true, confidence: 0.9, reason: 'simple_rerank' });
+        const outerSave = saveCalls()[1];
+        expect(outerSave[2]).toMatchObject({
+            approved: true,
+            confidence: 0.85,
+            reason: 'fallback_simplified: test rationale',
+        });
+        // The outer save's key belongs to the ORIGINAL name-space, not the
+        // simplified one.
+        expect(String(outerSave[3].canonicalBase)).not.toContain('beef');
+    });
+
+    it('DOES apply the sanity caps exit (i) bypasses — and the save happens BEFORE the cap rejects the result', async () => {
+        // Same absurd grams as the exit (i) test. There it came back to the
+        // caller; here the common tail's finalize nulls it — but only AFTER
+        // offering it to the cache. That ordering is current behavior; pin it.
+        const tailResult = mkResult('Roast Beef', ORIGINAL, { grams: 50000, kcal: 300, confidence: 0.85 });
+        wireExitTwo(tailResult);
+
+        const res = await map(ORIGINAL);
+
+        expect(res).toBeNull();
+        expect(saveLines()).toEqual([SIMPLIFIED, ORIGINAL]);
+        expect(saveCalls()[1][1]).toBe(tailResult);
+    });
+});
+
+describe('the dietary-prefix sibling (Step 2b-i) short-circuits before AI-simplify', () => {
+    it('returns the recursion result AS-IS — no rehydration, no simplify call, save only under the STRIPPED name', async () => {
+        const dietaryInner = mkResult('Mystery Platter', DIETARY_STRIPPED, { confidence: 1 });
+        mockHydrate.mockImplementation(async (c: { id: string }, _p: unknown, _conf: unknown, rawLine: string) =>
+            rawLine === DIETARY_STRIPPED && c.id === 'fdc_1111111' ? dietaryInner : null);
+
+        const res = await map(DIETARY_LINE);
+
+        // `return dietaryFallbackResult;` — the inner frame's object, unwrapped
+        // and NOT rehydrated against the original parsed input (unlike the
+        // simplify path, which does rehydrate).
+        expect(res).toBe(dietaryInner);
+        expect(mockHydrate).toHaveBeenCalledTimes(1);
+        expect(mockHydrate.mock.calls[0][3]).toBe(DIETARY_STRIPPED);
+
+        // AI-simplify was never consulted.
+        expect(mockAiSimplify).not.toHaveBeenCalled();
+
+        // One save, the inner frame's, under the stripped line — decided by
+        // the mocked rerank, same as the simplify arm (the token-twin pool
+        // keeps the gate from pre-empting here too).
+        expect(mockSave).toHaveBeenCalledTimes(1);
+        expect(saveLines()).toEqual([DIETARY_STRIPPED]);
+        expect(saveCalls()[0][2]).toMatchObject({ approved: true, confidence: 0.9, reason: 'simple_rerank' });
+        expect(saveLines()).not.toContain(DIETARY_LINE);
+    });
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -2625,6 +2625,11 @@ export async function mapIngredientWithFallback(
                         food: dietaryFallbackResult.foodName,
                         confidence: dietaryFallbackResult.confidence,
                     });
+                    logger.audit('mapping.recovery_path', {
+                        path: 'dietary_direct_return',
+                        original: trimmed,
+                        servedBy: dietaryFallbackResult.foodId,
+                    });
                     return dietaryFallbackResult;
                 }
             }
@@ -2696,6 +2701,11 @@ export async function mapIngredientWithFallback(
                                 mappedTo: fbr.foodName,
                                 serving: rehydratedResult.servingDescription,
                                 grams: rehydratedResult.grams,
+                            });
+                            logger.audit('mapping.recovery_path', {
+                                path: 'simplify_direct_return',
+                                original: trimmed,
+                                servedBy: rehydratedResult.foodId,
                             });
                             return rehydratedResult;
                         }
@@ -3071,6 +3081,11 @@ export async function mapIngredientWithFallback(
                         fallbackId: fallback.id,
                         fallbackName: fallback.name,
                     });
+                    logger.audit('mapping.recovery_path', {
+                        path: 'serving_failure_fallback',
+                        from: failedWinnerId,
+                        to: fallback.id,
+                    });
                     result = fallbackResult;
                     selectionReason = 'fallback_after_serving_failure';
                     return true;
@@ -3132,6 +3147,10 @@ export async function mapIngredientWithFallback(
                 failedId: winner.id,
                 failedName: winner.name,
             });
+            logger.audit('mapping.recovery_path', {
+                path: 'cache_failure_research',
+                from: winner.id,
+            });
 
             // Run full search to find candidates with working servings
             const searchGatherOptions: GatherOptions = {
@@ -3186,6 +3205,11 @@ export async function mapIngredientWithFallback(
                         originalId: failedCacheWinnerId,
                         fallbackId: candidate.id,
                         fallbackName: candidate.name,
+                    });
+                    logger.audit('mapping.recovery_path', {
+                        path: 'cache_failure_rebilled',
+                        from: failedCacheWinnerId,
+                        to: candidate.id,
                     });
                     result = retryResult;
                     selectionReason = 'fallback_search_after_cache_failure';
@@ -3257,6 +3281,11 @@ export async function mapIngredientWithFallback(
                     rawLine: trimmed,
                     baseFoodContext,
                     budget: aiNutritionBudget,
+                });
+                logger.audit('mapping.recovery_path', {
+                    path: 'backfill_after_winner',
+                    from: winner.id,
+                    served: aiResult.status === 'success',
                 });
 
                 if (aiResult.status === 'success') {


### PR DESCRIPTION
## What

Stage 1c of the pipeline hardening plan: prove the mapper cascade's producer behavior **before** stage 1d extracts it.

- **Commit 1 (tests only):** 37 characterization tests across 7 new files pinning current behavior — the second AI-backfill site firing after a winner exists (no save, no caps), Step 5b's re-search rebilling past the resave-skip, both AI-simplify exit disciplines, billed-vs-winner divergence, readEscapes delivery through all four append sites, normalizedName frozen-before-cascade, and negative independence witnesses. Zero production-code changes.
- **Commit 2 (instrument):** six `logger.audit('mapping.recovery_path')` emissions at the cascade's attribution-blind exits (dietary/simplify direct returns, serving-failure rebill, 5b entry+rebill, backfill-after-winner). All outside the winner-diff caller window — hashes unchanged (`caller=2aa35e26b52161d1 helpers=8c1e518d30331976`).

## Why

The census (`sync-docs/reports/2026-08-06_phase-1-stage-1c-handoff.md`, mobile repo) refuted the plan's four-mutually-exclusive-producers model: 8 result-producing exits, 6 bypassing the save path, plus two post-selection result-swappers. Each census violation now has a named red witness under a naive 'first non-null Selection' 1d design. The handoff's proposed 'exactly one producer fired' invariant was itself refuted (V1/V2 legally run two machineries) — the instrument ships path attribution instead.

## Gates

- jest 172 suites / 3,431 passed / 1 skipped / 0 failed (was 165/3,394/1 pre-1c)
- tsc 0 · lint:ci 0 errors (591/700 warnings) · `next build` green · doc-check 109/109
- winner-diff caller+helpers hashes byte-identical
- Authored by a 7-agent fan-out; hardened by a 6-agent adversarial review (5 must-fix findings applied, incl. two vacuous-pass paths and a confounded confidence pin); fix fleet re-verified per file

## Post-merge

Deploy per §Deploying, then cold gate ×3 restarted — abort condition: the same 11 stable ids with byte-identical observed values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu