### PR TITLE
fix(eval): screen's real-anchor pass now bills the production unitless-1x path (parsed was null → all bare-serving guards off) + honest card serving labels

### DIFF
--- a/scripts/eval/__tests__/real-anchor-bare-request.test.ts
+++ b/scripts/eval/__tests__/real-anchor-bare-request.test.ts
@@ -1,0 +1,189 @@
+/**
+ * real-anchor-bare-request.test.ts — pins the two 2026-08-08 screen fixes.
+ *
+ * DEFECT 1 (the load-bearing pin). resolveRealServings passed a literal `null`
+ * as the `parsed` argument of hydrateAndSelectServing. Both bare-request
+ * predicates in src/lib/servings/bare-query-guard.ts return `false` on a null
+ * parsed, so every bare-serving guard (category-default CAP/REPLACE, the
+ * name-sibling rungs, the FatSecret bare-plural suppression) was OFF in the
+ * screen while ON in production — the screen's own claim of billing "what the
+ * REQUEST PATH would bill for a unitless 1x" was false. Measured 2026-08-08:
+ * 12 of 14 serving-flagged triage rows showed `flat_100g_default` on their
+ * cards while production billed `bare_category_default` /
+ * `bare_name_sibling_serving_tight` / `fs_default_serving`.
+ *
+ * The pin imports the REAL predicates (not re-implementations) and asserts the
+ * parsed object the screen now builds satisfies them for a bare seed phrase.
+ * This is the test that dies if someone reverts `parsed` to null or forks the
+ * construction away from the production parser.
+ *
+ * DEFECT 2. The LLM card paired the cascade's billed grams with the record's
+ * STORED default-serving description (`0.6 g  (label: 1 cup)` on FatSecret
+ * "Baby Spinach" — grams from the "1 baby leaf" row, description from another).
+ * servingLabelFor owns the honest pairing rules; pinned here per origin.
+ *
+ * NO NETWORK, NO DATABASE, NO API KEY. bareUnitlessRequest lazy-requires the
+ * real parser chain (pure functions + on-disk JSON rules); nothing here touches
+ * the mapper, Prisma, or an LLM.
+ */
+
+import {
+    bareUnitlessRequest,
+    llmUserPrompt,
+    servingLabelFor,
+    type ScreenRow,
+} from '../correctness-screen';
+import {
+    isBareUnitlessQty1,
+    isBarePluralRequest,
+} from '../../../src/lib/servings/bare-query-guard';
+
+// ---------------------------------------------------------------------------
+// Defect 1: the parsed object the screen passes takes the production bare path
+// ---------------------------------------------------------------------------
+
+describe('bareUnitlessRequest: the screen bills the production unitless-1x path', () => {
+    it('DOCUMENTS THE DEFECT: a null parsed switches the bare guard off', () => {
+        // This is why the literal null was a bug — the predicate production runs
+        // can never pass, whatever the raw line says.
+        expect(isBareUnitlessQty1(null, 'grape jelly')).toBe(false);
+    });
+
+    it('a bare seed phrase parses to an object the REAL bare predicate accepts', () => {
+        const { parsed, rawLine } = bareUnitlessRequest('grape jelly', 'grape jelly');
+        expect(parsed).not.toBeNull();
+        // The real predicate, imported from production. Reverting parsed to null
+        // (or hand-building an object that drifts from the parser — qty !== 1,
+        // multiplier missing, a unit sneaking in) kills this line.
+        expect(isBareUnitlessQty1(parsed, rawLine)).toBe(true);
+        expect(parsed!.qty).toBe(1);
+        expect(parsed!.multiplier).toBe(1);
+        expect(parsed!.unit ?? null).toBeNull();
+        expect(parsed!.name.toLowerCase()).toContain('jelly');
+    });
+
+    it('a bare PLURAL seed satisfies the real bare-plural predicate too', () => {
+        const { parsed, rawLine } = bareUnitlessRequest('almonds', 'almond');
+        expect(parsed).not.toBeNull();
+        expect(isBareUnitlessQty1(parsed, rawLine)).toBe(true);
+        expect(isBarePluralRequest(parsed, rawLine, parsed!.name)).toBe(true);
+    });
+
+    it('falls back to the token-sorted key when the seed is missing — still bare', () => {
+        // attribute() fills seed with '' when a row cannot be attributed; the key
+        // ("jelly grape") is token-sorted but digitless and unitless, which is all
+        // the predicates read.
+        for (const seed of ['', undefined] as const) {
+            const { parsed, rawLine } = bareUnitlessRequest(seed, 'jelly grape');
+            expect(rawLine).toBe('jelly grape');
+            expect(isBareUnitlessQty1(parsed, rawLine)).toBe(true);
+        }
+    });
+
+    it('empty seed AND key yield a null parsed, not a fabricated request', () => {
+        const { parsed, rawLine } = bareUnitlessRequest('', '');
+        expect(parsed).toBeNull();
+        expect(rawLine).toBe('');
+    });
+
+    it('does NOT force bareness: a quantified seed stays on the counted path', () => {
+        // The fix must reproduce production behaviour, not maximise guard firing:
+        // a digit-carrying line is exactly what the digit gate exists to exclude.
+        const { parsed, rawLine } = bareUnitlessRequest('15 pretzels', '15 pretzels');
+        expect(parsed).not.toBeNull();
+        expect(isBareUnitlessQty1(parsed, rawLine)).toBe(false);
+        const cup = bareUnitlessRequest('2 cups milk', 'cup milk');
+        expect(isBareUnitlessQty1(cup.parsed, cup.rawLine)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 2: the card's serving label must correspond to the printed grams
+// ---------------------------------------------------------------------------
+
+/** A FatSecret row shaped like the Baby Spinach artifact. */
+function fsRow(over: Partial<ScreenRow> = {}): ScreenRow {
+    return {
+        key: 'baby spinach',
+        src: 'fatsecret',
+        conf: 0.9,
+        validatedby: 'ai',
+        mapfoodname: 'Baby Spinach',
+        mapbrand: '',
+        recname: 'Baby Spinach',
+        recbrand: '',
+        per100g: { calories: 23, protein: 2.9, carbs: 3.6, fat: 0.4 },
+        off_serving_grams: null,
+        off_serving_size: '',
+        pkg_qty: null,
+        pkg_unit: '',
+        corruptreason: '',
+        dupof: '',
+        fs_serving_desc: '1 cup',            // the stored DEFAULT serving row
+        fs_serving_grams: 30,
+        fs_serving_nutrients: null,
+        recid: '12345',
+        n_off_servings: 0,
+        off_serv_min_g: null,
+        off_serv_max_g: null,
+        fdc_serving_size: null,
+        fdc_serving_unit: '',
+        fdc_serv_min_g: null,
+        seed: 'baby spinach',
+        ...over,
+    };
+}
+
+describe('servingLabelFor: grams and label must come from the same serving', () => {
+    it('real-anchor grams never wear the stored default-serving description', () => {
+        // The Baby Spinach shape: hydration chose the "1 baby leaf" row (0.6 g),
+        // the stored default description is "1 cup". The old card printed
+        // `0.6 g (label: 1 cup)`.
+        const r = fsRow({
+            real: { grams: 0.6, tier: 'fs_default_serving', kcal: 0, desc: '1 leaf' },
+        });
+        const label = servingLabelFor(r, { grams: 0.6, from: 'hydrateAndSelectServing:fs_default_serving' });
+        expect(label).toBe('1 leaf');
+        expect(label).not.toBe('1 cup');
+    });
+
+    it('real-anchor grams with no hydration description drop the label entirely', () => {
+        const r = fsRow({
+            real: { grams: 0.6, tier: 'fs_default_serving', kcal: 0, desc: null },
+        });
+        expect(servingLabelFor(r, { grams: 0.6, from: 'hydrateAndSelectServing:fs_default_serving' })).toBeNull();
+        // Same rule for the AI-estimated (unjudged) origin.
+        expect(servingLabelFor(r, { grams: 30, from: 'ai-estimated:count_unit_ai' })).toBeNull();
+    });
+
+    it('reconstruction grams keep the stored label ONLY from their own row', () => {
+        const r = fsRow({ off_serving_size: '2 tbsp (32 g)', real: undefined });
+        // Consistent pairs — same DB row by ROW_SQL's join construction.
+        expect(servingLabelFor(r, { grams: 32, from: 'OffFood.servingGrams' })).toBe('2 tbsp (32 g)');
+        expect(servingLabelFor(r, { grams: 30, from: 'FatSecretServing.grams' })).toBe('1 cup');
+        // Origins with no stored description in the row get none.
+        expect(servingLabelFor(r, { grams: 25, from: 'OffServing.grams' })).toBeNull();
+        expect(servingLabelFor(r, { grams: 25, from: 'FdcServing.grams' })).toBeNull();
+        expect(servingLabelFor(r, { grams: 25, from: 'FdcFood.servingSize' })).toBeNull();
+        // No grams, no label.
+        expect(servingLabelFor(r, { grams: null, from: 'none (flat-100g default)' })).toBeNull();
+    });
+
+    it('END TO END: the card prints the hydration label, not the stored one', () => {
+        const r = fsRow({
+            real: { grams: 0.6, tier: 'fs_default_serving', kcal: 0, desc: '1 leaf' },
+        });
+        const card = llmUserPrompt(r);
+        expect(card).toContain('default serving: 0.6 g  (label: 1 leaf, via hydrateAndSelectServing:fs_default_serving)');
+        expect(card).not.toContain('label: 1 cup');
+    });
+
+    it('END TO END: a label-less real anchor prints origin only — no dishonest label', () => {
+        const r = fsRow({
+            real: { grams: 0.6, tier: 'fs_default_serving', kcal: 0, desc: null },
+        });
+        const card = llmUserPrompt(r);
+        expect(card).toContain('default serving: 0.6 g  (via hydrateAndSelectServing:fs_default_serving)');
+        expect(card).not.toContain('label:');
+    });
+});

--- a/scripts/eval/correctness-screen.ts
+++ b/scripts/eval/correctness-screen.ts
@@ -139,6 +139,9 @@ import * as path from 'path';
 import { detectBrandInQuery } from '../../src/lib/mapping/brand-detector';
 import { servingMacros } from '../../src/lib/mapping/fs-serving-macros';
 import { isReplayNondeterministicTier } from '../../src/lib/mapping/serving-ai-tiers';
+// Type-only: erased at compile time, so importing this module still does not load
+// the parse chain. The parser itself is lazy-required inside bareUnitlessRequest.
+import type { ParsedIngredient } from '../../src/lib/parse/ingredient-line';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -201,6 +204,15 @@ export interface RealServing {
     grams: number | null;
     tier: string | null;
     kcal: number | null;
+    /**
+     * The serving description the hydration lane itself chose for these grams
+     * (e.g. "1 leaf", "28.0g"). Card-display only: it lets llmUserPrompt pair the
+     * billed grams with THEIR OWN label instead of the record's stored
+     * default-serving description, which can belong to a different serving row
+     * entirely (FatSecret "Baby Spinach": 0.6 g is the "1 baby leaf" row's grams,
+     * "1 cup" a different row's description — see servingLabelFor).
+     */
+    desc?: string | null;
     error?: string;
 }
 
@@ -784,8 +796,46 @@ Use UNSURE when you cannot tell whether it is the same product from the informat
  * is unusable but serving-level nutrition exists, the card now prints that panel
  * and says where the billed number comes from.
  */
+/**
+ * The label description that may honestly sit next to `sg.grams` on the LLM card
+ * — or null when no stored description corresponds to those grams.
+ *
+ * The card used to print `label: ${r.off_serving_size || r.fs_serving_desc}` next
+ * to whatever grams realServing() returned: the record's STORED default-serving
+ * description paired with the CASCADE's billed grams, which can come from a
+ * different serving row entirely. Real example (2026-08-08): FatSecret
+ * "Baby Spinach" printed `0.6 g  (label: 1 cup)` — 0.6 g is the "1 baby leaf"
+ * row's grams, "1 cup" a different row's description — and a judge reads that
+ * pairing as label corruption on a correct record.
+ *
+ * Rules:
+ *   - grams from the real pass (`hydrateAndSelectServing:*` / `ai-estimated:*`)
+ *     pair only with the description the hydration result itself carried
+ *     (`r.real.desc`); when it carried none, the label is dropped;
+ *   - reconstruction grams pair only with the stored description of the SAME
+ *     row resolveServingGrams read them from (OffFood.servingGrams ↔
+ *     off_serving_size, FatSecretServing.grams ↔ fs_serving_desc — each pair is
+ *     one DB row by construction, see ROW_SQL's joins);
+ *   - every other origin (OffServing/FdcServing minima, FdcFood.servingSize)
+ *     has no stored description in the row, so no label.
+ */
+export function servingLabelFor(
+    r: ScreenRow,
+    sg: { grams: number | null; from: string },
+): string | null {
+    if (sg.grams == null) return null;
+    if (sg.from.startsWith('hydrateAndSelectServing:') || sg.from.startsWith('ai-estimated:')) {
+        const d = r.real && !r.real.error ? r.real.desc : null;
+        return d && d.trim() !== '' ? d.trim() : null;
+    }
+    if (sg.from === 'OffFood.servingGrams') return r.off_serving_size?.trim() || null;
+    if (sg.from === 'FatSecretServing.grams') return r.fs_serving_desc?.trim() || null;
+    return null;
+}
+
 export function llmUserPrompt(r: ScreenRow): string {
     const sg = realServing(r);
+    const label = servingLabelFor(r, sg);
     const aw = atwater(r.per100g);
     const p = r.per100g ?? {};
     const servKcal = servingLevelKcal(r);
@@ -812,7 +862,7 @@ export function llmUserPrompt(r: ScreenRow): string {
             : '',
         aw ? `Atwater check: declared/computed = ${aw.ratio.toFixed(2)}` : 'Atwater check: not computable',
         sg.grams != null
-            ? `default serving: ${sg.grams} g  (label: ${r.off_serving_size || r.fs_serving_desc || 'n/a'}, via ${sg.from})  -> a "1 x" log bills ${billed}`
+            ? `default serving: ${sg.grams} g  (${label ? `label: ${label}, ` : ''}via ${sg.from})  -> a "1 x" log bills ${billed}`
             : `default serving: NONE resolved (${sg.from}) -> a "1 x" log bills a flat 100 g = ${billed}`,
         r.pkg_qty ? `package quantity: ${r.pkg_qty} ${r.pkg_unit}` : '',
     ].filter(Boolean);
@@ -1020,6 +1070,41 @@ function candidateId(r: ScreenRow): string | null {
 }
 
 /**
+ * The ParsedIngredient a real unitless "1 x" request carries, built by the REAL
+ * parser (`parseIngredientLine`, the same function `preflightIngredientLine` in
+ * map-ingredient-with-fallback.ts calls) on the shopper's seed phrase — falling
+ * back to the stored key when the seed is missing (token-sorted, but still a
+ * digitless unitless phrase, which is all the bare-request predicates read).
+ *
+ * This exists because the real-anchor pass used to hand `hydrateAndSelectServing`
+ * a literal `null` for `parsed`. Both bare-request predicates in
+ * src/lib/servings/bare-query-guard.ts — `isBareUnitlessQty1` and
+ * `isBarePluralRequest` — return `false` on a null parsed, so every bare-serving
+ * guard (the category-default CAP/REPLACE override, the name-sibling rungs, the
+ * FatSecret bare-plural suppression) was OFF in the screen while ON in
+ * production. Measured 2026-08-08: 12 of 14 serving-flagged triage rows showed
+ * `flat_100g_default` on their cards while production billed
+ * `bare_category_default` 14 g / `bare_name_sibling_serving_tight` 5–30 g /
+ * `fs_default_serving` label servings. The screen was grading a pipeline
+ * production never runs.
+ *
+ * Parser is lazy-required so importing this module stays side-effect-light for
+ * the unit tests that never run the real pass (same pattern as
+ * resolveRealServings' own require of the mapper).
+ */
+export function bareUnitlessRequest(
+    seed: string | undefined,
+    key: string,
+): { parsed: ParsedIngredient | null; rawLine: string } {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { parseIngredientLine } =
+        require('../../src/lib/parse/ingredient-line') as typeof import('../../src/lib/parse/ingredient-line');
+    const rawLine = (seed ?? '').trim() || (key ?? '').trim();
+    if (!rawLine) return { parsed: null, rawLine };
+    return { parsed: parseIngredientLine(rawLine), rawLine };
+}
+
+/**
  * Fill `row.real` with what the REQUEST PATH would bill for a unitless `1 x`.
  *
  * This calls `hydrateAndSelectServing` — the same function route.ts calls — rather
@@ -1027,6 +1112,11 @@ function candidateId(r: ScreenRow): string | null {
  * could not see count-label serving, dose-anchored serving or the FatSecret weight
  * oracle, and PR #174 moved the real anchor further from it still. A screen that
  * evicts cache rows on a number the user is not billed is grading the wrong thing.
+ *
+ * The `parsed` argument is built by `bareUnitlessRequest` above — the real parser
+ * over the seed phrase — never a literal `null`, which would switch every
+ * bare-serving guard off and bill a pipeline production never runs (see that
+ * function's comment for the measured artifact).
  *
  * Rows it cannot resolve get `error` set, which makes D5/D6 abstain. Failure is
  * never silently converted into agreement.
@@ -1071,7 +1161,8 @@ export async function resolveRealServings(rows: ScreenRow[], concurrency = 8): P
                 rawData: {},
             };
             try {
-                const res = await hydrateAndSelectServing(candidate, null, r.conf ?? 0.9, r.seed || r.key);
+                const { parsed, rawLine } = bareUnitlessRequest(r.seed, r.key);
+                const res = await hydrateAndSelectServing(candidate, parsed, r.conf ?? 0.9, rawLine);
                 if (!res) { r.real = null; continue; }
                 r.real = {
                     grams: typeof res.grams === 'number' ? res.grams : null,
@@ -1079,6 +1170,11 @@ export async function resolveRealServings(rows: ScreenRow[], concurrency = 8): P
                     // `kcal` is the TOTAL for the resolved grams — the same field
                     // route.ts records as MappingEventLog.totalKcal.
                     kcal: typeof res.kcal === 'number' ? res.kcal : null,
+                    // The description the lane chose for THESE grams; the card must
+                    // never pair them with the stored default-serving description.
+                    desc: typeof res.servingDescription === 'string' && res.servingDescription.trim() !== ''
+                        ? res.servingDescription
+                        : null,
                 };
             } catch (err: unknown) {
                 const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## What

Two verified defects (2026-08-08) in the warm-campaign screening instrument, both in `scripts/eval/correctness-screen.ts`. **`scripts/` only — no production runtime code under `src/` changes.** This changes what future warm-batch screens judge, which is the point: they will finally judge production behavior.

## Defect 1 — the real-anchor pass billed a pipeline production never runs

`resolveRealServings()` called `hydrateAndSelectServing(candidate, null, r.conf ?? 0.9, r.seed || r.key)` with a literal `null` for `parsed`. Both bare-request predicates in `src/lib/servings/bare-query-guard.ts` — `isBareUnitlessQty1(parsed, rawLine)` and `isBarePluralRequest(...)` — return `false` when `parsed` is null, so every bare-serving guard (category default CAP/REPLACE, the name-sibling rungs, FatSecret bare-plural handling) was OFF in the screen while ON in production. The pass's own doc comment claims it bills "what the REQUEST PATH would bill for a unitless 1x"; with null parsed that claim was false.

**Measured artifact:** 12 of 14 serving-flagged triage rows showed `flat_100g_default` on their cards while production bills `bare_category_default` 14 g / `bare_name_sibling_serving_tight` 5–30 g / `fs_default_serving` label servings.

**Fix:** new `bareUnitlessRequest(seed, key)` builds the ParsedIngredient a real unitless "1x" request carries by calling the **real parser** — `parseIngredientLine()`, the same function `preflightIngredientLine()` in `map-ingredient-with-fallback.ts` calls — on the shopper's seed phrase, falling back to the token-sorted key when the seed is empty (still a digitless, unitless phrase, which is all the predicates read). No hand-built literal that can drift from the parser. Confidence and the remaining arguments are unchanged; the parser is lazy-required, same pattern as the pass's existing mapper require.

## Defect 2 — card label/grams pairing

The LLM card printed `default serving: ${sg.grams} g  (label: ${r.off_serving_size || r.fs_serving_desc || 'n/a'}, ...)` — the record's **stored** default-serving description paired with the **cascade's** billed grams, which can come from a different serving row. Real example: FatSecret "Baby Spinach" printed `0.6 g (label: 1 cup)` — 0.6 g is the "1 baby leaf" row's grams, "1 cup" a different row's description. A judge reads that pairing as label corruption on a correct record.

**Fix:** `servingLabelFor(r, sg)` owns the pairing:
- grams from the real pass (`hydrateAndSelectServing:*` / `ai-estimated:*`) pair only with the description the hydration result itself carried (captured into a new display-only `RealServing.desc` from `res.servingDescription`); when it carried none, the label is dropped;
- reconstruction grams keep the stored label only when it comes from the same DB row (`OffFood.servingGrams` ↔ `off_serving_size`, `FatSecretServing.grams` ↔ `fs_serving_desc` — each pair is one row by `ROW_SQL`'s joins);
- other origins (`OffServing`/`FdcServing` minima, `FdcFood.servingSize`) have no stored description in the row → no label.

## Tests

`scripts/eval/__tests__/real-anchor-bare-request.test.ts` (11 tests, no network/DB/LLM):
- imports the **real** `isBareUnitlessQty1`/`isBarePluralRequest` and pins that the parsed object the screen passes satisfies them for a bare seed phrase — the test that dies if someone reverts `parsed` to null;
- pins the key-fallback, empty-input, and digit-carrying (non-bare) behaviors;
- pins `servingLabelFor`'s rules per origin plus two end-to-end `llmUserPrompt` card assertions (hydration label printed, stored `1 cup` never printed next to foreign grams).

Local gates: `npx jest scripts/eval/__tests__` 21 suites / 1103 tests green; `npx tsc --noEmit` exit 0; `npm run lint:ci` 0 errors (592/700 warnings, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu