### PR TITLE
refactor(mapping): stage 1d — extract the selection cascade into module-private producer/recovery functions

### DIFF
--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -2916,53 +2916,10 @@ export async function mapIngredientWithFallback(
             return null;
         }
 
-        // Step 5: Hydrate and select serving with fallback to next candidates
-        let result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
-
         // Step 5a: If hydration failed and user requested a weight unit (oz, g, lb),
         // try AI backfill for weight serving on the winner BEFORE falling back to other candidates.
         // This prevents falling back to lower-ranked candidates just because they have gram servings.
         const isWeightUnit = parsed?.unit && /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms)$/i.test(parsed.unit);
-
-        if (!result && isWeightUnit && winner.source === 'ai_generated') {
-            // See the rerank instrumentation note above. If this never fires, weight
-            // serving backfill has been silently off since the lane was relabelled
-            // 'fatsecret' — corroborated by MEASURED 0 occurrences of the warn-level
-            // mapping.weight_backfill_failed in 12 days of production log. The repair
-            // would then be to WIDEN this guard to 'fatsecret', not to delete it.
-            logger.audit('backfill.ai_generated_winner_seen', {
-                foodId: winner.id,
-                foodName: winner.name,
-                path: 'weight',
-            });
-            logger.info('mapping.weight_backfill_attempt', {
-                foodId: winner.id,
-                foodName: winner.name,
-                unit: parsed!.unit,
-            });
-
-            const backfillResult = await backfillWeightServing(winner.id);
-
-            if (backfillResult.success) {
-                // Retry hydration now that we have a weight serving
-                result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
-
-                if (result) {
-                    logger.info('mapping.weight_backfill_success', {
-                        foodId: winner.id,
-                        foodName: winner.name,
-                        unit: parsed!.unit,
-                        grams: result.grams,
-                    });
-                    selectionReason = 'weight_backfill_success';
-                }
-            } else {
-                logger.warn('mapping.weight_backfill_failed', {
-                    foodId: winner.id,
-                    reason: backfillResult.reason,
-                });
-            }
-        }
 
         // Step 5a-VOLUME: If hydration failed for a VOLUME unit (cup, tbsp, tsp, etc.),
         // try AI volume backfill to estimate density for the winner BEFORE falling back to other candidates.
