### PR TITLE
docs: docket D3 — flywheel-sweep.timer durably disabled, registry claim re-pinned

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -666,15 +666,15 @@
     },
     {
       "id": "flywheel-sweep-timer-is-deliberately-stopped",
-      "claim": "flywheel-sweep.timer is STOPPED on purpose for the duration of the pipeline-hardening program (decided 2026-08-04, plan section 'Running under all of this'), so no nightly writer moves a warm number underneath a measurement. It is still `is-enabled`=enabled, so the pause is NOT durable across a box reboot — this claim goes red the moment the timer is running again, which is the prompt to update the plan's restart line rather than let a stale 'stopped for the duration' outlive the program.",
+      "claim": "flywheel-sweep.timer is durably DISABLED (docket D3, decided and executed 2026-08-07): is-active=inactive AND is-enabled=disabled, so a box reboot no longer silently re-arms it. Re-enable deliberately when the item-17 warm campaign resumes (plan section 'Running under all of this'), repairing the failed service at the same time. This claim goes red if the timer is re-enabled or running again, which is the prompt to rewrite that plan section rather than let 'disabled' outlive the decision.",
       "ownerDoc": "mobile:sync-docs/pipeline_hardening_plan.md",
       "where": "box",
-      "command": "systemctl --user is-active flywheel-sweep.timer 2>/dev/null || true",
+      "command": "echo \"$(systemctl --user is-active flywheel-sweep.timer 2>/dev/null || true):$(systemctl --user is-enabled flywheel-sweep.timer 2>/dev/null || true)\"",
       "expect": {
         "kind": "equals",
-        "value": "inactive"
+        "value": "inactive:disabled"
       },
-      "verified": "2026-08-04"
+      "verified": "2026-08-07"
     },
     {
       "id": "off-corrupt-marks-restored",


### PR DESCRIPTION
Docket D3 (2026-08-07, Diego's call): durable disable over repair-and-restart. Executed on the box: `systemctl --user disable flywheel-sweep.timer` → `is-enabled=disabled`, 0 timers listed.

This PR updates the one registry entry that tripwires the timer state: `flywheel-sweep-timer-is-deliberately-stopped` now pins `inactive:disabled` (both halves), re-dated 2026-08-07. Re-enable condition (warm campaign resumption) is recorded in the plan's §Running-under-all-of-this, which is the owner doc.

D2 note: the AiNormalizeCache v1 prune has no registry footprint — no claim pins the v1 count — so this PR is the whole docket registry delta.

Full doc-check run on this branch: **109/109 claims hold**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu