### PR TITLE
test: pin the 1d hoist's latent divergence — trailing-unit set disjoint from the hoisted unit-class regexes

### DIFF
--- a/src/lib/mapping/__tests__/trailing-unit-hoist-divergence.test.ts
+++ b/src/lib/mapping/__tests__/trailing-unit-hoist-divergence.test.ts
@@ -1,0 +1,66 @@
+import { TRAILING_UNIT_REGEX } from '../serving/hydration-lane';
+import { WEIGHT_UNIT_REGEX, VOLUME_UNIT_REGEX } from '../map-ingredient-with-fallback';
+
+/**
+ * Pins the 1d hoist's latent divergence CLOSED (log/2026-08-07_0230, Findings).
+ *
+ * hydrateAndSelectServing() mutates parsed.unit — trailing-unit recovery sets
+ * it from TRAILING_UNIT_REGEX when it was falsy — but the 1d-hoisted
+ * isWeightUnit / isVolumeUnit flags in the mapper evaluate parsed.unit BEFORE
+ * that mutation runs. The hoist is behaviour-preserving TODAY only because
+ * every trailing-unit token fails both unit regexes: a pre-mutation `false`
+ * and a post-mutation `false` agree. The moment the trailing-unit set gains a
+ * token that reads as a weight or volume unit, the hoisted flags and the
+ * pre-1d semantics diverge on live traffic with no test noticing — except
+ * this one.
+ *
+ * All three operands are the REAL production symbols, exported from the
+ * modules that execute them — never re-transcribed copies. A copy would pin
+ * the author's snapshot, not the code, and drift silently when either side
+ * moves: the exact class #249 killed for servingTier predicates.
+ *
+ * MUTATION (executed before commit, confirmed red): add a weight token to
+ * TRAILING_UNIT_REGEX in hydration-lane.ts — e.g.
+ * /\b(bunch|head|stalk|oz)\b/i — and the `oz` row of the disjointness test
+ * dies. Equivalently, adding `bunch` to WEIGHT_UNIT_REGEX kills the `bunch`
+ * row.
+ */
+
+/**
+ * Extract the alternation tokens from a single-group regex like
+ * /\b(bunch|head|stalk)\b/i. Reads the regex's own source so the tested set
+ * IS the shipped set. Fails closed: no group, or a token that is not a plain
+ * lowercase word, red-flags in the shape test below rather than passing
+ * vacuously.
+ */
+function alternationTokens(re: RegExp): string[] {
+    const group = re.source.match(/\(([^()]*)\)/);
+    if (!group) return [];
+    return group[1].split('|');
+}
+
+const trailingUnitTokens = alternationTokens(TRAILING_UNIT_REGEX);
+
+describe('trailing-unit recovery set vs the 1d-hoisted unit-class flags', () => {
+    it('extracts a non-empty set of plain-word tokens from the real regex (fail-closed)', () => {
+        expect(trailingUnitTokens.length).toBeGreaterThan(0);
+        for (const token of trailingUnitTokens) {
+            // A token with regex metacharacters (e.g. `fl\s*oz`) would make the
+            // per-token disjointness test below meaningless as a string probe —
+            // force human attention instead of a vacuous green.
+            expect(token).toMatch(/^[a-z]+$/);
+        }
+    });
+
+    // The recovery site lowercases the matched token before assigning
+    // parsed.unit, and both unit regexes are ^…$-anchored with /i — so
+    // testing the bare token is exactly the predicate the hoisted flags
+    // would apply post-mutation.
+    it.each(trailingUnitTokens)(
+        'trailing unit %j must match neither WEIGHT_UNIT_REGEX nor VOLUME_UNIT_REGEX',
+        (token) => {
+            expect(WEIGHT_UNIT_REGEX.test(token)).toBe(false);
+            expect(VOLUME_UNIT_REGEX.test(token)).toBe(false);
+        },
+    );
+});

--- a/src/lib/mapping/map-ingredient-with-fallback.ts
+++ b/src/lib/mapping/map-ingredient-with-fallback.ts
@@ -82,6 +82,20 @@ export {
     isTightNameGroup, buildOffResult,
 } from './serving/hydration-lane';
 
+/**
+ * Unit-class predicates for Step 5a's isWeightUnit / isVolumeUnit flags,
+ * hoisted above the cascade in Phase 1 stage 1d. They evaluate parsed.unit
+ * BEFORE the hydration lane runs — and hydrateAndSelectServing (no `()` here:
+ * the budget migration guard scans this file's text for call sites, comments
+ * included) mutates parsed.unit via trailing-unit recovery,
+ * TRAILING_UNIT_REGEX in ./serving/hydration-lane. The hoist is only
+ * divergence-free while the trailing-unit set matches NEITHER regex; exported so
+ * __tests__/trailing-unit-hoist-divergence.test.ts can pin that disjointness
+ * against the real symbols (log/2026-08-07_0230, Findings).
+ */
+export const WEIGHT_UNIT_REGEX = /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms)$/i;
+export const VOLUME_UNIT_REGEX = /^(cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|ml|milliliter|milliliters|floz|fl\s*oz|fluid\s*ounce|l|liter|liters)$/i;
+
 // ============================================================
 // Symmetric cache lookup with legacy-key fallback (Track 1c)
 // ============================================================
@@ -2483,12 +2497,12 @@ export async function mapIngredientWithFallback(
         // Step 5a: If hydration failed and user requested a weight unit (oz, g, lb),
         // try AI backfill for weight serving on the winner BEFORE falling back to other candidates.
         // This prevents falling back to lower-ranked candidates just because they have gram servings.
-        const isWeightUnit = parsed?.unit && /^(g|gram|grams|oz|ounce|ounces|lb|lbs|pound|pounds|kg|kilogram|kilograms)$/i.test(parsed.unit);
+        const isWeightUnit = parsed?.unit && WEIGHT_UNIT_REGEX.test(parsed.unit);
 
         // Step 5a-VOLUME: If hydration failed for a VOLUME unit (cup, tbsp, tsp, etc.),
         // try AI volume backfill to estimate density for the winner BEFORE falling back to other candidates.
         // This prevents falling back to semantically unrelated candidates just because they have volume servings.
-        const isVolumeUnit = parsed?.unit && /^(cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|ml|milliliter|milliliters|floz|fl\s*oz|fluid\s*ounce|l|liter|liters)$/i.test(parsed.unit);
+        const isVolumeUnit = parsed?.unit && VOLUME_UNIT_REGEX.test(parsed.unit);
 
         // Extract prep modifier from ingredient line for modifier-aware serving labels
         const prepModifier = extractPrepModifier(rawLine, parsed?.qualifiers);

--- a/src/lib/mapping/serving/hydration-lane.ts
+++ b/src/lib/mapping/serving/hydration-lane.ts
@@ -47,6 +47,24 @@ import { buildFatSecretResult } from '../build-fatsecret-result';
 import type { FatsecretMappedIngredient } from '../map-ingredient-with-fallback';
 
 /**
+ * Trailing-unit recovery set: units the parser sometimes fails to extract,
+ * leaving them in the name (e.g. "5 mint 1 bunch" => unit: null, name:
+ * "mint 1 bunch"). hydrateAndSelectServing and buildFdcResult both recover
+ * them from parsed.name; the first MUTATES parsed.unit when it fires.
+ * (Symbol names here deliberately carry no parens — the migration guard in
+ * __tests__/ai-nutrition-hydration-budget.test.ts scans this file's raw text
+ * for that name followed by an open paren, comments included.)
+ *
+ * INVARIANT (pinned by __tests__/trailing-unit-hoist-divergence.test.ts):
+ * this set must stay DISJOINT from WEIGHT_UNIT_REGEX and VOLUME_UNIT_REGEX in
+ * ../map-ingredient-with-fallback.ts. The 1d-hoisted isWeightUnit /
+ * isVolumeUnit flags evaluate parsed.unit BEFORE that mutation runs, so the
+ * hoist is only divergence-free while no member of this set reads as a weight
+ * or volume unit (log/2026-08-07_0230, Findings).
+ */
+export const TRAILING_UNIT_REGEX = /\b(bunch|head|stalk)\b/i;
+
+/**
  * Annotate ground meat food name with lean percentage when query didn't specify one.
  * This ensures users can see what lean % they're getting when they just typed "ground beef".
  * 
@@ -216,7 +234,7 @@ export async function hydrateAndSelectServing(
     // FIX: Sometimes the parser fails to extract units like "bunch" or "head", leaving them in the name.
     // E.g. "5 mint 1 bunch" => unit: null, name: "mint 1 bunch"
     if (parsed && !parsed.unit && parsed.name) {
-        const trailingUnitMatch = parsed.name.match(/\b(bunch|head|stalk)\b/i);
+        const trailingUnitMatch = parsed.name.match(TRAILING_UNIT_REGEX);
         if (trailingUnitMatch) {
             parsed.unit = trailingUnitMatch[1].toLowerCase();
         }
@@ -1172,7 +1190,7 @@ async function buildFdcResult(
 
     // FIX: Sometimes the parser fails to extract units like "bunch" or "head", leaving them in the name.
     if (parsed && !unit && parsed.name) {
-        const trailingUnitMatch = parsed.name.match(/\b(bunch|head|stalk)\b/i);
+        const trailingUnitMatch = parsed.name.match(TRAILING_UNIT_REGEX);
         if (trailingUnitMatch) {
             unit = trailingUnitMatch[1].toLowerCase();
         }


### PR DESCRIPTION
## What

One characterization test pinning the 1d hoist's only known latent divergence CLOSED, plus the named-const exports it needs to assert against real symbols.

## Why (the 1d write-off finding)

`log/2026-08-07_0230_stage-1d-shipped-zero-delta.md` (Findings): `hydrateAndSelectServing()` mutates `parsed.unit` — trailing-unit recovery sets it to `bunch`/`head`/`stalk` when previously falsy — but the 1d-hoisted `isWeightUnit`/`isVolumeUnit` flags evaluate `parsed.unit` PRE-mutation. The hoist is behaviour-preserving today ONLY because all three trailing-unit tokens fail both unit regexes. If that set ever gains a weight/volume token, the hoisted flags silently diverge from pre-1d semantics on live traffic. This test makes that growth loud.

## Export, not copy

The trailing-unit literal was inlined twice (`hydrateAndSelectServing` + `buildFdcResult`); the unit regexes were inlined at Step 5a. A test asserting against re-transcribed copies would pin the author's snapshot, not the code, and drift silently when either side moves — the exact class #249 killed for servingTier predicates. So the literals are hoisted to exported consts (`TRAILING_UNIT_REGEX`, `WEIGHT_UNIT_REGEX`, `VOLUME_UNIT_REGEX`) with regex sources byte-identical, and all four use sites read the consts. The test then derives its token rows from `TRAILING_UNIT_REGEX.source` itself, fail-closed: an empty extraction or a non-plain-word token reds the shape test instead of passing vacuously.

## Mutation evidence (executed, then reverted)

Adding `|oz` to `TRAILING_UNIT_REGEX`:

```
✕ trailing unit "oz" must match neither WEIGHT_UNIT_REGEX nor VOLUME_UNIT_REGEX (1 ms)
    expect(WEIGHT_UNIT_REGEX.test(token)).toBe(false);
    Expected: false
    Received: true
Tests: 1 failed, 4 passed, 5 total
```

The mutated token appears as its own test row automatically — the tested set is the shipped set by construction.

## Safety

- Both mapper edit sites are outside the winner-diff caller block (1662–2283); the trailing-unit sites are outside the five COPIED_HELPERS bodies — the pinned drift hashes are untouched.
- Shared regex objects carry no `/g` flag, so `.test()`/`.match()` semantics are identical to the inline literals.
- Comment mentions of the hydration entry point deliberately omit parens: the budget MIGRATION GUARD in `ai-nutrition-hydration-budget.test.ts` scans both files' raw text for the name followed by `(`, comments included (found the hard way — two red intermediate runs).

## Gates

jest (new test 4/4), executed mutation red, `npx tsc --noEmit` clean, `npm run test:ci` 172/172 suites green, `lint:ci` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