@@ -2972,413 +2929,47 @@ export async function mapIngredientWithFallback(
         // Extract prep modifier from ingredient line for modifier-aware serving labels
         const prepModifier = extractPrepModifier(rawLine, parsed?.qualifiers);
 
-        // Enable AI backfill for BOTH FatSecret and FDC sources (FDC often lacks volume servings)
-        if (!result && isVolumeUnit && (winner.source === 'ai_generated' || winner.source === 'fdc')) {
-            if (winner.source === 'ai_generated') {
-                logger.audit('backfill.ai_generated_winner_seen', {
-                    foodId: winner.id,
-                    foodName: winner.name,
-                    path: 'volume',
-                });
-            }
-            logger.info('mapping.volume_backfill_attempt', {
-                foodId: winner.id,
-                foodName: winner.name,
-                unit: parsed!.unit,
-                source: winner.source,
-                prepModifier,
-            });
-
-            const volumeBackfillResult = await insertAiServing(winner.id, 'volume', {
-                targetServingUnit: parsed?.unit ?? undefined,
-                prepModifier,
-                candidateData: winner,  // Pass candidate data to avoid DB lookup race condition
-            });
-
-            if (volumeBackfillResult.success) {
-                // Retry hydration now that we have a volume serving
-                result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
-
-                if (result) {
-                    logger.info('mapping.volume_backfill_success', {
-                        foodId: winner.id,
-                        foodName: winner.name,
-                        unit: parsed!.unit,
-                        grams: result.grams,
-                    });
-                    selectionReason = 'volume_backfill_success';
-                }
-            } else {
-                logger.warn('mapping.volume_backfill_failed', {
-                    foodId: winner.id,
-                    reason: volumeBackfillResult.reason,
-                });
-            }
-        }
+        // Step 5: Hydrate and select serving with fallback to next candidates
+        const hydrated = await hydrateWinnerWithBackfills({
+            winner, parsed, confidence, rawLine, aiHydrationBudget,
+            isWeightUnit, isVolumeUnit, prepModifier,
+        });
+        let result = hydrated.result;
+        if (hydrated.selectionReason !== undefined) selectionReason = hydrated.selectionReason;
 
         // If first choice fails (e.g., branded item without serving weights), try next candidates
         // Note: filtered may be empty if winner came from cache hit - skip fallback in that case
         if (!result && filtered.length > 0) {
-            logger.info('mapping.hydration_failed_retrying', {
-                failedId: winner.id,
-                failedName: winner.name,
-                remainingCandidates: filtered.length - 1
+            const servingFallback = await attemptServingFailureFallback({
+                winner, filtered, parsed, confidence, rawLine, trimmed, normalizedName,
+                aiHydrationBudget, isWeightUnit, isVolumeUnit, prepModifier,
             });
-
-            // Try next 3 candidates as fallbacks
-            const fallbackCandidates = filtered
-                .filter(c => c.id !== winner.id)
-                .slice(0, 3);
-
-            const failedWinnerId = winner.id;
-            const tryFallbackCandidate = async (fallback: UnifiedCandidate): Promise<boolean> => {
-                let fallbackResult = await hydrateAndSelectServing(
-                    fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
-                );
-
-                // If hydration failed for a FatSecret candidate, try backfill before giving up
-                if (!fallbackResult && fallback.source === 'ai_generated') {
-                    logger.audit('backfill.ai_generated_winner_seen', {
-                        foodId: fallback.id,
-                        foodName: fallback.name,
-                        path: 'fallback',
-                    });
-                    if (isVolumeUnit) {
-                        logger.info('mapping.fallback_volume_backfill_attempt', {
-                            foodId: fallback.id,
-                            foodName: fallback.name,
-                            unit: parsed?.unit,
-                            prepModifier,
-                        });
-                        const backfillResult = await insertAiServing(fallback.id, 'volume', {
-                            targetServingUnit: parsed?.unit ?? undefined,
-                            prepModifier,
-                            candidateData: fallback,  // Pass candidate data to avoid DB lookup race condition
-                        });
-                        if (backfillResult.success) {
-                            fallbackResult = await hydrateAndSelectServing(
-                                fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
-                            );
-                        }
-                    } else if (isWeightUnit) {
-                        logger.info('mapping.fallback_weight_backfill_attempt', {
-                            foodId: fallback.id,
-                            foodName: fallback.name,
-                            unit: parsed?.unit,
-                        });
-                        const backfillResult = await backfillWeightServing(fallback.id);
-                        if (backfillResult.success) {
-                            fallbackResult = await hydrateAndSelectServing(
-                                fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
-                            );
-                        }
-                    }
-                }
-
-                if (fallbackResult) {
-                    logger.info('mapping.fallback_success', {
-                        originalId: failedWinnerId,
-                        fallbackId: fallback.id,
-                        fallbackName: fallback.name,
-                    });
-                    logger.audit('mapping.recovery_path', {
-                        path: 'serving_failure_fallback',
-                        from: failedWinnerId,
-                        to: fallback.id,
-                    });
-                    result = fallbackResult;
-                    selectionReason = 'fallback_after_serving_failure';
-                    return true;
-                }
-                return false;
-            };
-
-            // PR D pt3 (B4): floor-hit fallbacks are set aside and only tried
-            // as a last resort; denylisted records are never accepted.
-            const floorRejectedFallbacks: UnifiedCandidate[] = [];
-
-            for (const fallback of fallbackCandidates) {
-                // CRITICAL: Validate semantic relevance before accepting fallback
-                // This prevents "golden flaxseed meal" → "Golden Delicious Apples" syndrome
-                // where the fallback is selected just because it has the right serving,
-                // despite being semantically unrelated to the query
-                if (hasCoreTokenMismatch(normalizedName, fallback.name, fallback.brandName)) {
-                    logger.debug('mapping.fallback_rejected_token_mismatch', {
-                        query: normalizedName,
-                        fallbackName: fallback.name,
-                        fallbackBrand: fallback.brandName,
-                    });
-                    continue; // Skip this fallback, try next one
-                }
-                if (isRankPlausibilityPartitionEnabled() && isDenylistedOffRecord(fallback.id)) {
-                    logger.warn('mapping.denylisted_candidate_dropped', {
-                        rawLine: trimmed,
-                        candidate: fallback.name,
-                        foodId: fallback.id,
-                    });
-                    continue;
-                }
-                if (candidateHitsPlausibilityFloor(normalizedName, fallback)) {
-                    logger.debug('mapping.fallback_rejected_plausibility_floor', {
-                        query: normalizedName,
-                        fallbackName: fallback.name,
-                    });
-                    floorRejectedFallbacks.push(fallback);
-                    continue;
-                }
-
-                if (await tryFallbackCandidate(fallback)) break;
-            }
-
-            // Last resort: every acceptable fallback was floor-hit — a
-            // floor-hit record still beats returning nothing (floors demote,
-            // never drop).
-            if (!result) {
-                for (const fallback of floorRejectedFallbacks) {
-                    if (await tryFallbackCandidate(fallback)) break;
-                }
+            if (servingFallback) {
+                result = servingFallback.result;
+                selectionReason = servingFallback.selectionReason;
             }
         }
 
         // Step 5b: If winner came from cache and serving selection failed, try full search
         // This handles cases where cached food has missing serving data
         if (!result && filtered.length === 0 && selectionReason === 'normalized_cache_hit') {
-            logger.info('mapping.cache_serving_failed_retrying_search', {
-                failedId: winner.id,
-                failedName: winner.name,
+            const cacheResearch = await attemptCacheFailureResearch({
+                winner, trimmed, normalizedName, parsed, rawLine, confidence, aiHydrationBudget,
+                aiNutritionEstimate, aiCanonicalBase, isBrandedQuery, brandDetection,
+                allSynonyms, skipCache, skipFdc, debug,
             });
-            logger.audit('mapping.recovery_path', {
-                path: 'cache_failure_research',
-                from: winner.id,
-            });
-
-            // Run full search to find candidates with working servings
-            const searchGatherOptions: GatherOptions = {
-                skipCache,
-                skipFdc,
-                isBrandedQuery,
-                targetBrand: brandDetection.matchedBrand ?? undefined,
-                aiSynonyms: allSynonyms,
-            };
-
-            const searchCandidates = await gatherCandidates(rawLine, parsed, normalizedName, searchGatherOptions);
-
-            if (searchCandidates.length > 0) {
-                const searchFilterResult = filterCandidatesByTokens(searchCandidates, normalizedName, { debug, rawLine: trimmed });
-
-                // Run reranker to ensure anomaly penalties (e.g. canned beans) are applied
-                const countedNounFB = countedPieceNoun(parsed);
-                const billsByServingFB = requestBillsByServing(parsed);
-                // Same grain-scoped volume serving-shape wiring as the primary
-                // rerank site (n-serv-06).
-                const grainVolumeUnitFB = !billsByServingFB && parsed?.unit
-                    && isMatchableVolumeUnit(parsed.unit)
-                    && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
-                    ? parsed.unit : null;
-                const rerankCandidates = searchFilterResult.filtered.map(c => toRerankCandidate({
-                    id: c.id,
-                    name: c.name,
-                    brandName: c.brandName,
-                    foodType: c.foodType,
-                    score: c.score,
-                    source: c.source,
-                    nutrition: c.nutrition,
-                    countLabelMatch: countedNounFB ? candidateHasCountLabel(c, countedNounFB) : undefined,
-                    servingLabelMatch: billsByServingFB ? candidateHasServingData(c)
-                        : grainVolumeUnitFB ? candidateHasVolumeServing(c, grainVolumeUnitFB) : undefined,
-                }));
-                const rerankQuery = aiCanonicalBase || stripPrepModifiers(normalizedName);
-                const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNounFB != null);
-                
-                // simpleRerank returns the fully sorted list based on semantic score, nutrition ties, and FDC preferencing
-                const sortedFallbackCandidates = rerankResult.sortedCandidates.map(
-                    rerankCand => searchFilterResult.filtered.find(c => c.id === rerankCand.id)!
-                ).filter(Boolean);
-
-                // Try each candidate until one works — denylisted records are
-                // never accepted; floor-hit ones only as a last resort (PR D pt3 B4).
-                const failedCacheWinnerId = winner.id;
-                const tryCacheFallbackCandidate = async (candidate: UnifiedCandidate): Promise<boolean> => {
-                    const retryResult = await hydrateAndSelectServing(candidate, parsed, confidence * 0.9, rawLine, aiHydrationBudget);
-                    if (!retryResult) return false;
-                    logger.info('mapping.cache_fallback_search_success', {
-                        originalId: failedCacheWinnerId,
-                        fallbackId: candidate.id,
-                        fallbackName: candidate.name,
-                    });
-                    logger.audit('mapping.recovery_path', {
-                        path: 'cache_failure_rebilled',
-                        from: failedCacheWinnerId,
-                        to: candidate.id,
-                    });
-                    result = retryResult;
-                    selectionReason = 'fallback_search_after_cache_failure';
-                    return true;
-                };
-
-                const floorRejectedRetries: UnifiedCandidate[] = [];
-                for (const candidate of sortedFallbackCandidates.slice(0, 5)) {
-                    if (isRankPlausibilityPartitionEnabled() && isDenylistedOffRecord(candidate.id)) {
-                        logger.warn('mapping.denylisted_candidate_dropped', {
-                            rawLine: trimmed,
-                            candidate: candidate.name,
-                            foodId: candidate.id,
-                        });
-                        continue;
-                    }
-                    if (candidateHitsPlausibilityFloor(normalizedName, candidate)) {
-                        logger.debug('mapping.fallback_rejected_plausibility_floor', {
-                            query: normalizedName,
-                            fallbackName: candidate.name,
-                        });
-                        floorRejectedRetries.push(candidate);
-                        continue;
-                    }
-                    if (await tryCacheFallbackCandidate(candidate)) break;
-                }
-                if (!result) {
-                    for (const candidate of floorRejectedRetries) {
-                        if (await tryCacheFallbackCandidate(candidate)) break;
-                    }
-                }
+            if (cacheResearch) {
+                result = cacheResearch.result;
+                selectionReason = cacheResearch.selectionReason;
             }
         }
 
         if (!result) {
-            if (ENABLE_MAPPING_ANALYSIS) {
-                logMappingAnalysis({
-                    rawIngredient: trimmed,
-                    parsed: {
-                        amount: parsed?.qty,
-                        unit: parsed?.unit,
-                        ingredient: parsed?.name,
-                    },
-                    topCandidates: filtered.slice(0, 5).map((c, i) => ({
-                        rank: i + 1,
-                        foodId: c.id,
-                        foodName: c.name,
-                        brandName: c.brandName || null,
-                        score: c.score,
-                        source: c.source,
-                    })),
-                    selectedCandidate: {
-                        foodId: winner.id,
-                        foodName: winner.name,
-                        brandName: winner.brandName || '',
-                        confidence,
-                        selectionReason,
-                    },
-                    finalResult: 'failed',
-                    failureReason: 'no_suitable_serving_found',
-                });
-            }
-
-            // Attempt AI Nutrition Backfill if all API pipeline candidates failed hydration
-            if (AI_NUTRITION_BACKFILL_ENABLED) {
-                logger.info('mapping.pipeline_failed_attempting_ai_backfill', { rawLine: trimmed });
-                const baseFoodContext = extractBaseFoodContext(allCandidates);
-                const aiResult = await requestAiNutrition(normalizedName, {
-                    rawLine: trimmed,
-                    baseFoodContext,
-                    budget: aiNutritionBudget,
-                });
-                logger.audit('mapping.recovery_path', {
-                    path: 'backfill_after_winner',
-                    from: winner.id,
-                    served: aiResult.status === 'success',
-                });
-
-                if (aiResult.status === 'success') {
-                    const parsedQty = parsed ? parsed.qty * parsed.multiplier : 1;
-                    const parsedUnit = parsed?.unit || 'serving';
-
-                    const servingResult = await getAiServingGrams(
-                        aiResult.foodId,
-                        parsedUnit,
-                        parsedQty,
-                    );
-
-                    const grams = servingResult?.grams ?? 100;
-                    const scale = grams / 100;
-
-                    const aiMapped: FatsecretMappedIngredient = {
-                        source: 'ai_generated',
-                        foodId: aiResult.foodId,
-                        foodName: aiResult.displayName,
-                        brandName: null,
-                        servingId: null,
-                        servingDescription: servingResult?.servingLabel ?? `${parsedQty} ${parsedUnit}`,
-                        grams,
-                        kcal: aiResult.caloriesPer100g * scale,
-                        protein: aiResult.proteinPer100g * scale,
-                        carbs: aiResult.carbsPer100g * scale,
-                        fat: aiResult.fatPer100g * scale,
-                        confidence: aiResult.confidence * 0.8,
-                        quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
-                        rawLine,
-                        servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
-                    };
-
-                    if (ENABLE_MAPPING_ANALYSIS) {
-                        logMappingAnalysis({
-                            rawIngredient: trimmed,
-                            parsed: {
-                                amount: parsed?.qty,
-                                unit: parsed?.unit,
-                                ingredient: parsed?.name,
-                            },
-                            topCandidates: [],
-                            selectedCandidate: {
-                                foodId: aiResult.foodId,
-                                foodName: aiResult.displayName,
-                                brandName: '',
-                                confidence: aiMapped.confidence,
-                                selectionReason: aiResult.cached ? 'ai_nutrition_cache_hit' : 'ai_nutrition_generated',
-                            },
-                            selectedNutrition: {
-                                calories: aiMapped.kcal,
-                                protein: aiMapped.protein,
-                                carbs: aiMapped.carbs,
-                                fat: aiMapped.fat,
-                                perGrams: aiMapped.grams,
-                            },
-                            servingSelection: {
-                                servingDescription: aiMapped.servingDescription || 'N/A',
-                                grams: aiMapped.grams,
-                                backfillUsed: true,
-                                backfillType: 'weight',
-                            },
-                            finalResult: 'success',
-                            source: 'full_pipeline',
-                            aiCalls: {
-                                normalize: {
-                                    called: !skippedLlmNormalize,
-                                    skipped: skippedLlmNormalize,
-                                },
-                                // 0.5(b). See the sibling site above.
-                                serving: servingAiCallForTier(aiMapped.servingTier),
-                                nutrition: { called: true, cached: aiResult.cached, success: true },
-                            },
-                        });
-                    }
-
-                    logger.info('mapping.ai_nutrition_backfill_success_after_hydration_failure', {
-                        rawLine: trimmed,
-                        foodName: aiResult.displayName,
-                        confidence: aiMapped.confidence,
-                        cached: aiResult.cached,
-                    });
-
-                    return aiMapped;
-                } else {
-                    logger.warn('mapping.ai_nutrition_backfill_failed_after_hydration_failure', {
-                        rawLine: trimmed,
-                        reason: aiResult.reason,
-                    });
-                }
-            }
-
-            return null;
+            return await runBackfillAfterWinner({
+                winner, trimmed, parsed, filtered, confidence, selectionReason,
+                allCandidates, normalizedName, aiNutritionBudget, rawLine,
+                skippedLlmNormalize,
+            });
         }
 
         return await finalizeAndSaveResult({
@@ -3405,6 +2996,546 @@ export async function mapIngredientWithFallback(
         inFlightLocks.delete(lockKey);
         resolveLock!(null);  // Resolve with null - waiting threads will re-fetch from cache
     }
+}
+
+// ============================================================
+// Step 5 cascade tail, extracted in stage 1d. Each function below is
+// module-private, takes a single params object destructured to the
+// original orchestrator identifier names, and carries its block
+// verbatim. Entry guards stay in the orchestrator; each function
+// reports back via its return value and never writes orchestrator
+// state directly.
+// ============================================================
+
+async function hydrateWinnerWithBackfills(params: {
+    winner: UnifiedCandidate;
+    parsed: ParsedIngredient | null;
+    confidence: number;
+    rawLine: string;
+    aiHydrationBudget: AiNutritionBudget;
+    isWeightUnit: boolean | '' | null | undefined;
+    isVolumeUnit: boolean | '' | null | undefined;
+    prepModifier: string | undefined;
+}): Promise<{ result: FatsecretMappedIngredient | null; selectionReason?: string }> {
+    const {
+        winner, parsed, confidence, rawLine, aiHydrationBudget,
+        isWeightUnit, isVolumeUnit, prepModifier,
+    } = params;
+    let selectionReason: string | undefined;
+
+    let result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
+
+    if (!result && isWeightUnit && winner.source === 'ai_generated') {
+        // See the rerank instrumentation note above. If this never fires, weight
+        // serving backfill has been silently off since the lane was relabelled
+        // 'fatsecret' — corroborated by MEASURED 0 occurrences of the warn-level
+        // mapping.weight_backfill_failed in 12 days of production log. The repair
+        // would then be to WIDEN this guard to 'fatsecret', not to delete it.
+        logger.audit('backfill.ai_generated_winner_seen', {
+            foodId: winner.id,
+            foodName: winner.name,
+            path: 'weight',
+        });
+        logger.info('mapping.weight_backfill_attempt', {
+            foodId: winner.id,
+            foodName: winner.name,
+            unit: parsed!.unit,
+        });
+
+        const backfillResult = await backfillWeightServing(winner.id);
+
+        if (backfillResult.success) {
+            // Retry hydration now that we have a weight serving
+            result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
+
+            if (result) {
+                logger.info('mapping.weight_backfill_success', {
+                    foodId: winner.id,
+                    foodName: winner.name,
+                    unit: parsed!.unit,
+                    grams: result.grams,
+                });
+                selectionReason = 'weight_backfill_success';
+            }
+        } else {
+            logger.warn('mapping.weight_backfill_failed', {
+                foodId: winner.id,
+                reason: backfillResult.reason,
+            });
+        }
+    }
+
+    // Enable AI backfill for BOTH FatSecret and FDC sources (FDC often lacks volume servings)
+    if (!result && isVolumeUnit && (winner.source === 'ai_generated' || winner.source === 'fdc')) {
+        if (winner.source === 'ai_generated') {
+            logger.audit('backfill.ai_generated_winner_seen', {
+                foodId: winner.id,
+                foodName: winner.name,
+                path: 'volume',
+            });
+        }
+        logger.info('mapping.volume_backfill_attempt', {
+            foodId: winner.id,
+            foodName: winner.name,
+            unit: parsed!.unit,
+            source: winner.source,
+            prepModifier,
+        });
+
+        const volumeBackfillResult = await insertAiServing(winner.id, 'volume', {
+            targetServingUnit: parsed?.unit ?? undefined,
+            prepModifier,
+            candidateData: winner,  // Pass candidate data to avoid DB lookup race condition
+        });
+
+        if (volumeBackfillResult.success) {
+            // Retry hydration now that we have a volume serving
+            result = await hydrateAndSelectServing(winner, parsed, confidence, rawLine, aiHydrationBudget);
+
+            if (result) {
+                logger.info('mapping.volume_backfill_success', {
+                    foodId: winner.id,
+                    foodName: winner.name,
+                    unit: parsed!.unit,
+                    grams: result.grams,
+                });
+                selectionReason = 'volume_backfill_success';
+            }
+        } else {
+            logger.warn('mapping.volume_backfill_failed', {
+                foodId: winner.id,
+                reason: volumeBackfillResult.reason,
+            });
+        }
+    }
+
+    return { result, selectionReason };
+}
+
+async function attemptServingFailureFallback(params: {
+    winner: UnifiedCandidate;
+    filtered: UnifiedCandidate[];
+    parsed: ParsedIngredient | null;
+    confidence: number;
+    rawLine: string;
+    trimmed: string;
+    normalizedName: string;
+    aiHydrationBudget: AiNutritionBudget;
+    isWeightUnit: boolean | '' | null | undefined;
+    isVolumeUnit: boolean | '' | null | undefined;
+    prepModifier: string | undefined;
+}): Promise<{ result: FatsecretMappedIngredient; selectionReason: string } | null> {
+    const {
+        winner, filtered, parsed, confidence, rawLine, trimmed, normalizedName,
+        aiHydrationBudget, isWeightUnit, isVolumeUnit, prepModifier,
+    } = params;
+    let result: FatsecretMappedIngredient | null = null;
+    let selectionReason = '';
+
+    logger.info('mapping.hydration_failed_retrying', {
+        failedId: winner.id,
+        failedName: winner.name,
+        remainingCandidates: filtered.length - 1
+    });
+
+    // Try next 3 candidates as fallbacks
+    const fallbackCandidates = filtered
+        .filter(c => c.id !== winner.id)
+        .slice(0, 3);
+
+    const failedWinnerId = winner.id;
+    const tryFallbackCandidate = async (fallback: UnifiedCandidate): Promise<boolean> => {
+        let fallbackResult = await hydrateAndSelectServing(
+            fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
+        );
+
+        // If hydration failed for a FatSecret candidate, try backfill before giving up
+        if (!fallbackResult && fallback.source === 'ai_generated') {
+            logger.audit('backfill.ai_generated_winner_seen', {
+                foodId: fallback.id,
+                foodName: fallback.name,
+                path: 'fallback',
+            });
+            if (isVolumeUnit) {
+                logger.info('mapping.fallback_volume_backfill_attempt', {
+                    foodId: fallback.id,
+                    foodName: fallback.name,
+                    unit: parsed?.unit,
+                    prepModifier,
+                });
+                const backfillResult = await insertAiServing(fallback.id, 'volume', {
+                    targetServingUnit: parsed?.unit ?? undefined,
+                    prepModifier,
+                    candidateData: fallback,  // Pass candidate data to avoid DB lookup race condition
+                });
+                if (backfillResult.success) {
+                    fallbackResult = await hydrateAndSelectServing(
+                        fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
+                    );
+                }
+            } else if (isWeightUnit) {
+                logger.info('mapping.fallback_weight_backfill_attempt', {
+                    foodId: fallback.id,
+                    foodName: fallback.name,
+                    unit: parsed?.unit,
+                });
+                const backfillResult = await backfillWeightServing(fallback.id);
+                if (backfillResult.success) {
+                    fallbackResult = await hydrateAndSelectServing(
+                        fallback, parsed, confidence * 0.95, rawLine, aiHydrationBudget
+                    );
+                }
+            }
+        }
+
+        if (fallbackResult) {
+            logger.info('mapping.fallback_success', {
+                originalId: failedWinnerId,
+                fallbackId: fallback.id,
+                fallbackName: fallback.name,
+            });
+            logger.audit('mapping.recovery_path', {
+                path: 'serving_failure_fallback',
+                from: failedWinnerId,
+                to: fallback.id,
+            });
+            result = fallbackResult;
+            selectionReason = 'fallback_after_serving_failure';
+            return true;
+        }
+        return false;
+    };
+
+    // PR D pt3 (B4): floor-hit fallbacks are set aside and only tried
+    // as a last resort; denylisted records are never accepted.
+    const floorRejectedFallbacks: UnifiedCandidate[] = [];
+
+    for (const fallback of fallbackCandidates) {
+        // CRITICAL: Validate semantic relevance before accepting fallback
+        // This prevents "golden flaxseed meal" → "Golden Delicious Apples" syndrome
+        // where the fallback is selected just because it has the right serving,
+        // despite being semantically unrelated to the query
+        if (hasCoreTokenMismatch(normalizedName, fallback.name, fallback.brandName)) {
+            logger.debug('mapping.fallback_rejected_token_mismatch', {
+                query: normalizedName,
+                fallbackName: fallback.name,
+                fallbackBrand: fallback.brandName,
+            });
+            continue; // Skip this fallback, try next one
+        }
+        if (isRankPlausibilityPartitionEnabled() && isDenylistedOffRecord(fallback.id)) {
+            logger.warn('mapping.denylisted_candidate_dropped', {
+                rawLine: trimmed,
+                candidate: fallback.name,
+                foodId: fallback.id,
+            });
+            continue;
+        }
+        if (candidateHitsPlausibilityFloor(normalizedName, fallback)) {
+            logger.debug('mapping.fallback_rejected_plausibility_floor', {
+                query: normalizedName,
+                fallbackName: fallback.name,
+            });
+            floorRejectedFallbacks.push(fallback);
+            continue;
+        }
+
+        if (await tryFallbackCandidate(fallback)) break;
+    }
+
+    // Last resort: every acceptable fallback was floor-hit — a
+    // floor-hit record still beats returning nothing (floors demote,
+    // never drop).
+    if (!result) {
+        for (const fallback of floorRejectedFallbacks) {
+            if (await tryFallbackCandidate(fallback)) break;
+        }
+    }
+
+    return result ? { result, selectionReason } : null;
+}
+
+async function attemptCacheFailureResearch(params: {
+    winner: UnifiedCandidate;
+    trimmed: string;
+    normalizedName: string;
+    parsed: ParsedIngredient | null;
+    rawLine: string;
+    confidence: number;
+    aiHydrationBudget: AiNutritionBudget;
+    aiNutritionEstimate: { caloriesPer100g: number; proteinPer100g: number; carbsPer100g: number; fatPer100g: number; confidence: number } | undefined;
+    aiCanonicalBase: string | undefined;
+    isBrandedQuery: boolean;
+    brandDetection: BrandKeyInput;
+    allSynonyms: string[];
+    skipCache: boolean;
+    skipFdc: boolean;
+    debug: boolean;
+}): Promise<{ result: FatsecretMappedIngredient; selectionReason: string } | null> {
+    const {
+        winner, trimmed, normalizedName, parsed, rawLine, confidence, aiHydrationBudget,
+        aiNutritionEstimate, aiCanonicalBase, isBrandedQuery, brandDetection,
+        allSynonyms, skipCache, skipFdc, debug,
+    } = params;
+    let result: FatsecretMappedIngredient | null = null;
+    let selectionReason = '';
+
+    logger.info('mapping.cache_serving_failed_retrying_search', {
+        failedId: winner.id,
+        failedName: winner.name,
+    });
+    logger.audit('mapping.recovery_path', {
+        path: 'cache_failure_research',
+        from: winner.id,
+    });
+
+    // Run full search to find candidates with working servings
+    const searchGatherOptions: GatherOptions = {
+        skipCache,
+        skipFdc,
+        isBrandedQuery,
+        targetBrand: brandDetection.matchedBrand ?? undefined,
+        aiSynonyms: allSynonyms,
+    };
+
+    const searchCandidates = await gatherCandidates(rawLine, parsed, normalizedName, searchGatherOptions);
+
+    if (searchCandidates.length > 0) {
+        const searchFilterResult = filterCandidatesByTokens(searchCandidates, normalizedName, { debug, rawLine: trimmed });
+
+        // Run reranker to ensure anomaly penalties (e.g. canned beans) are applied
+        const countedNounFB = countedPieceNoun(parsed);
+        const billsByServingFB = requestBillsByServing(parsed);
+        // Same grain-scoped volume serving-shape wiring as the primary
+        // rerank site (n-serv-06).
+        const grainVolumeUnitFB = !billsByServingFB && parsed?.unit
+            && isMatchableVolumeUnit(parsed.unit)
+            && detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+            ? parsed.unit : null;
+        const rerankCandidates = searchFilterResult.filtered.map(c => toRerankCandidate({
+            id: c.id,
+            name: c.name,
+            brandName: c.brandName,
+            foodType: c.foodType,
+            score: c.score,
+            source: c.source,
+            nutrition: c.nutrition,
+            countLabelMatch: countedNounFB ? candidateHasCountLabel(c, countedNounFB) : undefined,
+            servingLabelMatch: billsByServingFB ? candidateHasServingData(c)
+                : grainVolumeUnitFB ? candidateHasVolumeServing(c, grainVolumeUnitFB) : undefined,
+        }));
+        const rerankQuery = aiCanonicalBase || stripPrepModifiers(normalizedName);
+        const rerankResult = simpleRerank(rerankQuery, rerankCandidates, aiNutritionEstimate, trimmed, isBrandedQuery, brandDetection.matchedBrand ?? undefined, countedNounFB != null);
+
+        // simpleRerank returns the fully sorted list based on semantic score, nutrition ties, and FDC preferencing
+        const sortedFallbackCandidates = rerankResult.sortedCandidates.map(
+            rerankCand => searchFilterResult.filtered.find(c => c.id === rerankCand.id)!
+        ).filter(Boolean);
+
+        // Try each candidate until one works — denylisted records are
+        // never accepted; floor-hit ones only as a last resort (PR D pt3 B4).
+        const failedCacheWinnerId = winner.id;
+        const tryCacheFallbackCandidate = async (candidate: UnifiedCandidate): Promise<boolean> => {
+            const retryResult = await hydrateAndSelectServing(candidate, parsed, confidence * 0.9, rawLine, aiHydrationBudget);
+            if (!retryResult) return false;
+            logger.info('mapping.cache_fallback_search_success', {
+                originalId: failedCacheWinnerId,
+                fallbackId: candidate.id,
+                fallbackName: candidate.name,
+            });
+            logger.audit('mapping.recovery_path', {
+                path: 'cache_failure_rebilled',
+                from: failedCacheWinnerId,
+                to: candidate.id,
+            });
+            result = retryResult;
+            selectionReason = 'fallback_search_after_cache_failure';
+            return true;
+        };
+
+        const floorRejectedRetries: UnifiedCandidate[] = [];
+        for (const candidate of sortedFallbackCandidates.slice(0, 5)) {
+            if (isRankPlausibilityPartitionEnabled() && isDenylistedOffRecord(candidate.id)) {
+                logger.warn('mapping.denylisted_candidate_dropped', {
+                    rawLine: trimmed,
+                    candidate: candidate.name,
+                    foodId: candidate.id,
+                });
+                continue;
+            }
+            if (candidateHitsPlausibilityFloor(normalizedName, candidate)) {
+                logger.debug('mapping.fallback_rejected_plausibility_floor', {
+                    query: normalizedName,
+                    fallbackName: candidate.name,
+                });
+                floorRejectedRetries.push(candidate);
+                continue;
+            }
+            if (await tryCacheFallbackCandidate(candidate)) break;
+        }
+        if (!result) {
+            for (const candidate of floorRejectedRetries) {
+                if (await tryCacheFallbackCandidate(candidate)) break;
+            }
+        }
+    }
+
+    return result ? { result, selectionReason } : null;
+}
+
+async function runBackfillAfterWinner(params: {
+    winner: UnifiedCandidate;
+    trimmed: string;
+    parsed: ParsedIngredient | null;
+    filtered: UnifiedCandidate[];
+    confidence: number;
+    selectionReason: string;
+    allCandidates: UnifiedCandidate[];
+    normalizedName: string;
+    aiNutritionBudget: AiNutritionBudget;
+    rawLine: string;
+    skippedLlmNormalize: boolean;
+}): Promise<FatsecretMappedIngredient | null> {
+    const {
+        winner, trimmed, parsed, filtered, confidence, selectionReason,
+        allCandidates, normalizedName, aiNutritionBudget, rawLine,
+        skippedLlmNormalize,
+    } = params;
+
+    if (ENABLE_MAPPING_ANALYSIS) {
+        logMappingAnalysis({
+            rawIngredient: trimmed,
+            parsed: {
+                amount: parsed?.qty,
+                unit: parsed?.unit,
+                ingredient: parsed?.name,
+            },
+            topCandidates: filtered.slice(0, 5).map((c, i) => ({
+                rank: i + 1,
+                foodId: c.id,
+                foodName: c.name,
+                brandName: c.brandName || null,
+                score: c.score,
+                source: c.source,
+            })),
+            selectedCandidate: {
+                foodId: winner.id,
+                foodName: winner.name,
+                brandName: winner.brandName || '',
+                confidence,
+                selectionReason,
+            },
+            finalResult: 'failed',
+            failureReason: 'no_suitable_serving_found',
+        });
+    }
+
+    // Attempt AI Nutrition Backfill if all API pipeline candidates failed hydration
+    if (AI_NUTRITION_BACKFILL_ENABLED) {
+        logger.info('mapping.pipeline_failed_attempting_ai_backfill', { rawLine: trimmed });
+        const baseFoodContext = extractBaseFoodContext(allCandidates);
+        const aiResult = await requestAiNutrition(normalizedName, {
+            rawLine: trimmed,
+            baseFoodContext,
+            budget: aiNutritionBudget,
+        });
+        logger.audit('mapping.recovery_path', {
+            path: 'backfill_after_winner',
+            from: winner.id,
+            served: aiResult.status === 'success',
+        });
+
+        if (aiResult.status === 'success') {
+            const parsedQty = parsed ? parsed.qty * parsed.multiplier : 1;
+            const parsedUnit = parsed?.unit || 'serving';
+
+            const servingResult = await getAiServingGrams(
+                aiResult.foodId,
+                parsedUnit,
+                parsedQty,
+            );
+
+            const grams = servingResult?.grams ?? 100;
+            const scale = grams / 100;
+
+            const aiMapped: FatsecretMappedIngredient = {
+                source: 'ai_generated',
+                foodId: aiResult.foodId,
+                foodName: aiResult.displayName,
+                brandName: null,
+                servingId: null,
+                servingDescription: servingResult?.servingLabel ?? `${parsedQty} ${parsedUnit}`,
+                grams,
+                kcal: aiResult.caloriesPer100g * scale,
+                protein: aiResult.proteinPer100g * scale,
+                carbs: aiResult.carbsPer100g * scale,
+                fat: aiResult.fatPer100g * scale,
+                confidence: aiResult.confidence * 0.8,
+                quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
+                rawLine,
+                servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
+            };
+
+            if (ENABLE_MAPPING_ANALYSIS) {
+                logMappingAnalysis({
+                    rawIngredient: trimmed,
+                    parsed: {
+                        amount: parsed?.qty,
+                        unit: parsed?.unit,
+                        ingredient: parsed?.name,
+                    },
+                    topCandidates: [],
+                    selectedCandidate: {
+                        foodId: aiResult.foodId,
+                        foodName: aiResult.displayName,
+                        brandName: '',
+                        confidence: aiMapped.confidence,
+                        selectionReason: aiResult.cached ? 'ai_nutrition_cache_hit' : 'ai_nutrition_generated',
+                    },
+                    selectedNutrition: {
+                        calories: aiMapped.kcal,
+                        protein: aiMapped.protein,
+                        carbs: aiMapped.carbs,
+                        fat: aiMapped.fat,
+                        perGrams: aiMapped.grams,
+                    },
+                    servingSelection: {
+                        servingDescription: aiMapped.servingDescription || 'N/A',
+                        grams: aiMapped.grams,
+                        backfillUsed: true,
+                        backfillType: 'weight',
+                    },
+                    finalResult: 'success',
+                    source: 'full_pipeline',
+                    aiCalls: {
+                        normalize: {
+                            called: !skippedLlmNormalize,
+                            skipped: skippedLlmNormalize,
+                        },
+                        // 0.5(b). See the sibling site above.
+                        serving: servingAiCallForTier(aiMapped.servingTier),
+                        nutrition: { called: true, cached: aiResult.cached, success: true },
+                    },
+                });
+            }
+
+            logger.info('mapping.ai_nutrition_backfill_success_after_hydration_failure', {
+                rawLine: trimmed,
+                foodName: aiResult.displayName,
+                confidence: aiMapped.confidence,
+                cached: aiResult.cached,
+            });
+
+            return aiMapped;
+        } else {
+            logger.warn('mapping.ai_nutrition_backfill_failed_after_hydration_failure', {
+                rawLine: trimmed,
+                reason: aiResult.reason,
+            });
+        }
+    }
+
+    return null;
 }
 
 // ============================================================

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -1619,205 +1619,14 @@ export async function mapIngredientWithFallback(
 
         // Step 1c: Check validated cache for normalized name (User Optimization)
         // "1 cup chopped onion" -> normalized "onion" -> checks cache for "onion"
-        if (!winner) {
-            if (telemetry) telemetry.normalizedForm = normalizedName;
-            // skipCache must gate this layer too — without it a "cold" (nocache)
-            // run would still serve cached rows via step 1c and parity runs
-            // against the cache would be meaningless.
-            // PR D pt3 (C1) + key symmetry (Track 1c): same derived key
-            // (deriveMappingCacheKey incl. brand-prefix decision) as the early
-            // lookup and the Step-6 save — recomputed here because AI
-            // normalize may have replaced normalizedName. brandDetection is
-            // request-stable, so this key matches the save key exactly. A
-            // miss falls back to the legacy (pre-Track-1c) key.
-            const normalizedLookupRejection: CacheLookupRejection = { reason: null };
-            const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, normalizedLookupRejection, preBrandNormalizedName);
-            if (!normalizedCache && normalizedLookupRejection.reason) {
-                if (telemetry) telemetry.cacheEscape = 'lookup_normalized:' + normalizedLookupRejection.reason;
-                noteReadEscape(normalizedLookupRejection.targetKey, 'lookup_normalized:' + normalizedLookupRejection.reason);
-            }
-            if (normalizedCache) {
-                logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
-                const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);
-
-                // Validate nutrition data - reject cached mappings to foods with zero/null nutrition
-                let normalizedNutritionInvalid = false;
-                let normalizedCorruptMarked = false;
-                // fs_ only — see the matching flag in Step 1a.
-                let normalizedFsBillableViaServings = false;
-                let normalizedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
-                let normalizedCachedKcal100: number | null = null;
-                let normalizedCachedCarbs100: number | null = null;
-                if (!normalizedCoreTokenMismatch) {
-                    const { prisma } = await import('../db');
-                    let nutrients: any = null;
-                    if (normalizedCache.foodId.startsWith('fdc_')) {
-                        const fdcId = parseInt(normalizedCache.foodId.replace('fdc_', ''), 10);
-                        const fdc = await prisma.fdcFood.findUnique({
-                            where: { fdcId },
-                            select: { nutrientsPer100g: true }
-                        });
-                        nutrients = fdc?.nutrientsPer100g;
-                    } else if (normalizedCache.foodId.startsWith('off_')) {
-                        const barcode = normalizedCache.foodId.replace('off_', '');
-                        const off = await prisma.offFood.findUnique({
-                            where: { barcode },
-                            select: { nutrientsPer100g: true, servingSize: true, servingGrams: true, corruptReason: true }
-                        });
-                        nutrients = off?.nutrientsPer100g;
-                        if (off) {
-                            normalizedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
-                            normalizedCorruptMarked = off.corruptReason != null && isCorruptExclusionEnabled();
-                        }
-                    } else if (normalizedCache.foodId.startsWith('fs_')) {
-                        // Same gap as Step 1a, same fix — see the comment there for the
-                        // measurement. This arm was an aiGeneratedFood lookup that executed
-                        // on every fs_ hit and could never match.
-                        const fsId = normalizedCache.foodId.replace('fs_', '');
-                        const fsFood = await prisma.fatSecretFood.findUnique({
-                            where: { fsId },
-                            select: { nutrientsPer100g: true, servings: { select: { nutrients: true } } }
-                        });
-                        const fsPanel = fsFood?.nutrientsPer100g as Record<string, any> | null | undefined;
-                        nutrients = fsPanel && Object.keys(fsPanel).length > 0 ? fsPanel : null;
-                        normalizedFsBillableViaServings = (fsFood?.servings ?? []).some(
-                            s => servingMacros(s.nutrients as Record<string, unknown> | null) != null);
-                    } else {
-                        // Instrument only — see the matching note in Step 1a.
-                        logger.audit('cache.unrecognised_food_id_prefix', {
-                            foodId: normalizedCache.foodId,
-                            cachedFood: normalizedCache.foodName,
-                        });
-                    }
-
-                    if (nutrients) {
-                        const mappedNutrients = {
-                            kcal: nutrients.calories ?? nutrients.energy ?? nutrients.kcal ?? 0,
-                            protein: nutrients.protein ?? 0,
-                            carbs: nutrients.carbohydrate ?? nutrients.carbs ?? 0,
-                            fat: nutrients.fat ?? 0,
-                            per100g: true,
-                        };
-                        normalizedCachedKcal100 = mappedNutrients.kcal || null;
-                        normalizedCachedCarbs100 = mappedNutrients.carbs || null;
-                        normalizedNutritionInvalid = hasNullOrInvalidMacros(mappedNutrients, normalizedCache.foodName);
-                        if (normalizedNutritionInvalid) {
-                            logger.warn('mapping.normalized_cache_bad_nutrition', {
-                                rawLine: trimmed,
-                                cachedFood: normalizedCache.foodName,
-                                nutrients,
-                            });
-                        }
-                    } else if (normalizedCache.foodId.startsWith('off_')
-                        || (normalizedCache.foodId.startsWith('fs_') && !normalizedFsBillableViaServings)) {
-                        // Symmetric with Step 1a's safety net: a cache row pointing at a
-                        // record with no nutrition panel AND no macro-bearing serving must
-                        // re-resolve, not be served with nulls. An empty panel alone is not
-                        // enough — see the measurement in Step 1a's fs_ arm. Deliberately
-                        // NOT extended to fdc_ here — the fdc_ arm above has never had this
-                        // net and widening it is a separate, unmeasured behaviour change.
-                        normalizedNutritionInvalid = true;
-                        logger.warn('mapping.normalized_cache_missing_nutrition', {
-                            rawLine: trimmed,
-                            cachedFood: normalizedCache.foodName,
-                            foodId: normalizedCache.foodId,
-                        });
-                    }
-                }
-
-                // Counted-piece cache escape — same rationale as the early-cache
-                // check: without it this layer would re-pin the label-less food
-                // the early check just escaped from.
-                const normalizedCountedNoun = countedPieceNoun(parsed);
-                const normalizedCountLabelEscape = normalizedCountedNoun != null
-                    && normalizedCache.foodId.startsWith('off_')
-                    && !servingLabelCountsPiece(normalizedOffServing?.servingSize, normalizedOffServing?.servingGrams, normalizedCountedNoun);
-
-                // Cooked-grain cache escape — same rationale as the early-cache check.
-                const normalizedCachedLooksCooked = /\b(cooked|boiled|steamed|prepared)\b/i.test(normalizedCache.foodName)
-                    || (normalizedCachedKcal100 != null && normalizedCachedKcal100 > 60 && normalizedCachedKcal100 <= 250
-                        && normalizedCachedCarbs100 != null && normalizedCachedCarbs100 >= 12);
-                const normalizedGrainCookedEscape = detectGrainCookingContext(trimmed, normalizedName).softCooked === true
-                    && !normalizedCachedLooksCooked;
-
-                // Escape reason doubles as the telemetry label (PR D pt3 split
-                // the former catch-all 'filter_mismatch' into per-condition
-                // labels). Same predicates, same order as the former || chain.
-                let normalizedEscapeReason =
-                    normalizedCorruptMarked ? 'corrupt_record'
-                    : normalizedCoreTokenMismatch ? 'core_token_mismatch'
-                    : normalizedNutritionInvalid ? 'nutrition_invalid'
-                    : normalizedCountLabelEscape ? 'count_label'
-                    : normalizedGrainCookedEscape ? 'grain_cooked'
-                    : isCategoryMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName) ? 'category_mismatch'
-                    : isMultiIngredientMismatch(normalizedName, normalizedCache.foodName) ? 'multi_ingredient'
-                    // For branded queries: skip modifier mismatch when the cached food's brand
-                    // matches the detected brand (e.g. "Oikos" query → "Oikos Triple Zero Vanilla Nonfat"
-                    // should not be rejected just because "nonfat" is in the food name but not the query).
-                    : ((!isBrandedQuery || !(
-                        normalizedCache.brandName &&
-                        brandDetection.matchedBrand &&
-                        normalizedCache.brandName.toLowerCase().includes(brandDetection.matchedBrand.toLowerCase())
-                    )
-                        ? hasCriticalModifierMismatch(trimmed, normalizedCache.foodName, 'cache')
-                        : false
-                    )) ? 'modifier_mismatch'
-                    : isReplacementMismatch(trimmed, normalizedCache.foodName, normalizedCache.brandName) ? 'replacement_mismatch'
-                    // For branded queries with a known target brand: reject cached results from a
-                    // DIFFERENT brand. e.g. "Heinz Tomato Ketchup" query must not serve a cached
-                    // "TOMATO KETCHUP (WEIS)" result — force a fresh pipeline run to find Heinz.
-                    : (isBrandedQuery &&
-                        brandDetection.matchedBrand != null &&
-                        normalizedCache.brandName != null &&
-                        !normalizedCache.brandName.toLowerCase().includes(brandDetection.matchedBrand.toLowerCase())
-                    ) ? 'brand_guard'
-                    : null;
-
-                // Read-time trust (PR D pt3, HUMAN_ROW_TRUST) — same rationale
-                // as the early-cache block: name-heuristic escapes skipped for
-                // human-triage rows; corrupt-record, core-token,
-                // nutrition-invalid and serving-shape escapes stay active for
-                // all rows.
-                if (normalizedEscapeReason
-                    && isHumanTrustSkippableEscape(normalizedEscapeReason)
-                    && isTrustedHumanRow(normalizedCache.validatedBy)) {
-                    logger.info('cache.human_row_trusted', {
-                        key: normalizedName,
-                        foodId: normalizedCache.foodId,
-                        skippedRejection: 'normalized:' + normalizedEscapeReason,
-                    });
-                    normalizedEscapeReason = null;
-                }
-
-                if (normalizedEscapeReason) {
-                    logger.warn('mapping.normalized_cache_filter_mismatch', {
-                        rawLine: trimmed,
-                        cachedFood: normalizedCache.foodName,
-                        normalized: normalizedName,
-                        coreTokenMismatch: normalizedCoreTokenMismatch,
-                        nutritionInvalid: normalizedNutritionInvalid,
-                    });
-                    if (telemetry) {
-                        telemetry.cacheEscape = 'normalized:' + normalizedEscapeReason;
-                    }
-                    noteReadEscape(targetKeyOfFoodId(normalizedCache.foodId), 'normalized:' + normalizedEscapeReason);
-                } else {
-                    winner = {
-                        id: normalizedCache.foodId,
-                        name: normalizedCache.foodName,
-                        brandName: normalizedCache.brandName || undefined,
-                        source: normalizedCache.source as any,
-                        score: normalizedCache.confidence,
-                        foodType: 'generic', // Assumption
-                        rawData: {},
-                    };
-                    confidence = normalizedCache.confidence;
-                    selectionReason = 'normalized_cache_hit';
-                    if (telemetry) telemetry.cacheHit = 'normalized';
-                    markFunnel(telemetry, 'cache_hit');
-                }
-            }
-
+        const cacheSel = await lookupNormalizedCacheProducer({
+            normalizedName, preBrandNormalizedName, parsed, brandDetection, trimmed,
+            skipCache, isBrandedQuery, telemetry, noteReadEscape,
+        });
+        if (cacheSel) {
+            winner = cacheSel.winner;
+            confidence = cacheSel.confidence;
+            selectionReason = cacheSel.selectionReason;
         }
 
         let allCandidates: UnifiedCandidate[] = [];
@@ -2591,278 +2400,33 @@ export async function mapIngredientWithFallback(
         if (shouldTryFallback && !_skipFallback) {
             logger.info('mapping.attempting_fallback', { rawLine: trimmed, currentConfidence: confidence, winner: winner?.name });
 
-            // ── Step 2b-i: Dietary-prefix stripping fallback ──────────────
-            // If the ingredient has a dietary-attribute prefix (fat-free, gluten-free, sugar-free, etc.),
-            // try re-searching WITHOUT it. These prefixes describe what's ABSENT, not what the food IS.
-            // We try the full term FIRST (above), and only strip as a fallback.
-            // Example flow: "gluten-free salad seasoning" → initial search fails → retry "salad seasoning"
-            const DIETARY_PREFIX_PATTERN = /\b(?:fat[- ]?free|nonfat|non[- ]?fat|gluten[- ]?free|sugar[- ]?free|dairy[- ]?free|grain[- ]?free|nut[- ]?free)\s+/gi;
-            const strippedLine = trimmed.replace(DIETARY_PREFIX_PATTERN, '').trim();
-
-            if (strippedLine !== trimmed && strippedLine.length > 2) {
-                logger.info('mapping.dietary_prefix_fallback', { original: trimmed, stripped: strippedLine });
-
-                const dietaryFallbackResult = await mapIngredientWithFallback(strippedLine, {
-                    ...options,
-                    // Explicit, NOT covered by the spread: `options` carries the
-                    // caller's value, which may be undefined while the
-                    // destructure above already minted one. Without this a
-                    // single ingredient line spends a fresh allowance per
-                    // recursion level.
-                    aiNutritionBudget,
-                    // Both allowances forward, for the same reason and with the
-                    // same explicit-over-spread caveat.
-                    aiHydrationBudget,
-                    minConfidence: 0.1,
-                    _skipInFlightLock: true,
-                    _skipFallback: true, // Prevent infinite recursion
-                });
-
-                if (dietaryFallbackResult && 'confidence' in dietaryFallbackResult && dietaryFallbackResult.confidence > 0) {
-                    logger.info('mapping.dietary_prefix_fallback_success', {
-                        original: trimmed,
-                        stripped: strippedLine,
-                        food: dietaryFallbackResult.foodName,
-                        confidence: dietaryFallbackResult.confidence,
-                    });
-                    logger.audit('mapping.recovery_path', {
-                        path: 'dietary_direct_return',
-                        original: trimmed,
-                        servedBy: dietaryFallbackResult.foodId,
-                    });
-                    return dietaryFallbackResult;
-                }
+            const dietary = await attemptDietaryPrefixFallback({
+                trimmed, options, aiNutritionBudget, aiHydrationBudget,
+            });
+            if (dietary) {
+                return dietary.served;
             }
 
-            // ── Step 2b-ii: LLM-based simplification ──────────────────────
-            // LLM-based simplification for complex ingredient names
-            const { aiSimplifyIngredient } = await import('./ai-simplify');
-
-            try {
-                const result = await aiSimplifyIngredient(trimmed, brandDetection.matchedBrand ?? undefined);
-
-                if (result && result.simplified && result.simplified !== normalizedName) {
-                    logger.info('mapping.fallback_simplification', { original: trimmed, simplified: result.simplified });
-
-                    // Recursively try to map the simplifed name
-                    // We use a lower minConfidence to accept matches
-                    // IMPORTANT: Pass _skipInFlightLock to prevent deadlock if simplified name
-                    // normalizes to the same lock key as the original
-                    const fallbackResult = await mapIngredientWithFallback(result.simplified, {
-                        ...options,
-                        aiNutritionBudget,   // see the dietary-fallback call above
-                        aiHydrationBudget,   // ditto — both allowances, explicitly
-                        minConfidence: 0.1, // Accept imperfect matches for fallback
-                        _skipInFlightLock: true, // Prevent recursive deadlock
-                        _skipFallback: true, // Prevent infinite fallback recursion
-                    });
-
-                    if (fallbackResult && 'foodId' in fallbackResult) {
-                        // Fallback found a food, but its serving data was computed without our original qty/unit
-                        // Re-hydrate using the ORIGINAL parsed input for correct serving selection
-                        const fbr = fallbackResult as FatsecretMappedIngredient;
-                        const fallbackCandidate: UnifiedCandidate = {
-                            id: fbr.foodId,
-                            name: fbr.foodName,
-                            brandName: fbr.brandName || undefined,
-                            source: fbr.foodId.startsWith('fdc_') ? 'fdc' :
-                                    fbr.foodId.startsWith('off_') ? 'openfoodfacts' : 'ai_generated',
-                            score: fbr.confidence * 0.85,
-                            foodType: 'generic',
-                            rawData: {},
-                        };
-
-                        // For FDC candidates, populate nutrition from fallback result
-                        // so buildFdcResult() can compute serving-specific nutrition
-                        if (fbr.foodId.startsWith('fdc_') && fbr.grams > 0) {
-                            const factor = 100 / fbr.grams;
-                            fallbackCandidate.nutrition = {
-                                kcal: fbr.kcal * factor,
-                                protein: fbr.protein * factor,
-                                carbs: fbr.carbs * factor,
-                                fat: fbr.fat * factor,
-                                per100g: true,
-                            };
-                        }
-
-                        // Re-hydrate with ORIGINAL parsed input to get correct serving for "0.25 cup"
-                        const rehydratedResult = await hydrateAndSelectServing(
-                            fallbackCandidate,
-                            parsed,  // Use original parsed input with qty/unit!
-                            fallbackCandidate.score,
-                            rawLine,
-                            aiHydrationBudget
-                        );
-
-                        if (rehydratedResult) {
-                            // Successfully re-hydrated with correct serving
-                            logger.info('mapping.fallback_success', {
-                                original: trimmed,
-                                mappedTo: fbr.foodName,
-                                serving: rehydratedResult.servingDescription,
-                                grams: rehydratedResult.grams,
-                            });
-                            logger.audit('mapping.recovery_path', {
-                                path: 'simplify_direct_return',
-                                original: trimmed,
-                                servedBy: rehydratedResult.foodId,
-                            });
-                            return rehydratedResult;
-                        }
-
-                        // If re-hydration failed, still create winner for fallback processing
-                        winner = fallbackCandidate;
-                        confidence = winner.score;
-                        selectionReason = `fallback_simplified: ${result.rationale}`;
-
-                        logger.info('mapping.fallback_partial', {
-                            original: trimmed,
-                            mappedTo: fallbackResult.foodName,
-                            note: 'rehydration_failed_continuing'
-                        });
-                    }
-                }
-            } catch (err) {
-                logger.error('mapping.fallback_error', { error: (err as Error).message });
+            const simplify = await attemptAiSimplifyFallback({
+                trimmed, rawLine, parsed, normalizedName, brandDetection, options,
+                aiNutritionBudget, aiHydrationBudget,
+            });
+            if (simplify.kind === 'served') {
+                return simplify.result;
+            }
+            if (simplify.kind === 'partial') {
+                winner = simplify.winner;
+                confidence = simplify.confidence;
+                selectionReason = simplify.selectionReason;
             }
         }
 
         if (!winner) {
-            // ============================================================
-            // AI NUTRITION BACKFILL: Last resort for unmappable ingredients
-            // ============================================================
-            if (AI_NUTRITION_BACKFILL_ENABLED) {
-                const baseFoodContext = extractBaseFoodContext(allCandidates);
-                const aiResult = await requestAiNutrition(normalizedName, {
-                    rawLine: trimmed,
-                    baseFoodContext,
-                    budget: aiNutritionBudget,
-                });
-
-                if (aiResult.status === 'success') {
-                    // Compute grams and nutrition for the requested serving
-                    const parsedQty = parsed ? parsed.qty * parsed.multiplier : 1;
-                    const parsedUnit = parsed?.unit || 'serving';
-
-                    const servingResult = await getAiServingGrams(
-                        aiResult.foodId,
-                        parsedUnit,
-                        parsedQty,
-                    );
-
-                    const grams = servingResult?.grams ?? 100;
-                    const scale = grams / 100;
-
-                    const aiMapped: FatsecretMappedIngredient = {
-                        source: 'ai_generated',
-                        foodId: aiResult.foodId,
-                        foodName: aiResult.displayName,
-                        brandName: null,
-                        servingId: null,
-                        servingDescription: servingResult?.servingLabel ?? `${parsedQty} ${parsedUnit}`,
-                        grams,
-                        kcal: aiResult.caloriesPer100g * scale,
-                        protein: aiResult.proteinPer100g * scale,
-                        carbs: aiResult.carbsPer100g * scale,
-                        fat: aiResult.fatPer100g * scale,
-                        confidence: aiResult.confidence * 0.8,  // Penalize slightly vs API matches
-                        quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
-                        rawLine,
-                        servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
-                    };
-
-                    if (ENABLE_MAPPING_ANALYSIS) {
-                        logMappingAnalysis({
-                            rawIngredient: trimmed,
-                            parsed: {
-                                amount: parsed?.qty,
-                                unit: parsed?.unit,
-                                ingredient: parsed?.name,
-                            },
-                            topCandidates: [],
-                            selectedCandidate: {
-                                foodId: aiResult.foodId,
-                                foodName: aiResult.displayName,
-                                brandName: '',
-                                confidence: aiMapped.confidence,
-                                selectionReason: aiResult.cached ? 'ai_nutrition_cache_hit' : 'ai_nutrition_generated',
-                            },
-                            selectedNutrition: {
-                                calories: aiMapped.kcal,
-                                protein: aiMapped.protein,
-                                carbs: aiMapped.carbs,
-                                fat: aiMapped.fat,
-                                perGrams: aiMapped.grams,
-                            },
-                            servingSelection: {
-                                servingDescription: aiMapped.servingDescription || 'N/A',
-                                grams: aiMapped.grams,
-                                backfillUsed: true,
-                                backfillType: 'weight',
-                            },
-                            finalResult: 'success',
-                            source: 'full_pipeline',
-                            aiCalls: {
-                                normalize: {
-                                    called: !skippedLlmNormalize && !usedGenericFallback,
-                                    skipped: skippedLlmNormalize,
-                                },
-                                // 0.5(b). `ai_generated_serving` is NOT an AI call —
-                                // getAiServingGrams() only reads AiGeneratedServing rows.
-                                serving: servingAiCallForTier(aiMapped.servingTier),
-                                nutrition: { called: true, cached: aiResult.cached, success: true },
-                            },
-                        });
-                    }
-
-                    logger.info('mapping.ai_nutrition_backfill_success', {
-                        rawLine: trimmed,
-                        foodName: aiResult.displayName,
-                        confidence: aiMapped.confidence,
-                        cached: aiResult.cached,
-                    });
-
-                    return aiMapped;
-                } else {
-                    logger.warn('mapping.ai_nutrition_backfill_failed', {
-                        rawLine: trimmed,
-                        reason: aiResult.reason,
-                    });
-                }
-            }
-
-            // Total failure — log and return null
-            if (ENABLE_MAPPING_ANALYSIS) {
-                logMappingAnalysis({
-                    rawIngredient: trimmed,
-                    parsed: {
-                        amount: parsed?.qty,
-                        unit: parsed?.unit,
-                        ingredient: parsed?.name,
-                    },
-                    topCandidates: [],
-                    selectedCandidate: {
-                        foodId: '',
-                        foodName: '',
-                        brandName: '',
-                        confidence: 0,
-                        selectionReason: 'no_candidates_after_fallback',
-                    },
-                    finalResult: 'failed',
-                    failureReason: 'no_candidates_found',
-                });
-            }
-            // Separate a dataset gap (retrieval found nothing to rank) from a
-            // filter gap (records existed but every one was dropped pre-rank)
-            // from a selection gap — they need completely different fixes.
-            if (allCandidates.length === 0) {
-                markFunnel(telemetry, 'no_candidates', 'dataset_gap');
-            } else if (filtered.length === 0) {
-                markFunnel(telemetry, 'all_filtered', 'no_candidate_survived_filters');
-            } else {
-                markFunnel(telemetry, 'no_match', 'no_winner_selected');
-            }
-            return null; // Return null if truly failed
+            return await runAiNutritionBackfillNoWinner({
+                normalizedName, trimmed, rawLine, parsed, aiNutritionBudget,
+                allCandidates, filtered, skippedLlmNormalize, usedGenericFallback,
+                telemetry,
+            });
         }
 
         // Step 4a: Hydrate ONLY the selected candidate immediately
@@ -2996,6 +2560,557 @@ export async function mapIngredientWithFallback(
         inFlightLocks.delete(lockKey);
         resolveLock!(null);  // Resolve with null - waiting threads will re-fetch from cache
     }
+}
+
+// ============================================================
+// Selection-cascade producers, extracted in stage 1d. Same discipline
+// as the tail functions further below: module-private, single params
+// object destructured to the original orchestrator identifier names,
+// block moved verbatim. Entry guards stay in the orchestrator; each
+// function reports back via its return value and never writes
+// orchestrator state directly.
+// ============================================================
+
+async function lookupNormalizedCacheProducer(params: {
+    normalizedName: string;
+    preBrandNormalizedName: string | undefined;
+    parsed: ParsedIngredient | null;
+    brandDetection: BrandKeyInput;
+    trimmed: string;
+    skipCache: boolean;
+    isBrandedQuery: boolean;
+    telemetry: MappingTelemetry | undefined;
+    noteReadEscape: (targetKey: string | null | undefined, reason: string) => void;
+}): Promise<{ winner: UnifiedCandidate; confidence: number; selectionReason: string } | null> {
+    const {
+        normalizedName, preBrandNormalizedName, parsed, brandDetection, trimmed,
+        skipCache, isBrandedQuery, telemetry, noteReadEscape,
+    } = params;
+
+    if (telemetry) telemetry.normalizedForm = normalizedName;
+    // skipCache must gate this layer too — without it a "cold" (nocache)
+    // run would still serve cached rows via step 1c and parity runs
+    // against the cache would be meaningless.
+    // PR D pt3 (C1) + key symmetry (Track 1c): same derived key
+    // (deriveMappingCacheKey incl. brand-prefix decision) as the early
+    // lookup and the Step-6 save — recomputed here because AI
+    // normalize may have replaced normalizedName. brandDetection is
+    // request-stable, so this key matches the save key exactly. A
+    // miss falls back to the legacy (pre-Track-1c) key.
+    const normalizedLookupRejection: CacheLookupRejection = { reason: null };
+    const normalizedCache = skipCache ? null : await lookupValidatedMappingWithLegacyFallback(normalizedName, parsed, brandDetection, trimmed, normalizedLookupRejection, preBrandNormalizedName);
+    if (!normalizedCache && normalizedLookupRejection.reason) {
+        if (telemetry) telemetry.cacheEscape = 'lookup_normalized:' + normalizedLookupRejection.reason;
+        noteReadEscape(normalizedLookupRejection.targetKey, 'lookup_normalized:' + normalizedLookupRejection.reason);
+    }
+    if (normalizedCache) {
+        logger.info('mapping.normalized_cache_hit', { rawLine: trimmed, normalizedName });
+        const normalizedCoreTokenMismatch = hasCoreTokenMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName);
+
+        // Validate nutrition data - reject cached mappings to foods with zero/null nutrition
+        let normalizedNutritionInvalid = false;
+        let normalizedCorruptMarked = false;
+        // fs_ only — see the matching flag in Step 1a.
+        let normalizedFsBillableViaServings = false;
+        let normalizedOffServing: { servingSize: string | null; servingGrams: number | null } | null = null;
+        let normalizedCachedKcal100: number | null = null;
+        let normalizedCachedCarbs100: number | null = null;
+        if (!normalizedCoreTokenMismatch) {
+            const { prisma } = await import('../db');
+            let nutrients: any = null;
+            if (normalizedCache.foodId.startsWith('fdc_')) {
+                const fdcId = parseInt(normalizedCache.foodId.replace('fdc_', ''), 10);
+                const fdc = await prisma.fdcFood.findUnique({
+                    where: { fdcId },
+                    select: { nutrientsPer100g: true }
+                });
+                nutrients = fdc?.nutrientsPer100g;
+            } else if (normalizedCache.foodId.startsWith('off_')) {
+                const barcode = normalizedCache.foodId.replace('off_', '');
+                const off = await prisma.offFood.findUnique({
+                    where: { barcode },
+                    select: { nutrientsPer100g: true, servingSize: true, servingGrams: true, corruptReason: true }
+                });
+                nutrients = off?.nutrientsPer100g;
+                if (off) {
+                    normalizedOffServing = { servingSize: off.servingSize, servingGrams: off.servingGrams };
+                    normalizedCorruptMarked = off.corruptReason != null && isCorruptExclusionEnabled();
+                }
+            } else if (normalizedCache.foodId.startsWith('fs_')) {
+                // Same gap as Step 1a, same fix — see the comment there for the
+                // measurement. This arm was an aiGeneratedFood lookup that executed
+                // on every fs_ hit and could never match.
+                const fsId = normalizedCache.foodId.replace('fs_', '');
+                const fsFood = await prisma.fatSecretFood.findUnique({
+                    where: { fsId },
+                    select: { nutrientsPer100g: true, servings: { select: { nutrients: true } } }
+                });
+                const fsPanel = fsFood?.nutrientsPer100g as Record<string, any> | null | undefined;
+                nutrients = fsPanel && Object.keys(fsPanel).length > 0 ? fsPanel : null;
+                normalizedFsBillableViaServings = (fsFood?.servings ?? []).some(
+                    s => servingMacros(s.nutrients as Record<string, unknown> | null) != null);
+            } else {
+                // Instrument only — see the matching note in Step 1a.
+                logger.audit('cache.unrecognised_food_id_prefix', {
+                    foodId: normalizedCache.foodId,
+                    cachedFood: normalizedCache.foodName,
+                });
+            }
+
+            if (nutrients) {
+                const mappedNutrients = {
+                    kcal: nutrients.calories ?? nutrients.energy ?? nutrients.kcal ?? 0,
+                    protein: nutrients.protein ?? 0,
+                    carbs: nutrients.carbohydrate ?? nutrients.carbs ?? 0,
+                    fat: nutrients.fat ?? 0,
+                    per100g: true,
+                };
+                normalizedCachedKcal100 = mappedNutrients.kcal || null;
+                normalizedCachedCarbs100 = mappedNutrients.carbs || null;
+                normalizedNutritionInvalid = hasNullOrInvalidMacros(mappedNutrients, normalizedCache.foodName);
+                if (normalizedNutritionInvalid) {
+                    logger.warn('mapping.normalized_cache_bad_nutrition', {
+                        rawLine: trimmed,
+                        cachedFood: normalizedCache.foodName,
+                        nutrients,
+                    });
+                }
+            } else if (normalizedCache.foodId.startsWith('off_')
+                || (normalizedCache.foodId.startsWith('fs_') && !normalizedFsBillableViaServings)) {
+                // Symmetric with Step 1a's safety net: a cache row pointing at a
+                // record with no nutrition panel AND no macro-bearing serving must
+                // re-resolve, not be served with nulls. An empty panel alone is not
+                // enough — see the measurement in Step 1a's fs_ arm. Deliberately
+                // NOT extended to fdc_ here — the fdc_ arm above has never had this
+                // net and widening it is a separate, unmeasured behaviour change.
+                normalizedNutritionInvalid = true;
+                logger.warn('mapping.normalized_cache_missing_nutrition', {
+                    rawLine: trimmed,
+                    cachedFood: normalizedCache.foodName,
+                    foodId: normalizedCache.foodId,
+                });
+            }
+        }
+
+        // Counted-piece cache escape — same rationale as the early-cache
+        // check: without it this layer would re-pin the label-less food
+        // the early check just escaped from.
+        const normalizedCountedNoun = countedPieceNoun(parsed);
+        const normalizedCountLabelEscape = normalizedCountedNoun != null
+            && normalizedCache.foodId.startsWith('off_')
+            && !servingLabelCountsPiece(normalizedOffServing?.servingSize, normalizedOffServing?.servingGrams, normalizedCountedNoun);
+
+        // Cooked-grain cache escape — same rationale as the early-cache check.
+        const normalizedCachedLooksCooked = /\b(cooked|boiled|steamed|prepared)\b/i.test(normalizedCache.foodName)
+            || (normalizedCachedKcal100 != null && normalizedCachedKcal100 > 60 && normalizedCachedKcal100 <= 250
+                && normalizedCachedCarbs100 != null && normalizedCachedCarbs100 >= 12);
+        const normalizedGrainCookedEscape = detectGrainCookingContext(trimmed, normalizedName).softCooked === true
+            && !normalizedCachedLooksCooked;
+
+        // Escape reason doubles as the telemetry label (PR D pt3 split
+        // the former catch-all 'filter_mismatch' into per-condition
+        // labels). Same predicates, same order as the former || chain.
+        let normalizedEscapeReason =
+            normalizedCorruptMarked ? 'corrupt_record'
+            : normalizedCoreTokenMismatch ? 'core_token_mismatch'
+            : normalizedNutritionInvalid ? 'nutrition_invalid'
+            : normalizedCountLabelEscape ? 'count_label'
+            : normalizedGrainCookedEscape ? 'grain_cooked'
+            : isCategoryMismatch(normalizedName, normalizedCache.foodName, normalizedCache.brandName) ? 'category_mismatch'
+            : isMultiIngredientMismatch(normalizedName, normalizedCache.foodName) ? 'multi_ingredient'
+            // For branded queries: skip modifier mismatch when the cached food's brand
+            // matches the detected brand (e.g. "Oikos" query → "Oikos Triple Zero Vanilla Nonfat"
+            // should not be rejected just because "nonfat" is in the food name but not the query).
+            : ((!isBrandedQuery || !(
+                normalizedCache.brandName &&
+                brandDetection.matchedBrand &&
+                normalizedCache.brandName.toLowerCase().includes(brandDetection.matchedBrand.toLowerCase())
+            )
+                ? hasCriticalModifierMismatch(trimmed, normalizedCache.foodName, 'cache')
+                : false
+            )) ? 'modifier_mismatch'
+            : isReplacementMismatch(trimmed, normalizedCache.foodName, normalizedCache.brandName) ? 'replacement_mismatch'
+            // For branded queries with a known target brand: reject cached results from a
+            // DIFFERENT brand. e.g. "Heinz Tomato Ketchup" query must not serve a cached
+            // "TOMATO KETCHUP (WEIS)" result — force a fresh pipeline run to find Heinz.
+            : (isBrandedQuery &&
+                brandDetection.matchedBrand != null &&
+                normalizedCache.brandName != null &&
+                !normalizedCache.brandName.toLowerCase().includes(brandDetection.matchedBrand.toLowerCase())
+            ) ? 'brand_guard'
+            : null;
+
+        // Read-time trust (PR D pt3, HUMAN_ROW_TRUST) — same rationale
+        // as the early-cache block: name-heuristic escapes skipped for
+        // human-triage rows; corrupt-record, core-token,
+        // nutrition-invalid and serving-shape escapes stay active for
+        // all rows.
+        if (normalizedEscapeReason
+            && isHumanTrustSkippableEscape(normalizedEscapeReason)
+            && isTrustedHumanRow(normalizedCache.validatedBy)) {
+            logger.info('cache.human_row_trusted', {
+                key: normalizedName,
+                foodId: normalizedCache.foodId,
+                skippedRejection: 'normalized:' + normalizedEscapeReason,
+            });
+            normalizedEscapeReason = null;
+        }
+
+        if (normalizedEscapeReason) {
+            logger.warn('mapping.normalized_cache_filter_mismatch', {
+                rawLine: trimmed,
+                cachedFood: normalizedCache.foodName,
+                normalized: normalizedName,
+                coreTokenMismatch: normalizedCoreTokenMismatch,
+                nutritionInvalid: normalizedNutritionInvalid,
+            });
+            if (telemetry) {
+                telemetry.cacheEscape = 'normalized:' + normalizedEscapeReason;
+            }
+            noteReadEscape(targetKeyOfFoodId(normalizedCache.foodId), 'normalized:' + normalizedEscapeReason);
+        } else {
+            const winner: UnifiedCandidate = {
+                id: normalizedCache.foodId,
+                name: normalizedCache.foodName,
+                brandName: normalizedCache.brandName || undefined,
+                source: normalizedCache.source as any,
+                score: normalizedCache.confidence,
+                foodType: 'generic', // Assumption
+                rawData: {},
+            };
+            const confidence = normalizedCache.confidence;
+            const selectionReason = 'normalized_cache_hit';
+            if (telemetry) telemetry.cacheHit = 'normalized';
+            markFunnel(telemetry, 'cache_hit');
+            return { winner, confidence, selectionReason };
+        }
+    }
+
+    return null;
+}
+
+async function attemptDietaryPrefixFallback(params: {
+    trimmed: string;
+    options: MapIngredientOptions;
+    aiNutritionBudget: AiNutritionBudget;
+    aiHydrationBudget: AiNutritionBudget;
+}): Promise<{ served: FatsecretMappedIngredient } | null> {
+    const { trimmed, options, aiNutritionBudget, aiHydrationBudget } = params;
+
+    // ── Step 2b-i: Dietary-prefix stripping fallback ──────────────
+    // If the ingredient has a dietary-attribute prefix (fat-free, gluten-free, sugar-free, etc.),
+    // try re-searching WITHOUT it. These prefixes describe what's ABSENT, not what the food IS.
+    // We try the full term FIRST (above), and only strip as a fallback.
+    // Example flow: "gluten-free salad seasoning" → initial search fails → retry "salad seasoning"
+    const DIETARY_PREFIX_PATTERN = /\b(?:fat[- ]?free|nonfat|non[- ]?fat|gluten[- ]?free|sugar[- ]?free|dairy[- ]?free|grain[- ]?free|nut[- ]?free)\s+/gi;
+    const strippedLine = trimmed.replace(DIETARY_PREFIX_PATTERN, '').trim();
+
+    if (strippedLine !== trimmed && strippedLine.length > 2) {
+        logger.info('mapping.dietary_prefix_fallback', { original: trimmed, stripped: strippedLine });
+
+        const dietaryFallbackResult = await mapIngredientWithFallback(strippedLine, {
+            ...options,
+            // Explicit, NOT covered by the spread: `options` carries the
+            // caller's value, which may be undefined while the
+            // destructure above already minted one. Without this a
+            // single ingredient line spends a fresh allowance per
+            // recursion level.
+            aiNutritionBudget,
+            // Both allowances forward, for the same reason and with the
+            // same explicit-over-spread caveat.
+            aiHydrationBudget,
+            minConfidence: 0.1,
+            _skipInFlightLock: true,
+            _skipFallback: true, // Prevent infinite recursion
+        });
+
+        if (dietaryFallbackResult && 'confidence' in dietaryFallbackResult && dietaryFallbackResult.confidence > 0) {
+            logger.info('mapping.dietary_prefix_fallback_success', {
+                original: trimmed,
+                stripped: strippedLine,
+                food: dietaryFallbackResult.foodName,
+                confidence: dietaryFallbackResult.confidence,
+            });
+            logger.audit('mapping.recovery_path', {
+                path: 'dietary_direct_return',
+                original: trimmed,
+                servedBy: dietaryFallbackResult.foodId,
+            });
+            return { served: dietaryFallbackResult };
+        }
+    }
+
+    return null;
+}
+
+async function attemptAiSimplifyFallback(params: {
+    trimmed: string;
+    rawLine: string;
+    parsed: ParsedIngredient | null;
+    normalizedName: string;
+    brandDetection: BrandKeyInput;
+    options: MapIngredientOptions;
+    aiNutritionBudget: AiNutritionBudget;
+    aiHydrationBudget: AiNutritionBudget;
+}): Promise<
+    | { kind: 'served'; result: FatsecretMappedIngredient }
+    | { kind: 'partial'; winner: UnifiedCandidate; confidence: number; selectionReason: string }
+    | { kind: 'none' }
+> {
+    const {
+        trimmed, rawLine, parsed, normalizedName, brandDetection, options,
+        aiNutritionBudget, aiHydrationBudget,
+    } = params;
+
+    // ── Step 2b-ii: LLM-based simplification ──────────────────────
+    // LLM-based simplification for complex ingredient names
+    const { aiSimplifyIngredient } = await import('./ai-simplify');
+
+    try {
+        const result = await aiSimplifyIngredient(trimmed, brandDetection.matchedBrand ?? undefined);
+
+        if (result && result.simplified && result.simplified !== normalizedName) {
+            logger.info('mapping.fallback_simplification', { original: trimmed, simplified: result.simplified });
+
+            // Recursively try to map the simplifed name
+            // We use a lower minConfidence to accept matches
+            // IMPORTANT: Pass _skipInFlightLock to prevent deadlock if simplified name
+            // normalizes to the same lock key as the original
+            const fallbackResult = await mapIngredientWithFallback(result.simplified, {
+                ...options,
+                aiNutritionBudget,   // see the dietary-fallback call above
+                aiHydrationBudget,   // ditto — both allowances, explicitly
+                minConfidence: 0.1, // Accept imperfect matches for fallback
+                _skipInFlightLock: true, // Prevent recursive deadlock
+                _skipFallback: true, // Prevent infinite fallback recursion
+            });
+
+            if (fallbackResult && 'foodId' in fallbackResult) {
+                // Fallback found a food, but its serving data was computed without our original qty/unit
+                // Re-hydrate using the ORIGINAL parsed input for correct serving selection
+                const fbr = fallbackResult as FatsecretMappedIngredient;
+                const fallbackCandidate: UnifiedCandidate = {
+                    id: fbr.foodId,
+                    name: fbr.foodName,
+                    brandName: fbr.brandName || undefined,
+                    source: fbr.foodId.startsWith('fdc_') ? 'fdc' :
+                            fbr.foodId.startsWith('off_') ? 'openfoodfacts' : 'ai_generated',
+                    score: fbr.confidence * 0.85,
+                    foodType: 'generic',
+                    rawData: {},
+                };
+
+                // For FDC candidates, populate nutrition from fallback result
+                // so buildFdcResult() can compute serving-specific nutrition
+                if (fbr.foodId.startsWith('fdc_') && fbr.grams > 0) {
+                    const factor = 100 / fbr.grams;
+                    fallbackCandidate.nutrition = {
+                        kcal: fbr.kcal * factor,
+                        protein: fbr.protein * factor,
+                        carbs: fbr.carbs * factor,
+                        fat: fbr.fat * factor,
+                        per100g: true,
+                    };
+                }
+
+                // Re-hydrate with ORIGINAL parsed input to get correct serving for "0.25 cup"
+                const rehydratedResult = await hydrateAndSelectServing(
+                    fallbackCandidate,
+                    parsed,  // Use original parsed input with qty/unit!
+                    fallbackCandidate.score,
+                    rawLine,
+                    aiHydrationBudget
+                );
+
+                if (rehydratedResult) {
+                    // Successfully re-hydrated with correct serving
+                    logger.info('mapping.fallback_success', {
+                        original: trimmed,
+                        mappedTo: fbr.foodName,
+                        serving: rehydratedResult.servingDescription,
+                        grams: rehydratedResult.grams,
+                    });
+                    logger.audit('mapping.recovery_path', {
+                        path: 'simplify_direct_return',
+                        original: trimmed,
+                        servedBy: rehydratedResult.foodId,
+                    });
+                    return { kind: 'served', result: rehydratedResult };
+                }
+
+                // If re-hydration failed, still create winner for fallback processing
+                const winner = fallbackCandidate;
+                const confidence = winner.score;
+                const selectionReason = `fallback_simplified: ${result.rationale}`;
+
+                logger.info('mapping.fallback_partial', {
+                    original: trimmed,
+                    mappedTo: fallbackResult.foodName,
+                    note: 'rehydration_failed_continuing'
+                });
+                return { kind: 'partial', winner, confidence, selectionReason };
+            }
+        }
+    } catch (err) {
+        logger.error('mapping.fallback_error', { error: (err as Error).message });
+    }
+
+    return { kind: 'none' };
+}
+
+async function runAiNutritionBackfillNoWinner(params: {
+    normalizedName: string;
+    trimmed: string;
+    rawLine: string;
+    parsed: ParsedIngredient | null;
+    aiNutritionBudget: AiNutritionBudget;
+    allCandidates: UnifiedCandidate[];
+    filtered: UnifiedCandidate[];
+    skippedLlmNormalize: boolean;
+    usedGenericFallback: boolean;
+    telemetry: MappingTelemetry | undefined;
+}): Promise<FatsecretMappedIngredient | null> {
+    const {
+        normalizedName, trimmed, rawLine, parsed, aiNutritionBudget,
+        allCandidates, filtered, skippedLlmNormalize, usedGenericFallback,
+        telemetry,
+    } = params;
+
+    // ============================================================
+    // AI NUTRITION BACKFILL: Last resort for unmappable ingredients
+    // ============================================================
+    if (AI_NUTRITION_BACKFILL_ENABLED) {
+        const baseFoodContext = extractBaseFoodContext(allCandidates);
+        const aiResult = await requestAiNutrition(normalizedName, {
+            rawLine: trimmed,
+            baseFoodContext,
+            budget: aiNutritionBudget,
+        });
+
+        if (aiResult.status === 'success') {
+            // Compute grams and nutrition for the requested serving
+            const parsedQty = parsed ? parsed.qty * parsed.multiplier : 1;
+            const parsedUnit = parsed?.unit || 'serving';
+
+            const servingResult = await getAiServingGrams(
+                aiResult.foodId,
+                parsedUnit,
+                parsedQty,
+            );
+
+            const grams = servingResult?.grams ?? 100;
+            const scale = grams / 100;
+
+            const aiMapped: FatsecretMappedIngredient = {
+                source: 'ai_generated',
+                foodId: aiResult.foodId,
+                foodName: aiResult.displayName,
+                brandName: null,
+                servingId: null,
+                servingDescription: servingResult?.servingLabel ?? `${parsedQty} ${parsedUnit}`,
+                grams,
+                kcal: aiResult.caloriesPer100g * scale,
+                protein: aiResult.proteinPer100g * scale,
+                carbs: aiResult.carbsPer100g * scale,
+                fat: aiResult.fatPer100g * scale,
+                confidence: aiResult.confidence * 0.8,  // Penalize slightly vs API matches
+                quality: aiResult.confidence >= 0.7 ? 'medium' : 'low',
+                rawLine,
+                servingTier: servingResult?.grams != null ? 'ai_generated_serving' : 'flat_100g_default',
+            };
+
+            if (ENABLE_MAPPING_ANALYSIS) {
+                logMappingAnalysis({
+                    rawIngredient: trimmed,
+                    parsed: {
+                        amount: parsed?.qty,
+                        unit: parsed?.unit,
+                        ingredient: parsed?.name,
+                    },
+                    topCandidates: [],
+                    selectedCandidate: {
+                        foodId: aiResult.foodId,
+                        foodName: aiResult.displayName,
+                        brandName: '',
+                        confidence: aiMapped.confidence,
+                        selectionReason: aiResult.cached ? 'ai_nutrition_cache_hit' : 'ai_nutrition_generated',
+                    },
+                    selectedNutrition: {
+                        calories: aiMapped.kcal,
+                        protein: aiMapped.protein,
+                        carbs: aiMapped.carbs,
+                        fat: aiMapped.fat,
+                        perGrams: aiMapped.grams,
+                    },
+                    servingSelection: {
+                        servingDescription: aiMapped.servingDescription || 'N/A',
+                        grams: aiMapped.grams,
+                        backfillUsed: true,
+                        backfillType: 'weight',
+                    },
+                    finalResult: 'success',
+                    source: 'full_pipeline',
+                    aiCalls: {
+                        normalize: {
+                            called: !skippedLlmNormalize && !usedGenericFallback,
+                            skipped: skippedLlmNormalize,
+                        },
+                        // 0.5(b). `ai_generated_serving` is NOT an AI call —
+                        // getAiServingGrams() only reads AiGeneratedServing rows.
+                        serving: servingAiCallForTier(aiMapped.servingTier),
+                        nutrition: { called: true, cached: aiResult.cached, success: true },
+                    },
+                });
+            }
+
+            logger.info('mapping.ai_nutrition_backfill_success', {
+                rawLine: trimmed,
+                foodName: aiResult.displayName,
+                confidence: aiMapped.confidence,
+                cached: aiResult.cached,
+            });
+
+            return aiMapped;
+        } else {
+            logger.warn('mapping.ai_nutrition_backfill_failed', {
+                rawLine: trimmed,
+                reason: aiResult.reason,
+            });
+        }
+    }
+
+    // Total failure — log and return null
+    if (ENABLE_MAPPING_ANALYSIS) {
+        logMappingAnalysis({
+            rawIngredient: trimmed,
+            parsed: {
+                amount: parsed?.qty,
+                unit: parsed?.unit,
+                ingredient: parsed?.name,
+            },
+            topCandidates: [],
+            selectedCandidate: {
+                foodId: '',
+                foodName: '',
+                brandName: '',
+                confidence: 0,
+                selectionReason: 'no_candidates_after_fallback',
+            },
+            finalResult: 'failed',
+            failureReason: 'no_candidates_found',
+        });
+    }
+    // Separate a dataset gap (retrieval found nothing to rank) from a
+    // filter gap (records existed but every one was dropped pre-rank)
+    // from a selection gap — they need completely different fixes.
+    if (allCandidates.length === 0) {
+        markFunnel(telemetry, 'no_candidates', 'dataset_gap');
+    } else if (filtered.length === 0) {
+        markFunnel(telemetry, 'all_filtered', 'no_candidate_survived_filters');
+    } else {
+        markFunnel(telemetry, 'no_match', 'no_winner_selected');
+    }
+    return null; // Return null if truly failed
 }
 
 // ============================================================


### PR DESCRIPTION
Phase 1 stage 1d: the selection cascade's producers and recovery paths become module-private functions with explicit params/returns, SAME FILE (a new-file cascade would create the mapper's first runtime import cycle via the two recursion sites). Zero behavior change; the orchestrator keeps the exact control flow the 1c census mapped — 8 result-producing exits (6 bypassing `finalizeAndSaveResult()`), both result-swappers, both AI-simplify exit disciplines, the Step-5b `selectionReason === 'normalized_cache_hit'` string-match guard, and the two-site backfill asymmetry (deliberately NOT unified — the analysis payloads differ).

Two commits:
- `6e2af80` (1/2, tail): hoists `isWeightUnit`/`isVolumeUnit`/`prepModifier` into the orchestrator (byte-identical initializers) and extracts `hydrateWinnerWithBackfills`, `attemptServingFailureFallback`, `attemptCacheFailureResearch`, `runBackfillAfterWinner`.
- `e1935d6` (2/2, producers): extracts `lookupNormalizedCacheProducer` (the vacuous `if (!winner)` wrapper dropped — winner provably null there), `attemptDietaryPrefixFallback`, `attemptAiSimplifyFallback` (three-way exit union: served / partial / none), `runAiNutritionBackfillNoWinner`.

All entry guards, the lock `try/finally` envelope, the SEARCH block (winner-diff hash window), preamble, 4a/4b clamp+floor, and `finalizeAndSaveResult` stay inline and byte-identical. All six `mapping.recovery_path` audits move verbatim with their blocks (grep = 6). Moved statement text is byte-identical via pinned-name destructuring (the budget test's source scan and three exact-count doc-check claims depend on the literal identifier text).

## Read/write ledger (params in → returns out; effects only via passed references)

| fn | reads (params) | returns | effects via refs |
|---|---|---|---|
| `lookupNormalizedCacheProducer` | normalizedName, preBrandNormalizedName, parsed, brandDetection, trimmed, skipCache, isBrandedQuery, telemetry, noteReadEscape | `{winner, confidence, selectionReason} \| null` | telemetry.normalizedForm/cacheEscape/cacheHit + markFunnel; readEscapes via the noteReadEscape closure |
| `attemptDietaryPrefixFallback` | trimmed, options, aiNutritionBudget, aiHydrationBudget | `{served} \| null` | recursion frame (shares telemetry via `...options`); `dietary_direct_return` audit |
| `attemptAiSimplifyFallback` | trimmed, rawLine, parsed, normalizedName, brandDetection, options, aiNutritionBudget, aiHydrationBudget | `{kind:'served',result} \| {kind:'partial',winner,confidence,selectionReason} \| {kind:'none'}` | recursion frame; `simplify_direct_return` audit; inner save under simplified key on the served arm |
| `runAiNutritionBackfillNoWinner` | normalizedName, trimmed, rawLine, parsed, aiNutritionBudget, allCandidates, filtered, skippedLlmNormalize, usedGenericFallback, telemetry | always returns (aiMapped \| null) | funnel marks; analysis log (`called: !skippedLlmNormalize && !usedGenericFallback`) |
| `hydrateWinnerWithBackfills` | winner, parsed, confidence, rawLine, aiHydrationBudget, isWeightUnit, isVolumeUnit, prepModifier | `{result, selectionReason?}` | serving-store writes via the lane; orchestrator assigns selectionReason ONLY when defined (preserves `normalized_cache_hit` for the 5b guard) |
| `attemptServingFailureFallback` | winner, filtered, parsed, confidence, rawLine, trimmed, normalizedName, aiHydrationBudget, isWeightUnit, isVolumeUnit, prepModifier | `{result, selectionReason} \| null` | `serving_failure_fallback` audit; confidence ×0.95 argument-only (outer never rescaled) |
| `attemptCacheFailureResearch` | winner, trimmed, normalizedName, parsed, rawLine, confidence, aiHydrationBudget, aiNutritionEstimate, aiCanonicalBase, isBrandedQuery, brandDetection, allSynonyms, skipCache, skipFdc, debug | `{result, selectionReason} \| null` | `cache_failure_research`/`cache_failure_rebilled` audits; confidence ×0.9 argument-only |
| `runBackfillAfterWinner` | winner, trimmed, parsed, filtered, confidence, selectionReason, allCandidates, normalizedName, aiNutritionBudget, rawLine, skippedLlmNormalize | always returns (aiMapped \| null) | `backfill_after_winner` audit; analysis log (`called: !skippedLlmNormalize` — no usedGenericFallback, asymmetry kept) |

Spec-census param deltas, both justified re-walks (the moved interiors provably never read them): fn 1 drops `readEscapes` (touched only via the passed `noteReadEscape` closure, same array); fn 8 drops `telemetry` (zero telemetry/markFunnel reads in the old interior).

## Gates (all measured on `e1935d6`)

- tsc 0 · full jest **172 suites / 3,431 passed / 1 skipped** (identical to the 1c baseline; zero test edits — verified only the mapper changed) · all 37 producer characterization pins green
- winner-diff **`caller=2aa35e26b52161d1 helpers=8c1e518d30331976`** unchanged (window bytes identical; `callerLines` shifted 1853–2474 → 1662–2283, position only)
- doc-check **109/109**, zero registry edits · lint:ci **0 errors / 591 warnings** (zero delta) · `next build` green
- `mapping.recovery_path` emissions grep = **6** (all move verbatim with their blocks)
- 6-agent adversarial review: **0 MUST-FIX / 0 SHOULD-FIX**; red team independently re-ran the verbatim-motion multiset proof — exactly 9 removed lines, all sanctioned conversions (wrapper drop, 6 assignment→const, 2 return rewrites)

Two discharged characterization notes (recorded for posterity, no action): the hoisted consts now evaluate before the first hydration, which can mutate `parsed.unit` — unobservable because the only installable values (`bunch|head|stalk`) fail both regexes and the flags are truthiness-only; fn-3's partial-path exception window narrowed — reachable only if `logger.info` throws, which the wrapper cannot.

Post-merge deploy gate: cold ×3 restarted vs the stable 11 baseline ids (byte-identical `observed`), plus the box `next-start.log` recovery-path grep proving V1/V2 survived live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
