### PR TITLE
test: pin ENABLE_MAPPING_ANALYSIS=false in jest — suites stop writing real logs/mapping-analysis-* files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,10 @@ module.exports = {
       // Blanks the provider credentials BEFORE any module is imported, so no test can
       // reach a live LLM. Must stay in `setupFiles`, not `setupFilesAfterEnv` — the
       // keys are captured into module-scope consts at import time. See the file.
-      setupFiles: ['<rootDir>/jest.setup.no-llm.js'],
+      // no-analysis-writes pins ENABLE_MAPPING_ANALYSIS to 'false' so no suite can
+      // write logs/mapping-analysis-* files — same import-time-const mechanism, see
+      // that file.
+      setupFiles: ['<rootDir>/jest.setup.no-llm.js', '<rootDir>/jest.setup.no-analysis-writes.js'],
     },
     {
       displayName: 'components',
@@ -44,7 +47,7 @@ module.exports = {
       },
       // Same gate as the `api` project: a component test can import the mapper chain
       // transitively, so the jsdom project needs it too.
-      setupFiles: ['<rootDir>/jest.setup.no-llm.js'],
+      setupFiles: ['<rootDir>/jest.setup.no-llm.js', '<rootDir>/jest.setup.no-analysis-writes.js'],
       setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
       extensionsToTreatAsEsm: ['.ts', '.tsx'],
       globals: {

--- a/jest.setup.no-analysis-writes.js
+++ b/jest.setup.no-analysis-writes.js
@@ -1,0 +1,47 @@
+/**
+ * Jest gate: a test may never write mapping-analysis files into `logs/`.
+ *
+ * WHY THIS FILE EXISTS
+ * Every `logMappingAnalysis()` call site sits behind
+ * `if (ENABLE_MAPPING_ANALYSIS)` in src/lib/mapping/map-ingredient-with-fallback.ts,
+ * and that gate is a module-scope const:
+ * `process.env.ENABLE_MAPPING_ANALYSIS === 'true'`, captured at import time. The
+ * same flag guards the `logs/ai-parse-events.jsonl` appendFileSync in the same
+ * file. On a dev Mac the mapper chain's `import 'dotenv/config'` loads a `.env`
+ * that sets ENABLE_MAPPING_ANALYSIS=true, so any suite that drives the mapper far
+ * enough to select a candidate writes real `logs/mapping-analysis-*.json` +
+ * `logs/mapping-summary-*.txt` files — the same namespace the box's decision
+ * corpora live in (109 sessions / 57,699 decisions), which analysis tooling globs.
+ *
+ * MEASURED 2026-08-07 on master @1b9089c (fresh worktree, no `.env`):
+ * `ENABLE_MAPPING_ANALYSIS=true npm run test:ci` wrote 6 files (3 analysis JSON +
+ * 3 summary txt; the filename timestamp has 1 s resolution, so parallel workers
+ * collapse into shared files). Running the unmocked mapper suites one at a time
+ * attributed the writes to NINE suites — enumerated in PR
+ * test/jest-mapping-logger-leak. The seven stage-1c producer-*.test.ts suites
+ * already `jest.mock('../mapping-logger')` and were never the leak.
+ *
+ * WHY `setupFiles` AND NOT `setupFilesAfterEnv`
+ * Same reason as jest.setup.no-llm.js: the gate is frozen into a module-scope
+ * const at import time, so the pin must land before the first import of the
+ * mapper chain. `setupFiles` runs before the test file is loaded.
+ *
+ * WHY THIS ASSIGNS 'false' AND MUST NEVER `delete`
+ * dotenv writes a key only when the property does not already exist on
+ * process.env (see jest.setup.no-llm.js for the full mechanism). Assigning
+ * 'false' creates the property, so the later `import 'dotenv/config'` cannot put
+ * the dev machine's `true` back. `delete process.env.ENABLE_MAPPING_ANALYSIS`
+ * would hand dotenv permission to do exactly that. The assignment also
+ * deliberately overrides an explicit `ENABLE_MAPPING_ANALYSIS=true` on the jest
+ * command line: no jest run may write into `logs/`.
+ *
+ * A test that needs the analysis writes' *behaviour* mocks the module instead —
+ * `jest.mock('../mapping-logger')`, the stage-1c producer-*.test.ts pattern.
+ *
+ * The invariant is asserted by
+ * src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts, which loads
+ * `dotenv/config` itself and requires the flag to still read 'false', and pins
+ * this file into BOTH jest projects' `setupFiles` (a component test can import
+ * the mapper chain transitively, same as the no-llm gate).
+ */
+process.env.ENABLE_MAPPING_ANALYSIS = 'false';

--- a/jest.setup.no-analysis-writes.js
+++ b/jest.setup.no-analysis-writes.js
@@ -5,9 +5,12 @@
  * Every `logMappingAnalysis()` call site sits behind
  * `if (ENABLE_MAPPING_ANALYSIS)` in src/lib/mapping/map-ingredient-with-fallback.ts,
  * and that gate is a module-scope const:
- * `process.env.ENABLE_MAPPING_ANALYSIS === 'true'`, captured at import time. The
- * same flag guards the `logs/ai-parse-events.jsonl` appendFileSync in the same
- * file. On a dev Mac the mapper chain's `import 'dotenv/config'` loads a `.env`
+ * `process.env.ENABLE_MAPPING_ANALYSIS === 'true'`, captured at import time.
+ * A SEPARATE const, ENABLE_AI_PARSE_LOG (same file, same capture-at-import
+ * mechanism), guards the `logs/ai-parse-events.jsonl` appendFileSync — it is
+ * pinned to 'false' below as well, or a dev machine opting into
+ * ENABLE_AI_PARSE_LOG=true would still leak from jest.
+ * On a dev Mac the mapper chain's `import 'dotenv/config'` loads a `.env`
  * that sets ENABLE_MAPPING_ANALYSIS=true, so any suite that drives the mapper far
  * enough to select a candidate writes real `logs/mapping-analysis-*.json` +
  * `logs/mapping-summary-*.txt` files — the same namespace the box's decision
@@ -45,3 +48,4 @@
  * the mapper chain transitively, same as the no-llm gate).
  */
 process.env.ENABLE_MAPPING_ANALYSIS = 'false';
+process.env.ENABLE_AI_PARSE_LOG = 'false';

--- a/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
+++ b/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
@@ -21,12 +21,21 @@ describe('no mapping-analysis file writes from jest', () => {
         expect(process.env.ENABLE_MAPPING_ANALYSIS).toBe('false');
     });
 
-    it('dotenv cannot restore the dev .env value over the pin', async () => {
+    it('ENABLE_AI_PARSE_LOG is pinned too — a separate const guards the ai-parse-events.jsonl append', () => {
+        // The logs/ai-parse-events.jsonl appendFileSync in the same file is gated
+        // by its own module-scope const (ENABLE_AI_PARSE_LOG), not by
+        // ENABLE_MAPPING_ANALYSIS — pinning only the latter would still leak on a
+        // machine opting into ENABLE_AI_PARSE_LOG=true.
+        expect(process.env.ENABLE_AI_PARSE_LOG).toBe('false');
+    });
+
+    it('dotenv cannot restore the dev .env values over the pins', async () => {
         // dotenv only writes keys that are not already own-properties of
-        // process.env, so the setup file's assignment must survive this import
-        // even on a machine whose .env sets ENABLE_MAPPING_ANALYSIS=true.
+        // process.env, so the setup file's assignments must survive this import
+        // even on a machine whose .env sets either flag to true.
         await import('dotenv/config');
         expect(process.env.ENABLE_MAPPING_ANALYSIS).toBe('false');
+        expect(process.env.ENABLE_AI_PARSE_LOG).toBe('false');
     });
 
     it('both jest projects load the no-analysis-writes setup file', () => {
@@ -54,6 +63,7 @@ describe('no mapping-analysis file writes from jest', () => {
             .replace(/\/\*[\s\S]*?\*\//g, '')
             .replace(/\/\/[^\n]*/g, '');
         expect(codeOnly).toContain("process.env.ENABLE_MAPPING_ANALYSIS = 'false'");
+        expect(codeOnly).toContain("process.env.ENABLE_AI_PARSE_LOG = 'false'");
         expect(codeOnly).not.toMatch(/delete\s+process\.env/);
     });
 });

--- a/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
+++ b/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
@@ -51,8 +51,10 @@ describe('no mapping-analysis file writes from jest', () => {
     });
 
     it('the setup file assigns the pin and never deletes the env var', () => {
-        // `delete process.env.X` would hand dotenv permission to put the dev
-        // machine's `true` straight back — same rule as jest.setup.no-llm.js.
+        // A `delete` of either env key would hand dotenv permission to put the
+        // dev machine's `true` straight back — same rule as jest.setup.no-llm.js.
+        // (Worded without the literal delete-expression: CI's env-parity scan
+        // greps `process.env.<NAME>` in src/** including comments.)
         const setupSource = fs.readFileSync(
             path.join(__dirname, '../../../../jest.setup.no-analysis-writes.js'),
             'utf-8'

--- a/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
+++ b/src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Asserts the invariants of jest.setup.no-analysis-writes.js — the gate that
+ * stops jest suites writing real logs/mapping-analysis-* files on dev machines
+ * whose .env sets ENABLE_MAPPING_ANALYSIS=true. See that file for the measured
+ * leak (9 suites, 2026-08-07) and the mechanism.
+ *
+ * Mirrors src/lib/ai/__tests__/no-live-llm-egress.test.ts: it does not trust the
+ * setup file to have run — it loads `dotenv/config` itself and requires the pin
+ * to survive, and it pins the setup file into BOTH jest projects so a config
+ * edit cannot silently drop one.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+describe('no mapping-analysis file writes from jest', () => {
+    it('ENABLE_MAPPING_ANALYSIS is pinned to the string false before any module import', () => {
+        // Assigned (not deleted) by jest.setup.no-analysis-writes.js in setupFiles,
+        // i.e. before the module-scope const in map-ingredient-with-fallback.ts is
+        // captured.
+        expect(process.env.ENABLE_MAPPING_ANALYSIS).toBe('false');
+    });
+
+    it('dotenv cannot restore the dev .env value over the pin', async () => {
+        // dotenv only writes keys that are not already own-properties of
+        // process.env, so the setup file's assignment must survive this import
+        // even on a machine whose .env sets ENABLE_MAPPING_ANALYSIS=true.
+        await import('dotenv/config');
+        expect(process.env.ENABLE_MAPPING_ANALYSIS).toBe('false');
+    });
+
+    it('both jest projects load the no-analysis-writes setup file', () => {
+        const config = require('../../../../jest.config.js') as {
+            projects: Array<{ displayName: string; setupFiles?: string[] }>;
+        };
+        expect(config.projects.length).toBeGreaterThanOrEqual(2);
+        for (const project of config.projects) {
+            expect(project.setupFiles ?? []).toContain(
+                '<rootDir>/jest.setup.no-analysis-writes.js'
+            );
+        }
+    });
+
+    it('the setup file assigns the pin and never deletes the env var', () => {
+        // `delete process.env.X` would hand dotenv permission to put the dev
+        // machine's `true` straight back — same rule as jest.setup.no-llm.js.
+        const setupSource = fs.readFileSync(
+            path.join(__dirname, '../../../../jest.setup.no-analysis-writes.js'),
+            'utf-8'
+        );
+        // The header comment documents the delete-hands-dotenv-the-pen trap, so
+        // strip comments and assert on the code alone.
+        const codeOnly = setupSource
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/[^\n]*/g, '');
+        expect(codeOnly).toContain("process.env.ENABLE_MAPPING_ANALYSIS = 'false'");
+        expect(codeOnly).not.toMatch(/delete\s+process\.env/);
+    });
+});


### PR DESCRIPTION
## Problem

On a dev Mac, jest suites that drive the mapper write REAL `logs/mapping-analysis-*.json` + `mapping-summary-*.txt` files: the mapper chain's `import 'dotenv/config'` loads the machine's `.env` (which sets `ENABLE_MAPPING_ANALYSIS=true`), and every `logMappingAnalysis()` call site in `map-ingredient-with-fallback.ts` sits behind a module-scope const captured at import time. The 7 stage-1c `producer-*.test.ts` suites mock `../mapping-logger`; the house exemplar suites did not. Those files land in the same `logs/` namespace as the box's decision corpora, which analysis tooling globs.

## Control (before-instrument)

Fresh worktree of master @1b9089c, no `.env`, no `logs/`: `ENABLE_MAPPING_ANALYSIS=true npm run test:ci` wrote **6 files** (3 analysis JSON + 3 summary txt). The filename timestamp has 1 s resolution, so parallel workers collapse into shared files — the file count is a **lower bound** on leaking suites. Running each unmocked mapper-importing suite in isolation attributed the writes to **9 suites** (not the suspected ~21):

- `src/lib/mapping/__tests__/map-alias-loop-removed.test.ts`
- `src/lib/mapping/__tests__/abstention-confidence.test.ts`
- `src/lib/mapping/__tests__/legacy-key-fallback.test.ts`
- `src/lib/mapping/__tests__/identity-hint-reaches-retrieval.test.ts`
- `src/lib/mapping/__tests__/llm-output-guard-wiring.test.ts`
- `src/lib/mapping/__tests__/fs-cache-nutrition-validation.test.ts`
- `src/lib/mapping/__tests__/map-hit-resave-skip.test.ts`
- `src/lib/mapping/__tests__/identity-qualifier-reaches-retrieval.test.ts`
- `src/lib/mapping/__tests__/map-ingredient-with-fallback.test.ts`

(20 further suites import the mapper unmocked but never reach a guarded write path — they produced 0 files in isolation.)

## Fix — shared setup, both projects, no per-suite edits

New `jest.setup.no-analysis-writes.js`, registered in **both** jest projects' `setupFiles` (the `jest.setup.no-llm.js` precedent): it **ASSIGNS** `process.env.ENABLE_MAPPING_ANALYSIS = 'false'` — never `delete`, or dotenv would put the dev `.env`'s `true` straight back — before the gate const is captured. One pin covers every write path (all ten `logMappingAnalysis` sites plus the `ai-parse-events.jsonl` append are behind the same flag). Suites that assert logger behaviour are untouched: the 7 producer suites keep their own `jest.mock('../mapping-logger')`, and `serving-ai-tiers.test.ts` only checks a type union. No suite asserts `ENABLE_MAPPING_ANALYSIS=true` behaviour (grep: comments only).

Permanent guard `src/lib/mapping/__tests__/no-mapping-analysis-writes.test.ts` (mirrors `no-live-llm-egress.test.ts`): asserts the pin, loads `dotenv/config` itself and requires the pin to survive, pins the setup file into both projects' `setupFiles`, and asserts assign-never-delete in the setup file's code.

## Tripwire gate — both halves (2026-08-07)

1. **Post-fix delta 0**: `ENABLE_MAPPING_ANALYSIS=true npm run test:ci` → 172/172 green, **0** mapping-analysis files, `logs/` never created.
2. **Disarm proves the instrument**: with the pin line temporarily commented out, one previously-leaking suite (`map-ingredient-with-fallback.test.ts`) run with the env flag wrote **1 analysis + 1 summary file**. Reverted. The half-1 zero is a working gate, not a broken instrument.

## Other gates

- Plain `npm run test:ci`: 172/172 green (3434 passed, 1 skipped).
- `npm run lint:ci`: 455 warnings / 0 errors — under the 700 cap; the new files add zero warnings.
- `git diff --stat`: only `jest.config.js`, the new setup file, and the new guard test.

## Review amendment (commit 6b49e66)

Adversarial review caught a false claim in the setup header: the `logs/ai-parse-events.jsonl` append is guarded by a SEPARATE const (`ENABLE_AI_PARSE_LOG`), not `ENABLE_MAPPING_ANALYSIS`. The header is corrected, the second flag is now pinned too (assigned `'false'`, never deleted), and the invariant test asserts both pins survive dotenv. Out of scope but recorded: `debug-logger.ts` mkdirSync's `logs/` at import and appends unconditionally with no env gate — no current test imports it (verified by grep), latent only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu
