### PR TITLE
doc-check: claim that OFF records are effectively single-serving

### DIFF
--- a/scripts/doc-check/claims.json
+++ b/scripts/doc-check/claims.json
@@ -1323,6 +1323,19 @@
       },
       "verified": "2026-08-07",
       "timeoutMs": 60000
+    },
+    {
+      "id": "off-records-are-effectively-single-serving",
+      "claim": "OFF records that carry any serving row carry EXACTLY ONE of them, and that is the load-bearing fact behind the 2026-08-09 decision NOT to build serving-class cache keys. Measured 2026-08-09: of 770,995 OffFood barcodes with an OffServing row, 770,902 have exactly one and only 93 have two or more (n=2 -> 42, n=3 -> 13, n=4 -> 37, n=5 -> 1), i.e. 0.012%. Contrast FatSecretFood, where 20,616 of 24,123 (85.5%) carry >=2 and ZERO carry none. That separation is why 'prefer the candidate carrying the requested unit' is not a per-record ranking feature at all but a LANE PREFERENCE in disguise (OFF is 3,550 of the 4,702 cached identities), which re-opens plan item #18 and collides with the cross_source_margin save gate. If an OFF ingest ever starts delivering genuinely multi-descriptor records, the ranking half of that decision must be re-adjudicated: there would finally be something to select over. This claim is deliberately a THRESHOLD, not a count, so ordinary ingest drift does not red it and a structural change does: it emits 1 while >=2-descriptor OFF records stay under 1% of OFF records with any serving row. It says NOTHING about whether the descriptors are good; OffServing is ~8.7% pure restatements of the per-100g basis ('100g', '1 portion (100 g)'), so the real per-unit choice inside the OFF lane is smaller than even 0.012% suggests.",
+      "ownerDoc": "mobile:sync-docs/reports/2026-08-09_serving-class-keys-the-pick-is-already-unit-aware.md",
+      "where": "box",
+      "command": "docker exec mealspire-db psql -U postgres -d mealspire -At -c \"SELECT CASE WHEN (SELECT count(*) FROM (SELECT barcode FROM \\\"OffServing\\\" GROUP BY 1 HAVING count(*)>=2) t) * 100.0 / GREATEST((SELECT count(DISTINCT barcode) FROM \\\"OffServing\\\"),1) < 1.0 THEN 1 ELSE 0 END\"",
+      "expect": {
+        "kind": "equals",
+        "value": "1"
+      },
+      "verified": "2026-08-09",
+      "timeoutMs": 120000
     }
   ]
 }


### PR DESCRIPTION
Adds one `box`-context claim to `scripts/doc-check/claims.json`. No source changes, no schema, no behaviour.

## Why

It guards the load-bearing fact behind the 2026-08-09 decision **not** to build serving-class cache keys
(owner: `mobile:sync-docs/reports/2026-08-09_serving-class-keys-the-pick-is-already-unit-aware.md`).

Measured on the box 2026-08-09: of **770,995** `OffFood` barcodes carrying any `OffServing` row,
**770,902 carry exactly one** and only **93 carry two or more** (n=2 → 42, n=3 → 13, n=4 → 37, n=5 → 1),
i.e. **0.012%**. Contrast `FatSecretFood`, where **20,616 of 24,123 (85.5%)** carry ≥2 and **zero** carry none.

That separation is the whole argument: because serving-richness is a *source* property rather than a *record*
property, "prefer the candidate carrying the requested unit" is not a per-record ranking feature at all — it is
a **lane preference in disguise** (OFF is 3,550 of the 4,702 cached identities), which re-opens plan item #18
and collides with the `cross_source_margin` save gate.

If an OFF ingest ever starts delivering genuinely multi-descriptor records, that decision must be
re-adjudicated — there would finally be something to select over. This claim is how we find out.

## Design notes

- **Threshold, not a count.** It emits `1` while ≥2-descriptor OFF records stay under 1% of OFF records with
  any serving row. Ordinary ingest drift therefore does not red it; a structural change does. A raw `93` would
  red on the next OFF refresh and get muted, which is the failure mode the registry exists to avoid.
- **`where: box`, and cwd-independent.** Per CLAUDE.md, the box has no reliable cwd when the checker shells out
  as `ssh <host> <command>` with no `cd`, so this uses `docker exec` and touches no relative path.
- The claim text records explicitly that it says **nothing** about descriptor *quality* — `OffServing` is ~8.7%
  pure restatements of the per-100g basis, so the real per-unit choice inside the OFF lane is smaller than even
  0.012% suggests.

## Verified

- `npm run doc-check -- --only off-records-are-effectively-single-serving` → `1/1 claims hold`
- Registry parses; diff is **+13 lines, 0 deletions** (an earlier scripted edit ASCII-escaped every em-dash and
  `§` in the file — reverted and redone with `ensure_ascii=False`)
- Read-only against the box throughout; `FoodMapping` 4,702 before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hoybfY5pMethRuJr389xu