### PR TITLE
chore(eval): commit the uncached-seed dump helper instead of leaving it untracked

### DIFF
--- a/scripts/eval/_dump_uncached.ts
+++ b/scripts/eval/_dump_uncached.ts
@@ -1,0 +1,24 @@
+/** Read-only: dump the uncached seeds of a coverage corpus, with domain. */
+import 'dotenv/config';
+import * as fs from 'fs';
+import { PrismaClient } from '@prisma/client';
+import { canonicalizeCacheKey } from '../../src/lib/mapping/normalization-rules';
+
+async function main() {
+    const corpus = process.argv[2];
+    const out = process.argv[3];
+    const prisma = new PrismaClient();
+    const live = new Set((await prisma.foodMapping.findMany({ select: { normalizedForm: true } })).map(r => r.normalizedForm));
+    const lines = fs.readFileSync(corpus, 'utf8').trim().split('\n');
+    const hdr = lines.shift();
+    if (!hdr || !hdr.startsWith('domain')) throw new Error('unexpected header: ' + hdr);
+    const rows = lines.map(l => { const [domain, baseline, seed] = l.split('\t'); return { domain, baseline, seed }; });
+    const un = rows.filter(r => !live.has(canonicalizeCacheKey(r.seed)));
+    fs.writeFileSync(out, ['domain\tbaseline\tseed\tcachekey', ...un.map(r => `${r.domain}\t${r.baseline}\t${r.seed}\t${canonicalizeCacheKey(r.seed)}`)].join('\n'));
+    const byDomain = new Map<string, number>();
+    for (const r of un) byDomain.set(r.domain, (byDomain.get(r.domain) ?? 0) + 1);
+    console.log(`corpus ${rows.length} · live keys ${live.size} · UNCACHED ${un.length} (${(100 * (rows.length - un.length) / rows.length).toFixed(1)}% cached)`);
+    console.log([...byDomain.entries()].sort((a, b) => b[1] - a[1]).map(([d, n]) => `${d}\t${n}`).join('\n'));
+    await prisma.$disconnect();
+}
+main();


### PR DESCRIPTION
## What

`scripts/eval/_dump_uncached.ts` — lists a coverage corpus's uncached seeds with their domain, by comparing `canonicalizeCacheKey(seed)` against live `FoodMapping` keys. Read-only: one `findMany` and a file write.

## Why it exists

It is the cheap counterpart to `probe-classify-seeds.ts` (#273). Stage 0 probes every seed and costs a live parse per row; this just answers *"which seeds are uncached, and in which domain"* for free — which is what you need to build a sampling frame or size a batch before spending anything.

## Why committed rather than deleted

It produced the sampling frame for the accuracy measurement in the mobile repo's `reports/2026-08-08_coverage-is-not-the-accuracy-lever.md`. That report's method is only re-derivable if this script exists.

## Why committed rather than left untracked

A script under `scripts/` with no git history is the pattern that already bit this project: `run-batches.sh` spent its whole life in one copy per machine, carried only by Syncthing, with no history. Untracked executable code in a synced repo is a trap, not a convenience.

## Gates

- `npx tsc --noEmit` — 0 errors
- `lint:ci` — 0 errors (console warnings only, the same class every script here carries)
- No behaviour change to any served code path; new standalone script, nothing imports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu