### PR TITLE
docs: flywheel timer claim flipped — re-enabled 2026-08-08 (item-17 campaign resume)

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -665,16 +665,16 @@
       "verified": "2026-07-31"
     },
     {
-      "id": "flywheel-sweep-timer-is-deliberately-stopped",
-      "claim": "flywheel-sweep.timer is durably DISABLED (docket D3, decided and executed 2026-08-07): is-active=inactive AND is-enabled=disabled, so a box reboot no longer silently re-arms it. Re-enable deliberately when the item-17 warm campaign resumes (plan section 'Running under all of this'), repairing the failed service at the same time. This claim goes red if the timer is re-enabled or running again, which is the prompt to rewrite that plan section rather than let 'disabled' outlive the decision.",
+      "id": "flywheel-sweep-timer-re-enabled-for-item-17",
+      "claim": "flywheel-sweep.timer is RE-ENABLED (2026-08-08, item-17 warm campaign resume): is-active=active AND is-enabled=enabled. Its D3 re-enable condition was met and executed — the 2026-08-03 service failure was diagnosed (eval-gate red on n-prod-01, not infra) and repaired cache-side (apple key repointed to FDC 171688 as a human-triage pin), plus a second warm red found on the proof run (n-mq-41 brand_guard escape bypassing the correct fs_81276 row; promoted to human-triage). This claim goes red if the timer is stopped or disabled again, which is the prompt to rewrite the plan section 'Running under all of this' rather than let the state outlive the decision.",
       "ownerDoc": "mobile:sync-docs/pipeline_hardening_plan.md",
       "where": "box",
       "command": "echo \"$(systemctl --user is-active flywheel-sweep.timer 2>/dev/null || true):$(systemctl --user is-enabled flywheel-sweep.timer 2>/dev/null || true)\"",
       "expect": {
         "kind": "equals",
-        "value": "inactive:disabled"
+        "value": "active:enabled"
       },
-      "verified": "2026-08-07"
+      "verified": "2026-08-08"
     },
     {
       "id": "off-corrupt-marks-restored",


### PR DESCRIPTION
## What

Flips `flywheel-sweep-timer-is-deliberately-stopped` → `flywheel-sweep-timer-re-enabled-for-item-17`: the claim now pins `active:enabled` (verified 2026-08-08). Docs-only; no runtime change.

## Why

Docket D3's recorded re-enable condition — re-enable deliberately when the item-17 warm campaign resumes, repairing the failed service at the same time — was met and executed 2026-08-08:

- The 2026-08-03 service failure was diagnosed: eval-gate red on `n-prod-01` (`apple` → `off_9333022029263`, kcal100 23.9, item #4 population), not an infra fault.
- Repair was cache-side per Diego's decision: `apple` FoodMapping key repointed to FDC 171688 `Apples, raw, with skin` as a `human-triage` pin. Warm probe: kcal100 52, in band.
- The first proof run surfaced a second warm red: `n-mq-41` — the `brand_guard` cache escape bypassed the CORRECT cached `fs_81276` row (`ai` rows get no trust-skip) and the live pipeline billed the #18-era brandless winner. Fixed by promoting the row to `human-triage` (the escape is in `HUMAN_TRUST_SKIPPABLE_ESCAPES` by design). Warm probe: 260 g / 520 kcal, both bands green.
- Second proof run: **0 real failures / 12 known issues**, coverage 52.1% republished. Timer re-armed `active:enabled`, next fire 04:30.

Both cache rows are in the restore anchor `sync-docs/cache-snapshots/fm-pre-apple-repoint-2026-08-08.sql` (mobile repo).

Owner-doc rewrite (plan §Running-under-all-of-this) is in the mobile repo, committed alongside.

`npm run doc-check`: **109/109** on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu