### PR TITLE
fix(serving): tamari is a condiment — the missing token left rung (D)'s package borrow uncapped

### DIFF
--- a/src/lib/ai/__tests__/ambiguous-serving-estimator.test.ts
+++ b/src/lib/ai/__tests__/ambiguous-serving-estimator.test.ts
@@ -214,4 +214,15 @@ describe('getBareQueryDefault — token-containment guards (warm-2026-07-21 regr
         expect(grams('honey graham crackers')).toBe(28);   // salty snack (crackers)
         expect(grams('honey mustard')).toBe(14);           // still a condiment via mustard
     });
+
+    // `soy sauce` was always covered by the `sauce` token; `tamari` is the same
+    // condiment class spelled without it, so bare `tamari` returned null and the
+    // guard's CAP had no value to bound rung (D)'s brand-median PACKAGE borrow —
+    // live it billed 117.5g off `off_5400313430320` (Yakso). Measured 2026-08-08.
+    it('tamari is a condiment (14g) — without it the package-count borrow is uncapped', () => {
+        expect(grams('tamari')).toBe(14);
+        expect(grams('tamari sauce')).toBe(14);
+        expect(grams('gluten free tamari')).toBe(14);
+        expect(grams('soy sauce')).toBe(14); // the token that already covered the class
+    });
 });

--- a/src/lib/ai/ambiguous-serving-estimator.ts
+++ b/src/lib/ai/ambiguous-serving-estimator.ts
@@ -232,7 +232,7 @@ export function getBareQueryDefault(foodName: string): { grams: number, descript
     // cheerios', 'honey bunches of oats') keep their own categories — bare
     // honey otherwise flaps on the AI size estimate (21g vs the 340g bottle,
     // eval n-serv-49 2026-07-21).
-    if (/\b(mayo|mayonnaise|mustard|ketchup|relish|jam|jelly|peanut butter|butter|oil|vinegar|sauce|dressing|syrup|ghee|lard|tallow|miso|mirin|tahini|pesto|hummus|nutella|hazelnut spread|honey(?!\s+(nut|bunche?s|smacks|graham|oats?|roasted|glazed|bbq|barbecue)))\b/.test(nameStr)) {
+    if (/\b(mayo|mayonnaise|mustard|ketchup|relish|jam|jelly|peanut butter|butter|oil|vinegar|sauce|dressing|syrup|ghee|lard|tallow|miso|mirin|tamari|tahini|pesto|hummus|nutella|hazelnut spread|honey(?!\s+(nut|bunche?s|smacks|graham|oats?|roasted|glazed|bbq|barbecue)))\b/.test(nameStr)) {
         return { grams: 14, description: "1 tbsp (standard bare query serving)" };
     }
 


### PR DESCRIPTION
## What

One token: `tamari` added to the condiment regex in `getBareQueryDefault()` (`src/lib/ai/ambiguous-serving-estimator.ts`), plus a pinning test.

## Why

`soy sauce` was always covered by the regex's `sauce` token. `tamari` is the same condiment class spelled without it, so `getBareQueryDefault('tamari')` returned null.

That matters because `package_count_sibling` **is** in the bare-query guard's `CAP_TIERS` — but a cap needs a category default to bound against. With none, rung (D) WHOLE-PACKAGE COUNT in `buildOffResult()` called `borrowSiblingPackageGrams('Yakso')` and billed the brand-median *package*: **live, bare `tamari` billed 117.5 g** off `off_5400313430320`.

Rung (E)'s name group for tamari is **n=6 with p25 = p75 = 15 g** — the correct answer is already in the DB, but unreachable: (E) requires `servingTier === 'count_unresolved_floor'` and a NULL `brandName`, and (D) answers first. Adding the token is the cheapest sound fix; the existing CAP then bounds 117.5 g against the 14 g default.

Measured 2026-08-08. Owner: mobile `sync-docs/reports/2026-08-08_the-screen-bills-a-pipeline-production-never-runs.md` §4.

## Risk

**This moves billed grams**, so it takes the full deploy recipe plus a restarted cold gate ×3 against the §10r 10-id baseline — not a free merge. The token is distinctive (no product-name containment risk of the `bell pepper`/`cinnamon roll` kind that the neighbouring guards exist for).

## Gates

- jest **3,462 passed** / 175 suites, 0 failures
- `npx tsc --noEmit` — 0 errors
- `npm run lint:ci` — 0 errors
- New test asserts `tamari`, `tamari sauce`, `gluten free tamari` → 14 g, and pins `soy sauce` → 14 g as the token that already covered the class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu